### PR TITLE
docs: complete docs entrypoint baseline coverage

### DIFF
--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -66,11 +66,28 @@ This reading order is intended to help new contributors understand SafeQuery fro
 25. [design/evaluation-harness.md](./design/evaluation-harness.md)
     Use this to understand how NL2SQL quality should be measured safely in the current source-aware baseline.
 
-### 5. Local Setup and Threat Review
+### 5. Approved Follow-on Direction
 
-26. [local-development.md](./local-development.md)
+26. [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md)
+    Read first in this section to understand how SafeQuery expands beyond one hard-coded business source while keeping request, candidate, and execution paths single-source.
+27. [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md)
+    Review how source families, flavors, connector profiles, and guard profiles are separated so future onboarding does not redesign the control plane.
+28. [design/target-source-registry.md](./design/target-source-registry.md)
+    Use this to understand the concrete registry model, source lifecycle expectations, and application PostgreSQL separation guardrails.
+29. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
+    Review the family and flavor rollout matrix before planning connector, guard, or evaluation work for additional sources.
+30. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
+    Read this to understand why the product shell is workflow-first and why the Epic A shell remains a developer state demo.
+31. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
+    Review how SafeQuery may borrow OSS ergonomics without turning the product into a generic chat shell or moving trust boundaries.
+32. [implementation-roadmap.md](./implementation-roadmap.md)
+    Finish this section with the current implementation sequence so roadmap work stays aligned with the reviewed docs direction.
+
+### 6. Local Setup and Threat Review
+
+33. [local-development.md](./local-development.md)
     Use this once the document set is clear so local startup follows the reviewed topology and role split.
-27. [security/threat-model.md](./security/threat-model.md)
+34. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks for the current source-aware and UX-foundation baseline before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,16 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [design/evaluation-harness.md](./design/evaluation-harness.md): evaluation goals, datasets, and scoring for the current baseline
 - [security/threat-model.md](./security/threat-model.md): threat model and residual risk summary for the current source-aware and UX-foundation baseline
 
+### Approved Follow-on Direction
+
+- [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md): approved registry and single-source execution direction for multi-source expansion
+- [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md): approved source-family, flavor, and profile strategy for follow-on dialect support
+- [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md): approved product-shell direction that reclassifies Epic A as a state demo and the workflow shell as the product contract
+- [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md): UI stack and OSS adoption boundaries for the SafeQuery-owned operator shell
+- [design/target-source-registry.md](./design/target-source-registry.md): backend-owned registry model, activation semantics, and secret indirection expectations
+- [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md): compact family and flavor rollout matrix for connector, guard, and evaluation planning
+- [implementation-roadmap.md](./implementation-roadmap.md): current implementation sequence after Epic A, Epic A follow-up, and UX-1
+
 ## Documentation Intent
 
 These docs should be used as the current baseline for SafeQuery contributors:
@@ -81,3 +91,5 @@ These docs should be used as the current baseline for SafeQuery contributors:
 - implementation planning
 
 They should not be interpreted as final production deployment guidance. The current set is intentionally optimized for a safe first-phase PoC while still defining the current source-aware and UX-foundation baseline.
+
+The approved follow-on ADRs, design notes, and implementation roadmap extend that baseline direction without moving trust, execution, or audit authority outside the application.

--- a/docs/adr/ADR-0011-target-source-registry-and-single-source-execution-model.md
+++ b/docs/adr/ADR-0011-target-source-registry-and-single-source-execution-model.md
@@ -59,6 +59,8 @@ The registry is the authoritative place where the trusted backend resolves sourc
 - schema snapshot linkage
 - source activation state
 
+In this ADR, `source_id` means the stable backend-owned registry key for a registered source, not a display label, transient status field, or other derived identifier.
+
 SafeQuery will use a single-source execution model.
 
 In that model:

--- a/docs/adr/ADR-0011-target-source-registry-and-single-source-execution-model.md
+++ b/docs/adr/ADR-0011-target-source-registry-and-single-source-execution-model.md
@@ -1,0 +1,98 @@
+# ADR-0011: Target Source Registry and Single-Source Execution Model
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-21
+
+## Owner
+
+SafeQuery architecture
+
+## Decision Drivers
+
+- extend SafeQuery beyond one hard-coded business source without moving the trusted control boundary
+- preserve preview-before-execute and candidate-based execution integrity while multiple business sources are introduced
+- prevent cross-source ambiguity, auto-routing drift, and federated-query scope creep in the first expansion step
+
+## Supersedes
+
+None
+
+## Related Docs
+
+- [../requirements/requirements-baseline.md](../requirements/requirements-baseline.md)
+- [../design/runtime-flow.md](../design/runtime-flow.md)
+- [../design/query-lifecycle-state-machine.md](../design/query-lifecycle-state-machine.md)
+- [../design/target-source-registry.md](../design/target-source-registry.md)
+- [./ADR-0006-query-approval-and-execution-integrity.md](./ADR-0006-query-approval-and-execution-integrity.md)
+
+## Context
+
+The current SafeQuery baseline executes approved read-only SQL against a constrained business data source through an application-owned control path.
+
+Follow-on work expands that posture so the product can support more than one approved business source family without changing the core trust model. That expansion must not weaken:
+
+- application-owned authorization and execution control
+- preview-before-execute
+- candidate-only execution
+- replay protection
+- audit reconstruction
+
+The expansion also must not encourage cross-source execution before the application has explicit source-aware governance, guard, and execution controls.
+
+## Decision
+
+SafeQuery will introduce an application-owned target source registry.
+
+The registry is the authoritative place where the trusted backend resolves source metadata such as:
+
+- `source_id`
+- source family
+- optional source flavor
+- connector profile
+- dialect profile
+- dataset contract linkage
+- schema snapshot linkage
+- source activation state
+
+SafeQuery will use a single-source execution model.
+
+In that model:
+
+- every SQL-backed request binds to exactly one `source_id`
+- every stored candidate remains valid only for the `source_id` recorded with that candidate
+- every execution attempt uses the `source_id` already bound to the candidate
+- execution does not re-select a source at execute time
+
+Phase 1 source selection must be explicit and application-owned.
+
+The initial expansion does not allow:
+
+- cross-source joins
+- federated queries
+- fan-out execution across multiple sources
+- implicit source auto-routing
+
+## Consequences
+
+Positive outcomes:
+
+- multiple business sources can be onboarded without redesigning candidate integrity
+- the operator can understand and verify source identity before preview and execution
+- audit, evaluation, and policy checks can reason about one authoritative `source_id` per request path
+
+Tradeoffs:
+
+- the application must own source registration and lifecycle management
+- source-aware authorization, schema supply, and invalidation logic become required follow-on work
+- new source families must be onboarded deliberately instead of being inferred from the adapter
+
+## Rejected Alternatives
+
+- treating source selection as an adapter concern
+- allowing execute-time source switching after preview
+- supporting federated or auto-routed execution in the first expansion phase

--- a/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
+++ b/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
@@ -1,0 +1,95 @@
+# ADR-0012: Multi-Dialect Connector and Guard Profile Strategy
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-21
+
+## Owner
+
+SafeQuery architecture
+
+## Decision Drivers
+
+- expand beyond a single SQL dialect without redesigning the trusted control plane
+- keep SQL Guard fail-closed while multiple business source families are introduced
+- separate product-level source support from per-family connector and dialect implementation details
+
+## Supersedes
+
+None
+
+## Related Docs
+
+- [../requirements/technology-stack.md](../requirements/technology-stack.md)
+- [../design/sql-guard-spec.md](../design/sql-guard-spec.md)
+- [../design/dialect-capability-matrix.md](../design/dialect-capability-matrix.md)
+- [./ADR-0011-target-source-registry-and-single-source-execution-model.md](./ADR-0011-target-source-registry-and-single-source-execution-model.md)
+
+## Context
+
+SafeQuery started from a SQL Server-first baseline. Follow-on product scope now needs a structured way to add more business source families without turning connector logic, canonicalization rules, and guard behavior into one large special case.
+
+The application must stay responsible for:
+
+- source registration
+- connector selection
+- dialect-aware canonicalization
+- guard profile selection
+- execution policy enforcement
+
+## Decision
+
+SafeQuery will distinguish between source family and source flavor.
+
+Source families define the primary dialect and control behavior. The approved families for follow-on planning are:
+
+- `mssql`
+- `postgresql`
+- `mysql`
+- `mariadb`
+- `oracle`
+
+Source flavors refine deployment or connector posture without becoming a new top-level family. The initial approved examples are:
+
+- `aurora-postgresql`
+- `aurora-mysql`
+
+Each registered source uses:
+
+- a connector profile chosen by the trusted backend
+- a dialect profile used for canonicalization and guard behavior
+
+The connector profile defines how the application reaches the source safely.
+
+The dialect profile defines:
+
+- canonicalization expectations
+- row-bounding strategy
+- guard parsing and deny behavior
+- timeout and cancellation posture
+
+Future onboarding must happen by adding or approving profiles, not by redesigning the core SafeQuery control plane.
+
+## Consequences
+
+Positive outcomes:
+
+- future family onboarding becomes explicit and reviewable
+- connector behavior and guard behavior can evolve separately
+- Aurora and similar variants stay modeled as flavors instead of creating needless top-level families
+
+Tradeoffs:
+
+- SafeQuery must maintain profile metadata and rollout state
+- guard and evaluation coverage must expand with every new family
+- profile drift becomes an operational concern that must be audited and invalidated safely
+
+## Rejected Alternatives
+
+- one hard-coded driver and guard implementation for every source
+- treating Aurora as a separate SQL family
+- allowing the adapter to infer dialect support independently from backend policy

--- a/docs/adr/ADR-0013-operator-workflow-and-ui-foundation.md
+++ b/docs/adr/ADR-0013-operator-workflow-and-ui-foundation.md
@@ -1,0 +1,79 @@
+# ADR-0013: Operator Workflow and UI Foundation
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-21
+
+## Owner
+
+SafeQuery product and architecture
+
+## Decision Drivers
+
+- the Epic A shell is useful as a state demo but not strong enough as the product-facing operator workflow
+- SafeQuery needs an operator-first shell that reinforces trust, source identity, preview, guard review, and results inspection
+- the product must avoid drifting into a generic chat transcript that hides control boundaries
+
+## Supersedes
+
+None
+
+## Related Docs
+
+- [../design/operator-workflow-information-architecture.md](../design/operator-workflow-information-architecture.md)
+- [../../DESIGN.md](../../DESIGN.md)
+- [./ADR-0006-query-approval-and-execution-integrity.md](./ADR-0006-query-approval-and-execution-integrity.md)
+
+## Context
+
+The repository currently contains an Epic A shell that demonstrates high-level states and backend posture. That shell should not be mistaken for the long-term product information architecture.
+
+SafeQuery requires a workflow-first operator UI that keeps the governed request path visible:
+
+- request composition
+- source identity
+- SQL preview
+- guard outcome
+- result inspection
+
+## Decision
+
+SafeQuery will treat the product shell as an operator workflow, not a generic chat experience.
+
+The UI foundation must preserve these invariants:
+
+- the core shell remains application-owned
+- the shell makes source identity visible before and after preview
+- previewed SQL remains visibly separate from results
+- guard posture remains visible and cannot be hidden behind chat-like transcript flow
+- history behaves as navigation memory for requests, candidates, and runs rather than as a message log
+
+The Epic A shell remains a developer-facing state demo until the operator workflow contract is fully implemented.
+
+The normative workflow and screen contract lives in:
+
+- `docs/design/operator-workflow-information-architecture.md`
+- `DESIGN.md`
+
+## Consequences
+
+Positive outcomes:
+
+- the product UI stays aligned with SafeQuery's trusted control posture
+- future contributors have a stable workflow contract instead of inferring behavior from a demo shell
+- source-aware UX can be added without making execution semantics ambiguous
+
+Tradeoffs:
+
+- more UI planning is required before deep feature integration
+- chat-product ergonomics can be borrowed selectively, but the product shell cannot simply become a chat clone
+
+## Rejected Alternatives
+
+- treating the Epic A shell as the production information architecture
+- collapsing the operator workflow into a transcript-first chat layout
+- moving preview, guard, or source identity into optional secondary surfaces by default

--- a/docs/adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md
+++ b/docs/adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md
@@ -1,0 +1,78 @@
+# ADR-0014: UI Implementation Stack and OSS Adoption Boundaries
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-21
+
+## Owner
+
+SafeQuery product and frontend architecture
+
+## Decision Drivers
+
+- improve usability by borrowing proven interaction patterns without surrendering the SafeQuery shell to an external product model
+- keep the frontend aligned with FastAPI as the only trusted execution backend
+- avoid monolithic chat UI adoption that would blur workflow, source, and preview semantics
+
+## Supersedes
+
+None
+
+## Related Docs
+
+- [../requirements/technology-stack.md](../requirements/technology-stack.md)
+- [../design/operator-workflow-information-architecture.md](../design/operator-workflow-information-architecture.md)
+- [../../DESIGN.md](../../DESIGN.md)
+- [./ADR-0013-operator-workflow-and-ui-foundation.md](./ADR-0013-operator-workflow-and-ui-foundation.md)
+
+## Context
+
+SafeQuery needs a modern operator UI. Generic chat products and low-code shells offer useful interaction ideas, but they also carry assumptions that conflict with SafeQuery:
+
+- transcript-first navigation
+- assistant-centric framing
+- hidden source identity
+- backend shortcuts that bypass the trusted execution path
+
+## Decision
+
+SafeQuery will keep a custom Next.js UI as the primary product shell.
+
+The project may selectively adopt open-source UI primitives and ergonomic patterns when they support the SafeQuery workflow contract, especially for:
+
+- layout primitives
+- message-composer ergonomics adapted into a governed request composer
+- history navigation patterns
+- accessible dialog, drawer, and panel components
+
+The project will not adopt a monolithic chat UI or low-code shell as the SafeQuery product surface if doing so would:
+
+- weaken preview-before-execute
+- obscure source identity
+- bypass FastAPI as the trusted backend
+- make request, candidate, and run history indistinguishable
+
+Open-source UI building blocks are permitted. SafeQuery's operator shell, API contract, and governance semantics remain application-owned.
+
+## Consequences
+
+Positive outcomes:
+
+- the team can reuse mature UI building blocks without inheriting the wrong product model
+- SafeQuery keeps a stable workflow-first shell while still improving ergonomics
+- backend trust boundaries remain intact
+
+Tradeoffs:
+
+- more integration work remains on the application team
+- borrowed patterns must be adapted carefully rather than copied wholesale
+
+## Rejected Alternatives
+
+- adopting a full chat product shell as the SafeQuery primary UI
+- using a low-code admin surface as the main operator workflow
+- letting frontend convenience features redefine the core request, preview, or execution model

--- a/docs/design/dialect-capability-matrix.md
+++ b/docs/design/dialect-capability-matrix.md
@@ -1,0 +1,25 @@
+# Dialect Capability Matrix
+
+## Purpose
+
+This matrix records the follow-on source-family rollout posture without implying that every listed family is already implemented.
+
+It is a planning and review aid for connector, guard, and evaluation work.
+
+## Matrix
+
+| Family or Flavor | Generation Profile | Canonicalization Strategy | Guard Profile | Row-Bounding Strategy | Timeout and Cancellation Posture | Connector Profile | Evaluation Expectation | Rollout Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `mssql` | SQL Server-focused prompt and schema context | T-SQL canonicalization before guard and preview | T-SQL fail-closed guard profile | bounded canonical SQL before preview | timeout and cancellation required | initial read-only SQL Server connector | positive and deny corpus required | active baseline |
+| `postgresql` | PostgreSQL-focused prompt and schema context | PostgreSQL canonicalization before guard and preview | PostgreSQL fail-closed guard profile | bounded canonical SQL before preview | timeout and cancellation required | business PostgreSQL connector separate from app PostgreSQL | positive and deny corpus required | approved follow-on |
+| `mysql` | MySQL family profile | profile-specific canonicalization | MySQL family guard profile | to be defined by profile approval | to be defined by profile approval | future connector profile | future onboarding corpus required | planned |
+| `mariadb` | MariaDB delta or sibling profile to MySQL | profile-specific canonicalization | MariaDB guard profile | to be defined by profile approval | to be defined by profile approval | future connector profile | future onboarding corpus required | planned after MySQL |
+| `aurora-postgresql` | inherits PostgreSQL generation posture with flavor overrides | PostgreSQL family canonicalization plus flavor notes | PostgreSQL family guard profile with flavor notes | follows PostgreSQL family unless overridden | follows PostgreSQL family unless overridden | Aurora flavor connector profile | PostgreSQL suite plus flavor regressions | planned flavor |
+| `aurora-mysql` | inherits MySQL family generation posture with flavor overrides | MySQL family canonicalization plus flavor notes | MySQL family guard profile with flavor notes | follows MySQL family unless overridden | follows MySQL family unless overridden | Aurora flavor connector profile | MySQL suite plus flavor regressions | planned flavor |
+| `oracle` | Oracle-focused generation profile | Oracle-specific canonicalization | Oracle fail-closed guard profile | to be defined by profile approval | to be defined by profile approval | future connector profile | future onboarding corpus required | long-range planned |
+
+## Usage Notes
+
+- A family or flavor does not become implementation-ready just because it appears in this matrix.
+- Every new family or flavor still requires approved connector, guard, governance, and evaluation work.
+- The matrix complements the target source registry. It does not replace per-source registry records.

--- a/docs/design/dialect-capability-matrix.md
+++ b/docs/design/dialect-capability-matrix.md
@@ -21,5 +21,5 @@ It is a planning and review aid for connector, guard, and evaluation work.
 ## Usage Notes
 
 - A family or flavor does not become implementation-ready just because it appears in this matrix.
-- Every new family or flavor still requires approved connector, guard, governance, and evaluation work.
+- Every new family or flavor still requires approval of connector, guard, governance, and evaluation work.
 - The matrix complements the target source registry. It does not replace per-source registry records.

--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -1,0 +1,97 @@
+# Target Source Registry
+
+## Purpose
+
+This document defines the application-owned target source registry used by SafeQuery follow-on work to introduce multiple business sources without changing the trusted control boundary.
+
+## Registry Role
+
+The registry is the trusted backend's authoritative inventory of business sources that SafeQuery may target.
+
+It exists to answer these questions safely:
+
+- which `source_id` values are valid
+- which source family and optional source flavor each source uses
+- which connector profile and dialect profile apply
+- which dataset contract and schema snapshot are active
+- whether the source is healthy, paused, or blocked for execution
+
+The registry does not give the adapter direct execution authority.
+
+## Minimum Registry Fields
+
+Each source record should include at least:
+
+- `source_id`
+- source family
+- optional source flavor
+- connector profile identifier
+- dialect profile identifier
+- dataset contract version or reference
+- schema snapshot version or reference
+- execution policy version or reference
+- activation state
+- secret or connection indirection reference owned by the backend
+- operator-facing display label
+
+## Capability Flags
+
+The registry may also carry capability flags such as:
+
+- supports preview and execution
+- supports cancellation
+- supports row-bounding rewrite
+- supports governed search evidence labeling
+- supports analyst-style executed evidence labeling
+
+Capability flags are advisory backend configuration, not a substitute for execution-time checks.
+
+## Secrets and Connection Indirection
+
+The registry must never expose raw business-source credentials to the adapter or frontend.
+
+The registry points to backend-owned secret material indirectly, for example through:
+
+- secret names
+- vault keys
+- environment-backed secret handles
+
+The trusted backend resolves those references only for execution or health-check code paths that are already authorized to use them.
+
+## Activation and Deactivation
+
+The registry should support at least these source states:
+
+- active
+- paused
+- blocked
+- retired
+
+When a source changes to a non-executable state, SafeQuery should treat previously stored candidates for that source as stale and either:
+
+- invalidate them proactively
+- deny execution with an explicit stale-policy or invalidation outcome
+
+## Health Checks
+
+Registry-aware health checks should verify the backend can still resolve:
+
+- connector profile
+- dialect profile
+- secret indirection
+- dataset contract reference
+- schema snapshot reference
+
+Health checks should not expand into unrestricted schema crawling or adapter-owned introspection.
+
+## Application PostgreSQL Separation
+
+Application PostgreSQL is not implicitly a registered business source.
+
+If business PostgreSQL support is added, it must appear as an explicit business `source_id` with:
+
+- separate connection identity
+- separate connector profile
+- separate policy and dataset contract
+
+This prevents the application system of record from becoming a default execution target by accident.

--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -14,7 +14,7 @@ It exists to answer these questions safely:
 - which source family and optional source flavor each source uses
 - which connector profile and dialect profile apply
 - which dataset contract and schema snapshot are active
-- whether the source is healthy, paused, or blocked for execution
+- whether the source is active, paused, or blocked for execution
 
 The registry does not give the adapter direct execution authority.
 
@@ -94,4 +94,4 @@ If business PostgreSQL support is added, it must appear as an explicit business 
 - separate connector profile
 - separate policy and dataset contract
 
-This prevents the application system of record from becoming a default execution target by accident.
+This prevents the application system of record from becoming a default execution target inadvertently.

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -1,0 +1,84 @@
+# SafeQuery Implementation Roadmap
+
+## Purpose
+
+This roadmap summarizes the current implementation sequence after Epic A and its first documentation and UX follow-up work.
+
+It records approved direction for the next implementation steps without treating optional extensions as prerequisites for the core SafeQuery control path.
+
+## Current State
+
+- Epic A established the initial repository shell, local dev baseline, and first end-to-end project framing.
+- Epic A follow-up work hardened docs, repository hygiene, CI checks, and source-aware planning foundations.
+- UX-1 established the operator-workflow information architecture and UI-foundation contract so the product shell can move beyond the Epic A state demo.
+
+## Next Core Track
+
+### 1. Multi-source foundation hardening
+
+Focus areas:
+
+- introduce the target source registry
+- separate application PostgreSQL from any future business PostgreSQL source path
+- define distinct secret names and connection identities for application PostgreSQL, business PostgreSQL, and SQL Server
+- add source-aware smoke checks and telemetry
+- add safeguards that prevent accidental execution against application PostgreSQL
+
+### 2. Operator shell implementation against the UX-1 contract
+
+Focus areas:
+
+- replace the Epic A state demo with a workflow-first operator shell
+- implement left-rail history for request, candidate, and run navigation
+- implement explicit source visibility and source-selector lifecycle semantics
+- implement stable preview, guard, and result panel contracts
+- keep attachments out of the MVP unless separately approved
+
+### 3. Source-aware core control path
+
+Focus areas:
+
+- make request, candidate, and execution records source-aware
+- add source-aware entitlement checks and invalidation behavior
+- add per-source dataset contracts and schema snapshot handling
+- make adapter requests source-scoped and registry-driven
+- keep single-source execution as a hard invariant
+
+### 4. Connector and guard rollout
+
+Focus areas:
+
+- keep the SQL Server connector as the first active business-source connector
+- add PostgreSQL business-source connector work on a separate path from application PostgreSQL persistence
+- add dialect-aware canonicalization and guard profiles
+- extend deny corpus and evaluation coverage per source family
+
+### 5. Core vertical slice completion
+
+Focus areas:
+
+- complete preview-before-execute for the active source-aware path
+- complete source-aware audit and evaluation
+- complete result controls, kill switch behavior, and replay-safe execution handling
+- ship a core vertical slice that stays application-owned from request to execution
+
+## Optional Extension Tracks
+
+These tracks remain optional and may begin only after the source-aware core path is stable enough for their dependencies:
+
+- governed search
+- analyst-style orchestration
+- MLflow-backed engineering observability and evaluation support
+
+If an optional track is enabled, its governance, audit, and evaluation requirements become mandatory for that deployment.
+
+## Later Family Expansion
+
+After the two-source core path is stable:
+
+1. onboard `mysql`
+2. evaluate `mariadb` as a sibling or delta profile
+3. add Aurora as source flavors on top of PostgreSQL or MySQL families
+4. onboard `oracle` last
+
+Each later family must be added through source-registry onboarding plus connector, guard, and evaluation profile work rather than through a trusted-control-plane redesign.

--- a/tests/smoke/test-doc-entrypoints-current-set.sh
+++ b/tests/smoke/test-doc-entrypoints-current-set.sh
@@ -20,6 +20,7 @@ docs_index_required_patterns=(
   "^### Normative Baseline$"
   "^### UX Foundation$"
   "^### Source-Aware and Evaluation Baseline$"
+  "^### Approved Follow-on Direction$"
   "current source-aware and UX-foundation baseline"
   "current baseline for SafeQuery contributors"
 )
@@ -29,7 +30,8 @@ reading_order_required_patterns=(
   "^### 2\\. Architecture and Trust Decisions$"
   "^### 3\\. UX Foundation$"
   "^### 4\\. Source-Aware and Evaluation Baseline$"
-  "^### 5\\. Local Setup and Threat Review$"
+  "^### 5\\. Approved Follow-on Direction$"
+  "^### 6\\. Local Setup and Threat Review$"
   "current source-aware and UX-foundation baseline"
 )
 
@@ -63,6 +65,13 @@ docs_index_required_links=(
   "design/search-and-analyst-capabilities.md"
   "design/evaluation-harness.md"
   "security/threat-model.md"
+  "adr/ADR-0011-target-source-registry-and-single-source-execution-model.md"
+  "adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md"
+  "adr/ADR-0013-operator-workflow-and-ui-foundation.md"
+  "adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md"
+  "design/target-source-registry.md"
+  "design/dialect-capability-matrix.md"
+  "implementation-roadmap.md"
 )
 
 reading_order_required_links=(
@@ -91,6 +100,13 @@ reading_order_required_links=(
   "adr/ADR-0010-mlflow-observability-and-evaluation-plane.md"
   "design/search-and-analyst-capabilities.md"
   "design/evaluation-harness.md"
+  "adr/ADR-0011-target-source-registry-and-single-source-execution-model.md"
+  "adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md"
+  "design/target-source-registry.md"
+  "design/dialect-capability-matrix.md"
+  "adr/ADR-0013-operator-workflow-and-ui-foundation.md"
+  "adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md"
+  "implementation-roadmap.md"
   "local-development.md"
   "security/threat-model.md"
 )


### PR DESCRIPTION
## Summary
- add the missing follow-on ADR, design, and roadmap docs that the docs entrypoints were expected to surface
- update docs/README.md and docs/01_READING_ORDER.md so they point at the full current reviewed set
- strengthen the docs entrypoint smoke test so it guards the same complete set

## Verification
- bash tests/smoke/test-doc-entrypoints-current-set.sh

## Context
This closes the two follow-up findings against #54 and #55 by aligning the entrypoint docs, the referenced doc set, and the smoke-test guardrail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized reading order with a new "Approved Follow-on Direction" section and renumbered local setup/threat review
  * Added approved follow-on ADRs covering target source registry, single-source execution, multi-dialect connector/guard profiles, operator workflow/UI foundation, and UI adoption boundaries
  * Added design docs for target-source registry, dialect capability matrix, and an implementation roadmap with phased tracks

* **Tests**
  * Updated documentation validation tests to require the new section and linked documents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->