### PR TITLE
Implement MSSQL SQL Guard profile

### DIFF
--- a/backend/app/features/guard/__init__.py
+++ b/backend/app/features/guard/__init__.py
@@ -1,17 +1,21 @@
 """Application-owned SQL guard logic."""
 
 from app.features.guard.sql_guard import (
+    MSSQLGuardEvaluationInput,
     SQLGuardEvaluation,
     SQLGuardEvaluationInput,
     SQLGuardRejection,
     SQLGuardSourceBinding,
     evaluate_common_sql_guard,
+    evaluate_mssql_sql_guard,
 )
 
 __all__ = [
+    "MSSQLGuardEvaluationInput",
     "SQLGuardEvaluation",
     "SQLGuardEvaluationInput",
     "SQLGuardRejection",
     "SQLGuardSourceBinding",
     "evaluate_common_sql_guard",
+    "evaluate_mssql_sql_guard",
 ]

--- a/backend/app/features/guard/sql_guard.py
+++ b/backend/app/features/guard/sql_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, StringConstraints, ValidationError
@@ -27,7 +28,7 @@ class SQLGuardEvaluationInput(BaseModel):
 class SQLGuardRejection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    code: Literal["invalid_contract"]
+    code: NonEmptyTrimmedString
     detail: NonEmptyTrimmedString
     path: NonEmptyTrimmedString
 
@@ -36,10 +37,107 @@ class SQLGuardEvaluation(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     decision: Literal["allow", "reject"]
-    profile: Literal["common"]
+    profile: Literal["common", "mssql"]
     canonical_sql: Optional[str]
     source: Optional[SQLGuardSourceBinding]
     rejections: list[SQLGuardRejection]
+
+
+class MSSQLGuardSourceBinding(SQLGuardSourceBinding):
+    source_family: Literal["mssql"]
+
+
+class MSSQLGuardEvaluationInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_sql: NonEmptyTrimmedString
+    source: MSSQLGuardSourceBinding
+
+
+class MSSQLGuardRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: NonEmptyTrimmedString
+    detail: NonEmptyTrimmedString
+    pattern: str
+
+
+_MSSQL_DENY_RULES: tuple[MSSQLGuardRule, ...] = (
+    MSSQLGuardRule(
+        code="DENY_RESOURCE_ABUSE",
+        detail="WAITFOR is not allowed in the MSSQL guard profile.",
+        pattern=r"\bWAITFOR\b",
+    ),
+    MSSQLGuardRule(
+        code="DENY_EXTERNAL_DATA_ACCESS",
+        detail="External data access is not allowed in the MSSQL guard profile.",
+        pattern=r"\bOPENQUERY\b|\bOPENROWSET\b|\bOPENDATASOURCE\b",
+    ),
+    MSSQLGuardRule(
+        code="DENY_LINKED_SERVER",
+        detail="Linked-server references are not allowed in the MSSQL guard profile.",
+        pattern=r"\[[^\]]+\]\.\[[^\]]+\]\.\[[^\]]+\]\.\[[^\]]+\]",
+    ),
+    MSSQLGuardRule(
+        code="DENY_DYNAMIC_SQL",
+        detail="Dynamic SQL execution is not allowed in the MSSQL guard profile.",
+        pattern=r"\bsp_executesql\b|\bEXEC(?:UTE)?\s*\(",
+    ),
+    MSSQLGuardRule(
+        code="DENY_PROCEDURE_EXECUTION",
+        detail="Stored procedure execution is not allowed in the MSSQL guard profile.",
+        pattern=r"^\s*EXEC(?:UTE)?\b",
+    ),
+    MSSQLGuardRule(
+        code="DENY_WRITE_OPERATION",
+        detail="Write operations are not allowed in the MSSQL guard profile.",
+        pattern=(
+            r"\bINSERT\b|\bUPDATE\b|\bDELETE\b|\bMERGE\b|\bTRUNCATE\b|"
+            r"\bCREATE\b|\bALTER\b|\bDROP\b"
+        ),
+    ),
+    MSSQLGuardRule(
+        code="DENY_TEMP_OBJECT",
+        detail="Temporary object creation or mutation is not allowed in the MSSQL guard profile.",
+        pattern=r"#\w+|\bINTO\s+#\w+",
+    ),
+    MSSQLGuardRule(
+        code="DENY_DISALLOWED_HINT",
+        detail="Query hints are not allowed in the MSSQL guard profile.",
+        pattern=r"\bOPTION\s*\(",
+    ),
+)
+
+_MSSQL_QUERY_START = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
+_MSSQL_CROSS_DATABASE = re.compile(
+    r"(?:\[[^\]]+\]|\w+)\.(?:\[[^\]]+\]|\w+)\.(?:\[[^\]]+\]|\w+)",
+    re.IGNORECASE,
+)
+_MSSQL_MULTI_STATEMENT_SEPARATOR = re.compile(r";\s*\S|^\s*GO\s*$", re.IGNORECASE)
+
+
+def _reject_sql_guard(
+    *,
+    profile: Literal["common", "mssql"],
+    canonical_sql: Optional[str],
+    source: Optional[SQLGuardSourceBinding],
+    code: str,
+    detail: str,
+    path: str = "canonical_sql",
+) -> SQLGuardEvaluation:
+    return SQLGuardEvaluation(
+        decision="reject",
+        profile=profile,
+        canonical_sql=canonical_sql,
+        source=source,
+        rejections=[
+            SQLGuardRejection(
+                code=code,
+                detail=detail,
+                path=path,
+            )
+        ],
+    )
 
 
 def _contract_rejections(exc: ValidationError) -> list[SQLGuardRejection]:
@@ -75,6 +173,75 @@ def evaluate_common_sql_guard(
         decision="allow",
         profile="common",
         canonical_sql=request.canonical_sql,
+        source=request.source,
+        rejections=[],
+    )
+
+
+def evaluate_mssql_sql_guard(
+    payload: Union[MSSQLGuardEvaluationInput, SQLGuardEvaluationInput, dict[str, Any]],
+) -> SQLGuardEvaluation:
+    try:
+        request = (
+            payload
+            if isinstance(payload, MSSQLGuardEvaluationInput)
+            else MSSQLGuardEvaluationInput.model_validate(
+                payload.model_dump()
+                if isinstance(payload, SQLGuardEvaluationInput)
+                else payload
+            )
+        )
+    except ValidationError as exc:
+        return SQLGuardEvaluation(
+            decision="reject",
+            profile="mssql",
+            canonical_sql=None,
+            source=None,
+            rejections=_contract_rejections(exc),
+        )
+
+    canonical_sql = request.canonical_sql
+    if not _MSSQL_QUERY_START.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="mssql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code="DENY_UNSUPPORTED_SQL_SYNTAX",
+            detail="Canonical SQL must start with a supported SELECT query shape.",
+        )
+
+    if _MSSQL_MULTI_STATEMENT_SEPARATOR.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="mssql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code="DENY_MULTI_STATEMENT",
+            detail="Canonical SQL must contain exactly one SELECT statement.",
+        )
+
+    for rule in _MSSQL_DENY_RULES:
+        if re.search(rule.pattern, canonical_sql, re.IGNORECASE):
+            return _reject_sql_guard(
+                profile="mssql",
+                canonical_sql=canonical_sql,
+                source=request.source,
+                code=rule.code,
+                detail=rule.detail,
+            )
+
+    if _MSSQL_CROSS_DATABASE.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="mssql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code="DENY_CROSS_DATABASE",
+            detail="Cross-database references are not allowed in the MSSQL guard profile.",
+        )
+
+    return SQLGuardEvaluation(
+        decision="allow",
+        profile="mssql",
+        canonical_sql=canonical_sql,
         source=request.source,
         rejections=[],
     )

--- a/backend/app/features/guard/sql_guard.py
+++ b/backend/app/features/guard/sql_guard.py
@@ -113,7 +113,10 @@ _MSSQL_CROSS_DATABASE = re.compile(
     r"(?:\[[^\]]+\]|\w+)\.(?:\[[^\]]+\]|\w+)\.(?:\[[^\]]+\]|\w+)",
     re.IGNORECASE,
 )
-_MSSQL_MULTI_STATEMENT_SEPARATOR = re.compile(r";\s*\S|^\s*GO\s*$", re.IGNORECASE)
+_MSSQL_MULTI_STATEMENT_SEPARATOR = re.compile(
+    r";\s*\S|^\s*GO\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 
 def _reject_sql_guard(

--- a/backend/tests/test_sql_guard_mssql_profile.py
+++ b/backend/tests/test_sql_guard_mssql_profile.py
@@ -1,0 +1,126 @@
+from app.features.guard.sql_guard import (
+    SQLGuardEvaluationInput,
+    evaluate_mssql_sql_guard,
+)
+
+
+def test_mssql_sql_guard_allows_source_bound_select_query() -> None:
+    evaluation = evaluate_mssql_sql_guard(
+        SQLGuardEvaluationInput(
+            canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+            source={
+                "source_id": "business-mssql-source",
+                "source_family": "mssql",
+                "source_flavor": "sqlserver",
+            },
+        )
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "allow",
+        "profile": "mssql",
+        "canonical_sql": "SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+        "source": {
+            "source_id": "business-mssql-source",
+            "source_family": "mssql",
+            "source_flavor": "sqlserver",
+        },
+        "rejections": [],
+    }
+
+
+def test_mssql_sql_guard_rejects_multi_statement_input_fail_closed() -> None:
+    evaluation = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT vendor_name FROM dbo.approved_vendor_spend; SELECT @@VERSION"
+            ),
+            "source": {
+                "source_id": "business-mssql-source",
+                "source_family": "mssql",
+                "source_flavor": "sqlserver",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "mssql",
+        "canonical_sql": "SELECT vendor_name FROM dbo.approved_vendor_spend; SELECT @@VERSION",
+        "source": {
+            "source_id": "business-mssql-source",
+            "source_family": "mssql",
+            "source_flavor": "sqlserver",
+        },
+        "rejections": [
+            {
+                "code": "DENY_MULTI_STATEMENT",
+                "detail": "Canonical SQL must contain exactly one SELECT statement.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
+def test_mssql_sql_guard_rejects_non_mssql_source_binding_fail_closed() -> None:
+    evaluation = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": "SELECT vendor_name FROM dbo.approved_vendor_spend",
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "mssql",
+        "canonical_sql": None,
+        "source": None,
+        "rejections": [
+            {
+                "code": "invalid_contract",
+                "detail": "Input should be 'mssql'",
+                "path": "source.source_family",
+            }
+        ],
+    }
+
+
+def test_mssql_sql_guard_rejects_waitfor_delay_fail_closed() -> None:
+    evaluation = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT vendor_name FROM dbo.approved_vendor_spend "
+                "WAITFOR DELAY '00:00:05'"
+            ),
+            "source": {
+                "source_id": "business-mssql-source",
+                "source_family": "mssql",
+                "source_flavor": "sqlserver",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "mssql",
+        "canonical_sql": (
+            "SELECT vendor_name FROM dbo.approved_vendor_spend "
+            "WAITFOR DELAY '00:00:05'"
+        ),
+        "source": {
+            "source_id": "business-mssql-source",
+            "source_family": "mssql",
+            "source_flavor": "sqlserver",
+        },
+        "rejections": [
+            {
+                "code": "DENY_RESOURCE_ABUSE",
+                "detail": "WAITFOR is not allowed in the MSSQL guard profile.",
+                "path": "canonical_sql",
+            }
+        ],
+    }

--- a/backend/tests/test_sql_guard_mssql_profile.py
+++ b/backend/tests/test_sql_guard_mssql_profile.py
@@ -62,6 +62,45 @@ def test_mssql_sql_guard_rejects_multi_statement_input_fail_closed() -> None:
     }
 
 
+def test_mssql_sql_guard_rejects_go_batch_separator_fail_closed() -> None:
+    evaluation = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT vendor_name FROM dbo.approved_vendor_spend\n"
+                "GO\n"
+                "SELECT @@VERSION"
+            ),
+            "source": {
+                "source_id": "business-mssql-source",
+                "source_family": "mssql",
+                "source_flavor": "sqlserver",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "mssql",
+        "canonical_sql": (
+            "SELECT vendor_name FROM dbo.approved_vendor_spend\n"
+            "GO\n"
+            "SELECT @@VERSION"
+        ),
+        "source": {
+            "source_id": "business-mssql-source",
+            "source_family": "mssql",
+            "source_flavor": "sqlserver",
+        },
+        "rejections": [
+            {
+                "code": "DENY_MULTI_STATEMENT",
+                "detail": "Canonical SQL must contain exactly one SELECT statement.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
 def test_mssql_sql_guard_rejects_non_mssql_source_binding_fail_closed() -> None:
     evaluation = evaluate_mssql_sql_guard(
         {


### PR DESCRIPTION
## Summary
- add an MSSQL SQL Guard profile on top of the common contract
- fail closed on unsupported source bindings and unsafe MSSQL patterns
- add focused MSSQL allow and deny tests

Closes #93

## Testing
- cd backend && python3 -m pytest tests/test_sql_guard_mssql_profile.py
- cd backend && python3 -m pytest tests/test_sql_guard_common_contract.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MSSQL-specific SQL guard profile with validation rules to block multi-statement queries, dangerous MSSQL constructs (e.g., WAITFOR, external/data access, linked-server/dynamic execution), cross-database references, and disallowed hints.

* **Tests**
  * Added comprehensive tests covering allow/deny cases for the MSSQL SQL guard, multi-statement detection, contract validation, and resource-abuse patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->