### PR TITLE
[D-5] Implement the PostgreSQL SQL Guard profile (#94)

### DIFF
--- a/backend/app/features/guard/__init__.py
+++ b/backend/app/features/guard/__init__.py
@@ -2,20 +2,24 @@
 
 from app.features.guard.sql_guard import (
     MSSQLGuardEvaluationInput,
+    PostgreSQLGuardEvaluationInput,
     SQLGuardEvaluation,
     SQLGuardEvaluationInput,
     SQLGuardRejection,
     SQLGuardSourceBinding,
     evaluate_common_sql_guard,
     evaluate_mssql_sql_guard,
+    evaluate_postgresql_sql_guard,
 )
 
 __all__ = [
     "MSSQLGuardEvaluationInput",
+    "PostgreSQLGuardEvaluationInput",
     "SQLGuardEvaluation",
     "SQLGuardEvaluationInput",
     "SQLGuardRejection",
     "SQLGuardSourceBinding",
     "evaluate_common_sql_guard",
     "evaluate_mssql_sql_guard",
+    "evaluate_postgresql_sql_guard",
 ]

--- a/backend/app/features/guard/sql_guard.py
+++ b/backend/app/features/guard/sql_guard.py
@@ -153,11 +153,6 @@ _POSTGRESQL_DENY_RULES: tuple[MSSQLGuardRule, ...] = (
         pattern=r"\bCOPY\s+.+\b(?:FROM|TO)\b|\bdblink\s*\(|\bpostgres_fdw\b|\bfile_fdw\b",
     ),
     MSSQLGuardRule(
-        code="DENY_SYSTEM_CATALOG_ACCESS",
-        detail="System catalog access is not allowed in the PostgreSQL guard profile.",
-        pattern=r"\bpg_catalog\b|\binformation_schema\b|\bpg_[a-z_]+\b",
-    ),
-    MSSQLGuardRule(
         code="DENY_DISALLOWED_HINT",
         detail="Query hints are not allowed in the PostgreSQL guard profile.",
         pattern=r"/\*\+",
@@ -167,13 +162,86 @@ _POSTGRESQL_DENY_RULES: tuple[MSSQLGuardRule, ...] = (
 _POSTGRESQL_QUERY_START = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
 _POSTGRESQL_MULTI_STATEMENT_SEPARATOR = re.compile(r";\s*\S", re.IGNORECASE)
 _POSTGRESQL_IDENTIFIER = r"(?:\"(?:[^\"]|\"\")+\"|[A-Za-z_][\w$]*)"
-_POSTGRESQL_CROSS_DATABASE_RELATION = re.compile(
-    rf"\b(?:FROM|JOIN)\s+(?:ONLY\s+)?(?:LATERAL\s+)?"
-    rf"{_POSTGRESQL_IDENTIFIER}\s*\.\s*"
-    rf"{_POSTGRESQL_IDENTIFIER}\s*\.\s*"
-    rf"{_POSTGRESQL_IDENTIFIER}(?=$|[\s,)\n])",
+_POSTGRESQL_FROM_CLAUSE = re.compile(
+    r"\bFROM\b(?P<body>.*?)(?=\bWHERE\b|\bGROUP\s+BY\b|\bHAVING\b|\bORDER\s+BY\b|"
+    r"\bLIMIT\b|\bOFFSET\b|\bFETCH\b|\bFOR\b|\bUNION\b|\bINTERSECT\b|\bEXCEPT\b|$)",
+    re.IGNORECASE | re.DOTALL,
+)
+_POSTGRESQL_RELATION_REFERENCE = re.compile(
+    rf"^\s*(?:ONLY\s+)?(?:LATERAL\s+)?(?P<relation>"
+    rf"{_POSTGRESQL_IDENTIFIER}(?:\s*\.\s*{_POSTGRESQL_IDENTIFIER}){{0,2}}"
+    rf")",
     re.IGNORECASE,
 )
+_POSTGRESQL_JOIN_RELATION = re.compile(
+    rf"\bJOIN\s+(?:ONLY\s+)?(?:LATERAL\s+)?(?P<relation>"
+    rf"{_POSTGRESQL_IDENTIFIER}(?:\s*\.\s*{_POSTGRESQL_IDENTIFIER}){{0,2}}"
+    rf")",
+    re.IGNORECASE,
+)
+_POSTGRESQL_SYSTEM_NAMESPACE_ACCESS = re.compile(
+    rf"\b(?:pg_catalog|information_schema)\b\s*\.\s*{_POSTGRESQL_IDENTIFIER}",
+    re.IGNORECASE,
+)
+_POSTGRESQL_SYSTEM_FUNCTION_CALL = re.compile(
+    r"\b(?:pg_catalog\s*\.\s*)?pg_[A-Za-z_][\w$]*\s*\(",
+    re.IGNORECASE,
+)
+_POSTGRESQL_CROSS_DATABASE_RELATION = re.compile(
+    rf"^{_POSTGRESQL_IDENTIFIER}\s*\.\s*"
+    rf"{_POSTGRESQL_IDENTIFIER}\s*\.\s*"
+    rf"{_POSTGRESQL_IDENTIFIER}$",
+    re.IGNORECASE,
+)
+
+
+def _split_sql_top_level_commas(fragment: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    index = 0
+    while index < len(fragment):
+        char = fragment[index]
+        if quote == "'":
+            if char == "'" and index + 1 < len(fragment) and fragment[index + 1] == "'":
+                index += 2
+                continue
+            if char == "'":
+                quote = None
+        elif quote == '"':
+            if char == '"' and index + 1 < len(fragment) and fragment[index + 1] == '"':
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+        else:
+            if char == "'":
+                quote = "'"
+            elif char == '"':
+                quote = '"'
+            elif char == "(":
+                depth += 1
+            elif char == ")" and depth > 0:
+                depth -= 1
+            elif char == "," and depth == 0:
+                parts.append(fragment[start:index])
+                start = index + 1
+        index += 1
+
+    parts.append(fragment[start:])
+    return parts
+
+
+def _iter_postgresql_relation_references(canonical_sql: str):
+    for from_match in _POSTGRESQL_FROM_CLAUSE.finditer(canonical_sql):
+        for item in _split_sql_top_level_commas(from_match.group("body")):
+            relation_match = _POSTGRESQL_RELATION_REFERENCE.match(item)
+            if relation_match:
+                yield relation_match.group("relation")
+
+    for join_match in _POSTGRESQL_JOIN_RELATION.finditer(canonical_sql):
+        yield join_match.group("relation")
 
 
 def _reject_sql_guard(
@@ -362,7 +430,21 @@ def evaluate_postgresql_sql_guard(
                 detail=rule.detail,
             )
 
-    if _POSTGRESQL_CROSS_DATABASE_RELATION.search(canonical_sql):
+    if _POSTGRESQL_SYSTEM_NAMESPACE_ACCESS.search(canonical_sql) or _POSTGRESQL_SYSTEM_FUNCTION_CALL.search(
+        canonical_sql
+    ):
+        return _reject_sql_guard(
+            profile="postgresql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code="DENY_SYSTEM_CATALOG_ACCESS",
+            detail="System catalog access is not allowed in the PostgreSQL guard profile.",
+        )
+
+    if any(
+        _POSTGRESQL_CROSS_DATABASE_RELATION.search(relation)
+        for relation in _iter_postgresql_relation_references(canonical_sql)
+    ):
         return _reject_sql_guard(
             profile="postgresql",
             canonical_sql=canonical_sql,

--- a/backend/app/features/guard/sql_guard.py
+++ b/backend/app/features/guard/sql_guard.py
@@ -37,7 +37,7 @@ class SQLGuardEvaluation(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     decision: Literal["allow", "reject"]
-    profile: Literal["common", "mssql"]
+    profile: Literal["common", "mssql", "postgresql"]
     canonical_sql: Optional[str]
     source: Optional[SQLGuardSourceBinding]
     rejections: list[SQLGuardRejection]
@@ -52,6 +52,17 @@ class MSSQLGuardEvaluationInput(BaseModel):
 
     canonical_sql: NonEmptyTrimmedString
     source: MSSQLGuardSourceBinding
+
+
+class PostgreSQLGuardSourceBinding(SQLGuardSourceBinding):
+    source_family: Literal["postgresql"]
+
+
+class PostgreSQLGuardEvaluationInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_sql: NonEmptyTrimmedString
+    source: PostgreSQLGuardSourceBinding
 
 
 class MSSQLGuardRule(BaseModel):
@@ -116,6 +127,48 @@ _MSSQL_CROSS_DATABASE = re.compile(
 _MSSQL_MULTI_STATEMENT_SEPARATOR = re.compile(
     r";\s*\S|^\s*GO\s*$",
     re.IGNORECASE | re.MULTILINE,
+)
+_POSTGRESQL_DENY_RULES: tuple[MSSQLGuardRule, ...] = (
+    MSSQLGuardRule(
+        code="DENY_WRITE_OPERATION",
+        detail="Write operations are not allowed in the PostgreSQL guard profile.",
+        pattern=(
+            r"\bINSERT\b|\bUPDATE\b|\bDELETE\b|\bMERGE\b|\bTRUNCATE\b|"
+            r"\bCREATE\b|\bALTER\b|\bDROP\b|\bREINDEX\b|\bVACUUM\b|\bANALYZE\b"
+        ),
+    ),
+    MSSQLGuardRule(
+        code="DENY_PROCEDURE_EXECUTION",
+        detail="Stored procedure execution is not allowed in the PostgreSQL guard profile.",
+        pattern=r"^\s*CALL\b|\bDO\s+\$\$",
+    ),
+    MSSQLGuardRule(
+        code="DENY_DYNAMIC_SQL",
+        detail="Dynamic SQL execution is not allowed in the PostgreSQL guard profile.",
+        pattern=r"\bEXECUTE\b",
+    ),
+    MSSQLGuardRule(
+        code="DENY_EXTERNAL_DATA_ACCESS",
+        detail="External data access is not allowed in the PostgreSQL guard profile.",
+        pattern=r"\bCOPY\s+.+\b(?:FROM|TO)\b|\bdblink\s*\(|\bpostgres_fdw\b|\bfile_fdw\b",
+    ),
+    MSSQLGuardRule(
+        code="DENY_SYSTEM_CATALOG_ACCESS",
+        detail="System catalog access is not allowed in the PostgreSQL guard profile.",
+        pattern=r"\bpg_catalog\b|\binformation_schema\b|\bpg_[a-z_]+\b",
+    ),
+    MSSQLGuardRule(
+        code="DENY_DISALLOWED_HINT",
+        detail="Query hints are not allowed in the PostgreSQL guard profile.",
+        pattern=r"/\*\+",
+    ),
+)
+
+_POSTGRESQL_QUERY_START = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
+_POSTGRESQL_MULTI_STATEMENT_SEPARATOR = re.compile(r";\s*\S", re.IGNORECASE)
+_POSTGRESQL_CROSS_DATABASE = re.compile(
+    r"(?:\"[^\"]+\"|\w+)\.(?:\"[^\"]+\"|\w+)\.(?:\"[^\"]+\"|\w+)",
+    re.IGNORECASE,
 )
 
 
@@ -244,6 +297,79 @@ def evaluate_mssql_sql_guard(
     return SQLGuardEvaluation(
         decision="allow",
         profile="mssql",
+        canonical_sql=canonical_sql,
+        source=request.source,
+        rejections=[],
+    )
+
+
+def evaluate_postgresql_sql_guard(
+    payload: Union[
+        PostgreSQLGuardEvaluationInput,
+        SQLGuardEvaluationInput,
+        dict[str, Any],
+    ],
+) -> SQLGuardEvaluation:
+    try:
+        request = (
+            payload
+            if isinstance(payload, PostgreSQLGuardEvaluationInput)
+            else PostgreSQLGuardEvaluationInput.model_validate(
+                payload.model_dump()
+                if isinstance(payload, SQLGuardEvaluationInput)
+                else payload
+            )
+        )
+    except ValidationError as exc:
+        return SQLGuardEvaluation(
+            decision="reject",
+            profile="postgresql",
+            canonical_sql=None,
+            source=None,
+            rejections=_contract_rejections(exc),
+        )
+
+    canonical_sql = request.canonical_sql
+    if not _POSTGRESQL_QUERY_START.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="postgresql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code="DENY_UNSUPPORTED_SQL_SYNTAX",
+            detail="Canonical SQL must start with a supported SELECT query shape.",
+        )
+
+    if _POSTGRESQL_MULTI_STATEMENT_SEPARATOR.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="postgresql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code="DENY_MULTI_STATEMENT",
+            detail="Canonical SQL must contain exactly one SELECT statement.",
+        )
+
+    for rule in _POSTGRESQL_DENY_RULES:
+        if re.search(rule.pattern, canonical_sql, re.IGNORECASE | re.DOTALL):
+            return _reject_sql_guard(
+                profile="postgresql",
+                canonical_sql=canonical_sql,
+                source=request.source,
+                code=rule.code,
+                detail=rule.detail,
+            )
+
+    if _POSTGRESQL_CROSS_DATABASE.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="postgresql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code="DENY_CROSS_DATABASE",
+            detail="Cross-database references are not allowed in the PostgreSQL guard profile.",
+        )
+
+    return SQLGuardEvaluation(
+        decision="allow",
+        profile="postgresql",
         canonical_sql=canonical_sql,
         source=request.source,
         rejections=[],

--- a/backend/app/features/guard/sql_guard.py
+++ b/backend/app/features/guard/sql_guard.py
@@ -166,8 +166,12 @@ _POSTGRESQL_DENY_RULES: tuple[MSSQLGuardRule, ...] = (
 
 _POSTGRESQL_QUERY_START = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
 _POSTGRESQL_MULTI_STATEMENT_SEPARATOR = re.compile(r";\s*\S", re.IGNORECASE)
-_POSTGRESQL_CROSS_DATABASE = re.compile(
-    r"(?:\"[^\"]+\"|\w+)\.(?:\"[^\"]+\"|\w+)\.(?:\"[^\"]+\"|\w+)",
+_POSTGRESQL_IDENTIFIER = r"(?:\"(?:[^\"]|\"\")+\"|[A-Za-z_][\w$]*)"
+_POSTGRESQL_CROSS_DATABASE_RELATION = re.compile(
+    rf"\b(?:FROM|JOIN)\s+(?:ONLY\s+)?(?:LATERAL\s+)?"
+    rf"{_POSTGRESQL_IDENTIFIER}\s*\.\s*"
+    rf"{_POSTGRESQL_IDENTIFIER}\s*\.\s*"
+    rf"{_POSTGRESQL_IDENTIFIER}(?=$|[\s,)\n])",
     re.IGNORECASE,
 )
 
@@ -358,7 +362,7 @@ def evaluate_postgresql_sql_guard(
                 detail=rule.detail,
             )
 
-    if _POSTGRESQL_CROSS_DATABASE.search(canonical_sql):
+    if _POSTGRESQL_CROSS_DATABASE_RELATION.search(canonical_sql):
         return _reject_sql_guard(
             profile="postgresql",
             canonical_sql=canonical_sql,

--- a/backend/tests/test_sql_guard_postgresql_profile.py
+++ b/backend/tests/test_sql_guard_postgresql_profile.py
@@ -29,6 +29,37 @@ def test_postgresql_sql_guard_allows_source_bound_select_query() -> None:
     }
 
 
+def test_postgresql_sql_guard_allows_schema_table_column_projection() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT finance.approved_vendor_spend.vendor_name "
+                "FROM finance.approved_vendor_spend"
+            ),
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "allow",
+        "profile": "postgresql",
+        "canonical_sql": (
+            "SELECT finance.approved_vendor_spend.vendor_name "
+            "FROM finance.approved_vendor_spend"
+        ),
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [],
+    }
+
+
 def test_postgresql_sql_guard_rejects_write_operation_fail_closed() -> None:
     evaluation = evaluate_postgresql_sql_guard(
         {
@@ -62,6 +93,37 @@ def test_postgresql_sql_guard_rejects_write_operation_fail_closed() -> None:
             {
                 "code": "DENY_WRITE_OPERATION",
                 "detail": "Write operations are not allowed in the PostgreSQL guard profile.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
+def test_postgresql_sql_guard_rejects_cross_database_relation_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": "SELECT vendor_name FROM business.finance.approved_vendor_spend",
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": "SELECT vendor_name FROM business.finance.approved_vendor_spend",
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [
+            {
+                "code": "DENY_CROSS_DATABASE",
+                "detail": "Cross-database references are not allowed in the PostgreSQL guard profile.",
                 "path": "canonical_sql",
             }
         ],

--- a/backend/tests/test_sql_guard_postgresql_profile.py
+++ b/backend/tests/test_sql_guard_postgresql_profile.py
@@ -60,6 +60,33 @@ def test_postgresql_sql_guard_allows_schema_table_column_projection() -> None:
     }
 
 
+def test_postgresql_sql_guard_allows_pg_prefixed_business_columns() -> None:
+    source = {
+        "source_id": "business-postgres-source",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+    }
+
+    for canonical_sql in (
+        "SELECT pg_vendor_name FROM finance.approved_vendor_spend",
+        'SELECT "pg_vendor_name" FROM finance.approved_vendor_spend',
+    ):
+        evaluation = evaluate_postgresql_sql_guard(
+            {
+                "canonical_sql": canonical_sql,
+                "source": source,
+            }
+        )
+
+        assert evaluation.model_dump() == {
+            "decision": "allow",
+            "profile": "postgresql",
+            "canonical_sql": canonical_sql,
+            "source": source,
+            "rejections": [],
+        }
+
+
 def test_postgresql_sql_guard_rejects_write_operation_fail_closed() -> None:
     evaluation = evaluate_postgresql_sql_guard(
         {
@@ -130,6 +157,43 @@ def test_postgresql_sql_guard_rejects_cross_database_relation_fail_closed() -> N
     }
 
 
+def test_postgresql_sql_guard_rejects_cross_database_relation_in_later_from_item_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT 1 FROM finance.approved_vendor_spend, "
+                "business.public.other_table"
+            ),
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": (
+            "SELECT 1 FROM finance.approved_vendor_spend, "
+            "business.public.other_table"
+        ),
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [
+            {
+                "code": "DENY_CROSS_DATABASE",
+                "detail": "Cross-database references are not allowed in the PostgreSQL guard profile.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
 def test_postgresql_sql_guard_rejects_multi_statement_input_fail_closed() -> None:
     evaluation = evaluate_postgresql_sql_guard(
         {
@@ -183,6 +247,43 @@ def test_postgresql_sql_guard_rejects_system_catalog_access_fail_closed() -> Non
         "decision": "reject",
         "profile": "postgresql",
         "canonical_sql": "SELECT schemaname FROM pg_catalog.pg_tables",
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [
+            {
+                "code": "DENY_SYSTEM_CATALOG_ACCESS",
+                "detail": "System catalog access is not allowed in the PostgreSQL guard profile.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
+def test_postgresql_sql_guard_rejects_pg_prefixed_system_function_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT pg_relation_size('finance.approved_vendor_spend') "
+                "FROM finance.approved_vendor_spend"
+            ),
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": (
+            "SELECT pg_relation_size('finance.approved_vendor_spend') "
+            "FROM finance.approved_vendor_spend"
+        ),
         "source": {
             "source_id": "business-postgres-source",
             "source_family": "postgresql",

--- a/backend/tests/test_sql_guard_postgresql_profile.py
+++ b/backend/tests/test_sql_guard_postgresql_profile.py
@@ -1,0 +1,163 @@
+from app.features.guard.sql_guard import (
+    SQLGuardEvaluationInput,
+    evaluate_postgresql_sql_guard,
+)
+
+
+def test_postgresql_sql_guard_allows_source_bound_select_query() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        SQLGuardEvaluationInput(
+            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend",
+            source={
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        )
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "allow",
+        "profile": "postgresql",
+        "canonical_sql": "SELECT vendor_name FROM finance.approved_vendor_spend",
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [],
+    }
+
+
+def test_postgresql_sql_guard_rejects_write_operation_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": (
+                "WITH archived AS (DELETE FROM finance.approved_vendor_spend "
+                "RETURNING vendor_name) "
+                "SELECT vendor_name FROM archived"
+            ),
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": (
+            "WITH archived AS (DELETE FROM finance.approved_vendor_spend "
+            "RETURNING vendor_name) "
+            "SELECT vendor_name FROM archived"
+        ),
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [
+            {
+                "code": "DENY_WRITE_OPERATION",
+                "detail": "Write operations are not allowed in the PostgreSQL guard profile.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
+def test_postgresql_sql_guard_rejects_multi_statement_input_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT vendor_name FROM finance.approved_vendor_spend; "
+                "SELECT current_database()"
+            ),
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": (
+            "SELECT vendor_name FROM finance.approved_vendor_spend; "
+            "SELECT current_database()"
+        ),
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [
+            {
+                "code": "DENY_MULTI_STATEMENT",
+                "detail": "Canonical SQL must contain exactly one SELECT statement.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
+def test_postgresql_sql_guard_rejects_system_catalog_access_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": "SELECT schemaname FROM pg_catalog.pg_tables",
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": "SELECT schemaname FROM pg_catalog.pg_tables",
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [
+            {
+                "code": "DENY_SYSTEM_CATALOG_ACCESS",
+                "detail": "System catalog access is not allowed in the PostgreSQL guard profile.",
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
+def test_postgresql_sql_guard_rejects_non_postgresql_source_binding_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": "SELECT vendor_name FROM finance.approved_vendor_spend",
+            "source": {
+                "source_id": "business-mssql-source",
+                "source_family": "mssql",
+                "source_flavor": "sqlserver",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": None,
+        "source": None,
+        "rejections": [
+            {
+                "code": "invalid_contract",
+                "detail": "Input should be 'postgresql'",
+                "path": "source.source_family",
+            }
+        ],
+    }


### PR DESCRIPTION
Closes #94
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a PostgreSQL SQL Guard profile in [backend/app/features/guard/sql_guard.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-94/backend/app/features/guard/sql_guard.py) and exported it from [backend/app/features/guard/__init__.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-94/backend/app/features/guard/__init__.py). The new profile is source-family bound to `postgresql` and fails closed on invalid binding, unsupported non-`SELECT` shapes, multi-statement input, writes, procedural or dynamic execution constructs, external data access, system catalog access, hints, and cross-database-shaped references.

I added focused regressions in [backend/tests/test_sql_guard_postgresql_profile.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-94/backend/tests/test_sql_guard_postgresql_profile.py), reproduced the initial gap as a missing import, then verified the new profile plus existing common and MSSQL guard coverage. The code checkpoint is committed on `codex/issue-94` as `94abab1` with message `Add PostgreSQL SQL guard profile`.

Summary: Added the PostgreSQL SQL Guard profile with focused allow and fail-closed deny coverage, and committed it as `94abab1`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_sql_guard_postgresql_profile.py tests/test_sql_guard_common_contract.py tests/test_sql_guard_mssql_profile.py`
Failure signature: none
Next action: Decide whether to broaden PostgreSQL deny covera...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL guard now supports a PostgreSQL profile, enforcing security checks: only canonical SELECT/WITH queries, no multi-statement inputs, no write/procedure/dynamic-SQL operations, no external data imports, no system/catalog access, no query hints, and no cross-database relations. Rejected payloads return structured rejection details.

* **Tests**
  * Added tests covering acceptance and rejection scenarios for PostgreSQL validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->