### PR TITLE
[B-7] Implement source-aware execution entitlement checks (#66)

### DIFF
--- a/backend/app/features/auth/context.py
+++ b/backend/app/features/auth/context.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from fastapi import HTTPException, Request
+
+
+def _normalize_binding(binding: str) -> str | None:
+    normalized = binding.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+@dataclass(frozen=True)
+class AuthenticatedSubject:
+    subject_id: str
+    governance_bindings: frozenset[str] = field(default_factory=frozenset)
+
+    def normalized_subject_id(self) -> str:
+        normalized = self.subject_id.strip()
+        if not normalized:
+            raise HTTPException(
+                status_code=403,
+                detail="Authenticated subject context is malformed.",
+            )
+        return normalized
+
+    def normalized_governance_bindings(self) -> frozenset[str]:
+        normalized_bindings = {
+            normalized
+            for binding in self.governance_bindings
+            if (normalized := _normalize_binding(binding)) is not None
+        }
+        return frozenset(normalized_bindings)
+
+
+def require_authenticated_subject(request: Request) -> AuthenticatedSubject:
+    subject = getattr(request.state, "authenticated_subject", None)
+    if not isinstance(subject, AuthenticatedSubject):
+        raise HTTPException(
+            status_code=403,
+            detail="Authenticated subject context is required.",
+        )
+
+    return AuthenticatedSubject(
+        subject_id=subject.normalized_subject_id(),
+        governance_bindings=subject.normalized_governance_bindings(),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from time import perf_counter
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -17,6 +17,10 @@ from app.core.errors import (
 )
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
+from app.features.auth.context import (
+    AuthenticatedSubject,
+    require_authenticated_subject,
+)
 from app.services.health import check_database_health
 from app.services.request_preview import (
     PreviewSubmissionContractError,
@@ -155,9 +159,12 @@ def create_app() -> FastAPI:
     @app.post("/requests/preview", response_model=PreviewSubmissionResponse)
     def create_request_preview(
         payload: PreviewSubmissionRequest,
+        authenticated_subject: AuthenticatedSubject = Depends(
+            require_authenticated_subject
+        ),
     ) -> PreviewSubmissionResponse:
         try:
-            return submit_preview_request(payload)
+            return submit_preview_request(payload, authenticated_subject)
         except PreviewSubmissionContractError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -4,10 +4,12 @@ from pydantic import BaseModel, ConfigDict, StringConstraints
 from typing_extensions import Annotated
 from typing import Optional
 
+from app.db.models.dataset_contract import DatasetContract
 from app.db.models.source_registry import RegisteredSource
-from app.services.source_registry import (
-    SourceRegistryPostureError,
-    ensure_source_is_executable,
+from app.features.auth.context import AuthenticatedSubject
+from app.services.source_entitlements import (
+    SourceEntitlementError,
+    ensure_subject_is_entitled_for_source,
 )
 
 
@@ -73,6 +75,28 @@ def _phase1_registered_source(
     )
 
 
+def _phase1_dataset_contract(
+    *,
+    source: RegisteredSource,
+    owner_binding: Optional[str] = None,
+    security_review_binding: Optional[str] = None,
+    exception_policy_binding: Optional[str] = None,
+) -> DatasetContract:
+    return DatasetContract(
+        id=uuid5(NAMESPACE_URL, f"safequery://dataset-contract/{source.source_id}/v1"),
+        registered_source_id=source.id,
+        schema_snapshot_id=uuid5(
+            NAMESPACE_URL,
+            f"safequery://schema-snapshot/{source.source_id}/v1",
+        ),
+        contract_version=1,
+        display_name=f"{source.display_label} contract",
+        owner_binding=owner_binding,
+        security_review_binding=security_review_binding,
+        exception_policy_binding=exception_policy_binding,
+    )
+
+
 PHASE1_REGISTERED_SOURCES: dict[str, RegisteredSource] = {
     "sap-approved-spend": _phase1_registered_source(
         source_id="sap-approved-spend",
@@ -88,6 +112,18 @@ PHASE1_REGISTERED_SOURCES: dict[str, RegisteredSource] = {
     ),
 }
 
+PHASE1_DATASET_CONTRACTS: dict[str, DatasetContract] = {
+    "sap-approved-spend": _phase1_dataset_contract(
+        source=PHASE1_REGISTERED_SOURCES["sap-approved-spend"],
+        owner_binding="group:finance-analysts",
+        security_review_binding="group:finance-reviewers",
+    ),
+    "legacy-finance-archive": _phase1_dataset_contract(
+        source=PHASE1_REGISTERED_SOURCES["legacy-finance-archive"],
+        owner_binding="group:archive-operators",
+    ),
+}
+
 
 class PreviewSubmissionContractError(ValueError):
     """Raised when a preview submission does not carry an executable source binding."""
@@ -95,6 +131,7 @@ class PreviewSubmissionContractError(ValueError):
 
 def submit_preview_request(
     payload: PreviewSubmissionRequest,
+    authenticated_subject: AuthenticatedSubject,
 ) -> PreviewSubmissionResponse:
     source = PHASE1_REGISTERED_SOURCES.get(payload.source_id)
     if source is None:
@@ -103,13 +140,13 @@ def submit_preview_request(
         )
 
     try:
-        resolved_source = ensure_source_is_executable(source)
-    except SourceRegistryPostureError as exc:
+        resolved_source = ensure_subject_is_entitled_for_source(
+            authenticated_subject,
+            source,
+            PHASE1_DATASET_CONTRACTS.get(payload.source_id),
+        )
+    except SourceEntitlementError as exc:
         raise PreviewSubmissionContractError(str(exc)) from exc
-    except ValueError as exc:
-        raise PreviewSubmissionContractError(
-            f"Registered source '{payload.source_id}' has an invalid activation posture."
-        ) from exc
 
     return PreviewSubmissionResponse(
         request=RequestRecord(

--- a/backend/app/services/source_entitlements.py
+++ b/backend/app/services/source_entitlements.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.source_registry import RegisteredSource
+from app.features.auth.context import AuthenticatedSubject
+from app.services.source_registry import (
+    SourceRegistryPostureError,
+    ensure_source_is_executable,
+)
+
+
+class SourceEntitlementError(PermissionError):
+    """Raised when a subject is not entitled to use a selected registered source."""
+
+
+def _contract_governance_bindings(contract: DatasetContract) -> frozenset[str]:
+    bindings = {
+        binding
+        for binding in (
+            contract.owner_binding,
+            contract.security_review_binding,
+            contract.exception_policy_binding,
+        )
+        if binding is not None and binding.strip()
+    }
+    return frozenset(bindings)
+
+
+def ensure_subject_is_entitled_for_source(
+    subject: AuthenticatedSubject,
+    source: RegisteredSource,
+    dataset_contract: DatasetContract | None,
+) -> RegisteredSource:
+    try:
+        resolved_source = ensure_source_is_executable(source)
+    except (SourceRegistryPostureError, ValueError) as exc:
+        raise SourceEntitlementError(str(exc)) from exc
+
+    if dataset_contract is None or dataset_contract.registered_source_id != resolved_source.id:
+        raise SourceEntitlementError(
+            f"Registered source '{resolved_source.source_id}' is missing "
+            "authoritative source-scoped governance artifacts."
+        )
+
+    source_bindings = _contract_governance_bindings(dataset_contract)
+    if not source_bindings:
+        raise SourceEntitlementError(
+            f"Registered source '{resolved_source.source_id}' has no "
+            "source-scoped governance bindings."
+        )
+
+    subject_bindings = subject.normalized_governance_bindings()
+    if not subject_bindings:
+        raise SourceEntitlementError(
+            f"Authenticated subject '{subject.normalized_subject_id()}' has no "
+            "trusted governance bindings."
+        )
+
+    if subject_bindings.isdisjoint(source_bindings):
+        raise SourceEntitlementError(
+            f"Authenticated subject '{subject.normalized_subject_id()}' is not "
+            f"entitled to use registered source '{resolved_source.source_id}'."
+        )
+
+    return resolved_source

--- a/backend/app/services/source_entitlements.py
+++ b/backend/app/services/source_entitlements.py
@@ -15,13 +15,13 @@ class SourceEntitlementError(PermissionError):
 
 def _contract_governance_bindings(contract: DatasetContract) -> frozenset[str]:
     bindings = {
-        binding
+        normalized
         for binding in (
             contract.owner_binding,
             contract.security_review_binding,
             contract.exception_policy_binding,
         )
-        if binding is not None and binding.strip()
+        if binding is not None and (normalized := binding.strip())
     }
     return frozenset(bindings)
 

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from app.core.config import get_settings
+from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 from app.services.request_preview import (
     PHASE1_REGISTERED_SOURCES,
     _phase1_registered_source,
@@ -20,11 +21,38 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         get_settings.cache_clear()
         main_module = importlib.import_module("app.main")
         self.app = main_module.create_app()
+        self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
         self.client = TestClient(self.app)
 
     def tearDown(self) -> None:
         os.environ.pop("SAFEQUERY_APP_POSTGRES_URL", None)
         get_settings.cache_clear()
+        self.app.dependency_overrides.clear()
+
+    def test_preview_submission_rejects_missing_authenticated_subject_context(self) -> None:
+        self.app.dependency_overrides.clear()
+
+        response = self.client.post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "http_error",
+                    "message": "Forbidden",
+                }
+            },
+        )
 
     def test_preview_submission_requires_explicit_source_id(self) -> None:
         response = self.client.post(

--- a/backend/tests/test_source_bound_records.py
+++ b/backend/tests/test_source_bound_records.py
@@ -1,3 +1,4 @@
+from app.features.auth.context import AuthenticatedSubject
 from app.services.request_preview import (
     PreviewSubmissionRequest,
     submit_preview_request,
@@ -9,7 +10,11 @@ def test_preview_submission_binds_all_records_to_authoritative_source_id() -> No
         PreviewSubmissionRequest(
             question="Show approved vendors by quarterly spend",
             source_id="sap-approved-spend",
-        )
+        ),
+        AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        ),
     )
 
     assert response.model_dump() == {

--- a/backend/tests/test_source_entitlements.py
+++ b/backend/tests/test_source_entitlements.py
@@ -60,6 +60,21 @@ class SourceEntitlementTestCase(unittest.TestCase):
 
         self.assertIs(resolved_source, source)
 
+    def test_subject_with_matching_binding_after_contract_whitespace_normalization_is_allowed(self) -> None:
+        source = _registered_source(source_id="sap-approved-spend")
+        contract = _dataset_contract(
+            registered_source_id=source.id,
+            owner_binding=" group:finance-analysts ",
+        )
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+
+        resolved_source = ensure_subject_is_entitled_for_source(subject, source, contract)
+
+        self.assertIs(resolved_source, source)
+
     def test_subject_without_matching_source_binding_is_denied(self) -> None:
         source = _registered_source(source_id="sap-approved-spend")
         contract = _dataset_contract(

--- a/backend/tests/test_source_entitlements.py
+++ b/backend/tests/test_source_entitlements.py
@@ -1,0 +1,103 @@
+import unittest
+import uuid
+from typing import Optional
+
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.source_registry import RegisteredSource
+from app.features.auth.context import AuthenticatedSubject
+from app.services.source_entitlements import SourceEntitlementError, ensure_subject_is_entitled_for_source
+
+
+def _registered_source(*, source_id: str, activation_posture: str = "active") -> RegisteredSource:
+    return RegisteredSource(
+        id=uuid.uuid4(),
+        source_id=source_id,
+        display_label=source_id.replace("-", " ").title(),
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=activation_posture,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{source_id}",
+    )
+
+
+def _dataset_contract(
+    *,
+    registered_source_id: uuid.UUID,
+    owner_binding: Optional[str] = None,
+    security_review_binding: Optional[str] = None,
+    exception_policy_binding: Optional[str] = None,
+) -> DatasetContract:
+    return DatasetContract(
+        id=uuid.uuid4(),
+        registered_source_id=registered_source_id,
+        schema_snapshot_id=uuid.uuid4(),
+        contract_version=1,
+        display_name="Approved vendor spend contract",
+        owner_binding=owner_binding,
+        security_review_binding=security_review_binding,
+        exception_policy_binding=exception_policy_binding,
+    )
+
+
+class SourceEntitlementTestCase(unittest.TestCase):
+    def test_subject_with_matching_source_binding_is_allowed(self) -> None:
+        source = _registered_source(source_id="sap-approved-spend")
+        contract = _dataset_contract(
+            registered_source_id=source.id,
+            owner_binding="group:finance-analysts",
+        )
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+
+        resolved_source = ensure_subject_is_entitled_for_source(subject, source, contract)
+
+        self.assertIs(resolved_source, source)
+
+    def test_subject_without_matching_source_binding_is_denied(self) -> None:
+        source = _registered_source(source_id="sap-approved-spend")
+        contract = _dataset_contract(
+            registered_source_id=source.id,
+            owner_binding="group:finance-approvers",
+            security_review_binding="group:security-reviewers",
+        )
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+
+        with self.assertRaisesRegex(
+            SourceEntitlementError,
+            "is not entitled to use registered source 'sap-approved-spend'",
+        ):
+            ensure_subject_is_entitled_for_source(subject, source, contract)
+
+    def test_non_executable_source_posture_is_rejected_before_entitlement_allow(self) -> None:
+        source = _registered_source(
+            source_id="legacy-finance-archive",
+            activation_posture="paused",
+        )
+        contract = _dataset_contract(
+            registered_source_id=source.id,
+            owner_binding="group:finance-analysts",
+        )
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+
+        with self.assertRaisesRegex(
+            SourceEntitlementError,
+            "not executable while in paused posture",
+        ):
+            ensure_subject_is_entitled_for_source(subject, source, contract)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #66
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented source-aware execution entitlement checks on `codex/issue-66` and committed them as `1e1d9e1` with message `Implement source-aware execution entitlement checks`.

The backend now requires a trusted backend-owned `AuthenticatedSubject` dependency for `/requests/preview`, evaluates that subject against source-scoped governance bindings from the selected source’s dataset contract, and fails closed when auth context, governance artifacts, bindings, or executable posture are missing. I added the focused regression test module `backend/tests/test_source_entitlements.py` for allow, deny, and non-executable posture, and updated preview-path tests to use dependency overrides instead of any client-supplied identity. The issue journal’s Codex Working Notes section was updated locally before closing the turn.

Summary: Added backend-owned source-aware entitlement enforcement for preview submission, covered by focused allow/deny/non-executable tests, and committed as `1e1d9e1`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_source_entitlements.py`; `cd backend && python3 -m pytest tests/test_source_entitlements.py tests/test_request_source_selection.py tests/test_source_bound_records.py`
Failure signature: none
Next action: Move to local review or draft PR creation for the entitlement checkpoint on `codex/issue-66`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview requests now require authentication and validate user access to registered data sources based on organizational governance bindings.
  * Unauthorized or missing authentication contexts return 403 Forbidden.

* **Improvements**
  * Governance bindings are normalized (trimmed) so matching tolerates surrounding whitespace.
  * Authorization checks now enforce source-specific entitlements and return clearer denial errors.

* **Tests**
  * Added tests covering entitlement checks and the missing-authentication scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->