### PR TITLE
[E-5] Implement source-aware execution runtime controls (#109)

### DIFF
--- a/backend/app/features/execution/__init__.py
+++ b/backend/app/features/execution/__init__.py
@@ -7,6 +7,8 @@ from app.features.execution.connector_selection import (
 )
 from app.features.execution.runtime import (
     ExecutionConnectorExecutionError,
+    ExecutionRuntimeCancelledError,
+    ExecutionRuntimeControls,
     ExecutionResult,
     execute_candidate_sql,
 )
@@ -15,6 +17,8 @@ __all__ = [
     "ExecutionConnectorExecutionError",
     "ExecutionConnectorSelection",
     "ExecutionConnectorSelectionError",
+    "ExecutionRuntimeCancelledError",
+    "ExecutionRuntimeControls",
     "ExecutionResult",
     "execute_candidate_sql",
     "select_execution_connector",

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -110,8 +110,12 @@ def _default_mssql_query_runner(
 
     with pyodbc.connect(connection_string) as connection:
         cursor = connection.cursor()
-        if hasattr(cursor, "timeout"):
-            cursor.timeout = runtime_controls.timeout_seconds
+        if not hasattr(cursor, "timeout"):
+            raise RuntimeError(
+                "The MSSQL execution connector requires cursor timeout support to "
+                "enforce backend-owned runtime controls."
+            )
+        cursor.timeout = runtime_controls.timeout_seconds
         _raise_if_cancelled(
             runtime_controls=runtime_controls,
             connection=connection,
@@ -202,7 +206,10 @@ def _raise_if_cancelled(
         return
 
     if connection is not None and hasattr(connection, "cancel"):
-        connection.cancel()
+        try:
+            connection.cancel()
+        except Exception:
+            pass
     raise ExecutionRuntimeCancelledError(message)
 
 

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from pydantic import BaseModel, ConfigDict, StringConstraints
@@ -19,6 +21,24 @@ from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 QueryRunner = Callable[..., list[dict[str, Any]]]
+CancellationProbe = Callable[[], bool]
+
+DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY = {
+    "mssql": 30,
+    "postgresql": 30,
+}
+DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY = {
+    "mssql": 200,
+    "postgresql": 200,
+}
+
+
+@dataclass(frozen=True)
+class ExecutionRuntimeControls:
+    source_family: str
+    timeout_seconds: int
+    max_rows: int
+    cancellation_probe: CancellationProbe | None = None
 
 
 class ExecutionResult(BaseModel):
@@ -34,6 +54,10 @@ class ExecutionConnectorExecutionError(PermissionError):
     def __init__(self, *, deny_code: str, message: str) -> None:
         super().__init__(f"{deny_code}: {message}")
         self.deny_code = deny_code
+
+
+class ExecutionRuntimeCancelledError(RuntimeError):
+    pass
 
 
 def _source_flavor_matches(
@@ -75,6 +99,7 @@ def _default_mssql_query_runner(
     *,
     connection_string: str,
     canonical_sql: str,
+    runtime_controls: ExecutionRuntimeControls,
 ) -> list[dict[str, Any]]:
     try:
         import pyodbc  # type: ignore[import-not-found]
@@ -85,15 +110,29 @@ def _default_mssql_query_runner(
 
     with pyodbc.connect(connection_string) as connection:
         cursor = connection.cursor()
+        if hasattr(cursor, "timeout"):
+            cursor.timeout = runtime_controls.timeout_seconds
+        _raise_if_cancelled(
+            runtime_controls=runtime_controls,
+            connection=connection,
+            message="Execution canceled before the MSSQL query started.",
+        )
         cursor.execute(canonical_sql)
+        _raise_if_cancelled(
+            runtime_controls=runtime_controls,
+            connection=connection,
+            message="Execution canceled before the MSSQL result set was read.",
+        )
         column_names = [column[0] for column in cursor.description or ()]
-        return [dict(zip(column_names, row)) for row in cursor.fetchall()]
+        rows = cursor.fetchmany(runtime_controls.max_rows + 1)
+        return [dict(zip(column_names, row)) for row in rows]
 
 
 def _default_postgresql_query_runner(
     *,
     database_url: str,
     canonical_sql: str,
+    runtime_controls: ExecutionRuntimeControls,
 ) -> list[dict[str, Any]]:
     try:
         import psycopg  # type: ignore[import-not-found]
@@ -103,10 +142,95 @@ def _default_postgresql_query_runner(
             "psycopg must be installed before the PostgreSQL execution connector can run."
         ) from exc
 
-    with psycopg.connect(database_url) as connection:
+    timeout_milliseconds = runtime_controls.timeout_seconds * 1000
+    with psycopg.connect(
+        database_url,
+        connect_timeout=runtime_controls.timeout_seconds,
+        options=(
+            f"-c statement_timeout={timeout_milliseconds} "
+            f"-c lock_timeout={timeout_milliseconds}"
+        ),
+    ) as connection:
         with connection.cursor(row_factory=dict_row) as cursor:
+            _raise_if_cancelled(
+                runtime_controls=runtime_controls,
+                connection=connection,
+                message="Execution canceled before the PostgreSQL query started.",
+            )
             cursor.execute(canonical_sql)
-            return [dict(row) for row in cursor.fetchall()]
+            _raise_if_cancelled(
+                runtime_controls=runtime_controls,
+                connection=connection,
+                message="Execution canceled before the PostgreSQL result set was read.",
+            )
+            return [dict(row) for row in cursor.fetchmany(runtime_controls.max_rows + 1)]
+
+
+def _resolve_runtime_controls(
+    *,
+    selection: ExecutionConnectorSelection,
+    cancellation_probe: CancellationProbe | None,
+) -> ExecutionRuntimeControls:
+    try:
+        timeout_seconds = DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY[selection.source_family]
+        max_rows = DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY[selection.source_family]
+    except KeyError as exc:
+        raise ExecutionConnectorSelectionError(
+            deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
+            message=(
+                "No source-aware execution runtime controls are registered for source "
+                f"family '{selection.source_family}'."
+            ),
+        ) from exc
+
+    return ExecutionRuntimeControls(
+        source_family=selection.source_family,
+        timeout_seconds=timeout_seconds,
+        max_rows=max_rows,
+        cancellation_probe=cancellation_probe,
+    )
+
+
+def _raise_if_cancelled(
+    *,
+    runtime_controls: ExecutionRuntimeControls,
+    message: str,
+    connection: Any | None = None,
+) -> None:
+    cancellation_probe = runtime_controls.cancellation_probe
+    if cancellation_probe is None or not cancellation_probe():
+        return
+
+    if connection is not None and hasattr(connection, "cancel"):
+        connection.cancel()
+    raise ExecutionRuntimeCancelledError(message)
+
+
+def _execute_query_runner(
+    *,
+    query_runner: QueryRunner,
+    runtime_controls: ExecutionRuntimeControls,
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
+    signature = inspect.signature(query_runner)
+    parameters = signature.parameters.values()
+    accepts_runtime_controls = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD or parameter.name == "runtime_controls"
+        for parameter in parameters
+    )
+    if accepts_runtime_controls:
+        return query_runner(runtime_controls=runtime_controls, **kwargs)
+    return query_runner(**kwargs)
+
+
+def _cap_rows(
+    rows: list[dict[str, Any]],
+    *,
+    runtime_controls: ExecutionRuntimeControls,
+) -> list[dict[str, Any]]:
+    if len(rows) <= runtime_controls.max_rows:
+        return rows
+    return rows[: runtime_controls.max_rows]
 
 
 def execute_candidate_sql(
@@ -117,6 +241,7 @@ def execute_candidate_sql(
     business_mssql_connection_string: NonEmptyTrimmedString | None = None,
     business_postgres_url: NonEmptyTrimmedString | None = None,
     query_runner: QueryRunner | None = None,
+    cancellation_probe: CancellationProbe | None = None,
 ) -> ExecutionResult:
     _require_matching_selection(
         candidate_source=candidate_source,
@@ -129,6 +254,15 @@ def execute_candidate_sql(
             message="Execution connectors must remain backend-owned.",
         )
 
+    runtime_controls = _resolve_runtime_controls(
+        selection=selection,
+        cancellation_probe=cancellation_probe,
+    )
+    _raise_if_cancelled(
+        runtime_controls=runtime_controls,
+        message="Execution canceled before the backend-owned query runner started.",
+    )
+
     if selection.connector_id == "mssql_readonly":
         if business_mssql_connection_string is None:
             raise RuntimeError(
@@ -137,7 +271,9 @@ def execute_candidate_sql(
             )
 
         effective_query_runner = query_runner or _default_mssql_query_runner
-        rows = effective_query_runner(
+        rows = _execute_query_runner(
+            query_runner=effective_query_runner,
+            runtime_controls=runtime_controls,
             connection_string=business_mssql_connection_string,
             canonical_sql=canonical_sql,
         )
@@ -149,7 +285,9 @@ def execute_candidate_sql(
             )
 
         effective_query_runner = query_runner or _default_postgresql_query_runner
-        rows = effective_query_runner(
+        rows = _execute_query_runner(
+            query_runner=effective_query_runner,
+            runtime_controls=runtime_controls,
             database_url=business_postgres_url,
             canonical_sql=canonical_sql,
         )
@@ -161,9 +299,10 @@ def execute_candidate_sql(
                 f"'{selection.connector_id}'."
             ),
         )
+
     return ExecutionResult(
         source_id=selection.source_id,
         connector_id=selection.connector_id,
         ownership=selection.ownership,
-        rows=rows,
+        rows=_cap_rows(rows, runtime_controls=runtime_controls),
     )

--- a/backend/tests/test_execution_runtime_controls.py
+++ b/backend/tests/test_execution_runtime_controls.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.features.execution.connector_selection import ExecutionConnectorSelection
+from app.features.execution.runtime import (
+    DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY,
+    DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY,
+)
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+
+
+def _candidate_source(
+    *,
+    source_id: str,
+    source_family: str,
+    source_flavor: str | None,
+) -> SourceBoundCandidateMetadata:
+    return SourceBoundCandidateMetadata(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        dataset_contract_version=3,
+        schema_snapshot_version=7,
+    )
+
+
+def _selection(
+    *,
+    source_id: str,
+    source_family: str,
+    source_flavor: str | None,
+    connector_id: str,
+) -> ExecutionConnectorSelection:
+    return ExecutionConnectorSelection(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        connector_id=connector_id,
+        ownership="backend",
+    )
+
+
+def test_execute_candidate_sql_passes_source_aware_controls_to_mssql_runner() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    captured: dict[str, Any] = {}
+
+    def fake_query_runner(
+        *,
+        connection_string: str,
+        canonical_sql: str,
+        runtime_controls: Any,
+    ) -> list[dict[str, Any]]:
+        captured["connection_string"] = connection_string
+        captured["canonical_sql"] = canonical_sql
+        captured["runtime_controls"] = runtime_controls
+        return [{"vendor_name": "Northwind"}]
+
+    execute_candidate_sql(
+        canonical_sql="SELECT TOP 1 vendor_name FROM dbo.approved_vendor_spend",
+        candidate_source=_candidate_source(
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver",
+        ),
+        selection=_selection(
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver",
+            connector_id="mssql_readonly",
+        ),
+        business_mssql_connection_string=(
+            "Driver={ODBC Driver 18 for SQL Server};"
+            "Server=tcp:business-mssql-source,1433;"
+            "Database=business;"
+            "Uid=svc_safequery_exec;"
+            "Pwd=super-secret;"
+            "Encrypt=yes;"
+            "TrustServerCertificate=no"
+        ),
+        query_runner=fake_query_runner,
+    )
+
+    runtime_controls = captured["runtime_controls"]
+    assert runtime_controls.source_family == "mssql"
+    assert runtime_controls.timeout_seconds == DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY["mssql"]
+    assert runtime_controls.max_rows == DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY["mssql"]
+
+
+def test_execute_candidate_sql_passes_source_aware_controls_to_postgresql_runner() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    captured: dict[str, Any] = {}
+
+    def fake_query_runner(
+        *,
+        database_url: str,
+        canonical_sql: str,
+        runtime_controls: Any,
+    ) -> list[dict[str, Any]]:
+        captured["database_url"] = database_url
+        captured["canonical_sql"] = canonical_sql
+        captured["runtime_controls"] = runtime_controls
+        return [{"vendor_name": "Northwind"}]
+
+    execute_candidate_sql(
+        canonical_sql=(
+            "SELECT vendor_name FROM finance.approved_vendor_spend "
+            "ORDER BY approved_spend DESC LIMIT 1"
+        ),
+        candidate_source=_candidate_source(
+            source_id="approved-spend",
+            source_family="postgresql",
+            source_flavor="warehouse",
+        ),
+        selection=_selection(
+            source_id="approved-spend",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            connector_id="postgresql_readonly",
+        ),
+        business_postgres_url=(
+            "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+        ),
+        query_runner=fake_query_runner,
+    )
+
+    runtime_controls = captured["runtime_controls"]
+    assert runtime_controls.source_family == "postgresql"
+    assert runtime_controls.timeout_seconds == DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY["postgresql"]
+    assert runtime_controls.max_rows == DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY["postgresql"]
+
+
+def test_execute_candidate_sql_blocks_pre_cancelled_execution_fail_closed() -> None:
+    from app.features.execution import (
+        ExecutionRuntimeCancelledError,
+        execute_candidate_sql,
+    )
+
+    def fake_query_runner(*, database_url: str, canonical_sql: str) -> list[dict[str, Any]]:
+        raise AssertionError("query runner should not run after cancellation")
+
+    with pytest.raises(
+        ExecutionRuntimeCancelledError,
+        match="Execution canceled before the backend-owned query runner started.",
+    ):
+        execute_candidate_sql(
+            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
+            candidate_source=_candidate_source(
+                source_id="approved-spend",
+                source_family="postgresql",
+                source_flavor="warehouse",
+            ),
+            selection=_selection(
+                source_id="approved-spend",
+                source_family="postgresql",
+                source_flavor="warehouse",
+                connector_id="postgresql_readonly",
+            ),
+            business_postgres_url=(
+                "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+            ),
+            query_runner=fake_query_runner,
+            cancellation_probe=lambda: True,
+        )
+
+
+def test_execute_candidate_sql_caps_rows_to_source_bound_maximum() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    result = execute_candidate_sql(
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend",
+        candidate_source=_candidate_source(
+            source_id="approved-spend",
+            source_family="postgresql",
+            source_flavor="warehouse",
+        ),
+        selection=_selection(
+            source_id="approved-spend",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            connector_id="postgresql_readonly",
+        ),
+        business_postgres_url=(
+            "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+        ),
+        query_runner=lambda *, database_url, canonical_sql: [
+            {"row_number": row_number}
+            for row_number in range(
+                DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY["postgresql"] + 25
+            )
+        ],
+    )
+
+    assert len(result.rows) == DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY["postgresql"]
+    assert result.rows[0] == {"row_number": 0}
+    assert result.rows[-1] == {
+        "row_number": DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY["postgresql"] - 1
+    }

--- a/backend/tests/test_execution_runtime_controls.py
+++ b/backend/tests/test_execution_runtime_controls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Any
 
 import pytest
@@ -8,6 +9,9 @@ from app.features.execution.connector_selection import ExecutionConnectorSelecti
 from app.features.execution.runtime import (
     DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY,
     DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY,
+    ExecutionRuntimeCancelledError,
+    ExecutionRuntimeControls,
+    _default_mssql_query_runner,
 )
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
@@ -145,7 +149,7 @@ def test_execute_candidate_sql_blocks_pre_cancelled_execution_fail_closed() -> N
 
     with pytest.raises(
         ExecutionRuntimeCancelledError,
-        match="Execution canceled before the backend-owned query runner started.",
+        match=r"Execution canceled before the backend-owned query runner started\.",
     ):
         execute_candidate_sql(
             canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
@@ -200,3 +204,99 @@ def test_execute_candidate_sql_caps_rows_to_source_bound_maximum() -> None:
     assert result.rows[-1] == {
         "row_number": DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY["postgresql"] - 1
     }
+
+
+def test_default_mssql_query_runner_requires_timeout_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeCursor:
+        pass
+
+    class FakeConnection:
+        def __enter__(self) -> FakeConnection:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+        def cursor(self) -> FakeCursor:
+            return FakeCursor()
+
+    class FakePyodbcModule:
+        @staticmethod
+        def connect(connection_string: str) -> FakeConnection:
+            assert connection_string == "Driver={ODBC Driver 18 for SQL Server};Server=tcp:test"
+            return FakeConnection()
+
+    monkeypatch.setitem(sys.modules, "pyodbc", FakePyodbcModule())
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"The MSSQL execution connector requires cursor timeout support to "
+            r"enforce backend-owned runtime controls\."
+        ),
+    ):
+        _default_mssql_query_runner(
+            connection_string="Driver={ODBC Driver 18 for SQL Server};Server=tcp:test",
+            canonical_sql="SELECT 1",
+            runtime_controls=ExecutionRuntimeControls(
+                source_family="mssql",
+                timeout_seconds=30,
+                max_rows=200,
+            ),
+        )
+
+
+def test_default_mssql_query_runner_preserves_cancelled_error_when_cancel_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeCursor:
+        def __init__(self) -> None:
+            self.timeout: int | None = None
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.cancel_calls = 0
+            self._cursor = FakeCursor()
+
+        def __enter__(self) -> FakeConnection:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            return False
+
+        def cursor(self) -> FakeCursor:
+            return self._cursor
+
+        def cancel(self) -> None:
+            self.cancel_calls += 1
+            raise RuntimeError("driver cancellation failure")
+
+    connection = FakeConnection()
+
+    class FakePyodbcModule:
+        @staticmethod
+        def connect(connection_string: str) -> FakeConnection:
+            assert connection_string == "Driver={ODBC Driver 18 for SQL Server};Server=tcp:test"
+            return connection
+
+    monkeypatch.setitem(sys.modules, "pyodbc", FakePyodbcModule())
+
+    with pytest.raises(
+        ExecutionRuntimeCancelledError,
+        match=r"Execution canceled before the MSSQL query started\.",
+    ):
+        _default_mssql_query_runner(
+            connection_string="Driver={ODBC Driver 18 for SQL Server};Server=tcp:test",
+            canonical_sql="SELECT 1",
+            runtime_controls=ExecutionRuntimeControls(
+                source_family="mssql",
+                timeout_seconds=17,
+                max_rows=200,
+                cancellation_probe=lambda: True,
+            ),
+        )
+
+    assert connection.cancel_calls == 1
+    assert connection._cursor.timeout == 17

--- a/backend/tests/test_postgresql_execution_connector.py
+++ b/backend/tests/test_postgresql_execution_connector.py
@@ -7,7 +7,10 @@ import pytest
 
 from app.features.execution.connector_selection import ExecutionConnectorSelection
 from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
-from app.features.execution.runtime import _default_postgresql_query_runner
+from app.features.execution.runtime import (
+    ExecutionRuntimeControls,
+    _default_postgresql_query_runner,
+)
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 
@@ -141,4 +144,9 @@ def test_default_postgresql_query_runner_requires_psycopg_driver(
         _default_postgresql_query_runner(
             database_url="postgresql://business-postgres-source:5432/business",
             canonical_sql="SELECT 1",
+            runtime_controls=ExecutionRuntimeControls(
+                source_family="postgresql",
+                timeout_seconds=30,
+                max_rows=200,
+            ),
         )


### PR DESCRIPTION
Closes #109
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented the backend-owned runtime controls in `backend/app/features/execution/runtime.py` and committed them as `ea23f37` (`Add source-aware execution runtime controls`).

The runtime now resolves source-family defaults for MSSQL and PostgreSQL, passes those controls into compatible query runners, fails closed on pre-cancel, wires DB-specific timeout settings into the default runners, and caps returned rows on the backend path even if a runner over-returns. I added the focused regression file `backend/tests/test_execution_runtime_controls.py` and updated the existing PostgreSQL runner test for the new runtime-control argument. The issue journal’s Codex Working Notes were updated locally in `.codex-supervisor/issues/109/issue-journal.md`.

Summary: Added source-aware backend execution runtime controls with focused tests and committed the checkpoint as `ea23f37`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_execution_runtime_controls.py`; `cd backend && python3 -m pytest tests/test_execution_runtime_controls.py tests/test_mssql_execution_connector.py tests/test_postgresql_execution_connector.py tests/test_source_bound_execute_path.py`
Failure signature: none
Next action: Run a broader backend pytest slice for adjacent execution paths, then open a draft PR for the checkpoint if it stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution runtime controls including configurable timeouts and maximum row limits for both MSSQL and PostgreSQL queries.
  * Implemented execution cancellation enforcement to prevent runaway queries.
  * Query results are now automatically capped to configured maximum row limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->