### PR TITLE
[UX1-1] Define the operator workflow information architecture and screen model (#32)

### DIFF
--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -36,21 +36,23 @@ This reading order is intended to help new contributors understand SafeQuery fro
     Review how the major runtime parts collaborate.
 16. [design/runtime-flow.md](./design/runtime-flow.md)
     Finish with the end-to-end request lifecycle and execution control flow.
-17. [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md)
+17. [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md)
+    Read the operator shell contract before changing navigation, composition, preview, or result surfaces.
+18. [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md)
     Review how SafeQuery can add Cortex Search and Analyst-like capabilities without moving trust boundaries out of the application.
-18. [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md)
+19. [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md)
     Read the explicit lifecycle states before implementing generation, approval, or execution APIs.
-19. [design/sql-guard-spec.md](./design/sql-guard-spec.md)
+20. [design/sql-guard-spec.md](./design/sql-guard-spec.md)
     Use this as the baseline spec for T-SQL validation and deny behavior.
-20. [design/sql-guard-deny-catalog.md](./design/sql-guard-deny-catalog.md)
+21. [design/sql-guard-deny-catalog.md](./design/sql-guard-deny-catalog.md)
     Review the deny code taxonomy before implementing guard outcomes or audit mappings.
-21. [design/sql-guard-deny-corpus.md](./design/sql-guard-deny-corpus.md)
+22. [design/sql-guard-deny-corpus.md](./design/sql-guard-deny-corpus.md)
     Use this to understand the minimum deny scenarios the pilot must continue to block.
-22. [design/audit-event-model.md](./design/audit-event-model.md)
+23. [design/audit-event-model.md](./design/audit-event-model.md)
     Read this before implementing persistence, replay, or operational diagnostics.
-23. [design/evaluation-harness.md](./design/evaluation-harness.md)
+24. [design/evaluation-harness.md](./design/evaluation-harness.md)
     Use this to understand how NL2SQL quality should be measured safely.
-24. [security/threat-model.md](./security/threat-model.md)
+25. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [design/system-context.md](./design/system-context.md): high-level system boundary and actors
 - [design/container-view.md](./design/container-view.md): major runtime containers and responsibilities
 - [design/runtime-flow.md](./design/runtime-flow.md): end-to-end request, guard, preview, and execution flow
+- [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md): operator-facing shell regions, workflow states, and screen-model contract
 - [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md): governed semantic retrieval and analyst-style orchestration
 - [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md): candidate state transitions and approval TTL
 - [design/sql-guard-spec.md](./design/sql-guard-spec.md): baseline SQL Guard behavior and deny rules

--- a/docs/design/operator-workflow-information-architecture.md
+++ b/docs/design/operator-workflow-information-architecture.md
@@ -1,0 +1,159 @@
+# Operator Workflow Information Architecture
+
+## Purpose
+
+This document defines the workflow-first operator shell for SafeQuery. It describes the stable
+information architecture, screen regions, and state-by-state work surfaces that replace a generic
+demo shell with a product-facing application contract.
+
+The operator shell is workflow-first, not transcript-first.
+
+This issue defines the product shell and screen contract only. It does not introduce backend
+integration, real execution behavior, or production-complete interaction details.
+
+## Workflow Principles
+
+- Center the screen on the governed query workflow rather than a chat transcript.
+- Keep source visibility and Source identity present before, during, and after question handling.
+- Preserve a visible separation between Question composition, SQL preview, Guard review, and Result
+  inspection.
+- Require preview-before-execute in the information architecture. Execution belongs later in the
+  workflow and must never visually imply automatic approval.
+- Keep history, active work, and support context in distinct surfaces so the operator can maintain
+  orientation during long review sessions.
+- Do not collapse the shell into a generic chat transcript layout.
+
+## Screen Regions
+
+The default desktop shell uses three persistent regions.
+
+### Left rail history
+
+The left rail history is the operator's navigation memory. It holds:
+
+- prior query sessions and recent work items
+- lightweight status markers such as blocked, previewed, executed, or empty
+- saved or pinned workflow entries when later issues define that behavior
+- route entry points for new query work, source selection, and result revisits
+
+The left rail is not a message transcript. It is a workflow history and navigation index.
+
+### Main work surface
+
+The main work surface holds the active step in the current workflow. At any moment it should make
+one primary job obvious:
+
+- compose the question
+- review the generated SQL
+- review the guard outcome
+- inspect the returned results
+
+Only one of those jobs should dominate the main surface at a time, even if nearby context remains
+visible.
+
+### Support surfaces
+
+Support surfaces hold contextual information that should remain visible without overtaking the main
+task. They can appear as a right rail, stacked side panels, or bounded drawers depending on screen
+size. Typical support content includes:
+
+- Source identity and source status
+- guard rationale and denial or warning details
+- execution eligibility or preview metadata
+- audit anchors, timestamps, and future operator guidance
+
+## Source Visibility
+
+Source visibility is a first-class shell concern, not a secondary detail inside result content.
+
+The operator must be able to identify:
+
+- which source or governed dataset the question is targeting
+- whether the source is currently available for querying
+- whether the shown SQL preview and results belong to that same source binding
+
+Source identity should remain visible across the workflow so the operator does not lose scope when
+moving from composition to preview to results.
+
+## Primary Workflow
+
+The canonical operator path is:
+
+1. Select or confirm the active source.
+2. Enter or refine a natural-language question.
+3. Submit the question into preview.
+4. Review the generated SQL and guard outcome before any later execution step.
+5. Trigger execution only from an explicit reviewed state when future issues add that capability.
+6. Inspect results or empty-state outcomes while retaining access to the original question, source,
+   and review context.
+
+This sequence should read like a governed work process, not like an open-ended assistant
+conversation.
+
+## Screen Model by State
+
+### New query state
+
+- Left rail history shows recent sessions and a clear "new query" entry.
+- Main work surface prioritizes source confirmation and Question composition.
+- Support surfaces show source metadata, operator guidance, and empty placeholders for downstream
+  preview and guard context.
+
+### SQL preview state
+
+- Left rail history keeps the in-progress item selected and preserves nearby prior work.
+- Main work surface switches from composition to SQL preview.
+- Support surfaces show Guard review, source details, and the preview contract metadata needed for
+  later execution.
+
+### Guarded or blocked state
+
+- Main work surface stays anchored to the current query item rather than redirecting the operator
+  into a generic error conversation.
+- Support surfaces explain why execution remains closed and what prerequisite or policy caused the
+  block.
+- Left rail history keeps the failed attempt as a workflow item so the operator can revise or
+  compare without losing continuity.
+
+### Result inspection state
+
+- Main work surface focuses on Result inspection, including bounded rows or explicit no-data
+  outcomes.
+- Support surfaces keep the reviewed SQL, guard posture, source context, and execution metadata
+  visible.
+- Left rail history keeps the item available for revisit and comparison with later runs.
+
+## Transition Rules
+
+- The shell should maintain a consistent frame while the main work surface changes by workflow
+  state.
+- Source identity, current item identity, and workflow status should persist across transitions.
+- Preview and guard context must remain visible when results appear; results do not replace the
+  review history.
+- Empty or blocked outcomes should preserve the same workflow framing instead of sending the user
+  back to a blank start screen.
+
+## Responsive Model
+
+- Desktop keeps left rail history, main work surface, and support surfaces visible as separate
+  zones.
+- Tablet may stack support surfaces below the main work surface, but the left rail history or its
+  condensed equivalent must remain distinct from the active work surface.
+- Mobile may collapse the layout into stacked regions, but the order should remain: navigation and
+  history, active work surface, support context.
+
+## UX Issue Contract
+
+This document defines the shell contract for later UX-1 issues.
+
+Later issues should refine, not replace, these boundaries:
+
+- source selector behavior and source-status presentation
+- history information model and grouping behavior
+- composer interactions and submission affordances
+- preview panel details and SQL review behavior
+- guard panel contents and severity presentation
+- result panel structure, empty state handling, and revisit behavior
+
+If a later proposal conflicts with this shell model, update this document intentionally rather than
+silently drifting the operator workflow back toward a transcript UI.

--- a/docs/design/operator-workflow-information-architecture.md
+++ b/docs/design/operator-workflow-information-architecture.md
@@ -8,7 +8,7 @@ demo shell with a product-facing application contract.
 
 The operator shell is workflow-first, not transcript-first.
 
-This issue defines the product shell and screen contract only. It does not introduce backend
+This document defines the product shell and screen contract only. It does not introduce backend
 integration, real execution behavior, or production-complete interaction details.
 
 ## Workflow Principles

--- a/tests/smoke/test-operator-workflow-ia-contract.sh
+++ b/tests/smoke/test-operator-workflow-ia-contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+target_doc="docs/design/operator-workflow-information-architecture.md"
+
+if [[ ! -f "$target_doc" ]]; then
+  echo "missing operator workflow IA contract: $target_doc" >&2
+  exit 1
+fi
+
+required_regex_patterns=(
+  "^# Operator Workflow Information Architecture$"
+  "^## Purpose$"
+  "^## Workflow Principles$"
+  "^## Screen Regions$"
+  "^## Primary Workflow$"
+  "^## Screen Model by State$"
+  "^## UX Issue Contract$"
+)
+
+required_literal_patterns=(
+  "The operator shell is workflow-first, not transcript-first."
+  "Left rail history"
+  "Source identity"
+  "Question composition"
+  "SQL preview"
+  "Guard review"
+  "Result inspection"
+  "Do not collapse the shell into a generic chat transcript layout."
+  "This document defines the shell contract for later UX-1 issues."
+)
+
+for pattern in "${required_regex_patterns[@]}"; do
+  if ! grep -Eq "$pattern" "$target_doc"; then
+    echo "$target_doc missing required pattern: $pattern" >&2
+    exit 1
+  fi
+done
+
+for pattern in "${required_literal_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$target_doc"; then
+    echo "$target_doc missing required text: $pattern" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
Closes #32
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a dedicated operator workflow IA contract at [docs/design/operator-workflow-information-architecture.md](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-32/docs/design/operator-workflow-information-architecture.md:1) and linked it into [docs/README.md](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-32/docs/README.md:29) and [docs/01_READING_ORDER.md](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-32/docs/01_READING_ORDER.md:55). The new doc makes the shell explicitly workflow-first, defines the three core regions, keeps source identity visible throughout, and sets the contract for later UX-1 work on history, composer, preview, guard, and results.

To make the gap reproducible first, I added [tests/smoke/test-operator-workflow-ia-contract.sh](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-32/tests/smoke/test-operator-workflow-ia-contract.sh:1), ran it once to confirm the missing-doc failure, then implemented the doc until the focused check passed. I also ran `cd frontend && npm ci` because this worktree was missing local dependencies; after that, `npm run build` succeeded. The build still emits existing autoprefixer warnings in [frontend/app/globals.css](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-32/frontend/app/globals.css:77), but it completes successfully. I recorded the turn state in the issue journal and committed the checkpoint as `7c43be3` (`docs: define operator workflow IA`).

Summary: Added a workflow-first operator...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide describing operator workflow architecture, persistent screen regions, canonical workflow states (compose/preview/guard/result), source visibility rules, and responsive transition/layout behavior
  * Updated the documentation index to include the new operator workflow guide

* **Tests**
  * Added a smoke test to validate the presence and required sections of the new operator workflow guide
<!-- end of auto-generated comment: release notes by coderabbit.ai -->