### PR TITLE
[E-2] Implement the MSSQL execution connector (#106)

### DIFF
--- a/backend/app/features/execution/__init__.py
+++ b/backend/app/features/execution/__init__.py
@@ -5,9 +5,17 @@ from app.features.execution.connector_selection import (
     ExecutionConnectorSelectionError,
     select_execution_connector,
 )
+from app.features.execution.runtime import (
+    ExecutionConnectorExecutionError,
+    ExecutionResult,
+    execute_candidate_sql,
+)
 
 __all__ = [
+    "ExecutionConnectorExecutionError",
     "ExecutionConnectorSelection",
     "ExecutionConnectorSelectionError",
+    "ExecutionResult",
+    "execute_candidate_sql",
     "select_execution_connector",
 ]

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from pydantic import BaseModel, ConfigDict, StringConstraints
+from typing_extensions import Annotated
+
+from app.features.execution.connector_selection import (
+    ExecutionConnectorSelection,
+    ExecutionConnectorSelectionError,
+    select_execution_connector,
+)
+from app.features.guard.deny_taxonomy import (
+    DENY_SOURCE_BINDING_MISMATCH,
+    DENY_UNSUPPORTED_SOURCE_BINDING,
+)
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+MssqlQueryRunner = Callable[..., list[dict[str, Any]]]
+
+
+class ExecutionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: NonEmptyTrimmedString
+    connector_id: NonEmptyTrimmedString
+    ownership: str
+    rows: list[dict[str, Any]]
+
+
+class ExecutionConnectorExecutionError(PermissionError):
+    def __init__(self, *, deny_code: str, message: str) -> None:
+        super().__init__(f"{deny_code}: {message}")
+        self.deny_code = deny_code
+
+
+def _source_flavor_matches(
+    *,
+    candidate_source: SourceBoundCandidateMetadata,
+    selection: ExecutionConnectorSelection,
+) -> bool:
+    candidate_flavor = candidate_source.source_flavor.strip() if candidate_source.source_flavor else None
+    selection_flavor = selection.source_flavor.strip() if selection.source_flavor else None
+    return candidate_flavor == selection_flavor
+
+
+def _require_matching_selection(
+    *,
+    candidate_source: SourceBoundCandidateMetadata,
+    selection: ExecutionConnectorSelection,
+) -> None:
+    if (
+        candidate_source.source_id.strip() != selection.source_id
+        or candidate_source.source_family.strip() != selection.source_family
+        or not _source_flavor_matches(
+            candidate_source=candidate_source,
+            selection=selection,
+        )
+    ):
+        raise ExecutionConnectorExecutionError(
+            deny_code=DENY_SOURCE_BINDING_MISMATCH,
+            message=(
+                "The candidate-bound source metadata does not match the selected "
+                "connector binding."
+            ),
+        )
+
+
+def _default_mssql_query_runner(
+    *,
+    connection_string: str,
+    canonical_sql: str,
+) -> list[dict[str, Any]]:
+    try:
+        import pyodbc  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "pyodbc must be installed before the MSSQL execution connector can run."
+        ) from exc
+
+    with pyodbc.connect(connection_string) as connection:
+        cursor = connection.cursor()
+        cursor.execute(canonical_sql)
+        column_names = [column[0] for column in cursor.description or ()]
+        return [dict(zip(column_names, row)) for row in cursor.fetchall()]
+
+
+def execute_candidate_sql(
+    *,
+    canonical_sql: NonEmptyTrimmedString,
+    candidate_source: SourceBoundCandidateMetadata,
+    business_mssql_connection_string: NonEmptyTrimmedString,
+    selection: ExecutionConnectorSelection | None = None,
+    query_runner: MssqlQueryRunner | None = None,
+) -> ExecutionResult:
+    resolved_selection = (
+        selection
+        if selection is not None
+        else select_execution_connector(candidate_source=candidate_source)
+    )
+    _require_matching_selection(
+        candidate_source=candidate_source,
+        selection=resolved_selection,
+    )
+
+    if resolved_selection.ownership != "backend":
+        raise ExecutionConnectorExecutionError(
+            deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
+            message="Execution connectors must remain backend-owned.",
+        )
+
+    if resolved_selection.connector_id != "mssql_readonly":
+        raise ExecutionConnectorSelectionError(
+            deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
+            message=(
+                "No backend-owned execution runtime is registered for connector "
+                f"'{resolved_selection.connector_id}'."
+            ),
+        )
+
+    effective_query_runner = query_runner or _default_mssql_query_runner
+    rows = effective_query_runner(
+        connection_string=business_mssql_connection_string,
+        canonical_sql=canonical_sql,
+    )
+    return ExecutionResult(
+        source_id=resolved_selection.source_id,
+        connector_id=resolved_selection.connector_id,
+        ownership=resolved_selection.ownership,
+        rows=rows,
+    )

--- a/backend/tests/test_mssql_execution_connector.py
+++ b/backend/tests/test_mssql_execution_connector.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.execution.connector_selection import ExecutionConnectorSelection
+from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+
+
+def _candidate_source(
+    *,
+    source_id: str = "business-mssql-source",
+    source_family: str = "mssql",
+    source_flavor: str | None = "sqlserver",
+) -> SourceBoundCandidateMetadata:
+    return SourceBoundCandidateMetadata(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        dataset_contract_version=3,
+        schema_snapshot_version=7,
+    )
+
+
+def _selection(
+    *,
+    source_id: str = "business-mssql-source",
+    source_family: str = "mssql",
+    source_flavor: str | None = "sqlserver",
+    connector_id: str = "mssql_readonly",
+) -> ExecutionConnectorSelection:
+    return ExecutionConnectorSelection(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        connector_id=connector_id,
+        ownership="backend",
+    )
+
+
+def test_execute_mssql_connector_uses_backend_owned_connection_path() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    captured: dict[str, Any] = {}
+
+    def fake_query_runner(*, connection_string: str, canonical_sql: str) -> list[dict[str, Any]]:
+        captured["connection_string"] = connection_string
+        captured["canonical_sql"] = canonical_sql
+        return [
+            {
+                "vendor_name": "Northwind",
+                "approved_spend": 4200,
+            }
+        ]
+
+    result = execute_candidate_sql(
+        canonical_sql="SELECT TOP 1 vendor_name, approved_spend FROM dbo.approved_vendor_spend",
+        candidate_source=_candidate_source(),
+        selection=_selection(),
+        business_mssql_connection_string=(
+            "Driver={ODBC Driver 18 for SQL Server};"
+            "Server=tcp:business-mssql-source,1433;"
+            "Database=business;"
+            "Uid=svc_safequery_exec;"
+            "Pwd=super-secret;"
+            "Encrypt=yes;"
+            "TrustServerCertificate=no"
+        ),
+        query_runner=fake_query_runner,
+    )
+
+    assert result.model_dump() == {
+        "source_id": "business-mssql-source",
+        "connector_id": "mssql_readonly",
+        "ownership": "backend",
+        "rows": [
+            {
+                "vendor_name": "Northwind",
+                "approved_spend": 4200,
+            }
+        ],
+    }
+    assert captured == {
+        "connection_string": (
+            "Driver={ODBC Driver 18 for SQL Server};"
+            "Server=tcp:business-mssql-source,1433;"
+            "Database=business;"
+            "Uid=svc_safequery_exec;"
+            "Pwd=super-secret;"
+            "Encrypt=yes;"
+            "TrustServerCertificate=no"
+        ),
+        "canonical_sql": "SELECT TOP 1 vendor_name, approved_spend FROM dbo.approved_vendor_spend",
+    }
+
+
+def test_execute_mssql_connector_rejects_selection_binding_mismatch_fail_closed() -> None:
+    from app.features.execution import (
+        ExecutionConnectorExecutionError,
+        execute_candidate_sql,
+    )
+
+    with pytest.raises(
+        ExecutionConnectorExecutionError,
+        match="candidate-bound source metadata does not match the selected connector binding",
+    ) as exc_info:
+        execute_candidate_sql(
+            canonical_sql="SELECT TOP 1 vendor_name FROM dbo.approved_vendor_spend",
+            candidate_source=_candidate_source(),
+            selection=_selection(source_id="other-source"),
+            business_mssql_connection_string=(
+                "Driver={ODBC Driver 18 for SQL Server};"
+                "Server=tcp:business-mssql-source,1433;"
+                "Database=business;"
+                "Uid=svc_safequery_exec;"
+                "Pwd=super-secret;"
+                "Encrypt=yes;"
+                "TrustServerCertificate=no"
+            ),
+        )
+
+    assert exc_info.value.deny_code == DENY_SOURCE_BINDING_MISMATCH


### PR DESCRIPTION
Closes #106
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented a focused MSSQL execution runtime behind the existing source-bound selection seam. The new path exports `execute_candidate_sql`, enforces backend-owned execution, rejects source-binding mismatches fail closed, and uses an injectable MSSQL query runner so the unit test proves execution authority stays on the backend side without exposing credentials to adapter-facing code.

Added `backend/tests/test_mssql_execution_connector.py` first to reproduce the missing API as a targeted failure, then implemented [`backend/app/features/execution/runtime.py`](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-106/backend/app/features/execution/runtime.py) and updated [`backend/app/features/execution/__init__.py`](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-106/backend/app/features/execution/__init__.py). I also updated the local issue journal and created commit `81784e3` with the code changes.

Tests run:
- `cd backend && python3 -m pytest tests/test_mssql_execution_connector.py`
- `cd backend && python3 -m pytest tests/test_execution_connector_selection.py`

Summary: Added a backend-owned MSSQL execution connector runtime with focused happy-path and fail-closed binding tests, and committed it as `81784e3`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_mssql_execution_connector.py`; `cd backend && python3 -m pytest tests/test_execution_connector_selection.py`
Failure signature: none
Next action: Continue from...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL query execution functionality with structured result formatting.
  * Implemented validation for source and connector compatibility with specific error codes for configuration mismatches.

* **Tests**
  * Added test coverage for MSSQL execution operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->