### PR TITLE
[C-4] Enforce that the adapter cannot access business-source credentials (#82)

### DIFF
--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Protocol
 
 from pydantic import BaseModel, ConfigDict, StringConstraints
 from typing_extensions import Annotated
+
+from app.services.generation_context import PreparedGenerationContext
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
@@ -33,3 +35,26 @@ class SQLGenerationAdapterRequest(BaseModel):
     question: NonEmptyTrimmedString
     source: SQLGenerationSourceBinding
     context: SQLGenerationContextReferences
+
+
+class SQLGenerationAdapter(Protocol):
+    def generate_sql(self, request: SQLGenerationAdapterRequest) -> str:
+        """Generate SQL from the adapter-safe request projection."""
+
+
+def build_sql_generation_adapter_request(
+    prepared_context: PreparedGenerationContext,
+) -> SQLGenerationAdapterRequest:
+    return SQLGenerationAdapterRequest(
+        request_id=prepared_context.request.request_id,
+        question=prepared_context.request.question,
+        source=SQLGenerationSourceBinding(
+            source_id=prepared_context.source.source_id,
+            source_family=prepared_context.source.source_family,
+            source_flavor=prepared_context.source.source_flavor,
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract_id=prepared_context.governance.dataset_contract_id,
+            schema_snapshot_id=prepared_context.governance.schema_snapshot_id,
+        ),
+    )

--- a/backend/tests/test_adapter_credential_isolation.py
+++ b/backend/tests/test_adapter_credential_isolation.py
@@ -1,0 +1,55 @@
+from app.services.generation_context import (
+    GenerationContextGovernance,
+    GenerationContextRequest,
+    GenerationContextSource,
+    PreparedGenerationContext,
+)
+from app.services.sql_generation_adapter import (
+    SQLGenerationAdapterRequest,
+    build_sql_generation_adapter_request,
+)
+
+
+def test_build_sql_generation_adapter_request_uses_only_adapter_safe_fields() -> None:
+    prepared_context = PreparedGenerationContext(
+        request=GenerationContextRequest(
+            request_id="req_82_preview",
+            question="Show approved vendors by quarterly spend",
+        ),
+        source=GenerationContextSource(
+            source_id="sap-approved-spend",
+            display_label="SAP Approved Spend",
+            source_family="postgresql",
+            source_flavor="warehouse",
+        ),
+        governance=GenerationContextGovernance(
+            dataset_contract_id="contract_finance_v1",
+            schema_snapshot_id="snapshot_finance_v3",
+        ),
+        datasets=[],
+    )
+
+    adapter_request = build_sql_generation_adapter_request(prepared_context)
+
+    assert isinstance(adapter_request, SQLGenerationAdapterRequest)
+    assert adapter_request.model_dump() == {
+        "request_id": "req_82_preview",
+        "question": "Show approved vendors by quarterly spend",
+        "source": {
+            "source_id": "sap-approved-spend",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "context": {
+            "dataset_contract_id": "contract_finance_v1",
+            "schema_snapshot_id": "snapshot_finance_v3",
+            "glossary_id": None,
+            "policy_id": None,
+        },
+    }
+    dumped = adapter_request.model_dump()
+    assert "display_label" not in str(dumped)
+    assert "datasets" not in dumped
+    assert "connection_reference" not in str(dumped)
+    assert "connector_profile_id" not in str(dumped)
+    assert "execution_policy_id" not in str(dumped)


### PR DESCRIPTION
Closes #82
This PR was opened by codex-supervisor.
Latest Codex summary:

Added an explicit adapter-safe projection seam in [backend/app/services/sql_generation_adapter.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-82/backend/app/services/sql_generation_adapter.py) and a focused regression in [backend/tests/test_adapter_credential_isolation.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-82/backend/tests/test_adapter_credential_isolation.py). The new `build_sql_generation_adapter_request(...)` only forwards curated request/source/governance identifiers from `PreparedGenerationContext`, so backend-owned fields like `connection_reference`, connector handles, and execution policy references stay on the trusted side of the boundary. I also added a `SQLGenerationAdapter` protocol so the adapter contract stays replaceable without widening what it can receive.

The required journal was updated locally at [.codex-supervisor/issues/82/issue-journal.md](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-82/.codex-supervisor/issues/82/issue-journal.md), but that path is gitignored so it was not included in the commit. Checkpoint commit: `494bc10` (`Add adapter credential isolation boundary`).

Summary: Added an explicit adapter-safe request builder and focused credential-isolation test; committed as `494bc10`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_adapter_credential_isolation.py`; `cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py`
Failure sign...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced adapter interface for SQL generation from contextual data.

* **Tests**
  * Added test validating that only non-sensitive fields are passed to the SQL adapter, ensuring credentials and confidential configuration remain isolated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->