### PR TITLE
docs: reframe epic a shell as demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ SafeQuery is a controlled enterprise NL2SQL application. This repository checkpo
 
 The baseline intentionally stops at placeholder UI and health-oriented API behavior. No auth, SQL generation, SQL guard, or SQL execution logic is implemented yet.
 
+The current Epic A frontend should be treated as a developer state demo, not the intended production information architecture. It exists to make the baseline lifecycle and review states concrete while SafeQuery is still wiring the trusted backend boundary.
+
+For future UI implementation work, the next authoritative UI direction is the UX-1 workflow-first operator shell contract in [docs/design/operator-workflow-information-architecture.md](./docs/design/operator-workflow-information-architecture.md). Contributors should use that document as the source of truth for production-facing shell structure, workflow regions, and operator navigation rather than extending the current top-level demo shell as if it were the final product IA.
+
 ## Repository Shape
 
 ```text
@@ -123,6 +127,10 @@ The initial structure leaves explicit room for later feature work:
 - `backend/app/features/audit/` for lifecycle audit persistence
 
 The frontend remains a simple shell so later query input, SQL preview, and audit workflows can be added without changing the trusted backend boundary.
+
+That simple shell is a developer state demo for the Epic A prototype. It is useful for exercising baseline states and component posture, but it is not the intended production information architecture.
+
+When UI work moves beyond the current prototype, follow the UX-1 workflow-first operator shell contract in [docs/design/operator-workflow-information-architecture.md](./docs/design/operator-workflow-information-architecture.md) as the next authoritative UI direction.
 
 ## Focused Verification
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 This directory contains the initial documentation baseline for SafeQuery, a secure enterprise NL2SQL proof of concept.
 
+The current Epic A repository shell should be read as a developer state demo, not the production information architecture. It helps contributors inspect baseline UI states and backend posture while the product-facing shell contract is still being established.
+
+For future frontend structure and navigation work, the UX-1 workflow-first operator shell contract in `docs/design/operator-workflow-information-architecture.md` is the next authoritative UI direction. Do not treat the current top-level prototype shell as the production information architecture.
+
 The docs are organized to make three things clear from the start:
 
 - which architectural decisions are already fixed

--- a/tests/smoke/test-epic-a-doc-framing.sh
+++ b/tests/smoke/test-epic-a-doc-framing.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+readme_path="README.md"
+docs_index_path="docs/README.md"
+
+for path in "$readme_path" "$docs_index_path"; do
+  if [[ ! -f "$path" ]]; then
+    echo "missing required doc: $path" >&2
+    exit 1
+  fi
+done
+
+readme_required_patterns=(
+  "developer state demo"
+  "not the intended production information architecture"
+  "docs/design/operator-workflow-information-architecture.md"
+  "next authoritative UI direction"
+  "UX-1 workflow-first operator shell contract"
+)
+
+docs_index_required_patterns=(
+  "developer state demo"
+  "UX-1 workflow-first operator shell contract"
+  "authoritative UI direction"
+  "not the production information architecture"
+  "docs/design/operator-workflow-information-architecture.md"
+)
+
+missing=0
+
+for pattern in "${readme_required_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$readme_path"; then
+    echo "README missing Epic A framing text: $pattern" >&2
+    missing=1
+  fi
+done
+
+for pattern in "${docs_index_required_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$docs_index_path"; then
+    echo "docs/README missing Epic A framing text: $pattern" >&2
+    missing=1
+  fi
+done
+
+exit "$missing"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README files to clarify that the current Epic A frontend is a developer-state demo, not the production information architecture. Added guidance directing contributors to follow the UX-1 workflow-first operator shell contract outlined in the design documentation for future UI implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->