### PR TITLE
[C-3] Assemble generation context from dataset contracts and schema snapshots (#81)

### DIFF
--- a/backend/tests/test_generation_context_preparation.py
+++ b/backend/tests/test_generation_context_preparation.py
@@ -42,7 +42,10 @@ def _seed_source_governance(
     *,
     source_id: str,
     owner_binding: str = "group:finance-analysts",
+    snapshot_status: SchemaSnapshotReviewStatus = SchemaSnapshotReviewStatus.APPROVED,
     link_active_contract: bool = True,
+    link_active_snapshot: bool = True,
+    link_contract_snapshot: bool = True,
 ) -> RegisteredSource:
     source = RegisteredSource(
         id=uuid4(),
@@ -65,16 +68,28 @@ def _seed_source_governance(
         id=uuid4(),
         registered_source_id=source.id,
         snapshot_version=1,
-        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        review_status=snapshot_status,
         reviewed_at=datetime.now(timezone.utc),
     )
     session.add(snapshot)
     session.flush()
 
+    drift_snapshot = None
+    if not link_contract_snapshot:
+        drift_snapshot = SchemaSnapshot(
+            id=uuid4(),
+            registered_source_id=source.id,
+            snapshot_version=2,
+            review_status=SchemaSnapshotReviewStatus.APPROVED,
+            reviewed_at=datetime.now(timezone.utc),
+        )
+        session.add(drift_snapshot)
+        session.flush()
+
     contract = DatasetContract(
         id=uuid4(),
         registered_source_id=source.id,
-        schema_snapshot_id=snapshot.id,
+        schema_snapshot_id=snapshot.id if link_contract_snapshot else drift_snapshot.id,
         contract_version=1,
         display_name=f"{source_id} contract",
         owner_binding=owner_binding,
@@ -105,7 +120,8 @@ def _seed_source_governance(
 
     if link_active_contract:
         source.dataset_contract_id = contract.id
-    source.schema_snapshot_id = snapshot.id
+    if link_active_snapshot:
+        source.schema_snapshot_id = snapshot.id
 
     session.commit()
     session.refresh(source)
@@ -179,6 +195,59 @@ def test_prepare_generation_context_rejects_missing_active_contract_linkage() ->
         with pytest.raises(
             GenerationContextPreparationError,
             match=r"Registered source 'sap-approved-spend' has no active dataset contract\.",
+        ):
+            prepare_generation_context(
+                request_id="req_preview_80",
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+            )
+
+
+def test_prepare_generation_context_rejects_non_approved_schema_snapshot() -> None:
+    with _session_scope() as session:
+        _seed_source_governance(
+            session,
+            source_id="sap-approved-spend",
+            snapshot_status=SchemaSnapshotReviewStatus.PENDING,
+        )
+
+        with pytest.raises(
+            GenerationContextPreparationError,
+            match=(
+                r"Registered source 'sap-approved-spend' requires an approved schema snapshot\."
+            ),
+        ):
+            prepare_generation_context(
+                request_id="req_preview_80",
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+            )
+
+
+def test_prepare_generation_context_rejects_contract_snapshot_drift() -> None:
+    with _session_scope() as session:
+        _seed_source_governance(
+            session,
+            source_id="sap-approved-spend",
+            link_contract_snapshot=False,
+        )
+
+        with pytest.raises(
+            GenerationContextPreparationError,
+            match=(
+                r"Registered source 'sap-approved-spend' is missing "
+                r"authoritative source-scoped governance artifacts\."
+            ),
         ):
             prepare_generation_context(
                 request_id="req_preview_80",


### PR DESCRIPTION
Closes #81
This PR was opened by codex-supervisor.
Latest Codex summary:

Added focused fail-closed coverage on the generation-context path in [backend/tests/test_generation_context_preparation.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-81/backend/tests/test_generation_context_preparation.py). The service logic was already assembling authoritative, source-scoped context from dataset contracts and schema snapshots; the gap was that this path did not yet prove rejection for non-approved snapshots and contract/snapshot drift.

I also updated the supervisor journal locally at [.codex-supervisor/issues/81/issue-journal.md](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-81/.codex-supervisor/issues/81/issue-journal.md) and created checkpoint commit `40dde0c` with the test hardening. Focused verification passed:
`cd backend && python3 -m pytest tests/test_generation_context_preparation.py`
`cd backend && python3 -m pytest tests/test_preview_source_governance_resolution.py`

Summary: Tightened generation-context regression coverage for authoritative snapshot approval and contract/snapshot drift; committed as `40dde0c`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_generation_context_preparation.py`; `cd backend && python3 -m pytest tests/test_preview_source_governance_resolution.py`
Failure signature: none
Next action: Decide whether to open a draft PR for this checkpoint or continue with any remaining generation-context integration work beyond the now-covered authoritative assemb...