### PR TITLE
[A2-4] Clarify local multi-source development topology

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ BUSINESS_MSSQL_SOURCE_SA_PASSWORD=ChangeMeDevOnly_123
 
 # Backend application settings
 SAFEQUERY_APP_NAME=SafeQuery API
-SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@app-postgres:5432/safequery
+SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:change-me-for-shared-environments@app-postgres:5432/safequery
 SAFEQUERY_ENVIRONMENT=development
 # Leave business-source credentials unset in the baseline stack. Wire them
 # explicitly per source so application persistence credentials are never reused.

--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,28 @@
 # Copy this file to .env before starting the local stack.
 
-# Local database startup
-POSTGRES_DB=safequery
-POSTGRES_USER=safequery
-POSTGRES_PASSWORD=change-me-for-shared-environments
+# Local application PostgreSQL startup
+APP_POSTGRES_DB=safequery
+APP_POSTGRES_USER=safequery
+APP_POSTGRES_PASSWORD=change-me-for-shared-environments
+
+# Local business PostgreSQL source startup
+BUSINESS_POSTGRES_SOURCE_DB=business
+BUSINESS_POSTGRES_SOURCE_USER=source_reader
+BUSINESS_POSTGRES_SOURCE_PASSWORD=change-me-for-local-source-topology
+
+# Local business MSSQL source startup
+BUSINESS_MSSQL_SOURCE_SA_PASSWORD=ChangeMeDevOnly_123
 
 # Backend application settings
 SAFEQUERY_APP_NAME=SafeQuery API
-SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@postgres:5432/safequery
+SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@app-postgres:5432/safequery
 SAFEQUERY_ENVIRONMENT=development
 # Leave business-source credentials unset in the baseline stack. Wire them
 # explicitly per source so application persistence credentials are never reused.
-# SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me@postgres-source:5432/business
-# SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:mssql-source,1433;Database=business;Uid=source_reader;Pwd=change-me;Encrypt=yes;TrustServerCertificate=no
+# The reviewed local source containers use their own hostnames and credential
+# placeholders so application persistence values are never repurposed by guess.
+# SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me-for-local-source-topology@business-postgres-source:5432/business
+# SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:business-mssql-source,1433;Database=business;Uid=sa;Pwd=ChangeMeDevOnly_123;Encrypt=no;TrustServerCertificate=yes
 SAFEQUERY_CORS_ORIGINS=http://localhost:3000
 
 # Frontend application settings

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ BUSINESS_POSTGRES_SOURCE_PASSWORD=change-me-for-local-source-topology
 BUSINESS_MSSQL_SOURCE_SA_PASSWORD=ChangeMeDevOnly_123
 
 # Backend application settings
-SAFEQUERY_APP_NAME=SafeQuery API
+SAFEQUERY_APP_NAME="SafeQuery API"
 SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:change-me-for-shared-environments@app-postgres:5432/safequery
 SAFEQUERY_ENVIRONMENT=development
 # Leave business-source credentials unset in the baseline stack. Wire them

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ hostname:
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic current
 ```
 
 Application persistence and business-source access now use separate reviewed

--- a/README.md
+++ b/README.md
@@ -32,20 +32,24 @@ Quick start:
 cp .env.example .env
 ```
 
-The required startup values are:
+The required baseline startup values are:
 
 - `SAFEQUERY_APP_POSTGRES_URL`
 - `API_INTERNAL_BASE_URL`
 - `NEXT_PUBLIC_API_BASE_URL`
-- `POSTGRES_DB`
-- `POSTGRES_USER`
-- `POSTGRES_PASSWORD`
+- `APP_POSTGRES_DB`
+- `APP_POSTGRES_USER`
+- `APP_POSTGRES_PASSWORD`
 
 Optional values with reviewed defaults in code or compose:
 
 - `SAFEQUERY_APP_NAME`
 - `SAFEQUERY_ENVIRONMENT`
 - `SAFEQUERY_CORS_ORIGINS`
+- `BUSINESS_POSTGRES_SOURCE_DB`
+- `BUSINESS_POSTGRES_SOURCE_USER`
+- `BUSINESS_POSTGRES_SOURCE_PASSWORD`
+- `BUSINESS_MSSQL_SOURCE_SA_PASSWORD`
 - `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
 - `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
 
@@ -57,6 +61,12 @@ docker-compose --env-file .env -f infra/docker-compose.yml up --build -d
 
 If `.env` is missing or a required value is blank, Docker Compose will stop with
 an explicit missing-variable error instead of silently using local defaults.
+
+The baseline startup path still uses the same compose entrypoint, but the local
+topology now declares a separate application PostgreSQL service, a separate
+business PostgreSQL source, and a separate business MSSQL source so later
+source-aware work has explicit local anchors without implying that the
+application database is a business target.
 
 3. Confirm the UI is reachable:
 
@@ -130,7 +140,7 @@ docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend alem
 ```
 
 If you need to run Alembic from the host shell instead, provide an explicitly
-reachable database URL rather than relying on the compose-only `postgres`
+reachable database URL rather than relying on the compose-only `app-postgres`
 hostname:
 
 ```bash
@@ -151,6 +161,15 @@ names:
   execution source path
 
 Do not reuse the application PostgreSQL credential as a business-source secret.
+
+The compose topology mirrors those roles explicitly:
+
+- `app-postgres` for application PostgreSQL persistence
+- `business-postgres-source` for the optional local business PostgreSQL source
+- `business-mssql-source` for the optional local business MSSQL source
+
+The backend baseline still depends only on `app-postgres`; the source services
+exist to keep the local topology and credentials explicit for later work.
 
 The dedicated local startup guide remains the source of truth for contributor
 setup and troubleshooting.

--- a/backend/README.md
+++ b/backend/README.md
@@ -57,8 +57,8 @@ database that is explicitly reachable from your shell before running Alembic:
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic current
 ```
 
 The backend treats those names as separate identities:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -6,8 +6,13 @@ this repository today:
 
 - Next.js frontend
 - FastAPI backend
-- PostgreSQL application database
+- application PostgreSQL
 - Alembic migration scaffold
+
+The local topology also declares dedicated source-role services:
+
+- business PostgreSQL source
+- business MSSQL source
 
 Use this document as the source of truth for first local runs. `README.md`
 keeps a shorter entrypoint and links back here.
@@ -46,22 +51,36 @@ cp .env.example .env
 
 That file provides the baseline values for:
 
-- PostgreSQL startup: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`
+- application PostgreSQL startup: `APP_POSTGRES_DB`, `APP_POSTGRES_USER`,
+  `APP_POSTGRES_PASSWORD`
 - backend startup: `SAFEQUERY_APP_NAME`, `SAFEQUERY_ENVIRONMENT`,
   `SAFEQUERY_APP_POSTGRES_URL`, `SAFEQUERY_CORS_ORIGINS`
 - frontend startup: `API_INTERNAL_BASE_URL`, `NEXT_PUBLIC_API_BASE_URL`
 
-Optional reviewed-but-unset source credentials are also reserved there so later
-feature work cannot blur them with the application database secret:
+It also reserves distinct local-only credentials for the optional source
+containers:
+
+- business PostgreSQL source startup: `BUSINESS_POSTGRES_SOURCE_DB`,
+  `BUSINESS_POSTGRES_SOURCE_USER`, `BUSINESS_POSTGRES_SOURCE_PASSWORD`
+- business MSSQL source startup: `BUSINESS_MSSQL_SOURCE_SA_PASSWORD`
+
+Optional reviewed-but-unset source connection settings are also reserved there
+so later feature work cannot blur them with the application database secret:
 
 - `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
 - `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
 
 The checked-in baseline values are already wired to the compose network:
 
-- backend database hostname: `postgres`
+- application database hostname: `app-postgres`
 - frontend internal API hostname: `backend`
 - browser-facing API URL: `http://localhost:8000`
+
+The optional source-topology hostnames are also fixed in the checked-in
+examples so operators can inspect the intended role split without guessing:
+
+- business PostgreSQL source hostname: `business-postgres-source`
+- business MSSQL source hostname: `business-mssql-source`
 
 Optional host-shell env files are also available when you want to run a single
 component without Docker:
@@ -84,7 +103,7 @@ docker-compose --env-file .env -f infra/docker-compose.yml up --build -d
 
 This command starts services in the expected dependency order:
 
-1. PostgreSQL
+1. application PostgreSQL
 2. backend
 3. frontend
 
@@ -93,6 +112,11 @@ The compose file lives at `infra/docker-compose.yml`.
 If `.env` is missing or a required variable is blank, the startup should fail
 closed with an explicit Compose error instead of silently substituting guessed
 values.
+
+The backend baseline still depends only on application PostgreSQL. The separate
+business PostgreSQL source and business MSSQL source are present so operators
+can inspect the intended multi-source topology without guessing and without
+treating application PostgreSQL as a business target.
 
 ## 3. Verify Basic Health
 
@@ -126,7 +150,7 @@ to confirm the active revision.
 
 If you need to run Alembic from the host shell instead, use `backend/.env` or
 an explicit `SAFEQUERY_APP_POSTGRES_URL` that points at a database reachable from
-your shell. Do not reuse the compose-only `postgres` hostname from `.env` in a
+your shell. Do not reuse the compose-only `app-postgres` hostname from `.env` in a
 host-shell command.
 
 Example host-shell path:
@@ -182,9 +206,9 @@ Copy `.env.example` to `.env` again and confirm the required keys are present:
 - `SAFEQUERY_APP_POSTGRES_URL`
 - `API_INTERNAL_BASE_URL`
 - `NEXT_PUBLIC_API_BASE_URL`
-- `POSTGRES_DB`
-- `POSTGRES_USER`
-- `POSTGRES_PASSWORD`
+- `APP_POSTGRES_DB`
+- `APP_POSTGRES_USER`
+- `APP_POSTGRES_PASSWORD`
 
 ### `docker-compose up --build` fails with a missing `docker-buildx` plugin
 
@@ -221,6 +245,6 @@ If that succeeds, re-check the frontend env values in `.env` or
 
 ### Host-shell Alembic commands cannot reach PostgreSQL
 
-This is expected if you try to use the compose-only hostname `postgres` from a
+This is expected if you try to use the compose-only hostname `app-postgres` from a
 host shell. Use the compose-backed migration commands instead, or point
 `SAFEQUERY_APP_POSTGRES_URL` at a host-reachable database endpoint.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -158,8 +158,8 @@ Example host-shell path:
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:safequery@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic current
 ```
 
 ## 5. Optional Host-Shell Component Checks

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,24 +1,45 @@
 services:
-  postgres:
+  app-postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:?Missing POSTGRES_DB. Copy .env.example to .env.}
-      POSTGRES_USER: ${POSTGRES_USER:?Missing POSTGRES_USER. Copy .env.example to .env.}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Missing POSTGRES_PASSWORD. Copy .env.example to .env.}
+      POSTGRES_DB: ${APP_POSTGRES_DB:?Missing APP_POSTGRES_DB. Copy .env.example to .env.}
+      POSTGRES_USER: ${APP_POSTGRES_USER:?Missing APP_POSTGRES_USER. Copy .env.example to .env.}
+      POSTGRES_PASSWORD: ${APP_POSTGRES_PASSWORD:?Missing APP_POSTGRES_PASSWORD. Copy .env.example to .env.}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 12
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - app_postgres_data:/var/lib/postgresql/data
+
+  business-postgres-source:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${BUSINESS_POSTGRES_SOURCE_DB:?Missing BUSINESS_POSTGRES_SOURCE_DB. Copy .env.example to .env.}
+      POSTGRES_USER: ${BUSINESS_POSTGRES_SOURCE_USER:?Missing BUSINESS_POSTGRES_SOURCE_USER. Copy .env.example to .env.}
+      POSTGRES_PASSWORD: ${BUSINESS_POSTGRES_SOURCE_PASSWORD:?Missing BUSINESS_POSTGRES_SOURCE_PASSWORD. Copy .env.example to .env.}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    volumes:
+      - business_postgres_source_data:/var/lib/postgresql/data
+
+  business-mssql-source:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: Developer
+      MSSQL_SA_PASSWORD: ${BUSINESS_MSSQL_SOURCE_SA_PASSWORD:?Missing BUSINESS_MSSQL_SOURCE_SA_PASSWORD. Copy .env.example to .env.}
 
   backend:
     build:
       context: ..
       dockerfile: backend/Dockerfile
     depends_on:
-      postgres:
+      app-postgres:
         condition: service_healthy
     environment:
       SAFEQUERY_APP_NAME: ${SAFEQUERY_APP_NAME:-SafeQuery API}
@@ -54,4 +75,5 @@ services:
       - "3000:3000"
 
 volumes:
-  postgres_data:
+  app_postgres_data:
+  business_postgres_source_data:

--- a/tests/smoke/test-local-topology-roles.sh
+++ b/tests/smoke/test-local-topology-roles.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+tmp_env="$(mktemp)"
+trap 'rm -f "$tmp_env"' EXIT
+cp .env.example "$tmp_env"
+
+rendered_compose="$(docker-compose --env-file "$tmp_env" -f infra/docker-compose.yml config)"
+
+missing=0
+
+required_compose_patterns=(
+  "app-postgres:"
+  "business-postgres-source:"
+  "business-mssql-source:"
+  "SAFEQUERY_APP_POSTGRES_URL: postgresql://safequery:safequery@app-postgres:5432/safequery"
+  "MSSQL_SA_PASSWORD: ChangeMeDevOnly_123"
+  "app_postgres_data:"
+  "business_postgres_source_data:"
+)
+
+for pattern in "${required_compose_patterns[@]}"; do
+  if ! grep -Fq "$pattern" <<<"$rendered_compose"; then
+    echo "missing required topology pattern in rendered compose config: $pattern" >&2
+    missing=1
+  fi
+done
+
+if grep -Eq '^  postgres:$' <<<"$rendered_compose"; then
+  echo "found ambiguous baseline topology service name in rendered compose config" >&2
+  missing=1
+fi
+
+if grep -Eq '^  postgres_data:$' <<<"$rendered_compose"; then
+  echo "found ambiguous baseline topology volume name in rendered compose config" >&2
+  missing=1
+fi
+
+if grep -Fq "@postgres:5432" <<<"$rendered_compose"; then
+  echo "found ambiguous baseline topology hostname in rendered compose config: @postgres:5432" >&2
+  missing=1
+fi
+
+required_env_patterns=(
+  "SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@app-postgres:5432/safequery"
+  "# SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me-for-local-source-topology@business-postgres-source:5432/business"
+  "# SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:business-mssql-source,1433;Database=business;Uid=sa;Pwd=ChangeMeDevOnly_123;Encrypt=no;TrustServerCertificate=yes"
+)
+
+for pattern in "${required_env_patterns[@]}"; do
+  if ! grep -Fq "$pattern" .env.example; then
+    echo "missing required topology pattern in .env.example: $pattern" >&2
+    missing=1
+  fi
+done
+
+required_doc_patterns=(
+  "application PostgreSQL"
+  "business PostgreSQL source"
+  "business MSSQL source"
+  "app-postgres"
+  "business-postgres-source"
+  "business-mssql-source"
+)
+
+for pattern in "${required_doc_patterns[@]}"; do
+  if ! grep -Fq "$pattern" docs/local-development.md; then
+    echo "missing required topology pattern in docs/local-development.md: $pattern" >&2
+    missing=1
+  fi
+done
+
+exit "$missing"

--- a/tests/smoke/test-local-topology-roles.sh
+++ b/tests/smoke/test-local-topology-roles.sh
@@ -17,7 +17,7 @@ required_compose_patterns=(
   "app-postgres:"
   "business-postgres-source:"
   "business-mssql-source:"
-  "SAFEQUERY_APP_POSTGRES_URL: postgresql://safequery:safequery@app-postgres:5432/safequery"
+  "SAFEQUERY_APP_POSTGRES_URL: postgresql://safequery:change-me-for-shared-environments@app-postgres:5432/safequery"
   "MSSQL_SA_PASSWORD: ChangeMeDevOnly_123"
   "app_postgres_data:"
   "business_postgres_source_data:"
@@ -46,7 +46,7 @@ if grep -Fq "@postgres:5432" <<<"$rendered_compose"; then
 fi
 
 required_env_patterns=(
-  "SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@app-postgres:5432/safequery"
+  "SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:change-me-for-shared-environments@app-postgres:5432/safequery"
   "# SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me-for-local-source-topology@business-postgres-source:5432/business"
   "# SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:business-mssql-source,1433;Database=business;Uid=sa;Pwd=ChangeMeDevOnly_123;Encrypt=no;TrustServerCertificate=yes"
 )


### PR DESCRIPTION
## Summary
- rename the compose-owned application database service to `app-postgres`
- add explicit local business PostgreSQL and MSSQL source services with separate local-only credentials
- document and test the three local topology roles so operators do not infer business-source intent from the app database

## Verification
- bash tests/smoke/test-local-topology-roles.sh
- bash tests/smoke/test-local-startup-docs.sh
- docker-compose --env-file .env -f infra/docker-compose.yml config
- cd frontend && npm install && npm run build

Refs #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed app DB env vars (APP_POSTGRES_*) and updated app DB URL placeholder/hostname
  * Added baseline business source credentials (Postgres & MSSQL) and new compose services/volumes
* **Documentation**
  * Updated README, local-development, and backend docs to reflect new env names, hostnames, and examples
* **Tests**
  * Added a smoke test to validate local topology role wiring and env/config examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->