### PR TITLE
[D-2] Implement source-aware candidate lifecycle revalidation checks (#91)

### DIFF
--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -171,9 +171,10 @@ def revalidate_candidate_lifecycle(
         )
     except SourceEntitlementError as exc:
         message = str(exc)
+        cause = exc.__cause__
         deny_code = (
             "DENY_POLICY_VERSION_STALE"
-            if isinstance(exc.__cause__, SourceRegistryPostureError)
+            if isinstance(cause, (SourceRegistryPostureError, ValueError))
             else "DENY_ENTITLEMENT_CHANGED"
         )
         _raise_revalidation_error(

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from app.features.auth.context import AuthenticatedSubject
+from app.services.source_entitlements import (
+    SourceEntitlementError,
+    ensure_subject_is_entitled_for_source,
+)
+from app.services.source_governance import (
+    SourceGovernanceResolutionError,
+    resolve_authoritative_source_governance,
+)
+
+
+class SourceBoundCandidateMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str
+    source_family: str
+    source_flavor: Optional[str] = None
+    dataset_contract_version: int
+    schema_snapshot_version: int
+
+
+class CandidateLifecycleRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    owner_subject_id: str
+    approved_at: datetime
+    approval_expires_at: datetime
+    invalidated_at: Optional[datetime] = None
+    source: SourceBoundCandidateMetadata
+
+
+class CandidateLifecycleRevalidationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str
+    state: Literal["execution_eligible"]
+
+
+class CandidateLifecycleRevalidationError(PermissionError):
+    def __init__(self, *, deny_code: str, message: str) -> None:
+        super().__init__(f"{deny_code}: {message}")
+        self.deny_code = deny_code
+
+
+def _require_aware_datetime(value: datetime, *, field_name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise CandidateLifecycleRevalidationError(
+            deny_code="DENY_POLICY_VERSION_STALE",
+            message=f"Candidate {field_name} must be timezone-aware.",
+        )
+    return value
+
+
+def _raise_revalidation_error(*, deny_code: str, message: str) -> None:
+    raise CandidateLifecycleRevalidationError(
+        deny_code=deny_code,
+        message=message,
+    )
+
+
+def revalidate_candidate_lifecycle(
+    *,
+    candidate: CandidateLifecycleRecord,
+    authenticated_subject: AuthenticatedSubject,
+    session: Session,
+    as_of: datetime,
+    selected_source_id: str | None = None,
+) -> CandidateLifecycleRevalidationResult:
+    effective_as_of = _require_aware_datetime(as_of, field_name="as_of")
+    approval_expires_at = _require_aware_datetime(
+        candidate.approval_expires_at,
+        field_name="approval_expires_at",
+    )
+
+    if selected_source_id is not None and selected_source_id != candidate.source.source_id:
+        _raise_revalidation_error(
+            deny_code="DENY_ENTITLEMENT_CHANGED",
+            message=(
+                "Candidate source binding does not match the selected source. "
+                f"Expected '{candidate.source.source_id}' and received '{selected_source_id}'."
+            ),
+        )
+
+    normalized_subject_id = authenticated_subject.normalized_subject_id()
+    if normalized_subject_id != candidate.owner_subject_id.strip():
+        _raise_revalidation_error(
+            deny_code="DENY_CANDIDATE_OWNER_MISMATCH",
+            message=(
+                f"Candidate owner '{candidate.owner_subject_id}' does not match "
+                f"authenticated subject '{normalized_subject_id}'."
+            ),
+        )
+
+    if approval_expires_at <= effective_as_of:
+        _raise_revalidation_error(
+            deny_code="DENY_APPROVAL_EXPIRED",
+            message=(
+                f"Candidate approval for source '{candidate.source.source_id}' expired "
+                "before lifecycle revalidation completed."
+            ),
+        )
+
+    if candidate.invalidated_at is not None:
+        _require_aware_datetime(candidate.invalidated_at, field_name="invalidated_at")
+        _raise_revalidation_error(
+            deny_code="DENY_CANDIDATE_INVALIDATED",
+            message=(
+                f"Candidate for source '{candidate.source.source_id}' was invalidated "
+                "before lifecycle revalidation completed."
+            ),
+        )
+
+    try:
+        source, dataset_contract, schema_snapshot = resolve_authoritative_source_governance(
+            session,
+            source_id=candidate.source.source_id,
+        )
+    except SourceGovernanceResolutionError as exc:
+        _raise_revalidation_error(
+            deny_code="DENY_POLICY_VERSION_STALE",
+            message=str(exc),
+        )
+
+    if source.source_family != candidate.source.source_family:
+        _raise_revalidation_error(
+            deny_code="DENY_POLICY_VERSION_STALE",
+            message=(
+                f"Candidate source family '{candidate.source.source_family}' no longer "
+                f"matches authoritative source '{source.source_family}'."
+            ),
+        )
+    if source.source_flavor != candidate.source.source_flavor:
+        _raise_revalidation_error(
+            deny_code="DENY_POLICY_VERSION_STALE",
+            message=(
+                f"Candidate source flavor '{candidate.source.source_flavor}' no longer "
+                "matches the authoritative source posture."
+            ),
+        )
+    if dataset_contract.contract_version != candidate.source.dataset_contract_version:
+        _raise_revalidation_error(
+            deny_code="DENY_POLICY_VERSION_STALE",
+            message=(
+                "Candidate dataset contract version is stale against the "
+                "authoritative source-scoped governance record."
+            ),
+        )
+    if schema_snapshot.snapshot_version != candidate.source.schema_snapshot_version:
+        _raise_revalidation_error(
+            deny_code="DENY_POLICY_VERSION_STALE",
+            message=(
+                "Candidate schema snapshot version is stale against the "
+                "authoritative source-scoped governance record."
+            ),
+        )
+
+    try:
+        ensure_subject_is_entitled_for_source(
+            authenticated_subject,
+            source,
+            dataset_contract,
+        )
+    except SourceEntitlementError as exc:
+        message = str(exc)
+        deny_code = (
+            "DENY_POLICY_VERSION_STALE"
+            if "not executable" in message
+            else "DENY_ENTITLEMENT_CHANGED"
+        )
+        _raise_revalidation_error(
+            deny_code=deny_code,
+            message=message,
+        )
+
+    return CandidateLifecycleRevalidationResult(
+        source_id=source.source_id,
+        state="execution_eligible",
+    )

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -110,14 +110,18 @@ def revalidate_candidate_lifecycle(
         )
 
     if candidate.invalidated_at is not None:
-        _require_aware_datetime(candidate.invalidated_at, field_name="invalidated_at")
-        _raise_revalidation_error(
-            deny_code="DENY_CANDIDATE_INVALIDATED",
-            message=(
-                f"Candidate for source '{candidate.source.source_id}' was invalidated "
-                "before lifecycle revalidation completed."
-            ),
+        invalidated_at = _require_aware_datetime(
+            candidate.invalidated_at,
+            field_name="invalidated_at",
         )
+        if invalidated_at <= effective_as_of:
+            _raise_revalidation_error(
+                deny_code="DENY_CANDIDATE_INVALIDATED",
+                message=(
+                    f"Candidate for source '{candidate.source.source_id}' was invalidated "
+                    "before lifecycle revalidation completed."
+                ),
+            )
 
     try:
         source, dataset_contract, schema_snapshot = resolve_authoritative_source_governance(

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -15,6 +15,7 @@ from app.services.source_governance import (
     SourceGovernanceResolutionError,
     resolve_authoritative_source_governance,
 )
+from app.services.source_registry import SourceRegistryPostureError
 
 
 class SourceBoundCandidateMetadata(BaseModel):
@@ -172,7 +173,7 @@ def revalidate_candidate_lifecycle(
         message = str(exc)
         deny_code = (
             "DENY_POLICY_VERSION_STALE"
-            if "not executable" in message
+            if isinstance(exc.__cause__, SourceRegistryPostureError)
             else "DENY_ENTITLEMENT_CHANGED"
         )
         _raise_revalidation_error(

--- a/backend/tests/test_candidate_lifecycle_revalidation.py
+++ b/backend/tests/test_candidate_lifecycle_revalidation.py
@@ -21,6 +21,7 @@ from app.services.candidate_lifecycle import (
     SourceBoundCandidateMetadata,
     revalidate_candidate_lifecycle,
 )
+from app.services.source_entitlements import SourceEntitlementError
 
 
 @contextmanager
@@ -235,6 +236,45 @@ def test_revalidate_candidate_lifecycle_rejects_non_executable_bound_source() ->
             source_id="sap-approved-spend",
             activation_posture=SourceActivationPosture.PAUSED,
         )
+
+        with pytest.raises(
+            CandidateLifecycleRevalidationError,
+            match="DENY_POLICY_VERSION_STALE",
+        ) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert exc_info.value.deny_code == "DENY_POLICY_VERSION_STALE"
+
+
+def test_revalidate_candidate_lifecycle_classifies_wrapped_value_error_as_stale_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_wrapped_value_error(
+        authenticated_subject: AuthenticatedSubject,
+        source: object,
+        dataset_contract: object,
+    ) -> object:
+        del authenticated_subject, source, dataset_contract
+        try:
+            raise ValueError("Registered source posture metadata is invalid.")
+        except ValueError as exc:
+            raise SourceEntitlementError(str(exc)) from exc
+
+    monkeypatch.setattr(
+        "app.services.candidate_lifecycle.ensure_subject_is_entitled_for_source",
+        _raise_wrapped_value_error,
+    )
+
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
 
         with pytest.raises(
             CandidateLifecycleRevalidationError,

--- a/backend/tests/test_candidate_lifecycle_revalidation.py
+++ b/backend/tests/test_candidate_lifecycle_revalidation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
@@ -23,7 +24,7 @@ from app.services.candidate_lifecycle import (
 
 
 @contextmanager
-def _session_scope() -> Session:
+def _session_scope() -> Iterator[Session]:
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",
         connect_args={"check_same_thread": False},
@@ -41,6 +42,7 @@ def _seed_source(
     owner_binding: str = "group:finance-analysts",
     contract_version: int = 3,
     snapshot_version: int = 7,
+    activation_posture: SourceActivationPosture = SourceActivationPosture.ACTIVE,
 ) -> RegisteredSource:
     source = RegisteredSource(
         id=uuid4(),
@@ -48,7 +50,7 @@ def _seed_source(
         display_label=f"{source_id} display",
         source_family="postgresql",
         source_flavor="warehouse",
-        activation_posture=SourceActivationPosture.ACTIVE,
+        activation_posture=activation_posture,
         connector_profile_id=None,
         dialect_profile_id=None,
         dataset_contract_id=None,
@@ -215,6 +217,31 @@ def test_revalidate_candidate_lifecycle_rejects_stale_source_policy_versions() -
         ) as exc_info:
             revalidate_candidate_lifecycle(
                 candidate=_candidate(contract_version=3, snapshot_version=7),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert exc_info.value.deny_code == "DENY_POLICY_VERSION_STALE"
+
+
+def test_revalidate_candidate_lifecycle_rejects_non_executable_bound_source() -> None:
+    with _session_scope() as session:
+        _seed_source(
+            session,
+            source_id="sap-approved-spend",
+            activation_posture=SourceActivationPosture.PAUSED,
+        )
+
+        with pytest.raises(
+            CandidateLifecycleRevalidationError,
+            match="DENY_POLICY_VERSION_STALE",
+        ) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(),
                 authenticated_subject=AuthenticatedSubject(
                     subject_id="user:alice",
                     governance_bindings=frozenset({"group:finance-analysts"}),

--- a/backend/tests/test_candidate_lifecycle_revalidation.py
+++ b/backend/tests/test_candidate_lifecycle_revalidation.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.services.candidate_lifecycle import (
+    CandidateLifecycleRecord,
+    CandidateLifecycleRevalidationError,
+    SourceBoundCandidateMetadata,
+    revalidate_candidate_lifecycle,
+)
+
+
+@contextmanager
+def _session_scope() -> Session:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_source(
+    session: Session,
+    *,
+    source_id: str,
+    owner_binding: str = "group:finance-analysts",
+    contract_version: int = 3,
+    snapshot_version: int = 7,
+) -> RegisteredSource:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id=source_id,
+        display_label=f"{source_id} display",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{source_id}",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=snapshot_version,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=contract_version,
+        display_name=f"{source_id} contract",
+        owner_binding=owner_binding,
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.commit()
+    return source
+
+
+def _candidate(
+    *,
+    source_id: str = "sap-approved-spend",
+    contract_version: int = 3,
+    snapshot_version: int = 7,
+    approval_expires_at: datetime | None = None,
+    invalidated_at: datetime | None = None,
+) -> CandidateLifecycleRecord:
+    now = datetime.now(timezone.utc)
+    return CandidateLifecycleRecord(
+        owner_subject_id="user:alice",
+        approved_at=now - timedelta(minutes=5),
+        approval_expires_at=approval_expires_at or (now + timedelta(minutes=10)),
+        invalidated_at=invalidated_at,
+        source=SourceBoundCandidateMetadata(
+            source_id=source_id,
+            source_family="postgresql",
+            source_flavor="warehouse",
+            dataset_contract_version=contract_version,
+            schema_snapshot_version=snapshot_version,
+        ),
+    )
+
+
+def test_revalidate_candidate_lifecycle_accepts_current_source_bound_candidate() -> None:
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
+
+        result = revalidate_candidate_lifecycle(
+            candidate=_candidate(),
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session=session,
+            as_of=datetime.now(timezone.utc),
+        )
+
+    assert result.source_id == "sap-approved-spend"
+    assert result.state == "execution_eligible"
+
+
+def test_revalidate_candidate_lifecycle_rejects_expired_approval() -> None:
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
+
+        with pytest.raises(
+            CandidateLifecycleRevalidationError,
+            match="DENY_APPROVAL_EXPIRED",
+        ) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(
+                    approval_expires_at=datetime.now(timezone.utc) - timedelta(seconds=1)
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert exc_info.value.deny_code == "DENY_APPROVAL_EXPIRED"
+
+
+def test_revalidate_candidate_lifecycle_rejects_invalidated_candidate() -> None:
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
+
+        with pytest.raises(
+            CandidateLifecycleRevalidationError,
+            match="DENY_CANDIDATE_INVALIDATED",
+        ) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(invalidated_at=datetime.now(timezone.utc)),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert exc_info.value.deny_code == "DENY_CANDIDATE_INVALIDATED"
+
+
+def test_revalidate_candidate_lifecycle_rejects_entitlement_drift_on_bound_source() -> None:
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
+        _seed_source(
+            session,
+            source_id="marketing-approved-spend",
+            owner_binding="group:marketing-analysts",
+        )
+
+        with pytest.raises(
+            CandidateLifecycleRevalidationError,
+            match="DENY_ENTITLEMENT_CHANGED",
+        ) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(source_id="sap-approved-spend"),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:marketing-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert exc_info.value.deny_code == "DENY_ENTITLEMENT_CHANGED"
+
+
+def test_revalidate_candidate_lifecycle_rejects_stale_source_policy_versions() -> None:
+    with _session_scope() as session:
+        _seed_source(
+            session,
+            source_id="sap-approved-spend",
+            contract_version=4,
+            snapshot_version=8,
+        )
+
+        with pytest.raises(
+            CandidateLifecycleRevalidationError,
+            match="DENY_POLICY_VERSION_STALE",
+        ) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(contract_version=3, snapshot_version=7),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert exc_info.value.deny_code == "DENY_POLICY_VERSION_STALE"
+
+
+def test_revalidate_candidate_lifecycle_does_not_switch_to_another_source() -> None:
+    with _session_scope() as session:
+        _seed_source(
+            session,
+            source_id="sap-approved-spend",
+            owner_binding="group:finance-analysts",
+        )
+        _seed_source(
+            session,
+            source_id="marketing-approved-spend",
+            owner_binding="group:marketing-analysts",
+        )
+
+        with pytest.raises(
+            CandidateLifecycleRevalidationError,
+            match="DENY_ENTITLEMENT_CHANGED",
+        ) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(source_id="sap-approved-spend"),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset(
+                        {"group:finance-analysts", "group:marketing-analysts"}
+                    ),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+                selected_source_id="marketing-approved-spend",
+            )
+
+    assert exc_info.value.deny_code == "DENY_ENTITLEMENT_CHANGED"

--- a/backend/tests/test_candidate_lifecycle_revalidation.py
+++ b/backend/tests/test_candidate_lifecycle_revalidation.py
@@ -177,6 +177,26 @@ def test_revalidate_candidate_lifecycle_rejects_invalidated_candidate() -> None:
     assert exc_info.value.deny_code == "DENY_CANDIDATE_INVALIDATED"
 
 
+def test_revalidate_candidate_lifecycle_allows_future_dated_invalidation() -> None:
+    as_of = datetime.now(timezone.utc)
+
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
+
+        result = revalidate_candidate_lifecycle(
+            candidate=_candidate(invalidated_at=as_of + timedelta(minutes=1)),
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session=session,
+            as_of=as_of,
+        )
+
+    assert result.source_id == "sap-approved-spend"
+    assert result.state == "execution_eligible"
+
+
 def test_revalidate_candidate_lifecycle_rejects_entitlement_drift_on_bound_source() -> None:
     with _session_scope() as session:
         _seed_source(session, source_id="sap-approved-spend")


### PR DESCRIPTION
Closes #91
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a new source-bound lifecycle revalidation service in [backend/app/services/candidate_lifecycle.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-91/backend/app/services/candidate_lifecycle.py) and added the focused regression coverage in [backend/tests/test_candidate_lifecycle_revalidation.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-91/backend/tests/test_candidate_lifecycle_revalidation.py). The service denies expired approvals, invalidated candidates, owner mismatches, entitlement drift on the candidate’s bound source, stale governance-version drift, and source-switch attempts instead of re-routing to another source.

Focused verification passed for the new lifecycle tests and adjacent source-bound paths. I also updated the local issue journal and committed the code checkpoint as `c609093` with message `Add source-bound candidate lifecycle revalidation`.

Summary: Added source-bound candidate lifecycle revalidation service and focused tests for expiry, invalidation, entitlement drift, stale policy drift, and source-switch rejection
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_candidate_lifecycle_revalidation.py`; `cd backend && python3 -m pytest tests/test_candidate_source_metadata.py`; `cd backend && python3 -m pytest tests/test_source_bound_records.py`; `cd backend && python3 -m pytest tests/test_generation_context_preparation.py`
Failure signature: none
Next action: Wire `candidate_...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added candidate lifecycle revalidation: enforces timezone-aware timestamps, verifies owner and optional source alignment, checks approval/invalidated status, validates governance/version consistency, enforces entitlements, and returns an execution-eligible outcome with the resolved source.

* **Tests**
  * Added end-to-end tests covering successful revalidation and rejection cases (expired approvals, invalidation timing, governance/version drift, entitlement failures, and conflicting selected-source).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->