### PR TITLE
[B-4] Bind request, candidate, audit, and evaluation records to source_id (#63)

### DIFF
--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -21,9 +21,32 @@ class PreviewSubmissionRequest(BaseModel):
     source_id: NonEmptyTrimmedString
 
 
+class RequestRecord(BaseModel):
+    question: str
+    source_id: str
+    state: str
+
+
+class CandidateRecord(BaseModel):
+    source_id: str
+    state: str
+
+
+class AuditRecord(BaseModel):
+    source_id: str
+    state: str
+
+
+class EvaluationRecord(BaseModel):
+    source_id: str
+    state: str
+
+
 class PreviewSubmissionResponse(BaseModel):
-    request: dict[str, str]
-    candidate: dict[str, str]
+    request: RequestRecord
+    candidate: CandidateRecord
+    audit: AuditRecord
+    evaluation: EvaluationRecord
 
 
 def _phase1_registered_source(
@@ -89,13 +112,21 @@ def submit_preview_request(
         ) from exc
 
     return PreviewSubmissionResponse(
-        request={
-            "question": payload.question,
-            "source_id": resolved_source.source_id,
-            "state": "submitted",
-        },
-        candidate={
-            "source_id": resolved_source.source_id,
-            "state": "preview_ready",
-        },
+        request=RequestRecord(
+            question=payload.question,
+            source_id=resolved_source.source_id,
+            state="submitted",
+        ),
+        candidate=CandidateRecord(
+            source_id=resolved_source.source_id,
+            state="preview_ready",
+        ),
+        audit=AuditRecord(
+            source_id=resolved_source.source_id,
+            state="recorded",
+        ),
+        evaluation=EvaluationRecord(
+            source_id=resolved_source.source_id,
+            state="pending",
+        ),
     )

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -138,6 +138,14 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                     "source_id": "sap-approved-spend",
                     "state": "preview_ready",
                 },
+                "audit": {
+                    "source_id": "sap-approved-spend",
+                    "state": "recorded",
+                },
+                "evaluation": {
+                    "source_id": "sap-approved-spend",
+                    "state": "pending",
+                },
             },
         )
 

--- a/backend/tests/test_source_bound_records.py
+++ b/backend/tests/test_source_bound_records.py
@@ -1,0 +1,33 @@
+from app.services.request_preview import (
+    PreviewSubmissionRequest,
+    submit_preview_request,
+)
+
+
+def test_preview_submission_binds_all_records_to_authoritative_source_id() -> None:
+    response = submit_preview_request(
+        PreviewSubmissionRequest(
+            question="Show approved vendors by quarterly spend",
+            source_id="sap-approved-spend",
+        )
+    )
+
+    assert response.model_dump() == {
+        "request": {
+            "question": "Show approved vendors by quarterly spend",
+            "source_id": "sap-approved-spend",
+            "state": "submitted",
+        },
+        "candidate": {
+            "source_id": "sap-approved-spend",
+            "state": "preview_ready",
+        },
+        "audit": {
+            "source_id": "sap-approved-spend",
+            "state": "recorded",
+        },
+        "evaluation": {
+            "source_id": "sap-approved-spend",
+            "state": "pending",
+        },
+    }


### PR DESCRIPTION
Closes #63
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the focused fix on `codex/issue-63` and committed it as `df0ddb1` (`Bind preview records to source id`).

`backend/app/services/request_preview.py` now returns typed `request`, `candidate`, `audit`, and `evaluation` records, all bound to the resolved registry `source_id`. I added the narrow reproducer in [backend/tests/test_source_bound_records.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-63/backend/tests/test_source_bound_records.py) and updated the HTTP-level expectation in [backend/tests/test_request_source_selection.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-63/backend/tests/test_request_source_selection.py). The issue journal was updated in the required working-notes section before closing the turn.

Summary: Added focused source-bound record coverage and extended preview responses so request, candidate, audit, and evaluation all carry authoritative `source_id`
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_source_bound_records.py tests/test_request_source_selection.py`
Failure signature: none
Next action: Open or update the draft PR / continue with the next source-aware dependency once the supervisor advances past focused reproduction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview submission responses now include audit and evaluation records with source tracking and state information, providing comprehensive visibility into the complete submission workflow across all submission components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->