### PR TITLE
[UX1-7] Define terminal-state mapping for the operator UI (#38)

### DIFF
--- a/docs/design/operator-workflow-information-architecture.md
+++ b/docs/design/operator-workflow-information-architecture.md
@@ -387,6 +387,42 @@ Presentation and state rules:
 - If preview identity, guard posture, or execution anchors belong to a different source binding or candidate lineage, the panel must reject the mixed snapshot instead of stitching together a seemingly complete review.
 - Empty results must keep the same contract shape as populated results so revisit, export, and audit behavior can remain bound to one run record.
 
+### Terminal-state mapping
+
+The operator shell must present terminal outcomes through explicit UI states derived from the
+authoritative lifecycle record rather than a generic catch-all error bucket.
+
+The terminal-state mapping is:
+
+- `review_denied`: a pre-execution candidate terminal state reached when review or guard posture
+  blocks progress before any run record exists
+- `execution_denied`: a run-scoped terminal state reached when execute-time checks reject the
+  reviewed candidate before the backend begins execution
+- `failed`: a run-scoped terminal state reached when execution starts but ends in an error posture
+- `canceled`: a run-scoped terminal state reached when execution is intentionally stopped before a
+  terminal success or failure payload is produced
+- `empty`: a run-scoped terminal state reached when execution completes successfully with zero rows
+- `completed`: a run-scoped terminal state reached when execution completes successfully with
+  bounded rows
+
+The mapping must distinguish pre-execution review failures from post-execution outcomes.
+
+`review_denied` is candidate-anchored and must preserve request identity, source identity,
+candidate identity, candidate lifecycle state, and the timestamp that established the blocked
+review outcome.
+
+`execution_denied`, `failed`, `canceled`, `empty`, and `completed` are run-anchored and must
+preserve request identity, source identity, candidate identity, run identity, run lifecycle state,
+and the authoritative terminal timestamp for that run.
+
+The operator-facing state label may be calmer or more human-readable than the lifecycle field, but
+the surface must keep the authoritative request, candidate, and run anchors visible enough that the
+operator can tell exactly which record became terminal.
+
+If the shell lacks the authoritative source, request, candidate, or run anchor needed for one of
+these terminal states, it must stay blocked and surface the missing trusted prerequisite instead of
+guessing a terminal presentation from partial metadata.
+
 ## Primary Workflow
 
 The canonical operator path is:

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -145,6 +145,28 @@ describe("HomePage", () => {
     }
   });
 
+  it("keeps pre-submission states in a draft-only posture until a real request exists", async () => {
+    const { rerender } = render(await HomePage({}));
+
+    expect(screen.getByText(/request posture/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^Draft only$/i)).not.toHaveLength(0);
+    expect(screen.getByText(/lifecycle posture/i)).toBeInTheDocument();
+    expect(screen.getByText(/no submitted record yet/i)).toBeInTheDocument();
+    expect(screen.queryByText(/req-sq-204/i)).not.toBeInTheDocument();
+
+    rerender(
+      await HomePage({
+        searchParams: {
+          state: "signin"
+        }
+      })
+    );
+
+    expect(screen.getByRole("heading", { name: /sign in state/i })).toBeInTheDocument();
+    expect(screen.getByText(/request posture/i)).toBeInTheDocument();
+    expect(screen.queryByText(/req-sq-204/i)).not.toBeInTheDocument();
+  });
+
   it("falls back to the query state for inherited object keys", () => {
     expect(resolveWorkflowState("toString")).toBe("query");
   });

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -25,7 +25,7 @@ describe("HomePage", () => {
     expect(screen.getByText("Generated SQL")).toBeInTheDocument();
     expect(screen.getByText("Guard status")).toBeInTheDocument();
     expect(screen.getByText("Results")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /error state/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /review denied/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /empty state/i })).toBeInTheDocument();
   });
 
@@ -60,7 +60,7 @@ describe("HomePage", () => {
     expect(screen.getAllByText(/sql preview placeholder/i)).not.toHaveLength(0);
   });
 
-  it("renders explicit empty and error placeholder states", async () => {
+  it("renders explicit empty and review-denied placeholder states", async () => {
     const { rerender } = render(
       await HomePage({
         searchParams: {
@@ -81,8 +81,68 @@ describe("HomePage", () => {
       })
     );
 
-    expect(screen.getByText(/error state reached/i)).toBeInTheDocument();
-    expect(screen.getByText(/blocked pending trusted prerequisite/i)).toBeInTheDocument();
+    expect(screen.getByText(/review denied state reached/i)).toBeInTheDocument();
+    expect(screen.getByText(/review denied before execution/i)).toBeInTheDocument();
+  });
+
+  it("maps terminal outcomes to distinct operator-facing states with anchored context", async () => {
+    const question = "Show approved vendors by quarterly spend";
+    const terminalStateExpectations = [
+      {
+        state: "review_denied",
+        heading: /review denied state/i,
+        status: /review denied before execution/i,
+        lifecycle: /candidate state/i,
+        identity: /candidate-sq-204/i
+      },
+      {
+        state: "completed",
+        heading: /completed state/i,
+        status: /execution completed with rows/i,
+        lifecycle: /run state/i,
+        identity: /run-sq-204/i
+      },
+      {
+        state: "failed",
+        heading: /failed state/i,
+        status: /execution failed after run start/i,
+        lifecycle: /run state/i,
+        identity: /run-sq-204/i
+      },
+      {
+        state: "canceled",
+        heading: /canceled state/i,
+        status: /execution canceled before completion/i,
+        lifecycle: /run state/i,
+        identity: /run-sq-204/i
+      },
+      {
+        state: "execution_denied",
+        heading: /execution denied state/i,
+        status: /execution denied at execute time/i,
+        lifecycle: /run state/i,
+        identity: /run-sq-204/i
+      }
+    ] as const;
+
+    for (const terminalState of terminalStateExpectations) {
+      cleanup();
+      render(
+        await HomePage({
+          searchParams: {
+            question,
+            state: terminalState.state
+          }
+        })
+      );
+
+      expect(screen.getByRole("heading", { name: terminalState.heading })).toBeInTheDocument();
+      expect(screen.getByText(terminalState.status)).toBeInTheDocument();
+      expect(screen.getByText(/source identity/i)).toBeInTheDocument();
+      expect(screen.getByText(/request identity/i)).toBeInTheDocument();
+      expect(screen.getByText(terminalState.lifecycle)).toBeInTheDocument();
+      expect(screen.getByText(terminalState.identity)).toBeInTheDocument();
+    }
   });
 
   it("falls back to the query state for inherited object keys", () => {

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -40,8 +40,8 @@ type StateDefinition = {
 type WorkflowContext = {
   candidateIdentity?: string;
   candidateState?: string;
-  lifecycleTimestamp: string;
-  requestIdentity: string;
+  lifecycleTimestamp?: string;
+  requestIdentity?: string;
   runIdentity?: string;
   runState?: string;
   sourceIdentity: string;
@@ -156,8 +156,6 @@ function getWorkflowContext(state: CanonicalWorkflowState): WorkflowContext {
 
   if (state === "query" || state === "signin") {
     return {
-      lifecycleTimestamp: "2026-04-21 14:12 JST",
-      requestIdentity,
       sourceIdentity
     };
   }
@@ -694,8 +692,10 @@ export function QueryWorkflowShell({
                 <strong>{workflowContext.sourceIdentity}</strong>
               </div>
               <div className="guard-item">
-                <span className="meta-label">Request identity</span>
-                <strong>{workflowContext.requestIdentity}</strong>
+                <span className="meta-label">
+                  {workflowContext.requestIdentity ? "Request identity" : "Request posture"}
+                </span>
+                <strong>{workflowContext.requestIdentity ?? "Draft only"}</strong>
               </div>
               <div className="guard-item">
                 <span className="meta-label">
@@ -722,8 +722,10 @@ export function QueryWorkflowShell({
                 </>
               ) : null}
               <div className="guard-item">
-                <span className="meta-label">Terminal timestamp</span>
-                <strong>{workflowContext.lifecycleTimestamp}</strong>
+                <span className="meta-label">
+                  {workflowContext.lifecycleTimestamp ? "Lifecycle timestamp" : "Lifecycle posture"}
+                </span>
+                <strong>{workflowContext.lifecycleTimestamp ?? "No submitted record yet"}</strong>
               </div>
             </div>
           </section>

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1,7 +1,29 @@
 import { HealthStatusCard } from "./health-status-card";
 import type { HealthSnapshot } from "../lib/health";
 
-type WorkflowState = "signin" | "query" | "preview" | "results" | "empty" | "error";
+type WorkflowState =
+  | "signin"
+  | "query"
+  | "preview"
+  | "review_denied"
+  | "completed"
+  | "empty"
+  | "execution_denied"
+  | "failed"
+  | "canceled"
+  | "results"
+  | "error";
+
+type CanonicalWorkflowState =
+  | "signin"
+  | "query"
+  | "preview"
+  | "review_denied"
+  | "completed"
+  | "empty"
+  | "execution_denied"
+  | "failed"
+  | "canceled";
 
 type QueryWorkflowShellProps = {
   apiUrl: string;
@@ -15,14 +37,36 @@ type StateDefinition = {
   label: string;
 };
 
-const workflowStates: Record<WorkflowState, StateDefinition> = {
+type WorkflowContext = {
+  candidateIdentity?: string;
+  candidateState?: string;
+  lifecycleTimestamp: string;
+  requestIdentity: string;
+  runIdentity?: string;
+  runState?: string;
+  sourceIdentity: string;
+};
+
+const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
+  canceled: {
+    description: "Execution started from a reviewed candidate but stopped before the run completed.",
+    label: "Canceled"
+  },
+  completed: {
+    description: "Execution completed and returned bounded rows for the reviewed run record.",
+    label: "Completed"
+  },
   empty: {
-    description: "The workflow completed, but the approved query returned no rows.",
+    description: "Execution completed, but the reviewed run record returned no rows.",
     label: "Empty state"
   },
-  error: {
-    description: "The workflow hit a guarded failure path and is holding execution closed.",
-    label: "Error state"
+  execution_denied: {
+    description: "The reviewed candidate was blocked at execute time and no execution payload was produced.",
+    label: "Execution denied"
+  },
+  failed: {
+    description: "Execution started for the reviewed run record but ended in a controlled failure state.",
+    label: "Failed"
   },
   preview: {
     description: "The question has been staged for analyst review with generated SQL still in placeholder mode.",
@@ -32,9 +76,9 @@ const workflowStates: Record<WorkflowState, StateDefinition> = {
     description: "Compose a governed question and move into review without leaving the product shell.",
     label: "Query input"
   },
-  results: {
-    description: "Previewed SQL has advanced to a placeholder result view for future execution wiring.",
-    label: "Result state"
+  review_denied: {
+    description: "The request stopped during review before any execution run was allowed to start.",
+    label: "Review denied"
   },
   signin: {
     description: "Reserved sign-in entrypoint before any real authentication bridge is wired.",
@@ -42,15 +86,40 @@ const workflowStates: Record<WorkflowState, StateDefinition> = {
   }
 };
 
-export function resolveWorkflowState(value?: string): WorkflowState {
-  if (value && Object.prototype.hasOwnProperty.call(workflowStates, value)) {
-    return value as WorkflowState;
+const workflowStateAliases: Partial<Record<WorkflowState, CanonicalWorkflowState>> = {
+  error: "review_denied",
+  results: "completed"
+};
+
+const workflowStateOrder: CanonicalWorkflowState[] = [
+  "signin",
+  "query",
+  "preview",
+  "review_denied",
+  "completed",
+  "empty",
+  "execution_denied",
+  "failed",
+  "canceled"
+];
+
+export function resolveWorkflowState(value?: string): CanonicalWorkflowState {
+  if (!value) {
+    return "query";
+  }
+
+  if (Object.prototype.hasOwnProperty.call(workflowStateAliases, value)) {
+    return workflowStateAliases[value as WorkflowState] ?? "query";
+  }
+
+  if (Object.prototype.hasOwnProperty.call(workflowStates, value)) {
+    return value as CanonicalWorkflowState;
   }
 
   return "query";
 }
 
-function buildStateHref(state: WorkflowState, question: string): string {
+function buildStateHref(state: CanonicalWorkflowState, question: string): string {
   const params = new URLSearchParams({
     question,
     state
@@ -71,68 +140,159 @@ function getSqlPreview(question: string): string {
   ].join("\n");
 }
 
-function getGuardTone(state: WorkflowState): string {
-  if (state === "error") {
+function getWorkflowContext(state: CanonicalWorkflowState): WorkflowContext {
+  const sourceIdentity = "SAP spend cube / approved_vendor_spend";
+  const requestIdentity = "req-sq-204";
+
+  if (state === "preview" || state === "review_denied") {
+    return {
+      candidateIdentity: "candidate-sq-204",
+      candidateState: state === "review_denied" ? "guard_denied" : "preview_ready",
+      lifecycleTimestamp: state === "review_denied" ? "2026-04-21 14:24 JST" : "2026-04-21 14:18 JST",
+      requestIdentity,
+      sourceIdentity
+    };
+  }
+
+  if (state === "query" || state === "signin") {
+    return {
+      lifecycleTimestamp: "2026-04-21 14:12 JST",
+      requestIdentity,
+      sourceIdentity
+    };
+  }
+
+  return {
+    candidateIdentity: "candidate-sq-204",
+    candidateState: "approved_previewed",
+    lifecycleTimestamp:
+      state === "completed"
+        ? "2026-04-21 14:32 JST"
+        : state === "empty"
+          ? "2026-04-21 14:34 JST"
+          : state === "execution_denied"
+            ? "2026-04-21 14:31 JST"
+            : state === "failed"
+              ? "2026-04-21 14:35 JST"
+              : "2026-04-21 14:33 JST",
+    requestIdentity,
+    runIdentity: "run-sq-204",
+    runState:
+      state === "completed"
+        ? "executed"
+        : state === "empty"
+          ? "executed_empty"
+          : state === "execution_denied"
+            ? "execution_denied"
+            : state === "failed"
+              ? "execution_failed"
+              : "execution_canceled",
+    sourceIdentity
+  };
+}
+
+function getGuardTone(state: CanonicalWorkflowState): string {
+  if (state === "review_denied" || state === "execution_denied" || state === "failed") {
     return "danger";
   }
 
-  if (state === "results" || state === "empty") {
+  if (state === "completed" || state === "empty") {
     return "success";
+  }
+
+  if (state === "canceled") {
+    return "muted";
   }
 
   return "warning";
 }
 
-function getGuardHeadline(state: WorkflowState): string {
-  if (state === "error") {
-    return "Blocked pending trusted prerequisite";
+function getGuardHeadline(state: CanonicalWorkflowState): string {
+  if (state === "review_denied") {
+    return "Review denied before execution";
   }
 
-  if (state === "results") {
-    return "Preview approved for placeholder execution";
+  if (state === "completed") {
+    return "Execution completed with rows";
   }
 
   if (state === "empty") {
     return "Execution completed with no approved rows";
   }
 
+  if (state === "execution_denied") {
+    return "Execution denied at execute time";
+  }
+
+  if (state === "failed") {
+    return "Execution failed after run start";
+  }
+
+  if (state === "canceled") {
+    return "Execution canceled before completion";
+  }
+
   return "Awaiting analyst review";
 }
 
-function getGuardCopy(state: WorkflowState): string {
-  if (state === "error") {
-    return "No auth context, approval record, or execution binding is inferred here. The shell stays fail-closed and surfaces a review-needed error placeholder instead.";
+function getGuardCopy(state: CanonicalWorkflowState): string {
+  if (state === "review_denied") {
+    return "The request never crossed into execution. Guard denial stays anchored to the candidate review record instead of being restyled as a run failure.";
   }
 
-  if (state === "results") {
-    return "Guard status remains explicit even in placeholder mode so the workflow keeps query intent, SQL review, and result inspection separate.";
+  if (state === "completed") {
+    return "Result inspection stays tied to the reviewed candidate and run record so operators can distinguish executed evidence from nearby advisory context.";
   }
 
   if (state === "empty") {
     return "The result surface can represent a clean no-data outcome without restyling the rest of the page or hiding guard context.";
   }
 
+  if (state === "execution_denied") {
+    return "Execute-time checks revalidated ownership, approval freshness, and replay posture. The run stays denied instead of inferring success from an earlier preview.";
+  }
+
+  if (state === "failed") {
+    return "The run record exists, but the payload is not trusted as successful output. The shell keeps the failure anchored to that run instead of showing speculative rows.";
+  }
+
+  if (state === "canceled") {
+    return "Cancellation is distinct from denial and failure. The shell preserves run lineage and lifecycle context so the operator can see that execution started but did not finish.";
+  }
+
   return "The first shell stops at review boundaries. No real auth, SQL generation, or execution path is trusted in this issue.";
 }
 
-function getResultTitle(state: WorkflowState): string {
-  if (state === "results") {
-    return "Placeholder result set";
+function getResultTitle(state: CanonicalWorkflowState): string {
+  if (state === "completed") {
+    return "Completed result set";
   }
 
   if (state === "empty") {
     return "No rows returned";
   }
 
-  if (state === "error") {
-    return "Execution unavailable";
+  if (state === "review_denied") {
+    return "Review denied before run creation";
+  }
+
+  if (state === "execution_denied") {
+    return "Execution denied";
+  }
+
+  if (state === "failed") {
+    return "Execution failed";
+  }
+
+  if (state === "canceled") {
+    return "Execution canceled";
   }
 
   return "Results placeholder";
 }
 
-function renderResultContent(state: WorkflowState) {
-  if (state === "results") {
+function renderResultContent(state: CanonicalWorkflowState) {
+  if (state === "completed") {
     return (
       <div className="result-table" role="table" aria-label="Placeholder query results">
         <div className="result-row result-row-head" role="row">
@@ -159,6 +319,18 @@ function renderResultContent(state: WorkflowState) {
     );
   }
 
+  if (state === "review_denied") {
+    return (
+      <div className="state-callout state-callout-danger">
+        <p className="state-callout-title">Review denied state reached</p>
+        <p>
+          The request stopped before execution. Candidate review context remains visible so the
+          operator can revise without inventing a run record.
+        </p>
+      </div>
+    );
+  }
+
   if (state === "empty") {
     return (
       <div className="state-callout state-callout-empty">
@@ -171,13 +343,37 @@ function renderResultContent(state: WorkflowState) {
     );
   }
 
-  if (state === "error") {
+  if (state === "execution_denied") {
     return (
       <div className="state-callout state-callout-danger">
-        <p className="state-callout-title">Error state reached</p>
+        <p className="state-callout-title">Execution denied state reached</p>
         <p>
-          The shell presents a controlled failure placeholder instead of implying that an
-          unauthorized execution succeeded.
+          The shell preserves the denied run record and keeps execution closed instead of implying
+          that an earlier preview automatically became successful output.
+        </p>
+      </div>
+    );
+  }
+
+  if (state === "failed") {
+    return (
+      <div className="state-callout state-callout-danger">
+        <p className="state-callout-title">Failed state reached</p>
+        <p>
+          A run was created, but it ended in failure. The operator sees the run anchor and failure
+          posture instead of placeholder rows.
+        </p>
+      </div>
+    );
+  }
+
+  if (state === "canceled") {
+    return (
+      <div className="state-callout">
+        <p className="state-callout-title">Canceled state reached</p>
+        <p>
+          Cancellation keeps the run history visible and distinct from empty, denied, or failed
+          outcomes.
         </p>
       </div>
     );
@@ -194,7 +390,7 @@ function renderResultContent(state: WorkflowState) {
   );
 }
 
-function renderStatePanel(state: WorkflowState, question: string) {
+function renderStatePanel(state: CanonicalWorkflowState, question: string) {
   if (state === "signin") {
     return (
       <div className="state-hero">
@@ -224,8 +420,8 @@ function renderStatePanel(state: WorkflowState, question: string) {
           before any future execution path is introduced.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("results", question)}>
-            Open result placeholder
+          <a className="action-link" href={buildStateHref("completed", question)}>
+            Open completed state
           </a>
           <a className="ghost-link" href={buildStateHref("empty", question)}>
             Open empty state
@@ -235,21 +431,21 @@ function renderStatePanel(state: WorkflowState, question: string) {
     );
   }
 
-  if (state === "results") {
+  if (state === "completed") {
     return (
       <div className="state-hero">
         <p className="eyebrow">Inspection mode</p>
-        <h2>Result state</h2>
+        <h2>Completed state</h2>
         <p className="section-copy">
-          Placeholder rows confirm the layout contract for reviewed output without pretending that
-          SafeQuery already executes approved SQL.
+          Execution-backed rows stay separate from preview and guard surfaces so completed output
+          is anchored to a specific run instead of a generic result placeholder.
         </p>
         <div className="action-row">
           <a className="action-link" href={buildStateHref("empty", question)}>
             Open empty state
           </a>
-          <a className="ghost-link" href={buildStateHref("error", question)}>
-            Open error state
+          <a className="ghost-link" href={buildStateHref("failed", question)}>
+            Open failed state
           </a>
         </div>
       </div>
@@ -277,21 +473,84 @@ function renderStatePanel(state: WorkflowState, question: string) {
     );
   }
 
-  if (state === "error") {
+  if (state === "review_denied") {
     return (
       <div className="state-hero">
-        <p className="eyebrow">Guarded failure path</p>
-        <h2>Error state</h2>
+        <p className="eyebrow">Pre-execution block</p>
+        <h2>Review denied state</h2>
         <p className="section-copy">
-          Fail-closed placeholders keep boundary signals explicit. Missing trusted prerequisites do
-          not silently degrade into success or partial results.
+          Pre-execution review failures stay attached to the candidate review surface. The operator
+          sees a blocked candidate, not a synthetic run outcome.
         </p>
         <div className="action-row">
           <a className="action-link" href={buildStateHref("query", question)}>
             Return to query input
           </a>
-          <a className="ghost-link" href={buildStateHref("signin", question)}>
-            Open sign in
+          <a className="ghost-link" href={buildStateHref("preview", question)}>
+            Back to SQL preview
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "execution_denied") {
+    return (
+      <div className="state-hero">
+        <p className="eyebrow">Run denied</p>
+        <h2>Execution denied state</h2>
+        <p className="section-copy">
+          Execute-time denial is distinct from review denial. The shell keeps the operator on the
+          run-backed outcome that was rejected after preview.
+        </p>
+        <div className="action-row">
+          <a className="action-link" href={buildStateHref("preview", question)}>
+            Back to SQL preview
+          </a>
+          <a className="ghost-link" href={buildStateHref("query", question)}>
+            Revise question
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "failed") {
+    return (
+      <div className="state-hero">
+        <p className="eyebrow">Run failure</p>
+        <h2>Failed state</h2>
+        <p className="section-copy">
+          Failure after execution start keeps the run identity, source binding, and reviewed
+          candidate visible for operator diagnosis.
+        </p>
+        <div className="action-row">
+          <a className="action-link" href={buildStateHref("completed", question)}>
+            Open completed state
+          </a>
+          <a className="ghost-link" href={buildStateHref("query", question)}>
+            Revise question
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "canceled") {
+    return (
+      <div className="state-hero">
+        <p className="eyebrow">Run canceled</p>
+        <h2>Canceled state</h2>
+        <p className="section-copy">
+          Cancellation is presented as its own terminal outcome so operators do not confuse
+          interrupted work with denial, failure, or an empty result.
+        </p>
+        <div className="action-row">
+          <a className="action-link" href={buildStateHref("query", question)}>
+            Start a new draft
+          </a>
+          <a className="ghost-link" href={buildStateHref("completed", question)}>
+            Compare completed state
           </a>
         </div>
       </div>
@@ -316,10 +575,12 @@ export function QueryWorkflowShell({
   question,
   state
 }: QueryWorkflowShellProps) {
+  const normalizedState = resolveWorkflowState(state);
   const sqlPreview = getSqlPreview(question);
-  const activeState = workflowStates[state];
-  const queryLocked = state === "signin";
-  const guardTone = getGuardTone(state);
+  const activeState = workflowStates[normalizedState];
+  const queryLocked = normalizedState === "signin";
+  const guardTone = getGuardTone(normalizedState);
+  const workflowContext = getWorkflowContext(normalizedState);
 
   return (
     <main className="app-shell">
@@ -350,9 +611,9 @@ export function QueryWorkflowShell({
         </div>
 
         <nav aria-label="Workflow states" className="state-nav">
-          {(Object.keys(workflowStates) as WorkflowState[]).map((workflowState) => (
+          {workflowStateOrder.map((workflowState) => (
             <a
-              aria-current={workflowState === state ? "page" : undefined}
+              aria-current={workflowState === normalizedState ? "page" : undefined}
               className="state-nav-link"
               href={buildStateHref(workflowState, question)}
               key={workflowState}
@@ -365,7 +626,9 @@ export function QueryWorkflowShell({
 
       <section className="workspace-grid">
         <div className="primary-column">
-          <section className="surface surface-primary">{renderStatePanel(state, question)}</section>
+          <section className="surface surface-primary">
+            {renderStatePanel(normalizedState, question)}
+          </section>
 
           <section className="surface surface-primary">
             <div className="section-header">
@@ -395,8 +658,8 @@ export function QueryWorkflowShell({
                 <button disabled={queryLocked} type="submit">
                   Generate preview
                 </button>
-                <a className="ghost-link" href={buildStateHref("results", question)}>
-                  Open result state
+                <a className="ghost-link" href={buildStateHref("completed", question)}>
+                  Open completed state
                 </a>
               </div>
             </form>
@@ -420,12 +683,60 @@ export function QueryWorkflowShell({
           <section className="surface surface-secondary">
             <div className="section-header">
               <div>
+                <p className="eyebrow">Workflow anchors</p>
+                <h2 className="panel-title">Source and lifecycle context</h2>
+              </div>
+              <span className="surface-badge surface-badge-code">Bound context</span>
+            </div>
+            <div className="guard-list">
+              <div className="guard-item">
+                <span className="meta-label">Source identity</span>
+                <strong>{workflowContext.sourceIdentity}</strong>
+              </div>
+              <div className="guard-item">
+                <span className="meta-label">Request identity</span>
+                <strong>{workflowContext.requestIdentity}</strong>
+              </div>
+              <div className="guard-item">
+                <span className="meta-label">
+                  {workflowContext.candidateIdentity ? "Candidate identity" : "Draft posture"}
+                </span>
+                <strong>{workflowContext.candidateIdentity ?? "Draft only"}</strong>
+              </div>
+              <div className="guard-item">
+                <span className="meta-label">
+                  {workflowContext.candidateState ? "Candidate state" : "Lifecycle state"}
+                </span>
+                <strong>{workflowContext.candidateState ?? "drafting"}</strong>
+              </div>
+              {workflowContext.runIdentity ? (
+                <>
+                  <div className="guard-item">
+                    <span className="meta-label">Run identity</span>
+                    <strong>{workflowContext.runIdentity}</strong>
+                  </div>
+                  <div className="guard-item">
+                    <span className="meta-label">Run state</span>
+                    <strong>{workflowContext.runState}</strong>
+                  </div>
+                </>
+              ) : null}
+              <div className="guard-item">
+                <span className="meta-label">Terminal timestamp</span>
+                <strong>{workflowContext.lifecycleTimestamp}</strong>
+              </div>
+            </div>
+          </section>
+
+          <section className="surface surface-secondary">
+            <div className="section-header">
+              <div>
                 <p className="eyebrow">Guard status</p>
-                <h2 className="panel-title">{getGuardHeadline(state)}</h2>
+                <h2 className="panel-title">{getGuardHeadline(normalizedState)}</h2>
               </div>
               <span className={`surface-badge surface-badge-${guardTone}`}>{guardTone}</span>
             </div>
-            <p className="section-copy">{getGuardCopy(state)}</p>
+            <p className="section-copy">{getGuardCopy(normalizedState)}</p>
             <div className="guard-list">
               <div className="guard-item">
                 <span className="meta-label">Auth</span>
@@ -446,13 +757,13 @@ export function QueryWorkflowShell({
             <div className="section-header">
               <div>
                 <p className="eyebrow">Results</p>
-                <h2 className="panel-title">{getResultTitle(state)}</h2>
+                <h2 className="panel-title">{getResultTitle(normalizedState)}</h2>
               </div>
               <a className="inline-link" href={`${apiUrl}/health`} rel="noreferrer" target="_blank">
                 API health
               </a>
             </div>
-            {renderResultContent(state)}
+            {renderResultContent(normalizedState)}
           </section>
         </aside>
       </section>

--- a/tests/smoke/test-operator-workflow-ia-contract.sh
+++ b/tests/smoke/test-operator-workflow-ia-contract.sh
@@ -23,6 +23,7 @@ required_regex_patterns=(
   "^### Preview panel contract$"
   "^### Guard panel contract$"
   "^### Result panel contract$"
+  "^### Terminal-state mapping$"
   "^## Primary Workflow$"
   "^## Screen Model by State$"
   "^## UX Issue Contract$"
@@ -81,6 +82,25 @@ required_literal_patterns=(
   "guard code list or deny identifiers"
   "execution eligibility posture"
   "The result panel renders only execution-backed output for a specific run record and must not be used for speculative preview data, advisory text, or guard rationale."
+  "The operator shell must present terminal outcomes through explicit UI states derived from the"
+  "authoritative lifecycle record rather than a generic catch-all error bucket."
+  "The terminal-state mapping is:"
+  '`review_denied`'
+  '`execution_denied`'
+  '`failed`'
+  '`canceled`'
+  '`empty`'
+  '`completed`'
+  "The mapping must distinguish pre-execution review failures from post-execution outcomes."
+  '`review_denied` is candidate-anchored and must preserve request identity, source identity,'
+  'candidate identity, candidate lifecycle state, and the timestamp that established the blocked'
+  'review outcome.'
+  '`execution_denied`, `failed`, `canceled`, `empty`, and `completed` are run-anchored and must'
+  'preserve request identity, source identity, candidate identity, run identity, run lifecycle state,'
+  'and the authoritative terminal timestamp for that run.'
+  "If the shell lacks the authoritative source, request, candidate, or run anchor needed for one of"
+  "these terminal states, it must stay blocked and surface the missing trusted prerequisite instead of"
+  "guessing a terminal presentation from partial metadata."
   "Minimum result fields:"
   "run identity"
   "result state"


### PR DESCRIPTION
Closes #38
This PR was opened by codex-supervisor.
Latest Codex summary:

Defined the operator terminal-state contract in both the UX doc and the placeholder shell. The UI now distinguishes `review_denied`, `execution_denied`, `failed`, `canceled`, `empty`, and `completed`, keeps legacy `error`/`results` query params mapped forward safely, and shows bound `source`, `request`, `candidate`, and `run` context so terminal views stay anchored to authoritative lifecycle records. The focused regression test was added first, then the shell and IA contract were updated to satisfy it.

Verified with `frontend/app/page.test.tsx`, `tests/smoke/test-operator-workflow-ia-contract.sh`, and `cd frontend && npm run build`. Changes are committed as `0319a70` (`Define operator terminal state mapping`). The required issue journal was updated in `.codex-supervisor`, which is ignored from git as expected.

Summary: Added explicit operator terminal-state mapping to the IA contract and frontend shell, with anchored lifecycle context and focused regression coverage; committed as `0319a70`.
State hint: implementing
Blocked reason: none
Tests: `cd frontend && npm test -- --run app/page.test.tsx`; `bash tests/smoke/test-operator-workflow-ia-contract.sh`; `cd frontend && npm run build`
Failure signature: none
Next action: Open or update the draft PR for `codex/issue-38` with the committed terminal-state contract checkpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator shell now shows explicit terminal states (review denied, execution denied, failed, canceled, completed, empty) and a “fail-closed” blocked view that surfaces missing prerequisites instead of inferring outcomes
  * Added a “Workflow anchors” UI section showing request/source and lifecycle anchors

* **Documentation**
  * Added Terminal-state mapping section defining terminal states and anchoring rules

* **Tests**
  * Updated UI tests and smoke contract checks to validate new terminal-state representations and messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->