### PR TITLE
Extend preview candidate schema with source-aware metadata

### DIFF
--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,8 +1,10 @@
 from pydantic import BaseModel, ConfigDict, StringConstraints
 from sqlalchemy.orm import Session
+from typing import Optional
 from typing_extensions import Annotated
 
 from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
 from app.features.auth.context import AuthenticatedSubject
 from app.services.source_entitlements import (
@@ -33,6 +35,10 @@ class RequestRecord(BaseModel):
 
 class CandidateRecord(BaseModel):
     source_id: str
+    source_family: str
+    source_flavor: Optional[str]
+    dataset_contract_version: int
+    schema_snapshot_version: int
     state: str
 
 
@@ -61,16 +67,16 @@ def _resolve_authoritative_source_governance(
     session: Session,
     *,
     source_id: str,
-) -> tuple[RegisteredSource, DatasetContract]:
+) -> tuple[RegisteredSource, DatasetContract, SchemaSnapshot]:
     try:
-        source, dataset_contract, _ = resolve_authoritative_source_governance(
+        source, dataset_contract, schema_snapshot = resolve_authoritative_source_governance(
             session,
             source_id=source_id,
         )
     except SourceGovernanceResolutionError as exc:
         raise PreviewSubmissionContractError(str(exc)) from exc
 
-    return source, dataset_contract
+    return source, dataset_contract, schema_snapshot
 
 
 def submit_preview_request(
@@ -78,7 +84,7 @@ def submit_preview_request(
     authenticated_subject: AuthenticatedSubject,
     session: Session,
 ) -> PreviewSubmissionResponse:
-    source, dataset_contract = _resolve_authoritative_source_governance(
+    source, dataset_contract, schema_snapshot = _resolve_authoritative_source_governance(
         session,
         source_id=payload.source_id,
     )
@@ -100,6 +106,10 @@ def submit_preview_request(
         ),
         candidate=CandidateRecord(
             source_id=resolved_source.source_id,
+            source_family=resolved_source.source_family,
+            source_flavor=resolved_source.source_flavor,
+            dataset_contract_version=dataset_contract.contract_version,
+            schema_snapshot_version=schema_snapshot.snapshot_version,
             state="preview_ready",
         ),
         audit=AuditRecord(

--- a/backend/tests/test_candidate_source_metadata.py
+++ b/backend/tests/test_candidate_source_metadata.py
@@ -49,7 +49,7 @@ def _seed_authoritative_source_governance(session: Session) -> None:
     snapshot = SchemaSnapshot(
         id=uuid4(),
         registered_source_id=source.id,
-        snapshot_version=1,
+        snapshot_version=7,
         review_status=SchemaSnapshotReviewStatus.APPROVED,
         reviewed_at=datetime.now(timezone.utc),
     )
@@ -60,7 +60,7 @@ def _seed_authoritative_source_governance(session: Session) -> None:
         id=uuid4(),
         registered_source_id=source.id,
         schema_snapshot_id=snapshot.id,
-        contract_version=1,
+        contract_version=3,
         display_name="SAP spend cube contract",
         owner_binding="group:finance-analysts",
         security_review_binding=None,
@@ -74,7 +74,7 @@ def _seed_authoritative_source_governance(session: Session) -> None:
     session.commit()
 
 
-def test_preview_submission_binds_all_records_to_authoritative_source_id() -> None:
+def test_preview_candidate_carries_authoritative_source_metadata() -> None:
     with _session_scope() as session:
         _seed_authoritative_source_governance(session)
 
@@ -90,26 +90,11 @@ def test_preview_submission_binds_all_records_to_authoritative_source_id() -> No
             session,
         )
 
-    assert response.model_dump() == {
-        "request": {
-            "question": "Show approved vendors by quarterly spend",
-            "source_id": "sap-approved-spend",
-            "state": "submitted",
-        },
-        "candidate": {
-            "source_id": "sap-approved-spend",
-            "source_family": "postgresql",
-            "source_flavor": "warehouse",
-            "dataset_contract_version": 1,
-            "schema_snapshot_version": 1,
-            "state": "preview_ready",
-        },
-        "audit": {
-            "source_id": "sap-approved-spend",
-            "state": "recorded",
-        },
-        "evaluation": {
-            "source_id": "sap-approved-spend",
-            "state": "pending",
-        },
+    assert response.model_dump()["candidate"] == {
+        "source_id": "sap-approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "state": "preview_ready",
     }

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -221,10 +221,17 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             security_review_binding=None,
             exception_policy_binding=None,
         )
+        malformed_snapshot = SchemaSnapshot(
+            id=malformed_source.schema_snapshot_id,
+            registered_source_id=source_id,
+            snapshot_version=1,
+            review_status=SchemaSnapshotReviewStatus.APPROVED,
+            reviewed_at=datetime.now(timezone.utc),
+        )
 
         with patch(
             "app.services.request_preview._resolve_authoritative_source_governance",
-            return_value=(malformed_source, malformed_contract),
+            return_value=(malformed_source, malformed_contract, malformed_snapshot),
         ):
             response = self.client.post(
                 "/requests/preview",
@@ -270,6 +277,10 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                 },
                 "candidate": {
                     "source_id": "sap-approved-spend",
+                    "source_family": "postgresql",
+                    "source_flavor": "warehouse",
+                    "dataset_contract_version": 1,
+                    "schema_snapshot_version": 1,
                     "state": "preview_ready",
                 },
                 "audit": {


### PR DESCRIPTION
## Summary
- add source-aware metadata to preview candidates from authoritative governance records
- carry source family, optional source flavor, dataset contract version, and schema snapshot version in the candidate shape
- add a focused regression test for candidate source metadata and update related source-binding assertions

## Testing
- cd backend && python3 -m pytest tests/test_candidate_source_metadata.py
- cd backend && python3 -m pytest tests/test_candidate_source_metadata.py tests/test_source_bound_records.py tests/test_request_source_selection.py tests/test_preview_source_governance_resolution.py

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Preview responses now include enhanced source metadata: source family, source flavor, dataset contract version, and schema snapshot version in candidate records.

* **Tests**
  * Added test coverage for preview candidate source metadata validation.
  * Updated existing tests to assert new metadata fields in preview responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->