### PR TITLE
[B-F2] Separate execution entitlement allow rules from reviewer and exception bindings (#75)

### DIFF
--- a/backend/app/services/source_entitlements.py
+++ b/backend/app/services/source_entitlements.py
@@ -13,15 +13,21 @@ class SourceEntitlementError(PermissionError):
     """Raised when a subject is not entitled to use a selected registered source."""
 
 
-def _contract_governance_bindings(contract: DatasetContract) -> frozenset[str]:
+def _normalized_binding(binding: str | None) -> str | None:
+    if binding is None:
+        return None
+    normalized = binding.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _contract_execution_entitlement_bindings(contract: DatasetContract) -> frozenset[str]:
+    # Execution entitlement is currently limited to source operators.
+    # Review and exception bindings remain available for future role-aware policies
+    # but must not implicitly grant execution eligibility.
     bindings = {
-        normalized
-        for binding in (
-            contract.owner_binding,
-            contract.security_review_binding,
-            contract.exception_policy_binding,
-        )
-        if binding is not None and (normalized := binding.strip())
+        normalized for binding in (contract.owner_binding,) if (normalized := _normalized_binding(binding))
     }
     return frozenset(bindings)
 
@@ -42,11 +48,11 @@ def ensure_subject_is_entitled_for_source(
             "authoritative source-scoped governance artifacts."
         )
 
-    source_bindings = _contract_governance_bindings(dataset_contract)
+    source_bindings = _contract_execution_entitlement_bindings(dataset_contract)
     if not source_bindings:
         raise SourceEntitlementError(
             f"Registered source '{resolved_source.source_id}' has no "
-            "source-scoped governance bindings."
+            "execution-eligible source-scoped governance bindings."
         )
 
     subject_bindings = subject.normalized_governance_bindings()

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import unittest
 from datetime import datetime, timezone
+from typing import Optional
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -57,6 +58,9 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         source_id: str,
         source_posture: SourceActivationPosture,
         snapshot_status: SchemaSnapshotReviewStatus = SchemaSnapshotReviewStatus.APPROVED,
+        owner_binding: str = "group:finance-analysts",
+        security_review_binding: Optional[str] = None,
+        exception_policy_binding: Optional[str] = None,
     ) -> None:
         source = RegisteredSource(
             id=uuid4(),
@@ -91,9 +95,9 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             schema_snapshot_id=snapshot.id,
             contract_version=1,
             display_name=f"{source_id} contract",
-            owner_binding="group:finance-analysts",
-            security_review_binding=None,
-            exception_policy_binding=None,
+            owner_binding=owner_binding,
+            security_review_binding=security_review_binding,
+            exception_policy_binding=exception_policy_binding,
         )
         self.session.add(contract)
         self.session.flush()
@@ -276,6 +280,68 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                     "source_id": "sap-approved-spend",
                     "state": "pending",
                 },
+            },
+        )
+
+    def test_preview_submission_rejects_subject_matching_only_security_review_binding(self) -> None:
+        self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:security-reviewers"}),
+        )
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+            owner_binding="group:finance-analysts",
+            security_review_binding="group:security-reviewers",
+        )
+
+        response = self.client.post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
+            },
+        )
+
+    def test_preview_submission_rejects_subject_matching_only_exception_policy_binding(self) -> None:
+        self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:exception-approvers"}),
+        )
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+            owner_binding="group:finance-analysts",
+            exception_policy_binding="group:exception-approvers",
+        )
+
+        response = self.client.post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
             },
         )
 

--- a/backend/tests/test_source_entitlements.py
+++ b/backend/tests/test_source_entitlements.py
@@ -93,6 +93,42 @@ class SourceEntitlementTestCase(unittest.TestCase):
         ):
             ensure_subject_is_entitled_for_source(subject, source, contract)
 
+    def test_subject_matching_only_security_review_binding_is_denied(self) -> None:
+        source = _registered_source(source_id="sap-approved-spend")
+        contract = _dataset_contract(
+            registered_source_id=source.id,
+            owner_binding="group:finance-approvers",
+            security_review_binding="group:security-reviewers",
+        )
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:security-reviewers"}),
+        )
+
+        with self.assertRaisesRegex(
+            SourceEntitlementError,
+            "is not entitled to use registered source 'sap-approved-spend'",
+        ):
+            ensure_subject_is_entitled_for_source(subject, source, contract)
+
+    def test_subject_matching_only_exception_policy_binding_is_denied(self) -> None:
+        source = _registered_source(source_id="sap-approved-spend")
+        contract = _dataset_contract(
+            registered_source_id=source.id,
+            owner_binding="group:finance-approvers",
+            exception_policy_binding="group:exception-approvers",
+        )
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:exception-approvers"}),
+        )
+
+        with self.assertRaisesRegex(
+            SourceEntitlementError,
+            "is not entitled to use registered source 'sap-approved-spend'",
+        ):
+            ensure_subject_is_entitled_for_source(subject, source, contract)
+
     def test_non_executable_source_posture_is_rejected_before_entitlement_allow(self) -> None:
         source = _registered_source(
             source_id="legacy-finance-archive",


### PR DESCRIPTION
Closes #75
This PR was opened by codex-supervisor.
Latest Codex summary:

Separated execution entitlement evaluation so reviewer and exception bindings no longer implicitly grant source execution eligibility. The fix is in `backend/app/services/source_entitlements.py`, and I added focused regressions in `backend/tests/test_source_entitlements.py` plus request-boundary coverage in `backend/tests/test_request_source_selection.py`. Commit: `bb412fb` (`Separate execution entitlement bindings`).

Verification matched the issue guidance: `cd backend && python3 -m pytest tests/test_source_entitlements.py tests/test_request_source_selection.py` and all 14 tests passed. I also updated the local issue journal’s Codex Working Notes before finishing.

Summary: Narrowed source execution entitlement inputs to execution-eligible bindings only and added focused deny coverage for reviewer-only and exception-only subjects
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_source_entitlements.py tests/test_request_source_selection.py`
Failure signature: none
Next action: Open or update the draft PR for commit `bb412fb` if the supervisor flow wants an early checkpoint PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated source access control logic to restrict execution eligibility. Only owner-level governance bindings now grant access to registered sources; security review and exception policy bindings no longer qualify for execution rights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->