### PR TITLE
Add source-aware smoke checks and startup telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environm
 SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic current
 ```
 
+Source-foundation smoke verification:
+
+```bash
+cd backend
+python3 -m pytest tests/test_source_foundation_smoke.py
+```
+
 Application persistence and business-source access now use separate reviewed
 names:
 
@@ -170,6 +177,10 @@ The compose topology mirrors those roles explicitly:
 
 The backend baseline still depends only on `app-postgres`; the source services
 exist to keep the local topology and credentials explicit for later work.
+
+On startup, the backend logs `source_posture`, `configured_source_count`, and a
+`source_roles` map so local diagnosis can confirm which source role is
+configured or intentionally left unset without inferring from service names.
 
 The dedicated local startup guide remains the source of truth for contributor
 setup and troubleshooting.

--- a/backend/README.md
+++ b/backend/README.md
@@ -71,3 +71,16 @@ The backend treats those names as separate identities:
 If later code asks for either business-source configuration before the matching
 source-specific variable is set, settings access fails closed with an explicit
 runtime error instead of guessing or reusing the application database secret.
+
+The startup log now also emits:
+
+- `source_posture` to confirm the source baseline is coherent
+- `configured_source_count` to show how many reviewed source roles are active
+- `source_roles` to distinguish application persistence from each reserved
+  business-source role
+
+Focused source-foundation smoke verification:
+
+```bash
+PYTHONPATH=backend python3 -m pytest backend/tests/test_source_foundation_smoke.py
+```

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Optional
 
 from pydantic import BaseModel, Field, PostgresDsn, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -19,12 +19,24 @@ class BusinessMssqlSourceSettings(BaseModel):
     connection_string: str
 
 
+class SourceRoleTelemetry(BaseModel):
+    application_postgres_persistence: Literal["configured"] = "configured"
+    business_postgres_source_generation: Literal["configured", "unconfigured"]
+    business_mssql_source_execution: Literal["configured", "unconfigured"]
+
+
+class SourcePostureTelemetry(BaseModel):
+    source_posture: Literal["coherent"] = "coherent"
+    configured_source_count: int
+    source_roles: SourceRoleTelemetry
+
+
 class Settings(BaseSettings):
     app_name: str = "SafeQuery API"
     environment: Literal["development", "test", "staging", "production"] = "development"
     app_postgres_url: PostgresDsn
-    business_postgres_source_url: PostgresDsn | None = None
-    business_mssql_source_connection_string: str | None = None
+    business_postgres_source_url: Optional[PostgresDsn] = None
+    business_mssql_source_connection_string: Optional[str] = None
     cors_origins: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["http://localhost:3000"]
     )
@@ -85,6 +97,37 @@ class Settings(BaseSettings):
 
         return BusinessMssqlSourceSettings(
             connection_string=normalized_connection_string
+        )
+
+    def source_posture_telemetry(self) -> SourcePostureTelemetry:
+        business_postgres_role = (
+            "configured"
+            if self.business_postgres_source_url is not None
+            else "unconfigured"
+        )
+
+        connection_string = self.business_mssql_source_connection_string
+        if connection_string is None:
+            business_mssql_role = "unconfigured"
+        elif connection_string.strip():
+            business_mssql_role = "configured"
+        else:
+            raise RuntimeError(
+                "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must not be "
+                "whitespace-only when source posture smoke checks run."
+            )
+
+        source_roles = SourceRoleTelemetry(
+            business_postgres_source_generation=business_postgres_role,
+            business_mssql_source_execution=business_mssql_role,
+        )
+
+        return SourcePostureTelemetry(
+            configured_source_count=sum(
+                role == "configured"
+                for role in source_roles.model_dump().values()
+            ),
+            source_roles=source_roles,
         )
 
     @property

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,7 +26,8 @@ def create_app() -> FastAPI:
     logger = get_logger()
     try:
         settings = get_settings()
-    except ValidationError as exc:
+        source_posture = settings.source_posture_telemetry()
+    except (RuntimeError, ValidationError) as exc:
         log_startup_configuration_error(exc)
         raise
 
@@ -41,6 +42,7 @@ def create_app() -> FastAPI:
                     "environment": settings.environment,
                     "cors_origin_count": len(settings.cors_origins_list),
                     "database_configured": True,
+                    **source_posture.model_dump(),
                 }
             },
         )

--- a/backend/tests/test_source_foundation_smoke.py
+++ b/backend/tests/test_source_foundation_smoke.py
@@ -1,0 +1,107 @@
+import importlib
+import json
+import os
+import sys
+import unittest
+from io import StringIO
+
+from fastapi.testclient import TestClient
+
+from app.core.config import Settings, get_settings
+from app.core.logging import JsonLogFormatter, configure_logging, get_logger
+
+
+class SourceFoundationSmokeTestCase(unittest.TestCase):
+    def tearDown(self) -> None:
+        for name in (
+            "SAFEQUERY_APP_POSTGRES_URL",
+            "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+            "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING",
+        ):
+            os.environ.pop(name, None)
+        get_settings.cache_clear()
+
+    def _reload_main_module(self):
+        get_settings.cache_clear()
+        if "app.main" in sys.modules:
+            return importlib.reload(sys.modules["app.main"])
+        return importlib.import_module("app.main")
+
+    def test_safe_source_posture_reports_explicit_roles(self) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            business_postgres_source_url=(
+                "postgresql://source_reader:read-only@pg-source:5432/business"
+            ),
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        telemetry = settings.source_posture_telemetry()
+
+        self.assertEqual(telemetry.source_posture, "coherent")
+        self.assertEqual(telemetry.configured_source_count, 2)
+        self.assertEqual(
+            telemetry.source_roles.model_dump(),
+            {
+                "application_postgres_persistence": "configured",
+                "business_postgres_source_generation": "configured",
+                "business_mssql_source_execution": "unconfigured",
+            },
+        )
+
+    def test_ambiguous_source_configuration_fails_closed(self) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            business_mssql_source_connection_string="  \t  ",
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must not be "
+            "whitespace-only",
+        ):
+            settings.source_posture_telemetry()
+
+    def test_startup_logs_source_role_posture(self) -> None:
+        os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
+            "postgresql://safequery:safequery@db:5432/safequery"
+        )
+        stream = StringIO()
+        configure_logging()
+        handler = get_logger().handlers[0].__class__(stream)
+        handler.setFormatter(JsonLogFormatter())
+        get_logger().addHandler(handler)
+
+        try:
+            main_module = self._reload_main_module()
+            with TestClient(main_module.app):
+                pass
+        finally:
+            get_logger().removeHandler(handler)
+
+        lines = [line for line in stream.getvalue().splitlines() if line.strip()]
+        startup_events = [
+            json.loads(line)
+            for line in lines
+            if json.loads(line).get("event") == "app.startup"
+        ]
+
+        self.assertTrue(startup_events)
+        startup_event = startup_events[-1]
+        self.assertEqual(startup_event["source_posture"], "coherent")
+        self.assertEqual(startup_event["configured_source_count"], 1)
+        self.assertEqual(
+            startup_event["source_roles"],
+            {
+                "application_postgres_persistence": "configured",
+                "business_postgres_source_generation": "unconfigured",
+                "business_mssql_source_execution": "unconfigured",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a focused backend smoke test for source-foundation posture and fail-closed ambiguous config
- emit explicit source-role posture telemetry during startup for local diagnosis
- document the new smoke-check path and startup telemetry keys

## Verification
- PYTHONPATH=backend .venv/bin/python -m pytest backend/tests/test_source_foundation_smoke.py -q
- PYTHONPATH=backend .venv/bin/python -m pytest backend/tests/test_config.py backend/tests/test_api_errors.py -q
- python3 scripts/ci/check_repository_hygiene.py

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced startup logging now displays source configuration details, including source posture status, count of configured sources, and explicit source role states.

* **Documentation**
  * Updated documentation with explicit source foundation smoke testing verification steps.

* **Bug Fixes**
  * Improved error handling for invalid or ambiguous source configurations, with validation errors raised during startup.

* **Tests**
  * Added comprehensive smoke test suite for source configuration foundation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->