### PR TITLE
[A2-2] Define separate secret naming and connection identity for application PostgreSQL, business PostgreSQL source, and MSSQL (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,11 @@ POSTGRES_PASSWORD=change-me-for-shared-environments
 # Backend application settings
 SAFEQUERY_APP_NAME=SafeQuery API
 SAFEQUERY_ENVIRONMENT=development
-SAFEQUERY_DATABASE_URL=postgresql://safequery:safequery@postgres:5432/safequery
+SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@postgres:5432/safequery
+# Leave business-source credentials unset in the baseline stack. Wire them
+# explicitly per source so application persistence credentials are never reused.
+# SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me@postgres-source:5432/business
+# SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:mssql-source,1433;Database=business;Uid=source_reader;Pwd=change-me;Encrypt=yes;TrustServerCertificate=no
 SAFEQUERY_CORS_ORIGINS=http://localhost:3000
 
 # Frontend application settings

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ POSTGRES_PASSWORD=change-me-for-shared-environments
 
 # Backend application settings
 SAFEQUERY_APP_NAME=SafeQuery API
-SAFEQUERY_ENVIRONMENT=development
 SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@postgres:5432/safequery
+SAFEQUERY_ENVIRONMENT=development
 # Leave business-source credentials unset in the baseline stack. Wire them
 # explicitly per source so application persistence credentials are never reused.
 # SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me@postgres-source:5432/business

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cp .env.example .env
 
 The required startup values are:
 
-- `SAFEQUERY_DATABASE_URL`
+- `SAFEQUERY_APP_POSTGRES_URL`
 - `API_INTERNAL_BASE_URL`
 - `NEXT_PUBLIC_API_BASE_URL`
 - `POSTGRES_DB`
@@ -46,6 +46,8 @@ Optional values with reviewed defaults in code or compose:
 - `SAFEQUERY_APP_NAME`
 - `SAFEQUERY_ENVIRONMENT`
 - `SAFEQUERY_CORS_ORIGINS`
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
 
 2. Start the local stack:
 
@@ -134,9 +136,21 @@ hostname:
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_DATABASE_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_DATABASE_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
 ```
+
+Application persistence and business-source access now use separate reviewed
+names:
+
+- `SAFEQUERY_APP_POSTGRES_URL` for the application-owned PostgreSQL system of
+  record
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` for a business PostgreSQL source used
+  to curate generation context later
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` for the dedicated MSSQL
+  execution source path
+
+Do not reuse the application PostgreSQL credential as a business-source secret.
 
 The dedicated local startup guide remains the source of truth for contributor
 setup and troubleshooting.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,7 @@
 SAFEQUERY_APP_NAME=SafeQuery API
 SAFEQUERY_ENVIRONMENT=development
-SAFEQUERY_DATABASE_URL=postgresql://safequery:safequery@127.0.0.1:5432/safequery
+SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@127.0.0.1:5432/safequery
+# Keep business-source credentials separate from the application database URL.
+# SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me@127.0.0.1:5432/business
+# SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:127.0.0.1,1433;Database=business;Uid=source_reader;Pwd=change-me;Encrypt=yes;TrustServerCertificate=no
 SAFEQUERY_CORS_ORIGINS=http://localhost:3000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,6 @@
 SAFEQUERY_APP_NAME=SafeQuery API
-SAFEQUERY_ENVIRONMENT=development
 SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@127.0.0.1:5432/safequery
+SAFEQUERY_ENVIRONMENT=development
 # Keep business-source credentials separate from the application database URL.
 # SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me@127.0.0.1:5432/business
 # SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:127.0.0.1,1433;Database=business;Uid=source_reader;Pwd=change-me;Encrypt=yes;TrustServerCertificate=no

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,13 +23,17 @@ The backend loads typed application settings through `app.core.config.Settings`.
 
 Required:
 
-- `SAFEQUERY_DATABASE_URL`
+- `SAFEQUERY_APP_POSTGRES_URL`
 
 Optional:
 
 - `SAFEQUERY_APP_NAME` defaults to `SafeQuery API`
 - `SAFEQUERY_ENVIRONMENT` defaults to `development`
 - `SAFEQUERY_CORS_ORIGINS` defaults to `http://localhost:3000`
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` reserves a distinct business
+  PostgreSQL source identity for later generation-context work
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` reserves a distinct MSSQL
+  execution identity for later execution-path work
 
 Settings load from `.env` or `../.env`, which keeps the repository-level local
 startup path and direct backend commands aligned.
@@ -47,12 +51,23 @@ docker-compose -f infra/docker-compose.yml run --rm backend alembic upgrade head
 docker-compose -f infra/docker-compose.yml run --rm backend alembic current
 ```
 
-For host-side Alembic commands, point `SAFEQUERY_DATABASE_URL` at a database that
-is explicitly reachable from your shell before running Alembic:
+For host-side Alembic commands, point `SAFEQUERY_APP_POSTGRES_URL` at a
+database that is explicitly reachable from your shell before running Alembic:
 
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_DATABASE_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_DATABASE_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
 ```
+
+The backend treats those names as separate identities:
+
+- application persistence: `application_postgres_persistence`
+- business PostgreSQL generation source:
+  `business_postgres_source_generation`
+- business MSSQL execution source: `business_mssql_source_execution`
+
+If later code asks for either business-source configuration before the matching
+source-specific variable is set, settings access fails closed with an explicit
+runtime error instead of guessing or reusing the application database secret.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -23,7 +23,7 @@ def _sqlalchemy_database_url(database_url: str) -> str:
     return database_url
 
 
-sqlalchemy_database_url = _sqlalchemy_database_url(str(settings.database_url))
+sqlalchemy_database_url = _sqlalchemy_database_url(str(settings.app_postgres_url))
 config.set_main_option("sqlalchemy.url", sqlalchemy_database_url)
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -50,23 +50,37 @@ class Settings(BaseSettings):
         return "application_postgres_persistence"
 
     def require_business_postgres_source(self) -> BusinessPostgresSourceSettings:
-        if self.business_postgres_source_url is None:
+        source_url = self.business_postgres_source_url
+        if source_url is None:
             raise RuntimeError(
                 "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must be configured before "
                 "the business PostgreSQL generation source can be used."
             )
 
-        return BusinessPostgresSourceSettings(url=self.business_postgres_source_url)
+        if str(source_url) == str(self.app_postgres_url):
+            raise RuntimeError(
+                "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
+                "SAFEQUERY_APP_POSTGRES_URL."
+            )
+
+        return BusinessPostgresSourceSettings(url=source_url)
 
     def require_business_mssql_source(self) -> BusinessMssqlSourceSettings:
         connection_string = self.business_mssql_source_connection_string
-        if not connection_string:
+        if connection_string is None:
+            normalized_connection_string = ""
+        else:
+            normalized_connection_string = connection_string.strip()
+
+        if not normalized_connection_string:
             raise RuntimeError(
                 "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be "
                 "configured before the business MSSQL execution source can be used."
             )
 
-        return BusinessMssqlSourceSettings(connection_string=connection_string)
+        return BusinessMssqlSourceSettings(
+            connection_string=normalized_connection_string
+        )
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,14 +1,30 @@
 from functools import lru_cache
 from typing import Annotated, Literal
 
-from pydantic import Field, PostgresDsn, field_validator
+from pydantic import BaseModel, Field, PostgresDsn, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+
+class BusinessPostgresSourceSettings(BaseModel):
+    identity: Literal["business_postgres_source_generation"] = (
+        "business_postgres_source_generation"
+    )
+    url: PostgresDsn
+
+
+class BusinessMssqlSourceSettings(BaseModel):
+    identity: Literal["business_mssql_source_execution"] = (
+        "business_mssql_source_execution"
+    )
+    connection_string: str
 
 
 class Settings(BaseSettings):
     app_name: str = "SafeQuery API"
     environment: Literal["development", "test", "staging", "production"] = "development"
-    database_url: PostgresDsn
+    app_postgres_url: PostgresDsn
+    business_postgres_source_url: PostgresDsn | None = None
+    business_mssql_source_connection_string: str | None = None
     cors_origins: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["http://localhost:3000"]
     )
@@ -28,6 +44,29 @@ class Settings(BaseSettings):
             return [origin.strip() for origin in value.split(",") if origin.strip()]
 
         return value
+
+    @property
+    def app_postgres_identity(self) -> Literal["application_postgres_persistence"]:
+        return "application_postgres_persistence"
+
+    def require_business_postgres_source(self) -> BusinessPostgresSourceSettings:
+        if self.business_postgres_source_url is None:
+            raise RuntimeError(
+                "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must be configured before "
+                "the business PostgreSQL generation source can be used."
+            )
+
+        return BusinessPostgresSourceSettings(url=self.business_postgres_source_url)
+
+    def require_business_mssql_source(self) -> BusinessMssqlSourceSettings:
+        connection_string = self.business_mssql_source_connection_string
+        if not connection_string:
+            raise RuntimeError(
+                "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be "
+                "configured before the business MSSQL execution source can be used."
+            )
+
+        return BusinessMssqlSourceSettings(connection_string=connection_string)
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -132,7 +132,7 @@ def create_app() -> FastAPI:
 
     @app.get("/health")
     def read_health() -> JSONResponse:
-        database = check_database_health(str(settings.database_url))
+        database = check_database_health(str(settings.app_postgres_url))
         healthy = database["status"] == "ok"
 
         return JSONResponse(

--- a/backend/tests/test_api_errors.py
+++ b/backend/tests/test_api_errors.py
@@ -13,7 +13,7 @@ from app.core.logging import JsonLogFormatter, get_logger
 
 class ApiErrorHandlingTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ["SAFEQUERY_DATABASE_URL"] = (
+        os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
             "postgresql://safequery:safequery@db:5432/safequery"
         )
         get_settings.cache_clear()
@@ -22,7 +22,7 @@ class ApiErrorHandlingTestCase(unittest.TestCase):
         self.client = TestClient(self.app)
 
     def tearDown(self) -> None:
-        os.environ.pop("SAFEQUERY_DATABASE_URL", None)
+        os.environ.pop("SAFEQUERY_APP_POSTGRES_URL", None)
         get_settings.cache_clear()
 
     def test_method_not_allowed_uses_common_error_shape(self) -> None:

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -90,6 +90,51 @@ class SettingsTestCase(unittest.TestCase):
         ):
             settings.require_business_mssql_source()
 
+    def test_business_postgres_source_must_not_reuse_app_postgres_url(self) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            business_postgres_source_url=(
+                "postgresql://safequery:safequery@db:5432/safequery"
+            ),
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
+            "SAFEQUERY_APP_POSTGRES_URL",
+        ):
+            settings.require_business_postgres_source()
+
+    def test_business_mssql_source_whitespace_only_fails_closed(self) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            business_mssql_source_connection_string="   \t  ",
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError, "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING"
+        ):
+            settings.require_business_mssql_source()
+
+    def test_business_mssql_source_trims_outer_whitespace(self) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            business_mssql_source_connection_string=(
+                "  Driver={ODBC Driver 18 for SQL Server};Server=tcp:mssql,1433  "
+            ),
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        self.assertEqual(
+            settings.require_business_mssql_source().connection_string,
+            "Driver={ODBC Driver 18 for SQL Server};Server=tcp:mssql,1433",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -8,7 +8,7 @@ from app.core.config import Settings
 
 
 class SettingsTestCase(unittest.TestCase):
-    def test_missing_required_database_url_raises(self) -> None:
+    def test_missing_required_app_postgres_url_raises(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             previous_cwd = os.getcwd()
             try:
@@ -26,8 +26,18 @@ class SettingsTestCase(unittest.TestCase):
             env_path = os.path.join(tmpdir, ".env")
             with open(env_path, "w", encoding="utf-8") as env_file:
                 env_file.write(
-                    "SAFEQUERY_DATABASE_URL="
+                    "SAFEQUERY_APP_POSTGRES_URL="
                     "postgresql://safequery:safequery@db:5432/safequery\n"
+                    "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL="
+                    "postgresql://safequery_source:read-only@pg-source:5432/business\n"
+                    "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING="
+                    "Driver={ODBC Driver 18 for SQL Server};"
+                    "Server=tcp:mssql-source,1433;"
+                    "Database=business;"
+                    "Uid=safequery_reader;"
+                    "Pwd=change-me;"
+                    "Encrypt=yes;"
+                    "TrustServerCertificate=no\n"
                 )
 
             settings = Settings(
@@ -36,12 +46,49 @@ class SettingsTestCase(unittest.TestCase):
             )
 
         self.assertEqual(
-            str(settings.database_url),
+            str(settings.app_postgres_url),
             "postgresql://safequery:safequery@db:5432/safequery",
+        )
+        self.assertEqual(
+            settings.app_postgres_identity,
+            "application_postgres_persistence",
+        )
+        self.assertEqual(
+            str(settings.require_business_postgres_source().url),
+            "postgresql://safequery_source:read-only@pg-source:5432/business",
+        )
+        self.assertEqual(
+            settings.require_business_postgres_source().identity,
+            "business_postgres_source_generation",
+        )
+        self.assertIn(
+            "Driver={ODBC Driver 18 for SQL Server}",
+            settings.require_business_mssql_source().connection_string,
+        )
+        self.assertEqual(
+            settings.require_business_mssql_source().identity,
+            "business_mssql_source_execution",
         )
         self.assertEqual(settings.app_name, "SafeQuery API")
         self.assertEqual(settings.environment, "development")
         self.assertEqual(settings.cors_origins, ["http://localhost:3000"])
+
+    def test_missing_business_source_configuration_fails_closed_when_requested(self) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError, "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"
+        ):
+            settings.require_business_postgres_source()
+
+        with self.assertRaisesRegex(
+            RuntimeError, "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING"
+        ):
+            settings.require_business_mssql_source()
 
 
 if __name__ == "__main__":

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -48,8 +48,14 @@ That file provides the baseline values for:
 
 - PostgreSQL startup: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
 - backend startup: `SAFEQUERY_APP_NAME`, `SAFEQUERY_ENVIRONMENT`,
-  `SAFEQUERY_DATABASE_URL`, `SAFEQUERY_CORS_ORIGINS`
+  `SAFEQUERY_APP_POSTGRES_URL`, `SAFEQUERY_CORS_ORIGINS`
 - frontend startup: `API_INTERNAL_BASE_URL`, `NEXT_PUBLIC_API_BASE_URL`
+
+Optional reviewed-but-unset source credentials are also reserved there so later
+feature work cannot blur them with the application database secret:
+
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
 
 The checked-in baseline values are already wired to the compose network:
 
@@ -119,7 +125,7 @@ Use the first command to apply the scaffolded baseline migration and the second
 to confirm the active revision.
 
 If you need to run Alembic from the host shell instead, use `backend/.env` or
-an explicit `SAFEQUERY_DATABASE_URL` that points at a database reachable from
+an explicit `SAFEQUERY_APP_POSTGRES_URL` that points at a database reachable from
 your shell. Do not reuse the compose-only `postgres` hostname from `.env` in a
 host-shell command.
 
@@ -128,8 +134,8 @@ Example host-shell path:
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_DATABASE_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_DATABASE_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
 ```
 
 ## 5. Optional Host-Shell Component Checks
@@ -173,7 +179,7 @@ docker-compose --env-file .env -f infra/docker-compose.yml down -v
 
 Copy `.env.example` to `.env` again and confirm the required keys are present:
 
-- `SAFEQUERY_DATABASE_URL`
+- `SAFEQUERY_APP_POSTGRES_URL`
 - `API_INTERNAL_BASE_URL`
 - `NEXT_PUBLIC_API_BASE_URL`
 - `POSTGRES_DB`
@@ -217,4 +223,4 @@ If that succeeds, re-check the frontend env values in `.env` or
 
 This is expected if you try to use the compose-only hostname `postgres` from a
 host shell. Use the compose-backed migration commands instead, or point
-`SAFEQUERY_DATABASE_URL` at a host-reachable database endpoint.
+`SAFEQUERY_APP_POSTGRES_URL` at a host-reachable database endpoint.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       SAFEQUERY_APP_NAME: ${SAFEQUERY_APP_NAME:-SafeQuery API}
       SAFEQUERY_ENVIRONMENT: ${SAFEQUERY_ENVIRONMENT:-development}
-      SAFEQUERY_DATABASE_URL: ${SAFEQUERY_DATABASE_URL:?Missing SAFEQUERY_DATABASE_URL. Copy .env.example to .env.}
+      SAFEQUERY_APP_POSTGRES_URL: ${SAFEQUERY_APP_POSTGRES_URL:?Missing SAFEQUERY_APP_POSTGRES_URL. Copy .env.example to .env.}
       SAFEQUERY_CORS_ORIGINS: ${SAFEQUERY_CORS_ORIGINS:-http://localhost:3000}
     healthcheck:
       test:


### PR DESCRIPTION
Closes #18
This PR was opened by codex-supervisor.
Latest Codex summary:

Separated the configuration surface so the app database no longer shares a generic name with future business sources. The backend now uses `SAFEQUERY_APP_POSTGRES_URL` for application persistence, exposes explicit source identities for business PostgreSQL generation and MSSQL execution, and fails closed if later code requests either source config before the matching source-specific secret is set. I also updated the checked-in env examples and startup docs to stop advertising reuse of the application PostgreSQL credential for business sources.

Focused verification passed. I first reproduced the gap with a tighter config test, then verified the fix with `cd backend && pytest tests/test_config.py`, an extra startup-boundary smoke check via `python -m pytest backend/tests/test_api_errors.py backend/tests/test_config.py`, and `cd frontend && npm ci && npm run build`. The checkpoint commit is `3c8c04f` (`Separate app and source connection config names`).

Summary: Split canonical env names and connection identities for app PostgreSQL, business PostgreSQL source, and MSSQL; added fail-closed source config accessors and updated docs/examples.
State hint: implementing
Blocked reason: none
Tests: `cd backend && . ../.venv/bin/activate && pytest tests/test_config.py`; `cd /Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-18 && . .venv/bin/activate && python -m pytest backend/tests/test_api_errors.py backend/tests/test_config.py`; `cd frontend && npm ci && npm run build`
Failure...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Renamed primary database environment variable from `SAFEQUERY_DATABASE_URL` to `SAFEQUERY_APP_POSTGRES_URL`.
  * Added optional environment variables for business source connectivity: `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` and `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`.

* **Documentation**
  * Updated setup guides and examples to reflect new environment variable names.
  * Added clarification on separate credential handling for application and business sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->