### PR TITLE
Implement source registry persistence model

### DIFF
--- a/backend/alembic/versions/0002_source_registry_scaffold.py
+++ b/backend/alembic/versions/0002_source_registry_scaffold.py
@@ -21,7 +21,8 @@ def upgrade() -> None:
     op.create_table(
         "registered_sources",
         sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("source_identity", sa.String(length=255), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("display_label", sa.String(length=255), nullable=False),
         sa.Column("source_family", sa.String(length=64), nullable=False),
         sa.Column("source_flavor", sa.String(length=64), nullable=True),
         sa.Column("activation_posture", sa.String(length=32), nullable=False),
@@ -29,6 +30,8 @@ def upgrade() -> None:
         sa.Column("dialect_profile_id", sa.Uuid(), nullable=True),
         sa.Column("dataset_contract_id", sa.Uuid(), nullable=True),
         sa.Column("schema_snapshot_id", sa.Uuid(), nullable=True),
+        sa.Column("execution_policy_id", sa.Uuid(), nullable=True),
+        sa.Column("connection_reference", sa.String(length=255), nullable=False),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -43,8 +46,8 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_registered_sources")),
         sa.UniqueConstraint(
-            "source_identity",
-            name=op.f("uq_registered_sources_source_identity"),
+            "source_id",
+            name=op.f("uq_registered_sources_source_id"),
         ),
     )
 

--- a/backend/app/db/models/source_registry.py
+++ b/backend/app/db/models/source_registry.py
@@ -14,7 +14,7 @@ from app.db.base import Base
 class RegisteredSource(Base):
     __tablename__ = "registered_sources"
     __table_args__ = (
-        UniqueConstraint("source_identity"),
+        UniqueConstraint("source_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -22,7 +22,8 @@ class RegisteredSource(Base):
         primary_key=True,
         default=uuid.uuid4,
     )
-    source_identity: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    display_label: Mapped[str] = mapped_column(String(255), nullable=False)
     source_family: Mapped[str] = mapped_column(String(64), nullable=False)
     source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     activation_posture: Mapped[str] = mapped_column(String(32), nullable=False)
@@ -41,6 +42,14 @@ class RegisteredSource(Base):
     schema_snapshot_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         SqlAlchemyUuid,
         nullable=True,
+    )
+    execution_policy_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        SqlAlchemyUuid,
+        nullable=True,
+    )
+    connection_reference: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/tests/test_source_registry_models.py
+++ b/backend/tests/test_source_registry_models.py
@@ -10,7 +10,8 @@ def test_registered_source_scaffold_matches_minimum_shape() -> None:
 
     assert set(table.columns.keys()) == {
         "id",
-        "source_identity",
+        "source_id",
+        "display_label",
         "source_family",
         "source_flavor",
         "activation_posture",
@@ -18,11 +19,14 @@ def test_registered_source_scaffold_matches_minimum_shape() -> None:
         "dialect_profile_id",
         "dataset_contract_id",
         "schema_snapshot_id",
+        "execution_policy_id",
+        "connection_reference",
         "created_at",
         "updated_at",
     }
 
-    assert table.c.source_identity.nullable is False
+    assert table.c.source_id.nullable is False
+    assert table.c.display_label.nullable is False
     assert table.c.source_family.nullable is False
     assert table.c.source_flavor.nullable is True
     assert table.c.activation_posture.nullable is False
@@ -30,6 +34,8 @@ def test_registered_source_scaffold_matches_minimum_shape() -> None:
     assert table.c.dialect_profile_id.nullable is True
     assert table.c.dataset_contract_id.nullable is True
     assert table.c.schema_snapshot_id.nullable is True
+    assert table.c.execution_policy_id.nullable is True
+    assert table.c.connection_reference.nullable is False
     assert table.c.created_at.onupdate is None
     assert table.c.updated_at.onupdate is not None
 
@@ -39,4 +45,4 @@ def test_registered_source_scaffold_matches_minimum_shape() -> None:
         if isinstance(constraint, UniqueConstraint)
     }
 
-    assert ("source_identity",) in unique_constraints
+    assert ("source_id",) in unique_constraints


### PR DESCRIPTION
## Summary
- align the registered source model with the reviewed registry baseline
- use authoritative `source_id` naming and add display, execution-policy, and connection-indirection placeholders
- tighten the focused registry model test and verify the Alembic upgrade path

## Testing
- cd backend && python3 -m pytest tests/test_source_registry_models.py tests/test_source_foundation_smoke.py tests/test_application_postgres_guard.py
- DOCKER_HOST="unix://$HOME/.colima/default/docker.sock" DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend alembic upgrade head
- DOCKER_HOST="unix://$HOME/.colima/default/docker.sock" docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend alembic current

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured source registry database schema to support enhanced metadata including display labels, connection references, and execution policy associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->