### PR TITLE
[B-3] Require explicit source selection during request submission (#62)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from time import perf_counter
 from uuid import uuid4
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -18,6 +18,12 @@ from app.core.errors import (
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
 from app.services.health import check_database_health
+from app.services.request_preview import (
+    PreviewSubmissionContractError,
+    PreviewSubmissionRequest,
+    PreviewSubmissionResponse,
+    submit_preview_request,
+)
 
 configure_logging()
 
@@ -69,7 +75,7 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=settings.cors_origins_list,
         allow_credentials=False,
-        allow_methods=["GET"],
+        allow_methods=["GET", "POST"],
         allow_headers=["*"],
     )
 
@@ -145,6 +151,15 @@ def create_app() -> FastAPI:
                 "database": database,
             },
         )
+
+    @app.post("/requests/preview", response_model=PreviewSubmissionResponse)
+    def create_request_preview(
+        payload: PreviewSubmissionRequest,
+    ) -> PreviewSubmissionResponse:
+        try:
+            return submit_preview_request(payload)
+        except PreviewSubmissionContractError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     return app
 

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -83,6 +83,10 @@ def submit_preview_request(
         resolved_source = ensure_source_is_executable(source)
     except SourceRegistryPostureError as exc:
         raise PreviewSubmissionContractError(str(exc)) from exc
+    except ValueError as exc:
+        raise PreviewSubmissionContractError(
+            f"Registered source '{payload.source_id}' has an invalid activation posture."
+        ) from exc
 
     return PreviewSubmissionResponse(
         request={

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,0 +1,97 @@
+from uuid import NAMESPACE_URL, uuid5
+
+from pydantic import BaseModel, ConfigDict, StringConstraints
+from typing_extensions import Annotated
+from typing import Optional
+
+from app.db.models.source_registry import RegisteredSource
+from app.services.source_registry import (
+    SourceRegistryPostureError,
+    ensure_source_is_executable,
+)
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class PreviewSubmissionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    question: NonEmptyTrimmedString
+    source_id: NonEmptyTrimmedString
+
+
+class PreviewSubmissionResponse(BaseModel):
+    request: dict[str, str]
+    candidate: dict[str, str]
+
+
+def _phase1_registered_source(
+    *,
+    source_id: str,
+    display_label: str,
+    activation_posture: str,
+    source_family: str = "postgresql",
+    source_flavor: Optional[str] = None,
+) -> RegisteredSource:
+    return RegisteredSource(
+        id=uuid5(NAMESPACE_URL, f"safequery://registered-source/{source_id}"),
+        source_id=source_id,
+        display_label=display_label,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        activation_posture=activation_posture,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{source_id}",
+    )
+
+
+PHASE1_REGISTERED_SOURCES: dict[str, RegisteredSource] = {
+    "sap-approved-spend": _phase1_registered_source(
+        source_id="sap-approved-spend",
+        display_label="SAP spend cube / approved_vendor_spend",
+        activation_posture="active",
+        source_flavor="warehouse",
+    ),
+    "legacy-finance-archive": _phase1_registered_source(
+        source_id="legacy-finance-archive",
+        display_label="Legacy finance archive",
+        activation_posture="paused",
+        source_flavor="archive",
+    ),
+}
+
+
+class PreviewSubmissionContractError(ValueError):
+    """Raised when a preview submission does not carry an executable source binding."""
+
+
+def submit_preview_request(
+    payload: PreviewSubmissionRequest,
+) -> PreviewSubmissionResponse:
+    source = PHASE1_REGISTERED_SOURCES.get(payload.source_id)
+    if source is None:
+        raise PreviewSubmissionContractError(
+            f"Registered source '{payload.source_id}' does not exist."
+        )
+
+    try:
+        resolved_source = ensure_source_is_executable(source)
+    except SourceRegistryPostureError as exc:
+        raise PreviewSubmissionContractError(str(exc)) from exc
+
+    return PreviewSubmissionResponse(
+        request={
+            "question": payload.question,
+            "source_id": resolved_source.source_id,
+            "state": "submitted",
+        },
+        candidate={
+            "source_id": resolved_source.source_id,
+            "state": "preview_ready",
+        },
+    )

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -1,0 +1,110 @@
+import importlib
+import os
+import unittest
+
+from fastapi.testclient import TestClient
+
+from app.core.config import get_settings
+
+
+class RequestSourceSelectionTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
+            "postgresql://safequery:safequery@db:5432/safequery"
+        )
+        get_settings.cache_clear()
+        main_module = importlib.import_module("app.main")
+        self.app = main_module.create_app()
+        self.client = TestClient(self.app)
+
+    def tearDown(self) -> None:
+        os.environ.pop("SAFEQUERY_APP_POSTGRES_URL", None)
+        get_settings.cache_clear()
+
+    def test_preview_submission_requires_explicit_source_id(self) -> None:
+        response = self.client.post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
+            },
+        )
+
+    def test_preview_submission_rejects_unknown_source_id(self) -> None:
+        response = self.client.post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "unregistered-source",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
+            },
+        )
+
+    def test_preview_submission_rejects_non_executable_source_id(self) -> None:
+        response = self.client.post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "legacy-finance-archive",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
+            },
+        )
+
+    def test_preview_submission_accepts_registered_executable_source_id(self) -> None:
+        response = self.client.post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "request": {
+                    "question": "Show approved vendors by quarterly spend",
+                    "source_id": "sap-approved-spend",
+                    "state": "submitted",
+                },
+                "candidate": {
+                    "source_id": "sap-approved-spend",
+                    "state": "preview_ready",
+                },
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -1,10 +1,15 @@
 import importlib
 import os
 import unittest
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from app.core.config import get_settings
+from app.services.request_preview import (
+    PHASE1_REGISTERED_SOURCES,
+    _phase1_registered_source,
+)
 
 
 class RequestSourceSelectionTestCase(unittest.TestCase):
@@ -68,6 +73,37 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                 "source_id": "legacy-finance-archive",
             },
         )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
+            },
+        )
+
+    def test_preview_submission_rejects_malformed_source_posture(self) -> None:
+        with patch.dict(
+            PHASE1_REGISTERED_SOURCES,
+            {
+                "broken-source": _phase1_registered_source(
+                    source_id="broken-source",
+                    display_label="Broken source",
+                    activation_posture="bogus",
+                )
+            },
+            clear=False,
+        ):
+            response = self.client.post(
+                "/requests/preview",
+                json={
+                    "question": "Show approved vendors by quarterly spend",
+                    "source_id": "broken-source",
+                },
+            )
 
         self.assertEqual(response.status_code, 422)
         self.assertEqual(

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -21,7 +21,8 @@ describe("HomePage", () => {
 
     expect(screen.getByRole("heading", { name: /query workflow/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /sign in/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /generate preview/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /submit for preview/i })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /source/i })).toBeInTheDocument();
     expect(screen.getByText("Generated SQL")).toBeInTheDocument();
     expect(screen.getByText("Guard status")).toBeInTheDocument();
     expect(screen.getByText("Results")).toBeInTheDocument();
@@ -54,7 +55,8 @@ describe("HomePage", () => {
       await HomePage({
         searchParams: {
           question: "Show approved vendors by quarterly spend",
-          state: "preview"
+          source_id: "sap-approved-spend",
+          state: "preview",
         }
       })
     );
@@ -64,11 +66,44 @@ describe("HomePage", () => {
     expect(screen.getAllByText(/sql preview placeholder/i)).not.toHaveLength(0);
   });
 
+  it("requires an explicit source selection before preview state can be entered", async () => {
+    render(
+      await HomePage({
+        searchParams: {
+          question: "Show approved vendors by quarterly spend",
+          state: "preview"
+        }
+      })
+    );
+
+    expect(screen.getByRole("heading", { name: /query input state/i })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /source/i })).toHaveValue("");
+    expect(
+      screen.getByText(/select an executable source before preview can be requested/i)
+    ).toBeInTheDocument();
+  });
+
+  it("keeps source selection read-only after a preview-bound source is chosen", async () => {
+    render(
+      await HomePage({
+        searchParams: {
+          question: "Show approved vendors by quarterly spend",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    expect(screen.queryByRole("combobox", { name: /source/i })).not.toBeInTheDocument();
+    expect(screen.getAllByText(/sap spend cube \/ approved_vendor_spend/i)).not.toHaveLength(0);
+  });
+
   it("renders explicit empty and review-denied placeholder states", async () => {
     const { rerender } = render(
       await HomePage({
         searchParams: {
           question: "Show approved vendors by quarterly spend",
+          source_id: "sap-approved-spend",
           state: "empty"
         }
       })
@@ -80,6 +115,7 @@ describe("HomePage", () => {
       await HomePage({
         searchParams: {
           question: "Show approved vendors by quarterly spend",
+          source_id: "sap-approved-spend",
           state: "error"
         }
       })
@@ -134,10 +170,11 @@ describe("HomePage", () => {
       render(
         await HomePage({
           searchParams: {
-            question,
-            state: terminalState.state
-          }
-        })
+          question,
+          source_id: "sap-approved-spend",
+          state: terminalState.state
+        }
+      })
       );
 
       expect(screen.getByRole("heading", { name: terminalState.heading })).toBeInTheDocument();

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -20,6 +20,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const params = searchParams ? await searchParams : {};
   const config = getAppConfig();
   const question = readParam(params.question)?.trim() || "List the top 10 approved vendors by quarterly spend.";
+  const sourceId = readParam(params.source_id)?.trim();
   const state = resolveWorkflowState(readParam(params.state));
 
   return (
@@ -27,6 +28,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
       apiUrl={config.publicApiBaseUrl}
       health={DEFAULT_HEALTH_SNAPSHOT}
       question={question}
+      sourceId={sourceId}
       state={state}
     />
   );

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -29,6 +29,7 @@ type QueryWorkflowShellProps = {
   apiUrl: string;
   health: HealthSnapshot;
   question: string;
+  sourceId?: string;
   state: WorkflowState;
 };
 
@@ -45,6 +46,19 @@ type WorkflowContext = {
   runIdentity?: string;
   runState?: string;
   sourceIdentity: string;
+};
+
+type SourceOption = {
+  activationPosture: "active" | "paused";
+  description: string;
+  displayLabel: string;
+  sourceId: string;
+};
+
+type ResolvedSourceBinding = {
+  blockedReason?: string;
+  source?: SourceOption;
+  state: CanonicalWorkflowState;
 };
 
 const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
@@ -103,6 +117,21 @@ const workflowStateOrder: CanonicalWorkflowState[] = [
   "canceled"
 ];
 
+const previewSourceOptions: SourceOption[] = [
+  {
+    activationPosture: "active",
+    description: "Approved finance spend cube for governed preview and single-source execution.",
+    displayLabel: "SAP spend cube / approved_vendor_spend",
+    sourceId: "sap-approved-spend"
+  },
+  {
+    activationPosture: "paused",
+    description: "Historical archive is visible for posture review but not executable for preview.",
+    displayLabel: "Legacy finance archive",
+    sourceId: "legacy-finance-archive"
+  }
+];
+
 export function resolveWorkflowState(value?: string): CanonicalWorkflowState {
   if (!value) {
     return "query";
@@ -119,11 +148,70 @@ export function resolveWorkflowState(value?: string): CanonicalWorkflowState {
   return "query";
 }
 
-function buildStateHref(state: CanonicalWorkflowState, question: string): string {
+function findSourceOption(sourceId?: string): SourceOption | undefined {
+  return previewSourceOptions.find((source) => source.sourceId === sourceId);
+}
+
+function resolveSourceBinding(
+  state: CanonicalWorkflowState,
+  sourceId?: string
+): ResolvedSourceBinding {
+  const source = findSourceOption(sourceId);
+
+  if (state === "signin") {
+    return {
+      source,
+      state
+    };
+  }
+
+  if (state === "query") {
+    if (sourceId && source?.activationPosture !== "active") {
+      return {
+        blockedReason: "Select an executable source before preview can be requested.",
+        state: "query"
+      };
+    }
+
+    return {
+      source,
+      state
+    };
+  }
+
+  if (!sourceId || source === undefined) {
+    return {
+      blockedReason: "Select an executable source before preview can be requested.",
+      state: "query"
+    };
+  }
+
+  if (source.activationPosture !== "active") {
+    return {
+      blockedReason: "The selected source is not executable for preview submission.",
+      state: "query"
+    };
+  }
+
+  return {
+    source,
+    state
+  };
+}
+
+function buildStateHref(
+  state: CanonicalWorkflowState,
+  question: string,
+  sourceId?: string
+): string {
   const params = new URLSearchParams({
     question,
     state
   });
+
+  if (sourceId) {
+    params.set("source_id", sourceId);
+  }
 
   return `/?${params.toString()}`;
 }
@@ -140,8 +228,11 @@ function getSqlPreview(question: string): string {
   ].join("\n");
 }
 
-function getWorkflowContext(state: CanonicalWorkflowState): WorkflowContext {
-  const sourceIdentity = "SAP spend cube / approved_vendor_spend";
+function getWorkflowContext(
+  state: CanonicalWorkflowState,
+  source?: SourceOption
+): WorkflowContext {
+  const sourceIdentity = source?.displayLabel ?? "No source selected yet";
   const requestIdentity = "req-sq-204";
 
   if (state === "preview" || state === "review_denied") {
@@ -388,7 +479,11 @@ function renderResultContent(state: CanonicalWorkflowState) {
   );
 }
 
-function renderStatePanel(state: CanonicalWorkflowState, question: string) {
+function renderStatePanel(
+  state: CanonicalWorkflowState,
+  question: string,
+  sourceId?: string
+) {
   if (state === "signin") {
     return (
       <div className="state-hero">
@@ -399,7 +494,7 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           does not establish a real identity session yet.
         </p>
         <div className="signin-actions">
-          <a className="action-link" href={buildStateHref("query", question)}>
+          <a className="action-link" href={buildStateHref("query", question, sourceId)}>
             Continue to query input
           </a>
           <span className="inline-note">Real auth wiring stays out of scope.</span>
@@ -418,10 +513,10 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           before any future execution path is introduced.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("completed", question)}>
+          <a className="action-link" href={buildStateHref("completed", question, sourceId)}>
             Open completed state
           </a>
-          <a className="ghost-link" href={buildStateHref("empty", question)}>
+          <a className="ghost-link" href={buildStateHref("empty", question, sourceId)}>
             Open empty state
           </a>
         </div>
@@ -439,10 +534,10 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           is anchored to a specific run instead of a generic result placeholder.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("empty", question)}>
+          <a className="action-link" href={buildStateHref("empty", question, sourceId)}>
             Open empty state
           </a>
-          <a className="ghost-link" href={buildStateHref("failed", question)}>
+          <a className="ghost-link" href={buildStateHref("failed", question, sourceId)}>
             Open failed state
           </a>
         </div>
@@ -460,10 +555,10 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           denial, auth failure, or transport issues.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("query", question)}>
+          <a className="action-link" href={buildStateHref("query", question, sourceId)}>
             Revise question
           </a>
-          <a className="ghost-link" href={buildStateHref("preview", question)}>
+          <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
             Back to SQL preview
           </a>
         </div>
@@ -481,10 +576,10 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           sees a blocked candidate, not a synthetic run outcome.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("query", question)}>
+          <a className="action-link" href={buildStateHref("query", question, sourceId)}>
             Return to query input
           </a>
-          <a className="ghost-link" href={buildStateHref("preview", question)}>
+          <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
             Back to SQL preview
           </a>
         </div>
@@ -502,10 +597,10 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           run-backed outcome that was rejected after preview.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("preview", question)}>
+          <a className="action-link" href={buildStateHref("preview", question, sourceId)}>
             Back to SQL preview
           </a>
-          <a className="ghost-link" href={buildStateHref("query", question)}>
+          <a className="ghost-link" href={buildStateHref("query", question, sourceId)}>
             Revise question
           </a>
         </div>
@@ -523,10 +618,10 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           candidate visible for operator diagnosis.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("completed", question)}>
+          <a className="action-link" href={buildStateHref("completed", question, sourceId)}>
             Open completed state
           </a>
-          <a className="ghost-link" href={buildStateHref("query", question)}>
+          <a className="ghost-link" href={buildStateHref("query", question, sourceId)}>
             Revise question
           </a>
         </div>
@@ -544,10 +639,10 @@ function renderStatePanel(state: CanonicalWorkflowState, question: string) {
           interrupted work with denial, failure, or an empty result.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("query", question)}>
+          <a className="action-link" href={buildStateHref("query", question, sourceId)}>
             Start a new draft
           </a>
-          <a className="ghost-link" href={buildStateHref("completed", question)}>
+          <a className="ghost-link" href={buildStateHref("completed", question, sourceId)}>
             Compare completed state
           </a>
         </div>
@@ -571,14 +666,19 @@ export function QueryWorkflowShell({
   apiUrl,
   health,
   question,
+  sourceId,
   state
 }: QueryWorkflowShellProps) {
-  const normalizedState = resolveWorkflowState(state);
+  const requestedState = resolveWorkflowState(state);
+  const sourceBinding = resolveSourceBinding(requestedState, sourceId);
+  const normalizedState = sourceBinding.state;
   const sqlPreview = getSqlPreview(question);
   const activeState = workflowStates[normalizedState];
   const queryLocked = normalizedState === "signin";
   const guardTone = getGuardTone(normalizedState);
-  const workflowContext = getWorkflowContext(normalizedState);
+  const workflowContext = getWorkflowContext(normalizedState, sourceBinding.source);
+  const sourceSelectVisible = normalizedState === "query";
+  const boundSourceId = sourceBinding.source?.sourceId;
 
   return (
     <main className="app-shell">
@@ -613,7 +713,7 @@ export function QueryWorkflowShell({
             <a
               aria-current={workflowState === normalizedState ? "page" : undefined}
               className="state-nav-link"
-              href={buildStateHref(workflowState, question)}
+              href={buildStateHref(workflowState, question, boundSourceId)}
               key={workflowState}
             >
               {workflowStates[workflowState].label}
@@ -625,7 +725,7 @@ export function QueryWorkflowShell({
       <section className="workspace-grid">
         <div className="primary-column">
           <section className="surface surface-primary">
-            {renderStatePanel(normalizedState, question)}
+            {renderStatePanel(normalizedState, question, boundSourceId)}
           </section>
 
           <section className="surface surface-primary">
@@ -641,6 +741,47 @@ export function QueryWorkflowShell({
 
             <form action="/" className="query-form" method="get">
               <input name="state" type="hidden" value="preview" />
+              {sourceSelectVisible ? (
+                <>
+                  <label className="field-label" htmlFor="source_id">
+                    Source
+                  </label>
+                  <select defaultValue={boundSourceId ?? ""} id="source_id" name="source_id" required>
+                    <option value="">Select one source</option>
+                    {previewSourceOptions.map((source) => (
+                      <option
+                        disabled={source.activationPosture !== "active"}
+                        key={source.sourceId}
+                        value={source.sourceId}
+                      >
+                        {source.displayLabel}
+                        {source.activationPosture === "active" ? "" : " (Unavailable for preview)"}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="section-copy">
+                    Choose one explicit source before preview submission. SafeQuery does not infer or
+                    auto-route the initial source binding.
+                  </p>
+                  {sourceBinding.blockedReason ? (
+                    <div className="state-callout state-callout-danger">
+                      <p className="state-callout-title">Preview submission blocked</p>
+                      <p>{sourceBinding.blockedReason}</p>
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <div className="guard-list">
+                  <div className="guard-item">
+                    <span className="meta-label">Bound source</span>
+                    <strong>{workflowContext.sourceIdentity}</strong>
+                  </div>
+                  <div className="guard-item">
+                    <span className="meta-label">Source posture</span>
+                    <strong>Read-only after preview binding</strong>
+                  </div>
+                </div>
+              )}
               <label className="field-label" htmlFor="question">
                 Natural-language question
               </label>
@@ -654,11 +795,13 @@ export function QueryWorkflowShell({
               />
               <div className="form-actions">
                 <button disabled={queryLocked} type="submit">
-                  Generate preview
+                  Submit for preview
                 </button>
-                <a className="ghost-link" href={buildStateHref("completed", question)}>
-                  Open completed state
-                </a>
+                {boundSourceId ? (
+                  <a className="ghost-link" href={buildStateHref("completed", question, boundSourceId)}>
+                    Open completed state
+                  </a>
+                ) : null}
               </div>
             </form>
           </section>


### PR DESCRIPTION
Closes #62
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the explicit source-selection contract end to end and committed it as `9b7b082` on `codex/issue-62`.

The backend now exposes a minimal `POST /requests/preview` placeholder contract that requires `source_id` and rejects missing, unknown, or non-executable sources fail-closed. The frontend shell now makes source selection explicit in draft state, blocks preview entry when the source is missing or invalid, and keeps the bound source read-only after preview so links do not silently drop the source binding. I also added the focused backend test file for this issue and tightened the page test coverage around the new behavior. The issue journal’s Codex Working Notes section was updated locally as requested.

Summary: Added explicit `source_id` enforcement for preview submission in backend and frontend, added focused regression tests, and committed the checkpoint as `9b7b082`.
State hint: implementing
Blocked reason: none
Tests: `cd frontend && npm test -- --run app/page.test.tsx`; `cd frontend && npx tsc --noEmit`; `cd backend && python3 -m pytest tests/test_request_source_selection.py -q`; `PYTHONPATH=backend python3 -m pytest backend/tests/test_api_errors.py -q`
Failure signature: none
Next action: Review the committed checkpoint and, if desired, open or update the draft PR for issue #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a preview submission flow with a POST preview endpoint and required source selection
  - Source selector integrated into the query UI; selected source is preserved across workflow steps

* **Bug Fixes**
  - Improved validation and error responses for invalid or non-executable source submissions
  - Submit button label updated to "Submit for preview" and UI behavior adjusted for preview state

* **Tests**
  - Added end-to-end and unit tests covering source selection and preview submission scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->