### PR TITLE
[A2-1] Add the minimal source registry persistence scaffold (#17)

### DIFF
--- a/backend/alembic/versions/0002_source_registry_scaffold.py
+++ b/backend/alembic/versions/0002_source_registry_scaffold.py
@@ -1,0 +1,53 @@
+"""Add the initial registered sources persistence scaffold.
+
+This revision creates the first application-owned source registry table without
+introducing execution routing, source governance, or live connector behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002_source_registry_scaffold"
+down_revision: str | None = "0001_baseline"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "registered_sources",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("source_identity", sa.String(length=255), nullable=False),
+        sa.Column("source_family", sa.String(length=64), nullable=False),
+        sa.Column("source_flavor", sa.String(length=64), nullable=True),
+        sa.Column("activation_posture", sa.String(length=32), nullable=False),
+        sa.Column("connector_profile_id", sa.Uuid(), nullable=True),
+        sa.Column("dialect_profile_id", sa.Uuid(), nullable=True),
+        sa.Column("dataset_contract_id", sa.Uuid(), nullable=True),
+        sa.Column("schema_snapshot_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_registered_sources")),
+        sa.UniqueConstraint(
+            "source_identity",
+            name=op.f("uq_registered_sources_source_identity"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("registered_sources")

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,3 +1,4 @@
 from app.db.base import Base, target_metadata
+from app.db.models import RegisteredSource
 
-__all__ = ["Base", "target_metadata"]
+__all__ = ["Base", "RegisteredSource", "target_metadata"]

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -15,3 +15,6 @@ class Base(DeclarativeBase):
 
 
 target_metadata = Base.metadata
+
+# Import model modules so metadata is populated for Alembic and tests.
+import app.db.models  # noqa: F401,E402

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,0 +1,3 @@
+from app.db.models.source_registry import RegisteredSource
+
+__all__ = ["RegisteredSource"]

--- a/backend/app/db/models/source_registry.py
+++ b/backend/app/db/models/source_registry.py
@@ -51,4 +51,5 @@ class RegisteredSource(Base):
         DateTime(timezone=True),
         nullable=False,
         server_default=func.now(),
+        onupdate=func.now(),
     )

--- a/backend/app/db/models/source_registry.py
+++ b/backend/app/db/models/source_registry.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, String, UniqueConstraint, func
+from sqlalchemy import Uuid as SqlAlchemyUuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class RegisteredSource(Base):
+    __tablename__ = "registered_sources"
+    __table_args__ = (
+        UniqueConstraint("source_identity"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    source_identity: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_family: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    activation_posture: Mapped[str] = mapped_column(String(32), nullable=False)
+    connector_profile_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        SqlAlchemyUuid,
+        nullable=True,
+    )
+    dialect_profile_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        SqlAlchemyUuid,
+        nullable=True,
+    )
+    dataset_contract_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        SqlAlchemyUuid,
+        nullable=True,
+    )
+    schema_snapshot_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        SqlAlchemyUuid,
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/tests/test_source_registry_models.py
+++ b/backend/tests/test_source_registry_models.py
@@ -1,3 +1,5 @@
+from sqlalchemy import UniqueConstraint
+
 from app.db.models.source_registry import RegisteredSource
 
 
@@ -28,11 +30,13 @@ def test_registered_source_scaffold_matches_minimum_shape() -> None:
     assert table.c.dialect_profile_id.nullable is True
     assert table.c.dataset_contract_id.nullable is True
     assert table.c.schema_snapshot_id.nullable is True
+    assert table.c.created_at.onupdate is None
+    assert table.c.updated_at.onupdate is not None
 
     unique_constraints = {
         tuple(column.name for column in constraint.columns)
         for constraint in table.constraints
-        if constraint.__class__.__name__ == "UniqueConstraint"
+        if isinstance(constraint, UniqueConstraint)
     }
 
     assert ("source_identity",) in unique_constraints

--- a/backend/tests/test_source_registry_models.py
+++ b/backend/tests/test_source_registry_models.py
@@ -1,0 +1,38 @@
+from app.db.models.source_registry import RegisteredSource
+
+
+def test_registered_source_scaffold_matches_minimum_shape() -> None:
+    table = RegisteredSource.__table__
+
+    assert table.name == "registered_sources"
+
+    assert set(table.columns.keys()) == {
+        "id",
+        "source_identity",
+        "source_family",
+        "source_flavor",
+        "activation_posture",
+        "connector_profile_id",
+        "dialect_profile_id",
+        "dataset_contract_id",
+        "schema_snapshot_id",
+        "created_at",
+        "updated_at",
+    }
+
+    assert table.c.source_identity.nullable is False
+    assert table.c.source_family.nullable is False
+    assert table.c.source_flavor.nullable is True
+    assert table.c.activation_posture.nullable is False
+    assert table.c.connector_profile_id.nullable is True
+    assert table.c.dialect_profile_id.nullable is True
+    assert table.c.dataset_contract_id.nullable is True
+    assert table.c.schema_snapshot_id.nullable is True
+
+    unique_constraints = {
+        tuple(column.name for column in constraint.columns)
+        for constraint in table.constraints
+        if constraint.__class__.__name__ == "UniqueConstraint"
+    }
+
+    assert ("source_identity",) in unique_constraints


### PR DESCRIPTION
Closes #17
This PR was opened by codex-supervisor.
Latest Codex summary:

Added the minimal source registry persistence scaffold and committed it on `codex/issue-17` as `fba0ca5` (`Add source registry scaffold`).

The backend now has a concrete `RegisteredSource` ORM model with metadata registration, a new Alembic revision `0002_source_registry_scaffold`, and a focused regression test for the baseline registry shape. The scaffold covers source identity, family, optional flavor, activation posture, and nullable placeholders for connector profile, dialect profile, dataset contract, and schema snapshot linkage. I also updated the issue journal working notes in `.codex-supervisor/issues/17/issue-journal.md`.

Verification passed for the focused test, the broader backend test suite, and the compose-backed Alembic `upgrade`/`current` flow after rebuilding the backend image. One local repo inconsistency showed up during migration verification: `.env.example` uses a `SAFEQUERY_DATABASE_URL` password that does not match `POSTGRES_PASSWORD`, so I used a scoped env override for the compose Alembic checks instead of widening this issue.

Summary: Added the source registry ORM/migration scaffold, proved it with a focused test, verified backend tests, and validated Alembic upgrade/current in compose after rebuilding the backend image.
State hint: implementing
Blocked reason: none
Tests: `../.venv/bin/python -m pytest tests/test_source_registry_models.py`; `.venv/bin/python -m pytest backend/tests`; `DOCKER_HOST=unix:///Users/tsinfra/.colima/default/docker.soc...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a data source registry to store registered sources with identity, classification (family/flavor), activation posture, optional links to related profiles and snapshots, uniqueness on source identity, and created/updated timestamps.

* **Tests**
  * Added tests validating the registry’s table structure, required/optional columns, timestamp behavior, and uniqueness constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->