### PR TITLE
Implement common SQL guard contract

### DIFF
--- a/backend/app/features/guard/__init__.py
+++ b/backend/app/features/guard/__init__.py
@@ -1,1 +1,17 @@
-"""Reserved package for application-owned SQL guard logic."""
+"""Application-owned SQL guard logic."""
+
+from app.features.guard.sql_guard import (
+    SQLGuardEvaluation,
+    SQLGuardEvaluationInput,
+    SQLGuardRejection,
+    SQLGuardSourceBinding,
+    evaluate_common_sql_guard,
+)
+
+__all__ = [
+    "SQLGuardEvaluation",
+    "SQLGuardEvaluationInput",
+    "SQLGuardRejection",
+    "SQLGuardSourceBinding",
+    "evaluate_common_sql_guard",
+]

--- a/backend/app/features/guard/sql_guard.py
+++ b/backend/app/features/guard/sql_guard.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, StringConstraints, ValidationError
+from typing_extensions import Annotated
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class SQLGuardSourceBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: NonEmptyTrimmedString
+    source_family: NonEmptyTrimmedString
+    source_flavor: Optional[NonEmptyTrimmedString] = None
+
+
+class SQLGuardEvaluationInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_sql: NonEmptyTrimmedString
+    source: SQLGuardSourceBinding
+
+
+class SQLGuardRejection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: Literal["invalid_contract"]
+    detail: NonEmptyTrimmedString
+    path: NonEmptyTrimmedString
+
+
+class SQLGuardEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Literal["allow", "reject"]
+    profile: Literal["common"]
+    canonical_sql: Optional[str]
+    source: Optional[SQLGuardSourceBinding]
+    rejections: list[SQLGuardRejection]
+
+
+def _contract_rejections(exc: ValidationError) -> list[SQLGuardRejection]:
+    return [
+        SQLGuardRejection(
+            code="invalid_contract",
+            detail=error["msg"],
+            path=".".join(str(segment) for segment in error["loc"]),
+        )
+        for error in exc.errors()
+    ]
+
+
+def evaluate_common_sql_guard(
+    payload: Union[SQLGuardEvaluationInput, dict[str, Any]],
+) -> SQLGuardEvaluation:
+    try:
+        request = (
+            payload
+            if isinstance(payload, SQLGuardEvaluationInput)
+            else SQLGuardEvaluationInput.model_validate(payload)
+        )
+    except ValidationError as exc:
+        return SQLGuardEvaluation(
+            decision="reject",
+            profile="common",
+            canonical_sql=None,
+            source=None,
+            rejections=_contract_rejections(exc),
+        )
+
+    return SQLGuardEvaluation(
+        decision="allow",
+        profile="common",
+        canonical_sql=request.canonical_sql,
+        source=request.source,
+        rejections=[],
+    )

--- a/backend/tests/test_sql_guard_common_contract.py
+++ b/backend/tests/test_sql_guard_common_contract.py
@@ -1,0 +1,76 @@
+from app.features.guard.sql_guard import (
+    SQLGuardEvaluationInput,
+    evaluate_common_sql_guard,
+)
+
+
+def test_common_sql_guard_allows_source_bound_canonical_sql() -> None:
+    evaluation = evaluate_common_sql_guard(
+        SQLGuardEvaluationInput(
+            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend",
+            source={
+                "source_id": "sap-approved-spend",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        )
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "allow",
+        "profile": "common",
+        "canonical_sql": "SELECT vendor_name FROM finance.approved_vendor_spend",
+        "source": {
+            "source_id": "sap-approved-spend",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [],
+    }
+
+
+def test_common_sql_guard_rejects_missing_source_binding_fail_closed() -> None:
+    evaluation = evaluate_common_sql_guard(
+        {
+            "canonical_sql": "SELECT vendor_name FROM finance.approved_vendor_spend",
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "common",
+        "canonical_sql": None,
+        "source": None,
+        "rejections": [
+            {
+                "code": "invalid_contract",
+                "detail": "Field required",
+                "path": "source",
+            }
+        ],
+    }
+
+
+def test_common_sql_guard_rejects_partial_source_binding_fail_closed() -> None:
+    evaluation = evaluate_common_sql_guard(
+        {
+            "canonical_sql": "SELECT vendor_name FROM finance.approved_vendor_spend",
+            "source": {
+                "source_id": "sap-approved-spend",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "common",
+        "canonical_sql": None,
+        "source": None,
+        "rejections": [
+            {
+                "code": "invalid_contract",
+                "detail": "Field required",
+                "path": "source.source_family",
+            }
+        ],
+    }


### PR DESCRIPTION
## Summary
- add a common SQL guard contract for source-bound canonical SQL
- return machine-readable fail-closed outcomes for malformed or partial guard inputs
- cover common allow and fail-closed contract behavior with a focused backend test

## Verification
- cd backend && python3 -m pytest tests/test_sql_guard_common_contract.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced SQL guard validation that evaluates SQL statements against a common contract.
  * Returns allow or reject decisions based on whether required source binding information is present.
  * Failed validations include detailed error messages indicating which fields are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->