### PR TITLE
[E-3] Implement the PostgreSQL business-source execution connector (#107)

### DIFF
--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -92,8 +92,13 @@ def _default_postgresql_query_runner(
     database_url: str,
     canonical_sql: str,
 ) -> list[dict[str, Any]]:
-    import psycopg
-    from psycopg.rows import dict_row
+    try:
+        import psycopg  # type: ignore[import-not-found]
+        from psycopg.rows import dict_row  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "psycopg must be installed before the PostgreSQL execution connector can run."
+        ) from exc
 
     with psycopg.connect(database_url) as connection:
         with connection.cursor(row_factory=dict_row) as cursor:

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -18,7 +18,7 @@ from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
-MssqlQueryRunner = Callable[..., list[dict[str, Any]]]
+QueryRunner = Callable[..., list[dict[str, Any]]]
 
 
 class ExecutionResult(BaseModel):
@@ -87,13 +87,28 @@ def _default_mssql_query_runner(
         return [dict(zip(column_names, row)) for row in cursor.fetchall()]
 
 
+def _default_postgresql_query_runner(
+    *,
+    database_url: str,
+    canonical_sql: str,
+) -> list[dict[str, Any]]:
+    import psycopg
+    from psycopg.rows import dict_row
+
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(canonical_sql)
+            return [dict(row) for row in cursor.fetchall()]
+
+
 def execute_candidate_sql(
     *,
     canonical_sql: NonEmptyTrimmedString,
     candidate_source: SourceBoundCandidateMetadata,
-    business_mssql_connection_string: NonEmptyTrimmedString,
+    business_mssql_connection_string: NonEmptyTrimmedString | None = None,
+    business_postgres_url: NonEmptyTrimmedString | None = None,
     selection: ExecutionConnectorSelection | None = None,
-    query_runner: MssqlQueryRunner | None = None,
+    query_runner: QueryRunner | None = None,
 ) -> ExecutionResult:
     resolved_selection = (
         selection
@@ -111,7 +126,31 @@ def execute_candidate_sql(
             message="Execution connectors must remain backend-owned.",
         )
 
-    if resolved_selection.connector_id != "mssql_readonly":
+    if resolved_selection.connector_id == "mssql_readonly":
+        if business_mssql_connection_string is None:
+            raise RuntimeError(
+                "A backend-owned business MSSQL connection string is required before "
+                "the MSSQL execution connector can run."
+            )
+
+        effective_query_runner = query_runner or _default_mssql_query_runner
+        rows = effective_query_runner(
+            connection_string=business_mssql_connection_string,
+            canonical_sql=canonical_sql,
+        )
+    elif resolved_selection.connector_id == "postgresql_readonly":
+        if business_postgres_url is None:
+            raise RuntimeError(
+                "A backend-owned business PostgreSQL URL is required before the "
+                "PostgreSQL execution connector can run."
+            )
+
+        effective_query_runner = query_runner or _default_postgresql_query_runner
+        rows = effective_query_runner(
+            database_url=business_postgres_url,
+            canonical_sql=canonical_sql,
+        )
+    else:
         raise ExecutionConnectorSelectionError(
             deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
             message=(
@@ -119,12 +158,6 @@ def execute_candidate_sql(
                 f"'{resolved_selection.connector_id}'."
             ),
         )
-
-    effective_query_runner = query_runner or _default_mssql_query_runner
-    rows = effective_query_runner(
-        connection_string=business_mssql_connection_string,
-        canonical_sql=canonical_sql,
-    )
     return ExecutionResult(
         source_id=resolved_selection.source_id,
         connector_id=resolved_selection.connector_id,

--- a/backend/tests/test_postgresql_execution_connector.py
+++ b/backend/tests/test_postgresql_execution_connector.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.execution.connector_selection import ExecutionConnectorSelection
+from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+
+
+def _candidate_source(
+    *,
+    source_id: str = "approved-spend",
+    source_family: str = "postgresql",
+    source_flavor: str | None = "warehouse",
+) -> SourceBoundCandidateMetadata:
+    return SourceBoundCandidateMetadata(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        dataset_contract_version=3,
+        schema_snapshot_version=7,
+    )
+
+
+def _selection(
+    *,
+    source_id: str = "approved-spend",
+    source_family: str = "postgresql",
+    source_flavor: str | None = "warehouse",
+    connector_id: str = "postgresql_readonly",
+) -> ExecutionConnectorSelection:
+    return ExecutionConnectorSelection(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        connector_id=connector_id,
+        ownership="backend",
+    )
+
+
+def test_execute_postgresql_connector_uses_backend_owned_connection_path() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    captured: dict[str, Any] = {}
+
+    def fake_query_runner(*, database_url: str, canonical_sql: str) -> list[dict[str, Any]]:
+        captured["database_url"] = database_url
+        captured["canonical_sql"] = canonical_sql
+        return [
+            {
+                "vendor_name": "Northwind",
+                "approved_spend": 4200,
+            }
+        ]
+
+    result = execute_candidate_sql(
+        canonical_sql=(
+            "SELECT vendor_name, approved_spend "
+            "FROM finance.approved_vendor_spend "
+            "ORDER BY approved_spend DESC LIMIT 1"
+        ),
+        candidate_source=_candidate_source(),
+        business_postgres_url=(
+            "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+        ),
+        query_runner=fake_query_runner,
+    )
+
+    assert result.model_dump() == {
+        "source_id": "approved-spend",
+        "connector_id": "postgresql_readonly",
+        "ownership": "backend",
+        "rows": [
+            {
+                "vendor_name": "Northwind",
+                "approved_spend": 4200,
+            }
+        ],
+    }
+    assert captured == {
+        "database_url": (
+            "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+        ),
+        "canonical_sql": (
+            "SELECT vendor_name, approved_spend "
+            "FROM finance.approved_vendor_spend "
+            "ORDER BY approved_spend DESC LIMIT 1"
+        ),
+    }
+
+
+def test_execute_postgresql_connector_rejects_selection_binding_mismatch_fail_closed() -> None:
+    from app.features.execution import (
+        ExecutionConnectorExecutionError,
+        execute_candidate_sql,
+    )
+
+    with pytest.raises(
+        ExecutionConnectorExecutionError,
+        match="candidate-bound source metadata does not match the selected connector binding",
+    ) as exc_info:
+        execute_candidate_sql(
+            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
+            candidate_source=_candidate_source(),
+            selection=_selection(source_id="other-source"),
+            business_postgres_url=(
+                "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+            ),
+        )
+
+    assert exc_info.value.deny_code == DENY_SOURCE_BINDING_MISMATCH

--- a/backend/tests/test_postgresql_execution_connector.py
+++ b/backend/tests/test_postgresql_execution_connector.py
@@ -122,20 +122,20 @@ def test_default_postgresql_query_runner_requires_psycopg_driver(
 
     def fake_import(
         name: str,
-        globals: dict[str, Any] | None = None,
-        locals: dict[str, Any] | None = None,
+        globalns: dict[str, Any] | None = None,
+        localns: dict[str, Any] | None = None,
         fromlist: tuple[str, ...] = (),
         level: int = 0,
     ) -> Any:
         if name == "psycopg":
             raise ModuleNotFoundError("No module named 'psycopg'")
-        return real_import(name, globals, locals, fromlist, level)
+        return real_import(name, globalns, localns, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
     with pytest.raises(
         RuntimeError,
-        match="psycopg must be installed before the PostgreSQL execution connector can run.",
+        match=r"psycopg must be installed before the PostgreSQL execution connector can run\.",
     ):
         _default_postgresql_query_runner(
             database_url="postgresql://business-postgres-source:5432/business",

--- a/backend/tests/test_postgresql_execution_connector.py
+++ b/backend/tests/test_postgresql_execution_connector.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import builtins
 from typing import Any
 
 import pytest
 
 from app.features.execution.connector_selection import ExecutionConnectorSelection
 from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
+from app.features.execution.runtime import _default_postgresql_query_runner
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 
@@ -111,3 +113,31 @@ def test_execute_postgresql_connector_rejects_selection_binding_mismatch_fail_cl
         )
 
     assert exc_info.value.deny_code == DENY_SOURCE_BINDING_MISMATCH
+
+
+def test_default_postgresql_query_runner_requires_psycopg_driver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "psycopg":
+            raise ModuleNotFoundError("No module named 'psycopg'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(
+        RuntimeError,
+        match="psycopg must be installed before the PostgreSQL execution connector can run.",
+    ):
+        _default_postgresql_query_runner(
+            database_url="postgresql://business-postgres-source:5432/business",
+            canonical_sql="SELECT 1",
+        )


### PR DESCRIPTION
Closes #107
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the PostgreSQL business-source execution connector in [backend/app/features/execution/runtime.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-107/backend/app/features/execution/runtime.py) and added the focused regression coverage in [backend/tests/test_postgresql_execution_connector.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-107/backend/tests/test_postgresql_execution_connector.py). The runtime now dispatches `postgresql_readonly` through a backend-owned `psycopg` path, keeps the existing source-binding mismatch check fail-closed, and leaves application PostgreSQL persistence separate from business-source execution.

Focused verification passed:
`cd backend && python3 -m pytest tests/test_postgresql_execution_connector.py tests/test_mssql_execution_connector.py tests/test_execution_connector_selection.py`

Checkpoint commit: `cc2f2b3` (`Add PostgreSQL execution connector runtime`). The issue journal was updated locally as requested; it remains gitignored under `.codex-supervisor/`.

Summary: Added backend-owned PostgreSQL execution runtime support behind connector selection and covered it with focused PostgreSQL connector tests.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_postgresql_execution_connector.py`; `cd backend && python3 -m pytest tests/test_postgresql_execution_connector.py tests/test_mssql_execution_connector.py tests/test_execution_connector_selection.py`
Failure signat...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL execution connector support and ability to accept backend-owned connection inputs for both MSSQL and PostgreSQL.

* **Bug Fixes**
  * Execution now validates and routes to the appropriate connector, raising a clear error when a required connection is missing.

* **Tests**
  * Added tests for PostgreSQL execution, source-binding validation, and dependency enforcement for the default PostgreSQL runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->