### PR TITLE
Implement per-source schema snapshot linkage

### DIFF
--- a/backend/alembic/versions/0004_schema_snapshot_linkage.py
+++ b/backend/alembic/versions/0004_schema_snapshot_linkage.py
@@ -1,0 +1,150 @@
+"""Add per-source schema snapshot linkage.
+
+This revision adds source-scoped schema snapshots plus the linkage required to
+bind dataset contracts and active registry pointers to one approved schema view
+per registered source.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004_schema_snapshot_linkage"
+down_revision: str | None = "0003_dataset_contract_scaffold"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+schema_snapshot_review_status = sa.Enum(
+    "pending",
+    "approved",
+    "rejected",
+    "superseded",
+    name="schema_snapshot_review_status",
+    native_enum=False,
+    create_constraint=True,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "schema_snapshots",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("registered_source_id", sa.Uuid(), nullable=False),
+        sa.Column("snapshot_version", sa.Integer(), nullable=False),
+        sa.Column("review_status", schema_snapshot_review_status, nullable=False),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "captured_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["registered_source_id"],
+            ["registered_sources.id"],
+            name=op.f("fk_schema_snapshots_registered_source_id_registered_sources"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_schema_snapshots")),
+        sa.UniqueConstraint(
+            "registered_source_id",
+            "snapshot_version",
+            name=op.f("uq_schema_snapshots_registered_source_id_snapshot_version"),
+        ),
+        sa.UniqueConstraint(
+            "registered_source_id",
+            "id",
+            name=op.f("uq_schema_snapshots_registered_source_id_id"),
+        ),
+    )
+
+    op.add_column(
+        "dataset_contracts",
+        sa.Column("schema_snapshot_id", sa.Uuid(), nullable=False),
+    )
+    op.create_unique_constraint(
+        op.f("uq_dataset_contracts_registered_source_id_id"),
+        "dataset_contracts",
+        ["registered_source_id", "id"],
+    )
+    op.create_foreign_key(
+        op.f("fk_dataset_contracts_schema_snapshot_id_schema_snapshots"),
+        "dataset_contracts",
+        "schema_snapshots",
+        ["schema_snapshot_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        op.f(
+            "fk_dataset_contracts_registered_source_id_schema_snapshot_id_schema_snapshots"
+        ),
+        "dataset_contracts",
+        "schema_snapshots",
+        ["registered_source_id", "schema_snapshot_id"],
+        ["registered_source_id", "id"],
+    )
+
+    op.create_foreign_key(
+        op.f(
+            "fk_registered_sources_id_dataset_contract_id_dataset_contracts"
+        ),
+        "registered_sources",
+        "dataset_contracts",
+        ["id", "dataset_contract_id"],
+        ["registered_source_id", "id"],
+    )
+    op.create_foreign_key(
+        op.f(
+            "fk_registered_sources_id_schema_snapshot_id_schema_snapshots"
+        ),
+        "registered_sources",
+        "schema_snapshots",
+        ["id", "schema_snapshot_id"],
+        ["registered_source_id", "id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("fk_registered_sources_id_schema_snapshot_id_schema_snapshots"),
+        "registered_sources",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("fk_registered_sources_id_dataset_contract_id_dataset_contracts"),
+        "registered_sources",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f(
+            "fk_dataset_contracts_registered_source_id_schema_snapshot_id_schema_snapshots"
+        ),
+        "dataset_contracts",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("fk_dataset_contracts_schema_snapshot_id_schema_snapshots"),
+        "dataset_contracts",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        op.f("uq_dataset_contracts_registered_source_id_id"),
+        "dataset_contracts",
+        type_="unique",
+    )
+    op.drop_column("dataset_contracts", "schema_snapshot_id")
+    op.drop_table("schema_snapshots")

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,4 +1,10 @@
 from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
+from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
 
-__all__ = ["DatasetContract", "DatasetContractDataset", "RegisteredSource"]
+__all__ = [
+    "DatasetContract",
+    "DatasetContractDataset",
+    "RegisteredSource",
+    "SchemaSnapshot",
+]

--- a/backend/app/db/models/dataset_contract.py
+++ b/backend/app/db/models/dataset_contract.py
@@ -5,7 +5,16 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import DateTime, Enum as SqlEnum, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy import (
+    DateTime,
+    Enum as SqlEnum,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy import Uuid as SqlAlchemyUuid
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -20,7 +29,14 @@ class DatasetContractDatasetKind(str, Enum):
 
 class DatasetContract(Base):
     __tablename__ = "dataset_contracts"
-    __table_args__ = (UniqueConstraint("registered_source_id", "contract_version"),)
+    __table_args__ = (
+        UniqueConstraint("registered_source_id", "contract_version"),
+        UniqueConstraint("registered_source_id", "id"),
+        ForeignKeyConstraint(
+            ["registered_source_id", "schema_snapshot_id"],
+            ["schema_snapshots.registered_source_id", "schema_snapshots.id"],
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         SqlAlchemyUuid,
@@ -29,6 +45,10 @@ class DatasetContract(Base):
     )
     registered_source_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("registered_sources.id"),
+        nullable=False,
+    )
+    schema_snapshot_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("schema_snapshots.id"),
         nullable=False,
     )
     contract_version: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/db/models/schema_snapshot.py
+++ b/backend/app/db/models/schema_snapshot.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import (
+    DateTime,
+    Enum as SqlEnum,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy import Uuid as SqlAlchemyUuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class SchemaSnapshotReviewStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    SUPERSEDED = "superseded"
+
+
+class SchemaSnapshot(Base):
+    __tablename__ = "schema_snapshots"
+    __table_args__ = (
+        UniqueConstraint("registered_source_id", "snapshot_version"),
+        UniqueConstraint("registered_source_id", "id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    registered_source_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("registered_sources.id"),
+        nullable=False,
+    )
+    snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    review_status: Mapped[SchemaSnapshotReviewStatus] = mapped_column(
+        SqlEnum(
+            SchemaSnapshotReviewStatus,
+            name="schema_snapshot_review_status",
+            native_enum=False,
+            create_constraint=True,
+            validate_strings=True,
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
+        nullable=False,
+    )
+    reviewed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    captured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/db/models/source_registry.py
+++ b/backend/app/db/models/source_registry.py
@@ -5,7 +5,14 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import DateTime, Enum as SqlEnum, String, UniqueConstraint, func
+from sqlalchemy import (
+    DateTime,
+    Enum as SqlEnum,
+    ForeignKeyConstraint,
+    String,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy import Uuid as SqlAlchemyUuid
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -27,6 +34,14 @@ class RegisteredSource(Base):
     __tablename__ = "registered_sources"
     __table_args__ = (
         UniqueConstraint("source_id"),
+        ForeignKeyConstraint(
+            ["id", "dataset_contract_id"],
+            ["dataset_contracts.registered_source_id", "dataset_contracts.id"],
+        ),
+        ForeignKeyConstraint(
+            ["id", "schema_snapshot_id"],
+            ["schema_snapshots.registered_source_id", "schema_snapshots.id"],
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/backend/tests/test_dataset_contract_models.py
+++ b/backend/tests/test_dataset_contract_models.py
@@ -10,6 +10,7 @@ def test_dataset_contracts_are_scoped_to_one_registered_source() -> None:
     assert set(table.columns.keys()) == {
         "id",
         "registered_source_id",
+        "schema_snapshot_id",
         "contract_version",
         "display_name",
         "owner_binding",
@@ -20,6 +21,7 @@ def test_dataset_contracts_are_scoped_to_one_registered_source() -> None:
     }
 
     assert table.c.registered_source_id.nullable is False
+    assert table.c.schema_snapshot_id.nullable is False
     assert table.c.contract_version.nullable is False
     assert table.c.display_name.nullable is False
     assert table.c.owner_binding.nullable is True
@@ -35,6 +37,7 @@ def test_dataset_contracts_are_scoped_to_one_registered_source() -> None:
     }
 
     assert ("registered_source_id", "contract_version") in unique_constraints
+    assert ("registered_source_id", "id") in unique_constraints
 
     foreign_keys = {
         (
@@ -47,7 +50,24 @@ def test_dataset_contracts_are_scoped_to_one_registered_source() -> None:
 
     assert foreign_keys == {
         ("registered_source_id", "registered_sources", "id"),
+        ("registered_source_id", "schema_snapshots", "registered_source_id"),
+        ("schema_snapshot_id", "schema_snapshots", "id"),
     }
+
+    composite_foreign_keys = {
+        (
+            tuple(element.parent.name for element in constraint.elements),
+            tuple(element.column.table.name for element in constraint.elements),
+            tuple(element.column.name for element in constraint.elements),
+        )
+        for constraint in table.foreign_key_constraints
+    }
+
+    assert (
+        ("registered_source_id", "schema_snapshot_id"),
+        ("schema_snapshots", "schema_snapshots"),
+        ("registered_source_id", "id"),
+    ) in composite_foreign_keys
 
 
 def test_allowlisted_datasets_are_bound_to_one_contract_version() -> None:

--- a/backend/tests/test_schema_snapshot_linkage.py
+++ b/backend/tests/test_schema_snapshot_linkage.py
@@ -1,0 +1,115 @@
+from sqlalchemy import UniqueConstraint
+
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource
+
+
+def test_schema_snapshots_are_scoped_to_one_registered_source() -> None:
+    table = SchemaSnapshot.__table__
+
+    assert table.name == "schema_snapshots"
+    assert set(table.columns.keys()) == {
+        "id",
+        "registered_source_id",
+        "snapshot_version",
+        "review_status",
+        "reviewed_at",
+        "captured_at",
+        "created_at",
+        "updated_at",
+    }
+
+    assert table.c.registered_source_id.nullable is False
+    assert table.c.snapshot_version.nullable is False
+    assert table.c.review_status.nullable is False
+    assert table.c.reviewed_at.nullable is True
+    assert table.c.captured_at.nullable is False
+    assert table.c.created_at.onupdate is None
+    assert table.c.updated_at.onupdate is not None
+    assert tuple(table.c.review_status.type.enums) == (
+        SchemaSnapshotReviewStatus.PENDING.value,
+        SchemaSnapshotReviewStatus.APPROVED.value,
+        SchemaSnapshotReviewStatus.REJECTED.value,
+        SchemaSnapshotReviewStatus.SUPERSEDED.value,
+    )
+
+    unique_constraints = {
+        tuple(column.name for column in constraint.columns)
+        for constraint in table.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+
+    assert ("registered_source_id", "snapshot_version") in unique_constraints
+    assert ("registered_source_id", "id") in unique_constraints
+
+    foreign_keys = {
+        (
+            foreign_key.parent.name,
+            foreign_key.column.table.name,
+            foreign_key.column.name,
+        )
+        for foreign_key in table.foreign_keys
+    }
+
+    assert foreign_keys == {
+        ("registered_source_id", "registered_sources", "id"),
+    }
+
+
+def test_dataset_contracts_bind_to_one_source_scoped_schema_snapshot() -> None:
+    table = DatasetContract.__table__
+
+    assert "schema_snapshot_id" in table.columns
+    assert table.c.schema_snapshot_id.nullable is False
+
+    foreign_keys = {
+        (
+            foreign_key.parent.name,
+            foreign_key.column.table.name,
+            foreign_key.column.name,
+        )
+        for foreign_key in table.foreign_keys
+    }
+
+    assert ("registered_source_id", "registered_sources", "id") in foreign_keys
+    assert ("schema_snapshot_id", "schema_snapshots", "id") in foreign_keys
+
+    composite_foreign_keys = {
+        (
+            tuple(element.parent.name for element in constraint.elements),
+            tuple(element.column.table.name for element in constraint.elements),
+            tuple(element.column.name for element in constraint.elements),
+        )
+        for constraint in table.foreign_key_constraints
+    }
+
+    assert (
+        ("registered_source_id", "schema_snapshot_id"),
+        ("schema_snapshots", "schema_snapshots"),
+        ("registered_source_id", "id"),
+    ) in composite_foreign_keys
+
+
+def test_registered_source_links_active_contract_and_snapshot_without_cross_source_drift() -> None:
+    table = RegisteredSource.__table__
+
+    composite_foreign_keys = {
+        (
+            tuple(element.parent.name for element in constraint.elements),
+            tuple(element.column.table.name for element in constraint.elements),
+            tuple(element.column.name for element in constraint.elements),
+        )
+        for constraint in table.foreign_key_constraints
+    }
+
+    assert (
+        ("id", "dataset_contract_id"),
+        ("dataset_contracts", "dataset_contracts"),
+        ("registered_source_id", "id"),
+    ) in composite_foreign_keys
+    assert (
+        ("id", "schema_snapshot_id"),
+        ("schema_snapshots", "schema_snapshots"),
+        ("registered_source_id", "id"),
+    ) in composite_foreign_keys


### PR DESCRIPTION
## Summary
- add a schema snapshot model and migration for per-source reviewed snapshot records
- bind dataset contracts to a source-scoped schema snapshot and enforce single-source linkage
- add focused model tests for registry, contract, and schema snapshot linkage

## Testing
- cd backend && python3 -m pytest tests/test_schema_snapshot_linkage.py tests/test_dataset_contract_models.py tests/test_source_registry_models.py tests/test_source_registry_posture.py
- cd backend && python3 -m pytest