### PR TITLE
docs: refresh documentation entrypoints

### DIFF
--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -4,12 +4,17 @@ This reading order is intended to help new contributors understand SafeQuery fro
 
 ## Recommended Sequence
 
+### 1. Baseline Orientation
+
 1. [00_BRIEF_SafeQuery_docs.md](./00_BRIEF_SafeQuery_docs.md)
    Read the founding brief first to understand scope, non-goals, and fixed stack decisions.
 2. [requirements/requirements-baseline.md](./requirements/requirements-baseline.md)
    Read next to understand the product and control-plane requirements the implementation must satisfy.
 3. [requirements/technology-stack.md](./requirements/technology-stack.md)
    Use this to understand the current baseline stack and the constraints on implementation choices.
+
+### 2. Architecture and Trust Decisions
+
 4. [adr/ADR-0001-frontend-backend-split.md](./adr/ADR-0001-frontend-backend-split.md)
    Start the ADR set with the application shape and trust boundary split.
 5. [adr/ADR-0002-auth-bridge-with-saml-2-0.md](./adr/ADR-0002-auth-bridge-with-saml-2-0.md)
@@ -28,33 +33,44 @@ This reading order is intended to help new contributors understand SafeQuery fro
     Review how session handling, CSRF, and default-deny authorization are assigned to the trusted backend.
 12. [adr/ADR-0009-dataset-exposure-and-governance.md](./adr/ADR-0009-dataset-exposure-and-governance.md)
     Review how allow-listed data exposure, approved views, and schema governance work in the pilot.
-13. [adr/ADR-0010-mlflow-observability-and-evaluation-plane.md](./adr/ADR-0010-mlflow-observability-and-evaluation-plane.md)
-    Review why MLflow is used for tracing, evaluation, and model-lifecycle support without becoming the trusted control plane.
-14. [design/system-context.md](./design/system-context.md)
-   Move from decisions to architecture views.
-15. [design/container-view.md](./design/container-view.md)
+13. [design/system-context.md](./design/system-context.md)
+    Move from decisions to architecture views.
+14. [design/container-view.md](./design/container-view.md)
     Review how the major runtime parts collaborate.
-16. [design/runtime-flow.md](./design/runtime-flow.md)
-    Finish with the end-to-end request lifecycle and execution control flow.
-17. [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md)
-    Read the operator shell contract before changing navigation, composition, preview, or result surfaces.
-18. [../DESIGN.md](../DESIGN.md)
-    Read the visual design contract before changing shell hierarchy, typography, spacing, or interaction posture.
-19. [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md)
-    Review how SafeQuery can add Cortex Search and Analyst-like capabilities without moving trust boundaries out of the application.
-20. [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md)
-    Read the explicit lifecycle states before implementing generation, approval, or execution APIs.
-21. [design/sql-guard-spec.md](./design/sql-guard-spec.md)
+15. [design/runtime-flow.md](./design/runtime-flow.md)
+    Finish the baseline architecture pass with the end-to-end request lifecycle and execution control flow.
+16. [design/sql-guard-spec.md](./design/sql-guard-spec.md)
     Use this as the baseline spec for T-SQL validation and deny behavior.
-22. [design/sql-guard-deny-catalog.md](./design/sql-guard-deny-catalog.md)
+17. [design/sql-guard-deny-catalog.md](./design/sql-guard-deny-catalog.md)
     Review the deny code taxonomy before implementing guard outcomes or audit mappings.
-23. [design/sql-guard-deny-corpus.md](./design/sql-guard-deny-corpus.md)
+18. [design/sql-guard-deny-corpus.md](./design/sql-guard-deny-corpus.md)
     Use this to understand the minimum deny scenarios the pilot must continue to block.
-24. [design/audit-event-model.md](./design/audit-event-model.md)
+19. [design/audit-event-model.md](./design/audit-event-model.md)
     Read this before implementing persistence, replay, or operational diagnostics.
+
+### 3. UX Foundation
+
+20. [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md)
+    Read the operator shell contract before changing navigation, composition, preview, or result surfaces.
+21. [../DESIGN.md](../DESIGN.md)
+    Read the visual design contract after the workflow contract so shell hierarchy, typography, spacing, and interaction posture stay aligned.
+22. [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md)
+    Read the lifecycle state model before implementing UI states or backend transitions that must share the same authoritative vocabulary.
+
+### 4. Source-Aware and Evaluation Extensions
+
+23. [adr/ADR-0010-mlflow-observability-and-evaluation-plane.md](./adr/ADR-0010-mlflow-observability-and-evaluation-plane.md)
+    Review why MLflow is used for tracing, evaluation, and model-lifecycle support without becoming the trusted control plane.
+24. [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md)
+    Review how SafeQuery can add source-aware search and analyst-style capabilities without moving trust boundaries out of the application.
 25. [design/evaluation-harness.md](./design/evaluation-harness.md)
-    Use this to understand how NL2SQL quality should be measured safely.
-26. [security/threat-model.md](./security/threat-model.md)
+    Use this to understand how NL2SQL quality should be measured safely as the source-aware surface area expands.
+
+### 5. Local Setup and Threat Review
+
+26. [local-development.md](./local-development.md)
+    Use this once the document set is clear so local startup follows the reviewed topology and role split.
+27. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,10 +29,14 @@ If documents drift, do not silently let lower-level docs override upstream inten
 
 ## Documentation Structure
 
-- [local-development.md](./local-development.md): contributor startup path for env setup, compose startup, migrations, and baseline troubleshooting
+### Repository Entry Points
+
 - [00_BRIEF_SafeQuery_docs.md](./00_BRIEF_SafeQuery_docs.md): founding brief and initial architecture input retained as a repo document
 - [01_READING_ORDER.md](./01_READING_ORDER.md): recommended reading sequence for engineers and reviewers
-- [../DESIGN.md](../DESIGN.md): repo-root visual contract for the SafeQuery-owned operator shell, including surface hierarchy, spacing, typography, and interaction tone
+- [local-development.md](./local-development.md): contributor startup path for env setup, compose startup, migrations, and baseline troubleshooting
+
+### Normative Baseline
+
 - [requirements/requirements-baseline.md](./requirements/requirements-baseline.md): product and architectural requirements baseline
 - [requirements/technology-stack.md](./requirements/technology-stack.md): fixed technology stack and implementation constraints
 - [adr/ADR-0001-frontend-backend-split.md](./adr/ADR-0001-frontend-backend-split.md): frontend and backend separation
@@ -44,19 +48,26 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [adr/ADR-0007-adapter-isolation-and-schema-context-supply.md](./adr/ADR-0007-adapter-isolation-and-schema-context-supply.md): adapter isolation and context supply
 - [adr/ADR-0008-session-and-authorization-model.md](./adr/ADR-0008-session-and-authorization-model.md): session, CSRF, and authorization boundary
 - [adr/ADR-0009-dataset-exposure-and-governance.md](./adr/ADR-0009-dataset-exposure-and-governance.md): dataset exposure and governance controls
-- [adr/ADR-0010-mlflow-observability-and-evaluation-plane.md](./adr/ADR-0010-mlflow-observability-and-evaluation-plane.md): MLflow as observability, evaluation, and model-lifecycle plane
 - [design/system-context.md](./design/system-context.md): high-level system boundary and actors
 - [design/container-view.md](./design/container-view.md): major runtime containers and responsibilities
 - [design/runtime-flow.md](./design/runtime-flow.md): end-to-end request, guard, preview, and execution flow
-- [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md): operator-facing shell regions, workflow states, and screen-model contract
-- [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md): governed semantic retrieval and analyst-style orchestration
-- [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md): candidate state transitions and approval TTL
 - [design/sql-guard-spec.md](./design/sql-guard-spec.md): baseline SQL Guard behavior and deny rules
 - [design/sql-guard-deny-catalog.md](./design/sql-guard-deny-catalog.md): machine-readable deny code catalog for SQL Guard
 - [design/sql-guard-deny-corpus.md](./design/sql-guard-deny-corpus.md): representative deny scenarios required for guard testing
 - [design/audit-event-model.md](./design/audit-event-model.md): audit event taxonomy and required fields
+
+### UX Foundation
+
+- [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md): operator-facing shell regions, workflow states, and screen-model contract
+- [../DESIGN.md](../DESIGN.md): repo-root visual contract for the SafeQuery-owned operator shell, including surface hierarchy, spacing, typography, and interaction tone
+- [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md): candidate state transitions and approval TTL that UI and backend surfaces must share
+
+### Source-Aware and Evaluation Extensions
+
+- [adr/ADR-0010-mlflow-observability-and-evaluation-plane.md](./adr/ADR-0010-mlflow-observability-and-evaluation-plane.md): MLflow as observability, evaluation, and model-lifecycle plane
+- [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md): governed semantic retrieval and analyst-style orchestration
 - [design/evaluation-harness.md](./design/evaluation-harness.md): evaluation goals, datasets, and scoring
-- [security/threat-model.md](./security/threat-model.md): threat model and residual risk summary
+- [security/threat-model.md](./security/threat-model.md): threat model and residual risk summary for the current baseline and later extensions
 
 ## Documentation Intent
 

--- a/tests/smoke/test-doc-entrypoints-current-set.sh
+++ b/tests/smoke/test-doc-entrypoints-current-set.sh
@@ -20,7 +20,7 @@ docs_index_required_patterns=(
   "^### Normative Baseline$"
   "^### UX Foundation$"
   "^### Source-Aware and Evaluation Extensions$"
-  "docs/design/operator-workflow-information-architecture.md"
+  "design/operator-workflow-information-architecture.md"
   "../DESIGN.md"
   "adr/ADR-0010-mlflow-observability-and-evaluation-plane.md"
   "design/search-and-analyst-capabilities.md"

--- a/tests/smoke/test-doc-entrypoints-current-set.sh
+++ b/tests/smoke/test-doc-entrypoints-current-set.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+docs_index="docs/README.md"
+reading_order="docs/01_READING_ORDER.md"
+
+for path in "$docs_index" "$reading_order"; do
+  if [[ ! -f "$path" ]]; then
+    echo "missing required doc entrypoint: $path" >&2
+    exit 1
+  fi
+done
+
+docs_index_required_patterns=(
+  "^### Repository Entry Points$"
+  "^### Normative Baseline$"
+  "^### UX Foundation$"
+  "^### Source-Aware and Evaluation Extensions$"
+  "docs/design/operator-workflow-information-architecture.md"
+  "../DESIGN.md"
+  "adr/ADR-0010-mlflow-observability-and-evaluation-plane.md"
+  "design/search-and-analyst-capabilities.md"
+  "design/query-lifecycle-state-machine.md"
+  "design/evaluation-harness.md"
+)
+
+reading_order_required_patterns=(
+  "^### 1\\. Baseline Orientation$"
+  "^### 2\\. Architecture and Trust Decisions$"
+  "^### 3\\. UX Foundation$"
+  "^### 4\\. Source-Aware and Evaluation Extensions$"
+  "^### 5\\. Local Setup and Threat Review$"
+  "local-development.md"
+  "design/operator-workflow-information-architecture.md"
+  "../DESIGN.md"
+  "adr/ADR-0010-mlflow-observability-and-evaluation-plane.md"
+  "design/search-and-analyst-capabilities.md"
+  "design/evaluation-harness.md"
+)
+
+for pattern in "${docs_index_required_patterns[@]}"; do
+  if ! grep -Eq "$pattern" "$docs_index"; then
+    echo "$docs_index missing required entrypoint pattern: $pattern" >&2
+    exit 1
+  fi
+done
+
+for pattern in "${reading_order_required_patterns[@]}"; do
+  if ! grep -Eq "$pattern" "$reading_order"; then
+    echo "$reading_order missing required reading-order pattern: $pattern" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- regroup docs entrypoints so the repo index separates baseline, UX foundation, and source-aware extension material
- update the reading order to stage onboarding through baseline, UX foundation, and later source-aware docs
- add a focused smoke check that locks the current docs entrypoint set

## Testing
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- bash tests/smoke/test-epic-a-doc-framing.sh
- bash tests/smoke/test-operator-workflow-ia-contract.sh

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized reading guide into five labeled phases to clarify recommended sequence and progression
  * Grouped reference docs into three categorized sections, reordered entries, and improved descriptions
  * Moved design and ADR items into new phases; added local setup doc and explicit notes on shared UI/backend vocabulary and approval TTLs

* **Tests**
  * Added an automated smoke test to verify documentation entry points and reading-order contents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->