### PR TITLE
Align prototype shell copy with the operator-first UX contract (#50)

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -27,6 +27,10 @@ describe("HomePage", () => {
     expect(screen.getByText("Results")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /review denied/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /empty state/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /compose the operator request/i })).toBeInTheDocument();
+    expect(screen.getByText(/operator shell for governed question review, sql preview, and execution posture/i)).toBeInTheDocument();
+    expect(screen.queryByText(/compose the analyst question/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/awaiting analyst review/i)).not.toBeInTheDocument();
   });
 
   it("renders the shell before the health probe completes", async () => {

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -69,7 +69,7 @@ const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
     label: "Failed"
   },
   preview: {
-    description: "The question has been staged for analyst review with generated SQL still in placeholder mode.",
+    description: "The operator request has been staged for governed review with generated SQL still in placeholder mode.",
     label: "SQL preview"
   },
   query: {
@@ -230,7 +230,7 @@ function getGuardHeadline(state: CanonicalWorkflowState): string {
     return "Execution canceled before completion";
   }
 
-  return "Awaiting analyst review";
+  return "Awaiting operator review";
 }
 
 function getGuardCopy(state: CanonicalWorkflowState): string {
@@ -589,8 +589,8 @@ export function QueryWorkflowShell({
             <h1>Query workflow</h1>
           </div>
           <p className="frame-copy">
-            A governed application shell for review-first NL2SQL work. This first pass stays
-            independent from Vanna UI surfaces and keeps auth and execution as placeholders.
+            Operator shell for governed question review, SQL preview, and execution posture.
+            Analyst-style extensions stay optional and outside the core shell.
           </p>
         </div>
 
@@ -632,7 +632,7 @@ export function QueryWorkflowShell({
             <div className="section-header">
               <div>
                 <p className="eyebrow">Question input</p>
-                <h2 className="panel-title">Compose the analyst question</h2>
+                <h2 className="panel-title">Compose the operator request</h2>
               </div>
               <span className={`surface-badge surface-badge-${queryLocked ? "muted" : "active"}`}>
                 {queryLocked ? "Read only" : "Ready"}


### PR DESCRIPTION
Closes #50
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the prototype shell copy to match the operator-first UX contract. The shell frame now describes an operator workflow, the input panel is labeled `Compose the operator request`, the default guard heading is `Awaiting operator review`, and the preview-state description no longer frames the flow as analyst review. I also tightened [frontend/app/page.test.tsx](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-50/frontend/app/page.test.tsx:19) so it asserts the new operator-first copy and rejects the old analyst wording. The component change is in [frontend/components/query-workflow-shell.tsx](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-50/frontend/components/query-workflow-shell.tsx:72).

Focused verification passed with `CI=1 npm test -- --run app/page.test.tsx`, and `npm run build` passed. I committed the change as `0de1524` with message `Align prototype shell copy with operator workflow`.

Summary: Reproduced the shell-copy mismatch with a focused page test, replaced analyst-first shell phrasing with operator-first copy, and committed the fix.
State hint: implementing
Blocked reason: none
Tests: `cd frontend && CI=1 npm test -- --run app/page.test.tsx`; `cd frontend && npm run build`
Failure signature: none
Next action: Open or update the draft PR for commit `0de1524` if supervisor flow wants an early checkpoint published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Operator Request composition interface to the workflow.

* **Style**
  * Updated workflow terminology from "analyst review" to "operator review."
  * Renamed composition fields to reference "operator request" instead of "analyst question."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->