### PR TITLE
Strengthen the docs entrypoint smoke test for the full current baseline (#55)

### DIFF
--- a/tests/smoke/test-doc-entrypoints-current-set.sh
+++ b/tests/smoke/test-doc-entrypoints-current-set.sh
@@ -22,13 +22,6 @@ docs_index_required_patterns=(
   "^### Source-Aware and Evaluation Baseline$"
   "current source-aware and UX-foundation baseline"
   "current baseline for SafeQuery contributors"
-  "design/operator-workflow-information-architecture.md"
-  "../DESIGN.md"
-  "design/query-lifecycle-state-machine.md"
-  "adr/ADR-0010-mlflow-observability-and-evaluation-plane.md"
-  "design/search-and-analyst-capabilities.md"
-  "design/evaluation-harness.md"
-  "security/threat-model.md"
 )
 
 reading_order_required_patterns=(
@@ -38,13 +31,67 @@ reading_order_required_patterns=(
   "^### 4\\. Source-Aware and Evaluation Baseline$"
   "^### 5\\. Local Setup and Threat Review$"
   "current source-aware and UX-foundation baseline"
+)
+
+docs_index_required_links=(
+  "00_BRIEF_SafeQuery_docs.md"
+  "01_READING_ORDER.md"
+  "../README.md"
   "local-development.md"
+  "requirements/requirements-baseline.md"
+  "requirements/technology-stack.md"
+  "adr/ADR-0001-frontend-backend-split.md"
+  "adr/ADR-0002-auth-bridge-with-saml-2-0.md"
+  "adr/ADR-0003-sql-server-driver-strategy.md"
+  "adr/ADR-0004-postgresql-as-app-system-of-record.md"
+  "adr/ADR-0005-pluggable-sql-generation-engine.md"
+  "adr/ADR-0006-query-approval-and-execution-integrity.md"
+  "adr/ADR-0007-adapter-isolation-and-schema-context-supply.md"
+  "adr/ADR-0008-session-and-authorization-model.md"
+  "adr/ADR-0009-dataset-exposure-and-governance.md"
+  "design/system-context.md"
+  "design/container-view.md"
+  "design/runtime-flow.md"
+  "design/sql-guard-spec.md"
+  "design/sql-guard-deny-catalog.md"
+  "design/sql-guard-deny-corpus.md"
+  "design/audit-event-model.md"
   "design/operator-workflow-information-architecture.md"
   "../DESIGN.md"
   "design/query-lifecycle-state-machine.md"
   "adr/ADR-0010-mlflow-observability-and-evaluation-plane.md"
   "design/search-and-analyst-capabilities.md"
   "design/evaluation-harness.md"
+  "security/threat-model.md"
+)
+
+reading_order_required_links=(
+  "00_BRIEF_SafeQuery_docs.md"
+  "requirements/requirements-baseline.md"
+  "requirements/technology-stack.md"
+  "adr/ADR-0001-frontend-backend-split.md"
+  "adr/ADR-0002-auth-bridge-with-saml-2-0.md"
+  "adr/ADR-0003-sql-server-driver-strategy.md"
+  "adr/ADR-0004-postgresql-as-app-system-of-record.md"
+  "adr/ADR-0005-pluggable-sql-generation-engine.md"
+  "adr/ADR-0006-query-approval-and-execution-integrity.md"
+  "adr/ADR-0007-adapter-isolation-and-schema-context-supply.md"
+  "adr/ADR-0008-session-and-authorization-model.md"
+  "adr/ADR-0009-dataset-exposure-and-governance.md"
+  "design/system-context.md"
+  "design/container-view.md"
+  "design/runtime-flow.md"
+  "design/sql-guard-spec.md"
+  "design/sql-guard-deny-catalog.md"
+  "design/sql-guard-deny-corpus.md"
+  "design/audit-event-model.md"
+  "design/operator-workflow-information-architecture.md"
+  "../DESIGN.md"
+  "design/query-lifecycle-state-machine.md"
+  "adr/ADR-0010-mlflow-observability-and-evaluation-plane.md"
+  "design/search-and-analyst-capabilities.md"
+  "design/evaluation-harness.md"
+  "local-development.md"
   "security/threat-model.md"
 )
 
@@ -55,9 +102,23 @@ for pattern in "${docs_index_required_patterns[@]}"; do
   fi
 done
 
+for link in "${docs_index_required_links[@]}"; do
+  if ! grep -Fq "$link" "$docs_index"; then
+    echo "$docs_index missing required entrypoint link: $link" >&2
+    exit 1
+  fi
+done
+
 for pattern in "${reading_order_required_patterns[@]}"; do
   if ! grep -Eq "$pattern" "$reading_order"; then
     echo "$reading_order missing required reading-order pattern: $pattern" >&2
+    exit 1
+  fi
+done
+
+for link in "${reading_order_required_links[@]}"; do
+  if ! grep -Fq "$link" "$reading_order"; then
+    echo "$reading_order missing required reading-order link: $link" >&2
     exit 1
   fi
 done

--- a/tests/smoke/test-doc-entrypoints-current-set.sh
+++ b/tests/smoke/test-doc-entrypoints-current-set.sh
@@ -95,6 +95,34 @@ reading_order_required_links=(
   "security/threat-model.md"
 )
 
+require_markdown_link_target() {
+  local file="$1"
+  local link="$2"
+
+  if awk -v link="$link" '
+    /^[[:space:]]*(```|~~~)/ { in_fence = !in_fence; next }
+    in_fence { next }
+    index($0, "](" link ")") ||
+    index($0, "](./" link ")") ||
+    index($0, "](" link "#") ||
+    index($0, "](./" link "#") ||
+    index($0, "](" link "?") ||
+    index($0, "](./" link "?") ||
+    index($0, "<" link ">") ||
+    index($0, "<./" link ">") ||
+    index($0, "<" link "#") ||
+    index($0, "<./" link "#") ||
+    index($0, "<" link "?") ||
+    index($0, "<./" link "?") { found = 1; exit }
+    END { exit(found ? 0 : 1) }
+  ' "$file"; then
+    return 0
+  fi
+
+  echo "$file missing required markdown link target: $link" >&2
+  exit 1
+}
+
 for pattern in "${docs_index_required_patterns[@]}"; do
   if ! grep -Eq "$pattern" "$docs_index"; then
     echo "$docs_index missing required entrypoint pattern: $pattern" >&2
@@ -103,10 +131,7 @@ for pattern in "${docs_index_required_patterns[@]}"; do
 done
 
 for link in "${docs_index_required_links[@]}"; do
-  if ! grep -Fq "$link" "$docs_index"; then
-    echo "$docs_index missing required entrypoint link: $link" >&2
-    exit 1
-  fi
+  require_markdown_link_target "$docs_index" "$link"
 done
 
 for pattern in "${reading_order_required_patterns[@]}"; do
@@ -117,8 +142,5 @@ for pattern in "${reading_order_required_patterns[@]}"; do
 done
 
 for link in "${reading_order_required_links[@]}"; do
-  if ! grep -Fq "$link" "$reading_order"; then
-    echo "$reading_order missing required reading-order link: $link" >&2
-    exit 1
-  fi
+  require_markdown_link_target "$reading_order" "$link"
 done


### PR DESCRIPTION
Closes #55
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened [tests/smoke/test-doc-entrypoints-current-set.sh](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-55/tests/smoke/test-doc-entrypoints-current-set.sh:1) so it now enforces the full current docs entrypoint baseline instead of the older reduced subset. The updated contract checks stable section headings plus explicit link targets for the current normative ADR and design set, including `ADR-0009`, `system-context`, `container-view`, `runtime-flow`, `sql-guard-spec`, the deny docs, and `audit-event-model`. I kept the assertions focused on entrypoint completeness rather than Markdown formatting details.

I also reproduced the original gap before changing it: the old smoke test passed while those newer baseline docs were not part of its required set. There are no roadmap docs in the current repo baseline, so I anchored the stricter test to the authoritative live entrypoint files instead. The change is committed as `0463959` (`test: strengthen docs entrypoint smoke baseline`). The supervisor journal was updated locally as requested, but `.codex-supervisor` is gitignored so that note is not part of the commit.

Summary: Strengthened the docs entrypoint smoke test to require the full current baseline surfaced by `docs/README.md` and `docs/01_READING_ORDER.md`; committed as `0463959`.
State hint: implementing
Blocked reason: none
Tests: `bash tests/smoke/test-doc-entrypoints-current-set.sh`
Failure signature: none
Next action: Open a draft PR for commit `0463959` or ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved documentation-entry validation: replaced broad pattern checks with exact link-presence checks in the docs index and reading-order files.
  * New verification skips code blocks and explicitly reports any missing required doc links, failing the check when targets are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->