### PR TITLE
[E-4] Fix the execute path to reuse candidate-bound source selection (#108)

### DIFF
--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -51,6 +51,7 @@ def _require_matching_selection(
     candidate_source: SourceBoundCandidateMetadata,
     selection: ExecutionConnectorSelection,
 ) -> None:
+    expected_selection = select_execution_connector(candidate_source=candidate_source)
     if (
         candidate_source.source_id.strip() != selection.source_id
         or candidate_source.source_family.strip() != selection.source_family
@@ -58,6 +59,8 @@ def _require_matching_selection(
             candidate_source=candidate_source,
             selection=selection,
         )
+        or selection.connector_id != expected_selection.connector_id
+        or selection.ownership != expected_selection.ownership
     ):
         raise ExecutionConnectorExecutionError(
             deny_code=DENY_SOURCE_BINDING_MISMATCH,
@@ -110,28 +113,23 @@ def execute_candidate_sql(
     *,
     canonical_sql: NonEmptyTrimmedString,
     candidate_source: SourceBoundCandidateMetadata,
+    selection: ExecutionConnectorSelection,
     business_mssql_connection_string: NonEmptyTrimmedString | None = None,
     business_postgres_url: NonEmptyTrimmedString | None = None,
-    selection: ExecutionConnectorSelection | None = None,
     query_runner: QueryRunner | None = None,
 ) -> ExecutionResult:
-    resolved_selection = (
-        selection
-        if selection is not None
-        else select_execution_connector(candidate_source=candidate_source)
-    )
     _require_matching_selection(
         candidate_source=candidate_source,
-        selection=resolved_selection,
+        selection=selection,
     )
 
-    if resolved_selection.ownership != "backend":
+    if selection.ownership != "backend":
         raise ExecutionConnectorExecutionError(
             deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
             message="Execution connectors must remain backend-owned.",
         )
 
-    if resolved_selection.connector_id == "mssql_readonly":
+    if selection.connector_id == "mssql_readonly":
         if business_mssql_connection_string is None:
             raise RuntimeError(
                 "A backend-owned business MSSQL connection string is required before "
@@ -143,7 +141,7 @@ def execute_candidate_sql(
             connection_string=business_mssql_connection_string,
             canonical_sql=canonical_sql,
         )
-    elif resolved_selection.connector_id == "postgresql_readonly":
+    elif selection.connector_id == "postgresql_readonly":
         if business_postgres_url is None:
             raise RuntimeError(
                 "A backend-owned business PostgreSQL URL is required before the "
@@ -160,12 +158,12 @@ def execute_candidate_sql(
             deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
             message=(
                 "No backend-owned execution runtime is registered for connector "
-                f"'{resolved_selection.connector_id}'."
+                f"'{selection.connector_id}'."
             ),
         )
     return ExecutionResult(
-        source_id=resolved_selection.source_id,
-        connector_id=resolved_selection.connector_id,
-        ownership=resolved_selection.ownership,
+        source_id=selection.source_id,
+        connector_id=selection.connector_id,
+        ownership=selection.ownership,
         rows=rows,
     )

--- a/backend/tests/test_postgresql_execution_connector.py
+++ b/backend/tests/test_postgresql_execution_connector.py
@@ -64,6 +64,7 @@ def test_execute_postgresql_connector_uses_backend_owned_connection_path() -> No
             "ORDER BY approved_spend DESC LIMIT 1"
         ),
         candidate_source=_candidate_source(),
+        selection=_selection(),
         business_postgres_url=(
             "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
         ),

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from app.features.execution.connector_selection import ExecutionConnectorSelection
+from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+
+
+def _candidate_source() -> SourceBoundCandidateMetadata:
+    return SourceBoundCandidateMetadata(
+        source_id="approved-spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        dataset_contract_version=3,
+        schema_snapshot_version=7,
+    )
+
+
+def _selection(
+    *,
+    connector_id: str = "postgresql_readonly",
+) -> ExecutionConnectorSelection:
+    return ExecutionConnectorSelection(
+        source_id="approved-spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        connector_id=connector_id,
+        ownership="backend",
+    )
+
+
+def test_execute_candidate_sql_does_not_auto_select_execution_connector() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    signature = inspect.signature(execute_candidate_sql)
+
+    selection_parameter = signature.parameters["selection"]
+
+    assert selection_parameter.default is inspect._empty
+    assert selection_parameter.kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_execute_candidate_sql_rejects_connector_swaps_on_bound_source() -> None:
+    from app.features.execution import (
+        ExecutionConnectorExecutionError,
+        execute_candidate_sql,
+    )
+
+    with pytest.raises(
+        ExecutionConnectorExecutionError,
+        match="candidate-bound source metadata does not match the selected connector binding",
+    ) as exc_info:
+        execute_candidate_sql(
+            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
+            candidate_source=_candidate_source(),
+            selection=_selection(connector_id="postgresql_readonly_shadow"),
+            business_postgres_url=(
+                "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+            ),
+        )
+
+    assert exc_info.value.deny_code == DENY_SOURCE_BINDING_MISMATCH


### PR DESCRIPTION
Closes #108
This PR was opened by codex-supervisor.
Latest Codex summary:

Updated the execute helper so it no longer auto-selects a connector at run time. `execute_candidate_sql` now requires the candidate-bound `selection` explicitly, and it fails closed if that selection does not exactly match the canonical binding for the candidate source. I added a focused regression file at [backend/tests/test_source_bound_execute_path.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-108/backend/tests/test_source_bound_execute_path.py) and updated the PostgreSQL execution test to use the stricter API. The code change is in [backend/app/features/execution/runtime.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-108/backend/app/features/execution/runtime.py), and I checkpointed it in commit `4d3b0ac` (`Require bound selection for execute path`).

Verification run:
`cd backend && python3 -m pytest tests/test_source_bound_execute_path.py`
Also ran:
`cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_postgresql_execution_connector.py tests/test_mssql_execution_connector.py`

Summary: Required the execute path to consume an explicit candidate-bound selection and fail closed on connector swaps; added focused regression coverage and committed the checkpoint as `4d3b0ac`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_source_bound_execute_path.py`; `cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_postgresql_execution_connector.py t...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of database connector bindings during SQL execution to prevent mismatched configurations and ensure correct execution paths.
  * Enhanced error detection and messaging for connector binding mismatches.

* **Tests**
  * Added test coverage for explicit connector selection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->