### PR TITLE
[B-5] Implement the per-source dataset contract model (#64)

### DIFF
--- a/backend/alembic/versions/0003_dataset_contract_scaffold.py
+++ b/backend/alembic/versions/0003_dataset_contract_scaffold.py
@@ -1,0 +1,102 @@
+"""Add the per-source dataset contract scaffold.
+
+This revision adds application-owned dataset contract records that belong to one
+registered business source at a time and carry source-scoped allow-listed
+dataset entries.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003_dataset_contract_scaffold"
+down_revision: str | None = "0002_source_registry_scaffold"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+dataset_contract_dataset_kind = sa.Enum(
+    "view",
+    "table",
+    "materialized_view",
+    name="dataset_contract_dataset_kind",
+    native_enum=False,
+    create_constraint=True,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dataset_contracts",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("registered_source_id", sa.Uuid(), nullable=False),
+        sa.Column("contract_version", sa.Integer(), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("owner_binding", sa.String(length=255), nullable=True),
+        sa.Column("security_review_binding", sa.String(length=255), nullable=True),
+        sa.Column("exception_policy_binding", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["registered_source_id"],
+            ["registered_sources.id"],
+            name=op.f(
+                "fk_dataset_contracts_registered_source_id_registered_sources"
+            ),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_dataset_contracts")),
+        sa.UniqueConstraint(
+            "registered_source_id",
+            "contract_version",
+            name=op.f("uq_dataset_contracts_registered_source_id"),
+        ),
+    )
+    op.create_table(
+        "dataset_contract_datasets",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("dataset_contract_id", sa.Uuid(), nullable=False),
+        sa.Column("schema_name", sa.String(length=255), nullable=False),
+        sa.Column("dataset_name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "dataset_kind",
+            dataset_contract_dataset_kind,
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["dataset_contract_id"],
+            ["dataset_contracts.id"],
+            name=op.f(
+                "fk_dataset_contract_datasets_dataset_contract_id_dataset_contracts"
+            ),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_dataset_contract_datasets")),
+        sa.UniqueConstraint(
+            "dataset_contract_id",
+            "schema_name",
+            "dataset_name",
+            name=op.f("uq_dataset_contract_datasets_dataset_contract_id"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dataset_contract_datasets")
+    op.drop_table("dataset_contracts")

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,4 +1,10 @@
 from app.db.base import Base, target_metadata
-from app.db.models import RegisteredSource
+from app.db.models import DatasetContract, DatasetContractDataset, RegisteredSource
 
-__all__ = ["Base", "RegisteredSource", "target_metadata"]
+__all__ = [
+    "Base",
+    "DatasetContract",
+    "DatasetContractDataset",
+    "RegisteredSource",
+    "target_metadata",
+]

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,3 +1,4 @@
+from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
 from app.db.models.source_registry import RegisteredSource
 
-__all__ = ["RegisteredSource"]
+__all__ = ["DatasetContract", "DatasetContractDataset", "RegisteredSource"]

--- a/backend/app/db/models/dataset_contract.py
+++ b/backend/app/db/models/dataset_contract.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import DateTime, Enum as SqlEnum, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy import Uuid as SqlAlchemyUuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class DatasetContractDatasetKind(str, Enum):
+    VIEW = "view"
+    TABLE = "table"
+    MATERIALIZED_VIEW = "materialized_view"
+
+
+class DatasetContract(Base):
+    __tablename__ = "dataset_contracts"
+    __table_args__ = (UniqueConstraint("registered_source_id", "contract_version"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    registered_source_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("registered_sources.id"),
+        nullable=False,
+    )
+    contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    owner_binding: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    security_review_binding: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    exception_policy_binding: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class DatasetContractDataset(Base):
+    __tablename__ = "dataset_contract_datasets"
+    __table_args__ = (
+        UniqueConstraint("dataset_contract_id", "schema_name", "dataset_name"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    dataset_contract_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("dataset_contracts.id"),
+        nullable=False,
+    )
+    schema_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    dataset_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    dataset_kind: Mapped[DatasetContractDatasetKind] = mapped_column(
+        SqlEnum(
+            DatasetContractDatasetKind,
+            name="dataset_contract_dataset_kind",
+            native_enum=False,
+            create_constraint=True,
+            validate_strings=True,
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/tests/test_dataset_contract_models.py
+++ b/backend/tests/test_dataset_contract_models.py
@@ -1,0 +1,103 @@
+from sqlalchemy import UniqueConstraint
+
+from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
+
+
+def test_dataset_contracts_are_scoped_to_one_registered_source() -> None:
+    table = DatasetContract.__table__
+
+    assert table.name == "dataset_contracts"
+    assert set(table.columns.keys()) == {
+        "id",
+        "registered_source_id",
+        "contract_version",
+        "display_name",
+        "owner_binding",
+        "security_review_binding",
+        "exception_policy_binding",
+        "created_at",
+        "updated_at",
+    }
+
+    assert table.c.registered_source_id.nullable is False
+    assert table.c.contract_version.nullable is False
+    assert table.c.display_name.nullable is False
+    assert table.c.owner_binding.nullable is True
+    assert table.c.security_review_binding.nullable is True
+    assert table.c.exception_policy_binding.nullable is True
+    assert table.c.created_at.onupdate is None
+    assert table.c.updated_at.onupdate is not None
+
+    unique_constraints = {
+        tuple(column.name for column in constraint.columns)
+        for constraint in table.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+
+    assert ("registered_source_id", "contract_version") in unique_constraints
+
+    foreign_keys = {
+        (
+            foreign_key.parent.name,
+            foreign_key.column.table.name,
+            foreign_key.column.name,
+        )
+        for foreign_key in table.foreign_keys
+    }
+
+    assert foreign_keys == {
+        ("registered_source_id", "registered_sources", "id"),
+    }
+
+
+def test_allowlisted_datasets_are_bound_to_one_contract_version() -> None:
+    table = DatasetContractDataset.__table__
+
+    assert table.name == "dataset_contract_datasets"
+    assert set(table.columns.keys()) == {
+        "id",
+        "dataset_contract_id",
+        "schema_name",
+        "dataset_name",
+        "dataset_kind",
+        "created_at",
+    }
+
+    assert table.c.dataset_contract_id.nullable is False
+    assert table.c.schema_name.nullable is False
+    assert table.c.dataset_name.nullable is False
+    assert table.c.dataset_kind.nullable is False
+
+    unique_constraints = {
+        tuple(column.name for column in constraint.columns)
+        for constraint in table.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+
+    assert (
+        "dataset_contract_id",
+        "schema_name",
+        "dataset_name",
+    ) in unique_constraints
+
+    foreign_keys = {
+        (
+            foreign_key.parent.name,
+            foreign_key.column.table.name,
+            foreign_key.column.name,
+        )
+        for foreign_key in table.foreign_keys
+    }
+
+    assert foreign_keys == {
+        ("dataset_contract_id", "dataset_contracts", "id"),
+    }
+
+
+def test_dataset_contract_model_stays_separate_from_application_postgres_role() -> None:
+    contract_columns = DatasetContract.__table__.columns.keys()
+    dataset_columns = DatasetContractDataset.__table__.columns.keys()
+
+    for name in ("app_postgres_url", "application_postgres_identity"):
+        assert name not in contract_columns
+        assert name not in dataset_columns


### PR DESCRIPTION
Closes #64
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the per-source dataset contract scaffold in the backend. The work adds `DatasetContract` and `DatasetContractDataset` ORM models, exports them through the DB package, and adds Alembic revision `0003_dataset_contract_scaffold` so contracts are scoped to one registered source, versioned per source, and carry allow-listed dataset entries plus ownership/review placeholder bindings. The focused reproducer was `backend/tests/test_dataset_contract_models.py`, which initially failed on a missing model module and now passes.

Focused verification passed with `cd backend && python3 -m pytest tests/test_dataset_contract_models.py tests/test_source_registry_models.py`. I also updated the issue journal’s Codex Working Notes before ending the turn and checkpointed the code on `codex/issue-64` as commit `33443fa` (`Add per-source dataset contract scaffold`).

Summary: Added a source-scoped dataset contract ORM and migration scaffold with focused regression coverage, then checkpoint-committed it as `33443fa`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_dataset_contract_models.py tests/test_source_registry_models.py`
Failure signature: none
Next action: decide whether to wire `RegisteredSource.dataset_contract_id` to the new contract table as the authoritative active-contract reference or leave that for the next issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend database infrastructure with new schema and models for dataset contract management, including contract versioning and dataset association tracking.

* **Tests**
  * Added comprehensive tests validating dataset contract models, schema constraints, and data relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->