### PR TITLE
[C-5] Reject multi-source context supply at the adapter boundary (#83)

### DIFF
--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, Protocol
 
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
 from typing_extensions import Annotated
 
 from app.services.generation_context import PreparedGenerationContext
@@ -22,10 +22,17 @@ class SQLGenerationSourceBinding(BaseModel):
 class SQLGenerationContextReferences(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    dataset_contract_id: NonEmptyTrimmedString
-    schema_snapshot_id: NonEmptyTrimmedString
-    glossary_id: Optional[NonEmptyTrimmedString] = None
-    policy_id: Optional[NonEmptyTrimmedString] = None
+    dataset_contract: "SQLGenerationContextReference"
+    schema_snapshot: "SQLGenerationContextReference"
+    glossary: Optional["SQLGenerationContextReference"] = None
+    policy: Optional["SQLGenerationContextReference"] = None
+
+
+class SQLGenerationContextReference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context_id: NonEmptyTrimmedString
+    source_id: NonEmptyTrimmedString
 
 
 class SQLGenerationAdapterRequest(BaseModel):
@@ -35,6 +42,25 @@ class SQLGenerationAdapterRequest(BaseModel):
     question: NonEmptyTrimmedString
     source: SQLGenerationSourceBinding
     context: SQLGenerationContextReferences
+
+    @model_validator(mode="after")
+    def validate_single_source_context(self) -> "SQLGenerationAdapterRequest":
+        fragment_source_ids = {
+            fragment.source_id
+            for fragment in (
+                self.context.dataset_contract,
+                self.context.schema_snapshot,
+                self.context.glossary,
+                self.context.policy,
+            )
+            if fragment is not None
+        }
+        if fragment_source_ids != {self.source.source_id}:
+            raise ValueError(
+                "Adapter request context must stay bound to source_id "
+                f"'{self.source.source_id}'."
+            )
+        return self
 
 
 class SQLGenerationAdapter(Protocol):
@@ -54,7 +80,13 @@ def build_sql_generation_adapter_request(
             source_flavor=prepared_context.source.source_flavor,
         ),
         context=SQLGenerationContextReferences(
-            dataset_contract_id=prepared_context.governance.dataset_contract_id,
-            schema_snapshot_id=prepared_context.governance.schema_snapshot_id,
+            dataset_contract=SQLGenerationContextReference(
+                context_id=prepared_context.governance.dataset_contract_id,
+                source_id=prepared_context.source.source_id,
+            ),
+            schema_snapshot=SQLGenerationContextReference(
+                context_id=prepared_context.governance.schema_snapshot_id,
+                source_id=prepared_context.source.source_id,
+            ),
         ),
     )

--- a/backend/tests/test_adapter_credential_isolation.py
+++ b/backend/tests/test_adapter_credential_isolation.py
@@ -41,10 +41,16 @@ def test_build_sql_generation_adapter_request_uses_only_adapter_safe_fields() ->
             "source_flavor": "warehouse",
         },
         "context": {
-            "dataset_contract_id": "contract_finance_v1",
-            "schema_snapshot_id": "snapshot_finance_v3",
-            "glossary_id": None,
-            "policy_id": None,
+            "dataset_contract": {
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            "schema_snapshot": {
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            "glossary": None,
+            "policy": None,
         },
     }
     dumped = adapter_request.model_dump()

--- a/backend/tests/test_adapter_single_source_validation.py
+++ b/backend/tests/test_adapter_single_source_validation.py
@@ -1,0 +1,99 @@
+from pydantic import ValidationError
+
+from app.services.sql_generation_adapter import SQLGenerationAdapterRequest
+
+
+def test_adapter_request_accepts_single_source_context_fragments() -> None:
+    request = SQLGenerationAdapterRequest.model_validate(
+        {
+            "request_id": "req_83_preview",
+            "question": "Show approved vendors by quarterly spend",
+            "source": {
+                "source_id": "sap-approved-spend",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+            "context": {
+                "dataset_contract": {
+                    "context_id": "contract_finance_v1",
+                    "source_id": "sap-approved-spend",
+                },
+                "schema_snapshot": {
+                    "context_id": "snapshot_finance_v3",
+                    "source_id": "sap-approved-spend",
+                },
+                "glossary": {
+                    "context_id": "glossary_finance_v2",
+                    "source_id": "sap-approved-spend",
+                },
+                "policy": {
+                    "context_id": "policy_generation_v1",
+                    "source_id": "sap-approved-spend",
+                },
+            },
+        }
+    )
+
+    assert request.model_dump() == {
+        "request_id": "req_83_preview",
+        "question": "Show approved vendors by quarterly spend",
+        "source": {
+            "source_id": "sap-approved-spend",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "context": {
+            "dataset_contract": {
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            "schema_snapshot": {
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            "glossary": {
+                "context_id": "glossary_finance_v2",
+                "source_id": "sap-approved-spend",
+            },
+            "policy": {
+                "context_id": "policy_generation_v1",
+                "source_id": "sap-approved-spend",
+            },
+        },
+    }
+
+
+def test_adapter_request_rejects_mixed_source_context_fragments() -> None:
+    try:
+        SQLGenerationAdapterRequest.model_validate(
+            {
+                "request_id": "req_83_preview",
+                "question": "Show approved vendors by quarterly spend",
+                "source": {
+                    "source_id": "sap-approved-spend",
+                    "source_family": "postgresql",
+                    "source_flavor": "warehouse",
+                },
+                "context": {
+                    "dataset_contract": {
+                        "context_id": "contract_finance_v1",
+                        "source_id": "sap-approved-spend",
+                    },
+                    "schema_snapshot": {
+                        "context_id": "snapshot_sales_v5",
+                        "source_id": "crm-pipeline",
+                    },
+                },
+            }
+        )
+    except ValidationError as exc:
+        errors = exc.errors()
+        assert len(errors) == 1
+        assert errors[0]["type"] == "value_error"
+        assert errors[0]["loc"] == ()
+        assert (
+            "Adapter request context must stay bound to source_id "
+            "'sap-approved-spend'."
+        ) in errors[0]["msg"]
+    else:
+        raise AssertionError("Expected validation to fail for mixed-source context.")

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -17,10 +17,22 @@ def test_sql_generation_adapter_request_is_source_aware_and_single_source() -> N
             source_flavor="warehouse",
         ),
         context=SQLGenerationContextReferences(
-            dataset_contract_id="contract_finance_v1",
-            schema_snapshot_id="snapshot_finance_v3",
-            glossary_id="glossary_finance_v2",
-            policy_id="policy_generation_v1",
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            glossary={
+                "context_id": "glossary_finance_v2",
+                "source_id": "sap-approved-spend",
+            },
+            policy={
+                "context_id": "policy_generation_v1",
+                "source_id": "sap-approved-spend",
+            },
         ),
     )
 
@@ -33,10 +45,22 @@ def test_sql_generation_adapter_request_is_source_aware_and_single_source() -> N
             "source_flavor": "warehouse",
         },
         "context": {
-            "dataset_contract_id": "contract_finance_v1",
-            "schema_snapshot_id": "snapshot_finance_v3",
-            "glossary_id": "glossary_finance_v2",
-            "policy_id": "policy_generation_v1",
+            "dataset_contract": {
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            "schema_snapshot": {
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            "glossary": {
+                "context_id": "glossary_finance_v2",
+                "source_id": "sap-approved-spend",
+            },
+            "policy": {
+                "context_id": "policy_generation_v1",
+                "source_id": "sap-approved-spend",
+            },
         },
     }
 
@@ -52,8 +76,14 @@ def test_sql_generation_adapter_request_rejects_credentials_and_unbounded_contex
                     "source_family": "postgresql",
                 },
                 "context": {
-                    "dataset_contract_id": "contract_finance_v1",
-                    "schema_snapshot_id": "snapshot_finance_v3",
+                    "dataset_contract": {
+                        "context_id": "contract_finance_v1",
+                        "source_id": "sap-approved-spend",
+                    },
+                    "schema_snapshot": {
+                        "context_id": "snapshot_finance_v3",
+                        "source_id": "sap-approved-spend",
+                    },
                 },
                 "credentials": {
                     "username": "analyst",


### PR DESCRIPTION
Closes #83
This PR was opened by codex-supervisor.
Latest Codex summary:

Tightened the adapter boundary to require source-scoped context fragments and reject any mixed-source payload before downstream work can rely on it. The adapter request now carries `dataset_contract`, `schema_snapshot`, and optional `glossary`/`policy` as `{context_id, source_id}` objects, and `build_sql_generation_adapter_request()` stamps the authoritative source onto those references. I also added the focused regression file [backend/tests/test_adapter_single_source_validation.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-83/backend/tests/test_adapter_single_source_validation.py:1) and updated the adjacent adapter tests to match the new contract.

Focused verification passed:
`cd backend && python3 -m pytest tests/test_adapter_single_source_validation.py -q`
`cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py tests/test_adapter_credential_isolation.py -q`

Checkpoint commit: `bb31ff7` (`Reject mixed-source adapter context`).

Summary: Added source-scoped adapter context validation and focused regression coverage so mixed-source payloads fail closed at the adapter boundary
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_adapter_single_source_validation.py -q`; `cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py tests/test_adapter_credential_isolation.py -q`
Failure signature: none
Next action: Open or update the draft PR for branch `codex/issue-83`, then expa...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure all context fragments remain bound to a single source during SQL generation.

* **Tests**
  * Updated test expectations to align with restructured context reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->