### PR TITLE
Add startup guard against application Postgres reuse

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, PostgresDsn, field_validator
+from pydantic import BaseModel, Field, PostgresDsn, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
@@ -45,6 +45,17 @@ class Settings(BaseSettings):
 
         return value
 
+    @model_validator(mode="after")
+    def _validate_distinct_postgres_roles(self) -> "Settings":
+        source_url = self.business_postgres_source_url
+        if source_url is not None and str(source_url) == str(self.app_postgres_url):
+            raise ValueError(
+                "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
+                "SAFEQUERY_APP_POSTGRES_URL."
+            )
+
+        return self
+
     @property
     def app_postgres_identity(self) -> Literal["application_postgres_persistence"]:
         return "application_postgres_persistence"
@@ -55,12 +66,6 @@ class Settings(BaseSettings):
             raise RuntimeError(
                 "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must be configured before "
                 "the business PostgreSQL generation source can be used."
-            )
-
-        if str(source_url) == str(self.app_postgres_url):
-            raise RuntimeError(
-                "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
-                "SAFEQUERY_APP_POSTGRES_URL."
             )
 
         return BusinessPostgresSourceSettings(url=source_url)

--- a/backend/tests/test_application_postgres_guard.py
+++ b/backend/tests/test_application_postgres_guard.py
@@ -1,0 +1,66 @@
+import os
+import unittest
+
+from pydantic import ValidationError
+
+from app.core.config import Settings, get_settings
+
+
+class ApplicationPostgresGuardTestCase(unittest.TestCase):
+    def tearDown(self) -> None:
+        os.environ.pop("SAFEQUERY_APP_POSTGRES_URL", None)
+        os.environ.pop("SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL", None)
+        get_settings.cache_clear()
+
+    def test_unsafe_postgres_role_reuse_fails_during_settings_validation(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
+            "SAFEQUERY_APP_POSTGRES_URL",
+        ):
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                business_postgres_source_url=(
+                    "postgresql://safequery:safequery@db:5432/safequery"
+                ),
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
+
+    def test_safe_postgres_role_separation_remains_valid(self) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            business_postgres_source_url=(
+                "postgresql://safequery_source:read-only@pg-source:5432/business"
+            ),
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        self.assertEqual(
+            str(settings.app_postgres_url),
+            "postgresql://safequery:safequery@db:5432/safequery",
+        )
+        self.assertEqual(
+            str(settings.business_postgres_source_url),
+            "postgresql://safequery_source:read-only@pg-source:5432/business",
+        )
+
+    def test_startup_settings_cache_fails_closed_for_unsafe_env(self) -> None:
+        os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
+            "postgresql://safequery:safequery@db:5432/safequery"
+        )
+        os.environ["SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"] = (
+            "postgresql://safequery:safequery@db:5432/safequery"
+        )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
+            "SAFEQUERY_APP_POSTGRES_URL",
+        ):
+            get_settings()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -91,21 +91,19 @@ class SettingsTestCase(unittest.TestCase):
             settings.require_business_mssql_source()
 
     def test_business_postgres_source_must_not_reuse_app_postgres_url(self) -> None:
-        settings = Settings(
-            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
-            business_postgres_source_url=(
-                "postgresql://safequery:safequery@db:5432/safequery"
-            ),
-            _env_file=None,
-            _env_prefix="SAFEQUERY_",
-        )
-
         with self.assertRaisesRegex(
-            RuntimeError,
+            ValidationError,
             "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
             "SAFEQUERY_APP_POSTGRES_URL",
         ):
-            settings.require_business_postgres_source()
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                business_postgres_source_url=(
+                    "postgresql://safequery:safequery@db:5432/safequery"
+                ),
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
 
     def test_business_mssql_source_whitespace_only_fails_closed(self) -> None:
         settings = Settings(


### PR DESCRIPTION
## Summary
- fail closed during settings validation when the business PostgreSQL source URL reuses the application PostgreSQL URL
- move the regression to the settings/startup boundary instead of only later source access
- add focused guard tests for unsafe and safe configuration paths

## Verification
- cd backend && ../../issue-18/.venv/bin/python -m unittest tests.test_config tests.test_application_postgres_guard -v
- docker-compose --env-file .env.example -f infra/docker-compose.yml config