### PR TITLE
[UX1-5] Define the modern request composer contract for the operator shell (#36)

### DIFF
--- a/docs/design/operator-workflow-information-architecture.md
+++ b/docs/design/operator-workflow-information-architecture.md
@@ -71,6 +71,71 @@ size. Typical support content includes:
 - execution eligibility or preview metadata
 - audit anchors, timestamps, and future operator guidance
 
+## Request Composer Contract
+
+The request composer is a governed submission control, not a chat box.
+
+### Composer layout
+
+The composer keeps source identity visible in the same frame as the request draft.
+
+Desktop layout should treat the composer as a bounded work surface within the main workflow region:
+
+- a source-and-posture header that stays visually attached to the draft
+- the natural-language request field as the dominant editable control
+- supporting helper text that explains governed submission expectations
+- a compact action row for preview submission and allowed draft-level secondary actions
+
+On narrower screens, these elements may stack, but they should remain a single composer surface
+rather than dissolving into a transcript feed or disconnected controls.
+
+### Composer controls
+
+The primary editable control is a natural-language request field sized for multi-line operator
+prompts, revisions, and clarification before preview.
+
+The primary submit action must use governed language such as Submit for preview.
+
+The composer may expose helper text for governed submission, but it must not offer raw-SQL entry.
+
+Allowed secondary controls are limited to draft-safe actions such as clear draft, reopen as new
+draft, or explicit source-fork entry points when those actions are available.
+
+Free-form chat metaphors such as Send, message bubbles, or assistant-avatar framing are out of scope for this composer.
+
+### Source identity and submission posture
+
+The composer header should make three things obvious before submission:
+
+- the currently bound source identity
+- the governed submission posture, including that preview precedes any later execution step
+- whether the draft is editable, reopened from history, or blocked by missing trusted prerequisites
+
+Source identity and submit posture should remain visible without forcing the operator to open a
+separate side panel just to confirm where the request will go.
+
+If the draft was reopened from prior history, the composer should preserve lineage context and show
+whether the source is still historical read-only lineage or a newly created forked draft.
+
+### In-flight and blocked states
+
+While preview submission is in flight, the composer keeps the draft visible, locks mutable controls, and surfaces a non-success status until an authoritative outcome returns.
+
+The in-flight surface may show progress text, an inline pending indicator, and a disabled primary
+action, but it must not imply preview success before the authoritative request or candidate record
+exists.
+
+If source binding, policy posture, or trusted submission prerequisites are missing, the composer must stay blocked and explain the missing prerequisite rather than implying that submission succeeded.
+
+Blocked state messaging should stay attached to the composer so the operator can see which draft is
+being held and what must be fixed before preview can be requested.
+
+### Attachment posture
+
+Attachment support is not implemented in this issue.
+
+If attachments are shown at all, they must appear only as a disabled or omitted affordance with explicit out-of-scope copy.
+
 ## History Information Model
 
 History entities are authoritative workflow records, not transcript messages.

--- a/tests/smoke/test-operator-workflow-ia-contract.sh
+++ b/tests/smoke/test-operator-workflow-ia-contract.sh
@@ -17,6 +17,7 @@ required_regex_patterns=(
   "^## Purpose$"
   "^## Workflow Principles$"
   "^## Screen Regions$"
+  "^## Request Composer Contract$"
   "^## History Information Model$"
   "^## Primary Workflow$"
   "^## Screen Model by State$"
@@ -50,11 +51,27 @@ required_literal_patterns=(
   "To work against a different source after history reopen, the operator must explicitly start a separate new draft or explicit fork rather than editing the bound source in place."
   "The UI must not silently switch sources after preview, approval, execution, or history reopen."
   "Do not collapse the shell into a generic chat transcript layout."
+  "The request composer is a governed submission control, not a chat box."
+  "### Composer layout"
+  "### Composer controls"
+  "### Source identity and submission posture"
+  "### In-flight and blocked states"
+  "### Attachment posture"
+  "The composer keeps source identity visible in the same frame as the request draft."
+  "The primary submit action must use governed language such as Submit for preview."
+  "Free-form chat metaphors such as Send, message bubbles, or assistant-avatar framing are out of scope for this composer."
+  "The composer may expose helper text for governed submission, but it must not offer raw-SQL entry."
+  "Attachment support is not implemented in this issue."
+  "If attachments are shown at all, they must appear only as a disabled or omitted affordance with explicit out-of-scope copy."
+  "While preview submission is in flight, the composer keeps the draft visible, locks mutable controls, and surfaces a non-success status until an authoritative outcome returns."
+  "If source binding, policy posture, or trusted submission prerequisites are missing, the composer must stay blocked and explain the missing prerequisite rather than implying that submission succeeded."
   "This document defines the shell contract for later UX-1 issues."
 )
 
 forbidden_literal_patterns=(
   "the operator may choose or replace the source before submitting into"
+  "The request composer is a chat box."
+  "The primary submit action should use Send."
 )
 
 for pattern in "${required_regex_patterns[@]}"; do


### PR DESCRIPTION
Closes #36
This PR was opened by codex-supervisor.
Latest Codex summary:

Defined the missing request-composer contract in [docs/design/operator-workflow-information-architecture.md](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-36/docs/design/operator-workflow-information-architecture.md) and tightened [tests/smoke/test-operator-workflow-ia-contract.sh](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-36/tests/smoke/test-operator-workflow-ia-contract.sh) so the doc now has to specify composer layout, governed submit language, source identity and submission posture, fail-closed in-flight/blocked behavior, and explicit no-attachment posture. I reproduced the gap first by making the smoke test require a `Request Composer Contract` section, confirmed that failure, then updated the doc and committed the result as `0175bb0` (`Define request composer contract`).

Verification passed with `bash tests/smoke/test-operator-workflow-ia-contract.sh`, `bash tests/smoke/test-design-contract.sh`, and `cd frontend && npm install && npm run build`. The build initially failed because `next` was not installed in this worktree yet; after installing frontend dependencies locally, the required production build completed successfully.

Summary: Added and enforced the modern request composer contract for the operator shell, then verified the design docs and frontend build.
State hint: stabilizing
Blocked reason: none
Tests: `bash tests/smoke/test-operator-workflow-ia-contract.sh`; `bash tests/smoke/test-design-contract.sh`; `cd frontend && npm install &&...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operator workflow design specifications with comprehensive request composer contract requirements covering layout, governance rules, submission handling, and state visibility.
  * Added validation tests for design documentation compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->