### PR TITLE
[C-1] Define the source-aware SQL generation adapter request schema (#79)

### DIFF
--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, StringConstraints
+from typing_extensions import Annotated
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class SQLGenerationSourceBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: NonEmptyTrimmedString
+    source_family: NonEmptyTrimmedString
+    source_flavor: Optional[NonEmptyTrimmedString] = None
+
+
+class SQLGenerationContextReferences(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_contract_id: NonEmptyTrimmedString
+    schema_snapshot_id: NonEmptyTrimmedString
+    glossary_id: Optional[NonEmptyTrimmedString] = None
+    policy_id: Optional[NonEmptyTrimmedString] = None
+
+
+class SQLGenerationAdapterRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: NonEmptyTrimmedString
+    question: NonEmptyTrimmedString
+    source: SQLGenerationSourceBinding
+    context: SQLGenerationContextReferences

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -69,12 +69,15 @@ def test_sql_generation_adapter_request_rejects_credentials_and_unbounded_contex
             }
         )
     except ValidationError as exc:
-        error_fields = {error["loc"][0] for error in exc.errors()}
+        field_error_types = {
+            (error["loc"][0], error["type"])
+            for error in exc.errors()
+        }
     else:
         raise AssertionError("Expected validation to fail for forbidden adapter fields.")
 
-    assert error_fields == {
-        "credentials",
-        "execution_authority",
-        "raw_schema_inventory",
+    assert field_error_types == {
+        ("credentials", "extra_forbidden"),
+        ("execution_authority", "extra_forbidden"),
+        ("raw_schema_inventory", "extra_forbidden"),
     }

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -1,0 +1,80 @@
+from pydantic import ValidationError
+
+from app.services.sql_generation_adapter import (
+    SQLGenerationAdapterRequest,
+    SQLGenerationContextReferences,
+    SQLGenerationSourceBinding,
+)
+
+
+def test_sql_generation_adapter_request_is_source_aware_and_single_source() -> None:
+    request = SQLGenerationAdapterRequest(
+        request_id="req_79_preview",
+        question="Show approved vendors by quarterly spend",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+            source_flavor="warehouse",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract_id="contract_finance_v1",
+            schema_snapshot_id="snapshot_finance_v3",
+            glossary_id="glossary_finance_v2",
+            policy_id="policy_generation_v1",
+        ),
+    )
+
+    assert request.model_dump() == {
+        "request_id": "req_79_preview",
+        "question": "Show approved vendors by quarterly spend",
+        "source": {
+            "source_id": "sap-approved-spend",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "context": {
+            "dataset_contract_id": "contract_finance_v1",
+            "schema_snapshot_id": "snapshot_finance_v3",
+            "glossary_id": "glossary_finance_v2",
+            "policy_id": "policy_generation_v1",
+        },
+    }
+
+
+def test_sql_generation_adapter_request_rejects_credentials_and_unbounded_context() -> None:
+    try:
+        SQLGenerationAdapterRequest.model_validate(
+            {
+                "request_id": "req_79_preview",
+                "question": "Show approved vendors by quarterly spend",
+                "source": {
+                    "source_id": "sap-approved-spend",
+                    "source_family": "postgresql",
+                },
+                "context": {
+                    "dataset_contract_id": "contract_finance_v1",
+                    "schema_snapshot_id": "snapshot_finance_v3",
+                },
+                "credentials": {
+                    "username": "analyst",
+                    "password": "not-allowed",
+                },
+                "execution_authority": True,
+                "raw_schema_inventory": [
+                    {
+                        "schema": "finance",
+                        "table": "approved_vendor_spend",
+                    }
+                ],
+            }
+        )
+    except ValidationError as exc:
+        error_fields = {error["loc"][0] for error in exc.errors()}
+    else:
+        raise AssertionError("Expected validation to fail for forbidden adapter fields.")
+
+    assert error_fields == {
+        "credentials",
+        "execution_authority",
+        "raw_schema_inventory",
+    }


### PR DESCRIPTION
Closes #79
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the missing source-aware adapter request contract in [sql_generation_adapter.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-79/backend/app/services/sql_generation_adapter.py) and added a focused regression test in [test_sql_generation_adapter_request.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-79/backend/tests/test_sql_generation_adapter_request.py). The schema is explicitly single-source, carries `source_id` / `source_family` / optional `source_flavor`, and limits adapter context to curated references (`dataset_contract_id`, `schema_snapshot_id`, optional `glossary_id`, optional `policy_id`).

I first reproduced the gap with a failing focused pytest import error because the adapter schema module did not exist, then added the minimal Pydantic models and verified they reject forbidden fields like credentials, execution authority, and raw schema inventory. I also updated the issue journal working notes and committed the checkpoint as `8bce66e` (`Add source-aware SQL generation adapter request schema`).

Summary: Added and verified the explicit source-aware SQL generation adapter request schema and focused contract tests.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py`; `cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py tests/test_source_bound_records.py tests/test_request_source_selection.py`
Failure signature: none
Next action...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added stricter request validation for the SQL generation adapter to enforce required fields and reject unexpected input.
* **Tests**
  * Added tests covering request serialization and validation behavior, ensuring extra/unexpected fields are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->