### PR TITLE
[C-2] Implement curated source-scoped context preparation for the selected source (#80)

### DIFF
--- a/backend/app/services/generation_context.py
+++ b/backend/app/services/generation_context.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, StringConstraints
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from typing_extensions import Annotated
+
+from app.db.models.dataset_contract import DatasetContractDataset
+from app.features.auth.context import AuthenticatedSubject
+from app.services.source_entitlements import (
+    SourceEntitlementError,
+    ensure_subject_is_entitled_for_source,
+)
+from app.services.source_governance import (
+    SourceGovernanceResolutionError,
+    resolve_authoritative_source_governance,
+)
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class GenerationContextRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: NonEmptyTrimmedString
+    question: NonEmptyTrimmedString
+
+
+class GenerationContextSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: NonEmptyTrimmedString
+    display_label: NonEmptyTrimmedString
+    source_family: NonEmptyTrimmedString
+    source_flavor: Optional[NonEmptyTrimmedString] = None
+
+
+class GenerationContextGovernance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_contract_id: NonEmptyTrimmedString
+    schema_snapshot_id: NonEmptyTrimmedString
+
+
+class GenerationContextDataset(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_name: NonEmptyTrimmedString
+    dataset_name: NonEmptyTrimmedString
+    dataset_kind: NonEmptyTrimmedString
+
+
+class PreparedGenerationContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request: GenerationContextRequest
+    source: GenerationContextSource
+    governance: GenerationContextGovernance
+    datasets: list[GenerationContextDataset]
+
+
+class GenerationContextPreparationError(ValueError):
+    """Raised when curated generation context cannot be prepared safely."""
+
+
+def prepare_generation_context(
+    *,
+    request_id: str,
+    question: str,
+    source_id: str,
+    authenticated_subject: AuthenticatedSubject,
+    session: Session,
+) -> PreparedGenerationContext:
+    try:
+        source, dataset_contract, schema_snapshot = resolve_authoritative_source_governance(
+            session,
+            source_id=source_id,
+        )
+        resolved_source = ensure_subject_is_entitled_for_source(
+            authenticated_subject,
+            source,
+            dataset_contract,
+        )
+    except (SourceGovernanceResolutionError, SourceEntitlementError) as exc:
+        raise GenerationContextPreparationError(str(exc)) from exc
+
+    approved_datasets = session.execute(
+        select(DatasetContractDataset)
+        .where(DatasetContractDataset.dataset_contract_id == dataset_contract.id)
+        .order_by(
+            DatasetContractDataset.schema_name.asc(),
+            DatasetContractDataset.dataset_name.asc(),
+        )
+    ).scalars().all()
+    if not approved_datasets:
+        raise GenerationContextPreparationError(
+            f"Registered source '{resolved_source.source_id}' has no approved datasets in the active contract."
+        )
+
+    return PreparedGenerationContext(
+        request=GenerationContextRequest(
+            request_id=request_id,
+            question=question,
+        ),
+        source=GenerationContextSource(
+            source_id=resolved_source.source_id,
+            display_label=resolved_source.display_label,
+            source_family=resolved_source.source_family,
+            source_flavor=resolved_source.source_flavor,
+        ),
+        governance=GenerationContextGovernance(
+            dataset_contract_id=str(dataset_contract.id),
+            schema_snapshot_id=str(schema_snapshot.id),
+        ),
+        datasets=[
+            GenerationContextDataset(
+                schema_name=dataset.schema_name,
+                dataset_name=dataset.dataset_name,
+                dataset_kind=dataset.dataset_kind.value,
+            )
+            for dataset in approved_datasets
+        ],
+    )

--- a/backend/app/services/generation_context.py
+++ b/backend/app/services/generation_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, StringConstraints
 from sqlalchemy import select
@@ -20,6 +20,7 @@ from app.services.source_governance import (
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+DatasetKindLiteral = Literal["view", "table", "materialized_view"]
 
 
 class GenerationContextRequest(BaseModel):
@@ -50,7 +51,7 @@ class GenerationContextDataset(BaseModel):
 
     schema_name: NonEmptyTrimmedString
     dataset_name: NonEmptyTrimmedString
-    dataset_kind: NonEmptyTrimmedString
+    dataset_kind: DatasetKindLiteral
 
 
 class PreparedGenerationContext(BaseModel):

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,15 +1,17 @@
 from pydantic import BaseModel, ConfigDict, StringConstraints
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
 
 from app.db.models.dataset_contract import DatasetContract
-from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource
 from app.features.auth.context import AuthenticatedSubject
 from app.services.source_entitlements import (
     SourceEntitlementError,
     ensure_subject_is_entitled_for_source,
+)
+from app.services.source_governance import (
+    SourceGovernanceResolutionError,
+    resolve_authoritative_source_governance,
 )
 
 
@@ -60,52 +62,13 @@ def _resolve_authoritative_source_governance(
     *,
     source_id: str,
 ) -> tuple[RegisteredSource, DatasetContract]:
-    governance_row = session.execute(
-        select(RegisteredSource, DatasetContract, SchemaSnapshot)
-        .outerjoin(
-            DatasetContract,
-            DatasetContract.id == RegisteredSource.dataset_contract_id,
+    try:
+        source, dataset_contract, _ = resolve_authoritative_source_governance(
+            session,
+            source_id=source_id,
         )
-        .outerjoin(
-            SchemaSnapshot,
-            SchemaSnapshot.id == RegisteredSource.schema_snapshot_id,
-        )
-        .where(RegisteredSource.source_id == source_id)
-    ).one_or_none()
-    if governance_row is None:
-        raise PreviewSubmissionContractError(
-            f"Registered source '{source_id}' does not exist."
-        )
-
-    source, dataset_contract, schema_snapshot = governance_row
-
-    if source.dataset_contract_id is None:
-        raise PreviewSubmissionContractError(
-            f"Registered source '{source.source_id}' has no active dataset contract."
-        )
-    if source.schema_snapshot_id is None:
-        raise PreviewSubmissionContractError(
-            f"Registered source '{source.source_id}' has no linked schema snapshot."
-        )
-
-    if (
-        dataset_contract is None
-        or dataset_contract.registered_source_id != source.id
-        or dataset_contract.schema_snapshot_id != source.schema_snapshot_id
-    ):
-        raise PreviewSubmissionContractError(
-            f"Registered source '{source.source_id}' is missing "
-            "authoritative source-scoped governance artifacts."
-        )
-
-    if schema_snapshot is None or schema_snapshot.registered_source_id != source.id:
-        raise PreviewSubmissionContractError(
-            f"Registered source '{source.source_id}' has no linked schema snapshot."
-        )
-    if schema_snapshot.review_status != SchemaSnapshotReviewStatus.APPROVED:
-        raise PreviewSubmissionContractError(
-            f"Registered source '{source.source_id}' requires an approved schema snapshot."
-        )
+    except SourceGovernanceResolutionError as exc:
+        raise PreviewSubmissionContractError(str(exc)) from exc
 
     return source, dataset_contract
 

--- a/backend/app/services/source_governance.py
+++ b/backend/app/services/source_governance.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource
+
+
+class SourceGovernanceResolutionError(ValueError):
+    """Raised when a registered source lacks authoritative governance linkage."""
+
+
+def resolve_authoritative_source_governance(
+    session: Session,
+    *,
+    source_id: str,
+) -> tuple[RegisteredSource, DatasetContract, SchemaSnapshot]:
+    governance_row = session.execute(
+        select(RegisteredSource, DatasetContract, SchemaSnapshot)
+        .outerjoin(
+            DatasetContract,
+            DatasetContract.id == RegisteredSource.dataset_contract_id,
+        )
+        .outerjoin(
+            SchemaSnapshot,
+            SchemaSnapshot.id == RegisteredSource.schema_snapshot_id,
+        )
+        .where(RegisteredSource.source_id == source_id)
+    ).one_or_none()
+    if governance_row is None:
+        raise SourceGovernanceResolutionError(
+            f"Registered source '{source_id}' does not exist."
+        )
+
+    source, dataset_contract, schema_snapshot = governance_row
+
+    if source.dataset_contract_id is None:
+        raise SourceGovernanceResolutionError(
+            f"Registered source '{source.source_id}' has no active dataset contract."
+        )
+    if source.schema_snapshot_id is None:
+        raise SourceGovernanceResolutionError(
+            f"Registered source '{source.source_id}' has no linked schema snapshot."
+        )
+
+    if (
+        dataset_contract is None
+        or dataset_contract.registered_source_id != source.id
+        or dataset_contract.schema_snapshot_id != source.schema_snapshot_id
+    ):
+        raise SourceGovernanceResolutionError(
+            f"Registered source '{source.source_id}' is missing "
+            "authoritative source-scoped governance artifacts."
+        )
+
+    if schema_snapshot is None or schema_snapshot.registered_source_id != source.id:
+        raise SourceGovernanceResolutionError(
+            f"Registered source '{source.source_id}' has no linked schema snapshot."
+        )
+    if schema_snapshot.review_status != SchemaSnapshotReviewStatus.APPROVED:
+        raise SourceGovernanceResolutionError(
+            f"Registered source '{source.source_id}' requires an approved schema snapshot."
+        )
+
+    return source, dataset_contract, schema_snapshot

--- a/backend/tests/test_generation_context_preparation.py
+++ b/backend/tests/test_generation_context_preparation.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
@@ -175,7 +176,10 @@ def test_prepare_generation_context_rejects_missing_active_contract_linkage() ->
             link_active_contract=False,
         )
 
-        try:
+        with pytest.raises(
+            GenerationContextPreparationError,
+            match=r"Registered source 'sap-approved-spend' has no active dataset contract\.",
+        ):
             prepare_generation_context(
                 request_id="req_preview_80",
                 question="Show approved vendors by quarterly spend",
@@ -185,12 +189,4 @@ def test_prepare_generation_context_rejects_missing_active_contract_linkage() ->
                     governance_bindings=frozenset({"group:finance-analysts"}),
                 ),
                 session=session,
-            )
-        except GenerationContextPreparationError as exc:
-            assert str(exc) == (
-                "Registered source 'sap-approved-spend' has no active dataset contract."
-            )
-        else:
-            raise AssertionError(
-                "generation context preparation unexpectedly accepted missing contract linkage"
             )

--- a/backend/tests/test_generation_context_preparation.py
+++ b/backend/tests/test_generation_context_preparation.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import (
+    DatasetContract,
+    DatasetContractDataset,
+    DatasetContractDatasetKind,
+)
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.services.generation_context import (
+    GenerationContextPreparationError,
+    prepare_generation_context,
+)
+
+
+@contextmanager
+def _session_scope() -> Session:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_source_governance(
+    session: Session,
+    *,
+    source_id: str,
+    owner_binding: str = "group:finance-analysts",
+    link_active_contract: bool = True,
+) -> RegisteredSource:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id=source_id,
+        display_label=f"{source_id} display",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{source_id}",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=1,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=1,
+        display_name=f"{source_id} contract",
+        owner_binding=owner_binding,
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    session.add_all(
+        [
+            DatasetContractDataset(
+                id=uuid4(),
+                dataset_contract_id=contract.id,
+                schema_name="finance",
+                dataset_name=f"{source_id}_spend",
+                dataset_kind=DatasetContractDatasetKind.TABLE,
+            ),
+            DatasetContractDataset(
+                id=uuid4(),
+                dataset_contract_id=contract.id,
+                schema_name="analytics",
+                dataset_name=f"{source_id}_summary",
+                dataset_kind=DatasetContractDatasetKind.VIEW,
+            ),
+        ]
+    )
+
+    if link_active_contract:
+        source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+
+    session.commit()
+    session.refresh(source)
+    return source
+
+
+def test_prepare_generation_context_uses_only_selected_source_governance() -> None:
+    with _session_scope() as session:
+        selected_source = _seed_source_governance(
+            session,
+            source_id="sap-approved-spend",
+        )
+        other_source = _seed_source_governance(
+            session,
+            source_id="crm-pipeline",
+            owner_binding="group:sales-analysts",
+        )
+
+        prepared = prepare_generation_context(
+            request_id="req_preview_80",
+            question="Show approved vendors by quarterly spend",
+            source_id="sap-approved-spend",
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session=session,
+        )
+
+    assert prepared.model_dump() == {
+        "request": {
+            "request_id": "req_preview_80",
+            "question": "Show approved vendors by quarterly spend",
+        },
+        "source": {
+            "source_id": "sap-approved-spend",
+            "display_label": "sap-approved-spend display",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "governance": {
+            "dataset_contract_id": str(selected_source.dataset_contract_id),
+            "schema_snapshot_id": str(selected_source.schema_snapshot_id),
+        },
+        "datasets": [
+            {
+                "schema_name": "analytics",
+                "dataset_name": "sap-approved-spend_summary",
+                "dataset_kind": "view",
+            },
+            {
+                "schema_name": "finance",
+                "dataset_name": "sap-approved-spend_spend",
+                "dataset_kind": "table",
+            },
+        ],
+    }
+    assert "crm-pipeline" not in str(prepared.model_dump())
+    assert str(other_source.dataset_contract_id) not in str(prepared.model_dump())
+    assert "connection_reference" not in prepared.model_dump()
+
+
+def test_prepare_generation_context_rejects_missing_active_contract_linkage() -> None:
+    with _session_scope() as session:
+        _seed_source_governance(
+            session,
+            source_id="sap-approved-spend",
+            link_active_contract=False,
+        )
+
+        try:
+            prepare_generation_context(
+                request_id="req_preview_80",
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+            )
+        except GenerationContextPreparationError as exc:
+            assert str(exc) == (
+                "Registered source 'sap-approved-spend' has no active dataset contract."
+            )
+        else:
+            raise AssertionError(
+                "generation context preparation unexpectedly accepted missing contract linkage"
+            )

--- a/backend/tests/test_generation_context_preparation.py
+++ b/backend/tests/test_generation_context_preparation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from uuid import uuid4
@@ -24,7 +25,7 @@ from app.services.generation_context import (
 
 
 @contextmanager
-def _session_scope() -> Session:
+def _session_scope() -> Iterator[Session]:
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},


### PR DESCRIPTION
Closes #80
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the selected-source generation-context seam in `backend`: `app/services/generation_context.py` now resolves authoritative source governance, enforces source entitlement, and prepares curated context from the active contract and its approved datasets only. I also extracted the shared fail-closed resolver into `app/services/source_governance.py` and switched `request_preview.py` to reuse it so the linkage checks stay aligned.

Added `backend/tests/test_generation_context_preparation.py` to prove two things narrowly: successful preparation stays scoped to the selected source and excludes cross-source metadata, and missing active contract linkage is rejected. Focused verification passed, and I committed the checkpoint as `d1efefa` (`Add curated generation context preparation`).

Summary: Added curated source-scoped generation-context preparation with focused regression coverage and shared authoritative governance resolution.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_generation_context_preparation.py`; `cd backend && python3 -m pytest tests/test_preview_source_governance_resolution.py`; `cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py`
Failure signature: none
Next action: Open or update a draft PR for branch `codex/issue-80`, then continue with any review-driven integration of this preparation path into later generation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved governance and entitlement resolution to enforce dataset contract and snapshot validity more consistently, with clearer rejection when no approved datasets are available.

* **Bug Fixes**
  * Centralized authoritative source validation to reduce inconsistent checks and surface clearer failure conditions for preview and generation flows.

* **Chores**
  * Added targeted tests to validate context preparation and governance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->