### PR TITLE
[B-F1] Wire preview submission to authoritative persisted source-governance artifacts (#74)

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from functools import lru_cache
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+
+
+@lru_cache
+def get_engine(database_url: str) -> Engine:
+    return create_engine(database_url)
+
+
+def require_preview_submission_session() -> Iterator[Session]:
+    settings = get_settings()
+    with Session(get_engine(str(settings.app_postgres_url))) as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
+from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.errors import (
@@ -17,6 +18,7 @@ from app.core.errors import (
 )
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
+from app.db.session import require_preview_submission_session
 from app.features.auth.context import (
     AuthenticatedSubject,
     require_authenticated_subject,
@@ -162,9 +164,10 @@ def create_app() -> FastAPI:
         authenticated_subject: AuthenticatedSubject = Depends(
             require_authenticated_subject
         ),
+        session: Session = Depends(require_preview_submission_session),
     ) -> PreviewSubmissionResponse:
         try:
-            return submit_preview_request(payload, authenticated_subject)
+            return submit_preview_request(payload, authenticated_subject, session)
         except PreviewSubmissionContractError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -60,13 +60,24 @@ def _resolve_authoritative_source_governance(
     *,
     source_id: str,
 ) -> tuple[RegisteredSource, DatasetContract]:
-    source = session.scalar(
-        select(RegisteredSource).where(RegisteredSource.source_id == source_id)
-    )
-    if source is None:
+    governance_row = session.execute(
+        select(RegisteredSource, DatasetContract, SchemaSnapshot)
+        .outerjoin(
+            DatasetContract,
+            DatasetContract.id == RegisteredSource.dataset_contract_id,
+        )
+        .outerjoin(
+            SchemaSnapshot,
+            SchemaSnapshot.id == RegisteredSource.schema_snapshot_id,
+        )
+        .where(RegisteredSource.source_id == source_id)
+    ).one_or_none()
+    if governance_row is None:
         raise PreviewSubmissionContractError(
             f"Registered source '{source_id}' does not exist."
         )
+
+    source, dataset_contract, schema_snapshot = governance_row
 
     if source.dataset_contract_id is None:
         raise PreviewSubmissionContractError(
@@ -77,7 +88,6 @@ def _resolve_authoritative_source_governance(
             f"Registered source '{source.source_id}' has no linked schema snapshot."
         )
 
-    dataset_contract = session.get(DatasetContract, source.dataset_contract_id)
     if (
         dataset_contract is None
         or dataset_contract.registered_source_id != source.id
@@ -88,7 +98,6 @@ def _resolve_authoritative_source_governance(
             "authoritative source-scoped governance artifacts."
         )
 
-    schema_snapshot = session.get(SchemaSnapshot, source.schema_snapshot_id)
     if schema_snapshot is None or schema_snapshot.registered_source_id != source.id:
         raise PreviewSubmissionContractError(
             f"Registered source '{source.source_id}' has no linked schema snapshot."

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,10 +1,10 @@
-from uuid import NAMESPACE_URL, uuid5
-
 from pydantic import BaseModel, ConfigDict, StringConstraints
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 from typing_extensions import Annotated
-from typing import Optional
 
 from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource
 from app.features.auth.context import AuthenticatedSubject
 from app.services.source_entitlements import (
@@ -51,99 +51,71 @@ class PreviewSubmissionResponse(BaseModel):
     evaluation: EvaluationRecord
 
 
-def _phase1_registered_source(
-    *,
-    source_id: str,
-    display_label: str,
-    activation_posture: str,
-    source_family: str = "postgresql",
-    source_flavor: Optional[str] = None,
-) -> RegisteredSource:
-    return RegisteredSource(
-        id=uuid5(NAMESPACE_URL, f"safequery://registered-source/{source_id}"),
-        source_id=source_id,
-        display_label=display_label,
-        source_family=source_family,
-        source_flavor=source_flavor,
-        activation_posture=activation_posture,
-        connector_profile_id=None,
-        dialect_profile_id=None,
-        dataset_contract_id=None,
-        schema_snapshot_id=None,
-        execution_policy_id=None,
-        connection_reference=f"vault:{source_id}",
-    )
-
-
-def _phase1_dataset_contract(
-    *,
-    source: RegisteredSource,
-    owner_binding: Optional[str] = None,
-    security_review_binding: Optional[str] = None,
-    exception_policy_binding: Optional[str] = None,
-) -> DatasetContract:
-    return DatasetContract(
-        id=uuid5(NAMESPACE_URL, f"safequery://dataset-contract/{source.source_id}/v1"),
-        registered_source_id=source.id,
-        schema_snapshot_id=uuid5(
-            NAMESPACE_URL,
-            f"safequery://schema-snapshot/{source.source_id}/v1",
-        ),
-        contract_version=1,
-        display_name=f"{source.display_label} contract",
-        owner_binding=owner_binding,
-        security_review_binding=security_review_binding,
-        exception_policy_binding=exception_policy_binding,
-    )
-
-
-PHASE1_REGISTERED_SOURCES: dict[str, RegisteredSource] = {
-    "sap-approved-spend": _phase1_registered_source(
-        source_id="sap-approved-spend",
-        display_label="SAP spend cube / approved_vendor_spend",
-        activation_posture="active",
-        source_flavor="warehouse",
-    ),
-    "legacy-finance-archive": _phase1_registered_source(
-        source_id="legacy-finance-archive",
-        display_label="Legacy finance archive",
-        activation_posture="paused",
-        source_flavor="archive",
-    ),
-}
-
-PHASE1_DATASET_CONTRACTS: dict[str, DatasetContract] = {
-    "sap-approved-spend": _phase1_dataset_contract(
-        source=PHASE1_REGISTERED_SOURCES["sap-approved-spend"],
-        owner_binding="group:finance-analysts",
-        security_review_binding="group:finance-reviewers",
-    ),
-    "legacy-finance-archive": _phase1_dataset_contract(
-        source=PHASE1_REGISTERED_SOURCES["legacy-finance-archive"],
-        owner_binding="group:archive-operators",
-    ),
-}
-
-
 class PreviewSubmissionContractError(ValueError):
     """Raised when a preview submission does not carry an executable source binding."""
+
+
+def _resolve_authoritative_source_governance(
+    session: Session,
+    *,
+    source_id: str,
+) -> tuple[RegisteredSource, DatasetContract]:
+    source = session.scalar(
+        select(RegisteredSource).where(RegisteredSource.source_id == source_id)
+    )
+    if source is None:
+        raise PreviewSubmissionContractError(
+            f"Registered source '{source_id}' does not exist."
+        )
+
+    if source.dataset_contract_id is None:
+        raise PreviewSubmissionContractError(
+            f"Registered source '{source.source_id}' has no active dataset contract."
+        )
+    if source.schema_snapshot_id is None:
+        raise PreviewSubmissionContractError(
+            f"Registered source '{source.source_id}' has no linked schema snapshot."
+        )
+
+    dataset_contract = session.get(DatasetContract, source.dataset_contract_id)
+    if (
+        dataset_contract is None
+        or dataset_contract.registered_source_id != source.id
+        or dataset_contract.schema_snapshot_id != source.schema_snapshot_id
+    ):
+        raise PreviewSubmissionContractError(
+            f"Registered source '{source.source_id}' is missing "
+            "authoritative source-scoped governance artifacts."
+        )
+
+    schema_snapshot = session.get(SchemaSnapshot, source.schema_snapshot_id)
+    if schema_snapshot is None or schema_snapshot.registered_source_id != source.id:
+        raise PreviewSubmissionContractError(
+            f"Registered source '{source.source_id}' has no linked schema snapshot."
+        )
+    if schema_snapshot.review_status != SchemaSnapshotReviewStatus.APPROVED:
+        raise PreviewSubmissionContractError(
+            f"Registered source '{source.source_id}' requires an approved schema snapshot."
+        )
+
+    return source, dataset_contract
 
 
 def submit_preview_request(
     payload: PreviewSubmissionRequest,
     authenticated_subject: AuthenticatedSubject,
+    session: Session,
 ) -> PreviewSubmissionResponse:
-    source = PHASE1_REGISTERED_SOURCES.get(payload.source_id)
-    if source is None:
-        raise PreviewSubmissionContractError(
-            f"Registered source '{payload.source_id}' does not exist."
-        )
+    source, dataset_contract = _resolve_authoritative_source_governance(
+        session,
+        source_id=payload.source_id,
+    )
 
     try:
         resolved_source = ensure_subject_is_entitled_for_source(
             authenticated_subject,
             source,
-            PHASE1_DATASET_CONTRACTS.get(payload.source_id),
+            dataset_contract,
         )
     except SourceEntitlementError as exc:
         raise PreviewSubmissionContractError(str(exc)) from exc

--- a/backend/tests/test_preview_source_governance_resolution.py
+++ b/backend/tests/test_preview_source_governance_resolution.py
@@ -69,10 +69,22 @@ def _seed_authoritative_source_governance(
     session.add(snapshot)
     session.flush()
 
+    drift_snapshot = None
+    if not link_contract_snapshot:
+        drift_snapshot = SchemaSnapshot(
+            id=uuid4(),
+            registered_source_id=source.id,
+            snapshot_version=2,
+            review_status=SchemaSnapshotReviewStatus.APPROVED,
+            reviewed_at=datetime.now(timezone.utc),
+        )
+        session.add(drift_snapshot)
+        session.flush()
+
     contract = DatasetContract(
         id=uuid4(),
         registered_source_id=source.id,
-        schema_snapshot_id=snapshot.id if link_contract_snapshot else uuid4(),
+        schema_snapshot_id=snapshot.id if link_contract_snapshot else drift_snapshot.id,
         contract_version=1,
         display_name="Persisted approved spend contract",
         owner_binding="group:finance-analysts",

--- a/backend/tests/test_preview_source_governance_resolution.py
+++ b/backend/tests/test_preview_source_governance_resolution.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import Session
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.services.request_preview import (
+    PreviewSubmissionContractError,
+    PreviewSubmissionRequest,
+    submit_preview_request,
+)
+
+
+@contextmanager
+def _session_scope() -> Session:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_authoritative_source_governance(
+    session: Session,
+    *,
+    source_id: str = "persisted-approved-spend",
+    source_posture: SourceActivationPosture = SourceActivationPosture.ACTIVE,
+    snapshot_status: SchemaSnapshotReviewStatus = SchemaSnapshotReviewStatus.APPROVED,
+    link_active_contract: bool = True,
+    link_active_snapshot: bool = True,
+    link_contract_snapshot: bool = True,
+) -> RegisteredSource:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id=source_id,
+        display_label="Persisted approved spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=source_posture,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{source_id}",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=1,
+        review_status=snapshot_status,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id if link_contract_snapshot else uuid4(),
+        contract_version=1,
+        display_name="Persisted approved spend contract",
+        owner_binding="group:finance-analysts",
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    if link_active_contract:
+        source.dataset_contract_id = contract.id
+    if link_active_snapshot:
+        source.schema_snapshot_id = snapshot.id
+
+    session.commit()
+    session.refresh(source)
+    return source
+
+
+def test_preview_submission_resolves_persisted_source_governance_records() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="persisted-approved-spend",
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+        )
+
+    assert response.model_dump()["candidate"]["source_id"] == "persisted-approved-spend"
+
+
+def test_preview_submission_rejects_missing_active_contract_linkage() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session, link_active_contract=False)
+
+        try:
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by quarterly spend",
+                    source_id="persisted-approved-spend",
+                ),
+                AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session,
+            )
+        except PreviewSubmissionContractError as exc:
+            assert str(exc) == (
+                "Registered source 'persisted-approved-spend' has no active dataset contract."
+            )
+        else:
+            raise AssertionError("preview submission unexpectedly accepted missing contract linkage")
+
+
+def test_preview_submission_rejects_missing_linked_schema_snapshot() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session, link_active_snapshot=False)
+
+        try:
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by quarterly spend",
+                    source_id="persisted-approved-spend",
+                ),
+                AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session,
+            )
+        except PreviewSubmissionContractError as exc:
+            assert str(exc) == (
+                "Registered source 'persisted-approved-spend' has no linked schema snapshot."
+            )
+        else:
+            raise AssertionError("preview submission unexpectedly accepted missing snapshot linkage")
+
+
+def test_preview_submission_rejects_non_approved_schema_snapshot() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(
+            session,
+            snapshot_status=SchemaSnapshotReviewStatus.PENDING,
+        )
+
+        try:
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by quarterly spend",
+                    source_id="persisted-approved-spend",
+                ),
+                AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session,
+            )
+        except PreviewSubmissionContractError as exc:
+            assert str(exc) == (
+                "Registered source 'persisted-approved-spend' requires an approved schema snapshot."
+            )
+        else:
+            raise AssertionError("preview submission unexpectedly accepted a non-approved snapshot")
+
+
+def test_preview_submission_rejects_contract_snapshot_drift() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session, link_contract_snapshot=False)
+
+        try:
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by quarterly spend",
+                    source_id="persisted-approved-spend",
+                ),
+                AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session,
+            )
+        except PreviewSubmissionContractError as exc:
+            assert str(exc) == (
+                "Registered source 'persisted-approved-spend' is missing authoritative "
+                "source-scoped governance artifacts."
+            )
+        else:
+            raise AssertionError("preview submission unexpectedly accepted drifted contract linkage")

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -1,16 +1,22 @@
 import importlib
 import os
 import unittest
+from datetime import datetime, timezone
 from unittest.mock import patch
+from uuid import uuid4
 
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
 
 from app.core.config import get_settings
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
-from app.services.request_preview import (
-    PHASE1_REGISTERED_SOURCES,
-    _phase1_registered_source,
-)
 
 
 class RequestSourceSelectionTestCase(unittest.TestCase):
@@ -19,21 +25,88 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             "postgresql://safequery:safequery@db:5432/safequery"
         )
         get_settings.cache_clear()
+        self.engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(self.engine)
+        self.session = Session(self.engine)
+
         main_module = importlib.import_module("app.main")
         self.app = main_module.create_app()
         self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(
             subject_id="user:alice",
             governance_bindings=frozenset({"group:finance-analysts"}),
         )
+        self.app.dependency_overrides[require_preview_submission_session] = (
+            lambda: self.session
+        )
         self.client = TestClient(self.app)
 
     def tearDown(self) -> None:
+        self.session.close()
+        self.engine.dispose()
         os.environ.pop("SAFEQUERY_APP_POSTGRES_URL", None)
         get_settings.cache_clear()
         self.app.dependency_overrides.clear()
 
+    def _seed_authoritative_source_governance(
+        self,
+        *,
+        source_id: str,
+        source_posture: SourceActivationPosture,
+        snapshot_status: SchemaSnapshotReviewStatus = SchemaSnapshotReviewStatus.APPROVED,
+    ) -> None:
+        source = RegisteredSource(
+            id=uuid4(),
+            source_id=source_id,
+            display_label=f"{source_id} display",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            activation_posture=source_posture,
+            connector_profile_id=None,
+            dialect_profile_id=None,
+            dataset_contract_id=None,
+            schema_snapshot_id=None,
+            execution_policy_id=None,
+            connection_reference=f"vault:{source_id}",
+        )
+        self.session.add(source)
+        self.session.flush()
+
+        snapshot = SchemaSnapshot(
+            id=uuid4(),
+            registered_source_id=source.id,
+            snapshot_version=1,
+            review_status=snapshot_status,
+            reviewed_at=datetime.now(timezone.utc),
+        )
+        self.session.add(snapshot)
+        self.session.flush()
+
+        contract = DatasetContract(
+            id=uuid4(),
+            registered_source_id=source.id,
+            schema_snapshot_id=snapshot.id,
+            contract_version=1,
+            display_name=f"{source_id} contract",
+            owner_binding="group:finance-analysts",
+            security_review_binding=None,
+            exception_policy_binding=None,
+        )
+        self.session.add(contract)
+        self.session.flush()
+
+        source.dataset_contract_id = contract.id
+        source.schema_snapshot_id = snapshot.id
+        self.session.commit()
+
     def test_preview_submission_rejects_missing_authenticated_subject_context(self) -> None:
         self.app.dependency_overrides.clear()
+        self.app.dependency_overrides[require_preview_submission_session] = (
+            lambda: self.session
+        )
 
         response = self.client.post(
             "/requests/preview",
@@ -94,6 +167,11 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         )
 
     def test_preview_submission_rejects_non_executable_source_id(self) -> None:
+        self._seed_authoritative_source_governance(
+            source_id="legacy-finance-archive",
+            source_posture=SourceActivationPosture.PAUSED,
+        )
+
         response = self.client.post(
             "/requests/preview",
             json={
@@ -114,16 +192,35 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         )
 
     def test_preview_submission_rejects_malformed_source_posture(self) -> None:
-        with patch.dict(
-            PHASE1_REGISTERED_SOURCES,
-            {
-                "broken-source": _phase1_registered_source(
-                    source_id="broken-source",
-                    display_label="Broken source",
-                    activation_posture="bogus",
-                )
-            },
-            clear=False,
+        source_id = uuid4()
+        malformed_source = RegisteredSource(
+            id=source_id,
+            source_id="broken-source",
+            display_label="Broken source",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            activation_posture="bogus",
+            connector_profile_id=None,
+            dialect_profile_id=None,
+            dataset_contract_id=uuid4(),
+            schema_snapshot_id=uuid4(),
+            execution_policy_id=None,
+            connection_reference="vault:broken-source",
+        )
+        malformed_contract = DatasetContract(
+            id=malformed_source.dataset_contract_id,
+            registered_source_id=source_id,
+            schema_snapshot_id=malformed_source.schema_snapshot_id,
+            contract_version=1,
+            display_name="Broken contract",
+            owner_binding="group:finance-analysts",
+            security_review_binding=None,
+            exception_policy_binding=None,
+        )
+
+        with patch(
+            "app.services.request_preview._resolve_authoritative_source_governance",
+            return_value=(malformed_source, malformed_contract),
         ):
             response = self.client.post(
                 "/requests/preview",
@@ -145,6 +242,11 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         )
 
     def test_preview_submission_accepts_registered_executable_source_id(self) -> None:
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+        )
+
         response = self.client.post(
             "/requests/preview",
             json={

--- a/backend/tests/test_source_bound_records.py
+++ b/backend/tests/test_source_bound_records.py
@@ -1,21 +1,94 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
-from app.services.request_preview import (
-    PreviewSubmissionRequest,
-    submit_preview_request,
-)
+from app.services.request_preview import PreviewSubmissionRequest, submit_preview_request
+
+
+@contextmanager
+def _session_scope() -> Session:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_authoritative_source_governance(session: Session) -> None:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id="sap-approved-spend",
+        display_label="SAP spend cube / approved_vendor_spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference="vault:sap-approved-spend",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=1,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=1,
+        display_name="SAP spend cube contract",
+        owner_binding="group:finance-analysts",
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.commit()
 
 
 def test_preview_submission_binds_all_records_to_authoritative_source_id() -> None:
-    response = submit_preview_request(
-        PreviewSubmissionRequest(
-            question="Show approved vendors by quarterly spend",
-            source_id="sap-approved-spend",
-        ),
-        AuthenticatedSubject(
-            subject_id="user:alice",
-            governance_bindings=frozenset({"group:finance-analysts"}),
-        ),
-    )
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+        )
 
     assert response.model_dump() == {
         "request": {


### PR DESCRIPTION
Closes #74
This PR was opened by codex-supervisor.
Latest Codex summary:

Preview submission now resolves the selected source from persisted governance records instead of phase-1 in-memory fixtures. The live path in [backend/app/services/request_preview.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-74/backend/app/services/request_preview.py) loads the authoritative `registered_sources` row, requires its active `dataset_contract_id` and linked `schema_snapshot_id`, verifies the contract/snapshot stay source-scoped, and fails closed unless the linked snapshot is `approved`. The route in [backend/app/main.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-74/backend/app/main.py) now gets a DB session from [backend/app/db/session.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-74/backend/app/db/session.py).

I added focused regression coverage in [backend/tests/test_preview_source_governance_resolution.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-74/backend/tests/test_preview_source_governance_resolution.py) and updated the existing source-selection/binding tests to seed persisted governance rows instead of relying on hard-coded fixtures. Checkpoint commit: `9c184d0` (`Wire preview to persisted governance records`).

Summary: Wired preview submission to authoritative persisted source-governance records and added fail-closed regression coverage for missing contract linkage, missing snapshot linkage, non-approved snapshots, and contract/snapshot drift.
State hint: implementing
Blocked reason: none
Tests: `...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview submission now resolves source governance from the database and enforces approved schema status before accepting submissions.
* **Bug Fixes**
  * Improved validation to reject submissions when governance artifacts are missing, inconsistent, or unapproved.
* **Tests**
  * Added comprehensive tests for governance-resolution and failure modes.
  * Updated existing tests to use isolated in-memory databases for reliable setup and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->