### PR TITLE
[A2-6] Update local startup docs for the hardened multi-source foundation (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Optional values with reviewed defaults in code or compose:
 - `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
 - `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
 
+Keep the local roles distinct from the start:
+
+- application PostgreSQL uses `SAFEQUERY_APP_POSTGRES_URL` and the
+  `app-postgres` service for SafeQuery-owned state
+- business PostgreSQL source uses
+  `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` and the
+  `business-postgres-source` service for later generation-context work
+- business MSSQL source uses
+  `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` and the
+  `business-mssql-source` service for later execution-path work
+
 2. Start the local stack:
 
 ```bash
@@ -65,8 +76,7 @@ an explicit missing-variable error instead of silently using local defaults.
 The baseline startup path still uses the same compose entrypoint, but the local
 topology now declares a separate application PostgreSQL service, a separate
 business PostgreSQL source, and a separate business MSSQL source so later
-source-aware work has explicit local anchors without implying that the
-application database is a business target.
+source-aware work has explicit local anchors. This role split does not make the application database a business target.
 
 3. Confirm the UI is reachable:
 
@@ -157,6 +167,19 @@ cd backend
 python3 -m pytest tests/test_source_foundation_smoke.py
 ```
 
+Startup-guard verification:
+
+```bash
+cd backend
+python3 -m pytest tests/test_application_postgres_guard.py
+```
+
+Local topology smoke verification:
+
+```bash
+bash tests/smoke/test-local-topology-roles.sh
+```
+
 Application persistence and business-source access now use separate reviewed
 names:
 
@@ -168,6 +191,11 @@ names:
   execution source path
 
 Do not reuse the application PostgreSQL credential as a business-source secret.
+
+The fail-closed startup guards are intentional:
+
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse SAFEQUERY_APP_POSTGRES_URL`
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be configured before the business MSSQL execution source can be used.`
 
 The compose topology mirrors those roles explicitly:
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -70,6 +70,21 @@ so later feature work cannot blur them with the application database secret:
 - `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
 - `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
 
+Treat those as three different local roles:
+
+- application PostgreSQL is SafeQuery-owned persistence and stays bound to
+  `SAFEQUERY_APP_POSTGRES_URL`
+- business PostgreSQL source is a separate read-oriented source role reserved
+  for later generation-context work through
+  `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
+- business MSSQL source is a separate execution-oriented source role reserved
+  for later execution-path work through
+  `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
+
+The hardened local foundation keeps those roles explicit before any source-aware
+core path exists, so operators can inspect the topology without guessing and
+without treating application PostgreSQL as a business target.
+
 The checked-in baseline values are already wired to the compose network:
 
 - application database hostname: `app-postgres`
@@ -135,7 +150,43 @@ curl http://localhost:8000/health
 The backend `/health` endpoint is the baseline health check for the app and the
 database connection.
 
-## 4. Run Migrations
+## 4. Validate the Hardened Foundation
+
+Run the focused smoke checks that prove the local role split and fail-closed
+startup behavior before moving on to deeper source-aware work:
+
+```bash
+bash tests/smoke/test-local-topology-roles.sh
+cd backend
+python3 -m pytest tests/test_application_postgres_guard.py
+python3 -m pytest tests/test_source_foundation_smoke.py
+```
+
+Those checks cover different enforcement boundaries:
+
+- `tests/smoke/test-local-topology-roles.sh` proves the compose topology and
+  checked-in env examples keep `app-postgres`, `business-postgres-source`, and
+  `business-mssql-source` distinct
+- `tests/test_application_postgres_guard.py` proves startup validation fails
+  closed if `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` tries to reuse
+  `SAFEQUERY_APP_POSTGRES_URL`
+- `tests/test_source_foundation_smoke.py` proves the backend still reports a
+  coherent source posture when optional business sources are unset or configured
+
+When the startup guards fire, expect explicit messages instead of implicit
+fallbacks:
+
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse SAFEQUERY_APP_POSTGRES_URL`
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be configured before the business MSSQL execution source can be used.`
+
+On successful startup, inspect backend logs for the source-role telemetry fields
+that summarize the hardened foundation without inferring from service names:
+
+- `source_posture`
+- `configured_source_count`
+- `source_roles`
+
+## 5. Run Migrations
 
 The current baseline keeps PostgreSQL on the compose network only, so the
 compose-backed Alembic path is the default migration workflow:
@@ -162,7 +213,7 @@ SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environm
 SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic current
 ```
 
-## 5. Optional Host-Shell Component Checks
+## 6. Optional Host-Shell Component Checks
 
 Frontend build check:
 
@@ -183,7 +234,7 @@ python3 -m pip install -e backend
 The backend settings loader accepts `.env` and `../.env`, which keeps the repo
 root and `backend/` command paths aligned.
 
-## 6. Stop the Stack
+## 7. Stop the Stack
 
 Stop the running stack:
 

--- a/tests/smoke/test-local-startup-docs.sh
+++ b/tests/smoke/test-local-startup-docs.sh
@@ -65,10 +65,14 @@ readme_hardening_patterns=(
   "business PostgreSQL source"
   "business MSSQL source"
   "does not make the application database a business target"
+  "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse SAFEQUERY_APP_POSTGRES_URL"
+  "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be configured before the business MSSQL execution source can be used."
   "test_application_postgres_guard.py"
   "test_source_foundation_smoke.py"
   "tests/smoke/test-local-topology-roles.sh"
   "source_posture"
+  "configured_source_count"
+  "source_roles"
 )
 
 for pattern in "${readme_hardening_patterns[@]}"; do

--- a/tests/smoke/test-local-startup-docs.sh
+++ b/tests/smoke/test-local-startup-docs.sh
@@ -6,9 +6,15 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$repo_root"
 
 doc_path="docs/local-development.md"
+readme_path="README.md"
 
 if [[ ! -f "$doc_path" ]]; then
   echo "missing local startup guide: $doc_path" >&2
+  exit 1
+fi
+
+if [[ ! -f "$readme_path" ]]; then
+  echo "missing onboarding entrypoint: $readme_path" >&2
   exit 1
 fi
 
@@ -29,6 +35,45 @@ missing=0
 for pattern in "${required_patterns[@]}"; do
   if ! grep -Fq "$pattern" "$doc_path"; then
     echo "missing required startup-doc detail: $pattern" >&2
+    missing=1
+  fi
+done
+
+local_doc_hardening_patterns=(
+  "application PostgreSQL"
+  "business PostgreSQL source"
+  "business MSSQL source"
+  "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse SAFEQUERY_APP_POSTGRES_URL"
+  "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be configured before the business MSSQL execution source can be used."
+  "test_application_postgres_guard.py"
+  "test_source_foundation_smoke.py"
+  "tests/smoke/test-local-topology-roles.sh"
+  "source_posture"
+  "configured_source_count"
+  "source_roles"
+)
+
+for pattern in "${local_doc_hardening_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$doc_path"; then
+    echo "missing hardened local-doc detail: $pattern" >&2
+    missing=1
+  fi
+done
+
+readme_hardening_patterns=(
+  "application PostgreSQL"
+  "business PostgreSQL source"
+  "business MSSQL source"
+  "does not make the application database a business target"
+  "test_application_postgres_guard.py"
+  "test_source_foundation_smoke.py"
+  "tests/smoke/test-local-topology-roles.sh"
+  "source_posture"
+)
+
+for pattern in "${readme_hardening_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$readme_path"; then
+    echo "missing hardened README detail: $pattern" >&2
     missing=1
   fi
 done


### PR DESCRIPTION
Closes #22
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the onboarding path and local startup guide so the hardened multi-source foundation is explicit from the first read. `README.md` now distinguishes application PostgreSQL from the business PostgreSQL source and business MSSQL source, calls out that the application database is not a business target, and points operators to the startup-guard check, source-foundation smoke check, topology smoke check, and startup telemetry fields. `docs/local-development.md` now has a dedicated hardened-foundation validation section with the exact guard messages, the focused smoke commands, and the log fields to inspect. I also tightened `tests/smoke/test-local-startup-docs.sh` so future drift in either doc is caught.

Committed on `codex/issue-22` as `250d817` with message `docs: update hardened local startup guidance`.

Verification:
- `bash tests/smoke/test-local-startup-docs.sh`
- `bash tests/smoke/test-local-topology-roles.sh`
- `docker-compose --env-file .env -f infra/docker-compose.yml config`
- `cd frontend && npm install && npm run build`
- `cd backend && python3 -m pytest tests/test_application_postgres_guard.py`
- `cd backend && python3 -m pytest tests/test_source_foundation_smoke.py`

Local verification required repo-local setup: copied `.env.example` to `.env`, copied `frontend/.env.local.example` to `frontend/.env.local`, installed frontend dependencies, and installed host Python packages needed for the documented backend pytest commands.

Summary: Updated README/local st...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local development setup documentation with clearer configuration guidance for database and service roles.
  * Added new validation section with verification commands to ensure proper environment configuration.

* **Tests**
  * Introduced automated verification checks to validate hardened configuration requirements during local setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->