### PR TITLE
[E-F2] Tighten execution helpers to a candidate-only contract (#115)

### DIFF
--- a/backend/app/features/execution/__init__.py
+++ b/backend/app/features/execution/__init__.py
@@ -6,6 +6,7 @@ from app.features.execution.connector_selection import (
     select_execution_connector,
 )
 from app.features.execution.runtime import (
+    ExecutableCandidateRecord,
     ExecutionConnectorExecutionError,
     ExecutionRuntimeCancelledError,
     ExecutionRuntimeControls,
@@ -14,6 +15,7 @@ from app.features.execution.runtime import (
 )
 
 __all__ = [
+    "ExecutableCandidateRecord",
     "ExecutionConnectorExecutionError",
     "ExecutionConnectorSelection",
     "ExecutionConnectorSelectionError",

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -50,6 +50,13 @@ class ExecutionResult(BaseModel):
     rows: list[dict[str, Any]]
 
 
+class ExecutableCandidateRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_sql: NonEmptyTrimmedString
+    source: SourceBoundCandidateMetadata
+
+
 class ExecutionConnectorExecutionError(PermissionError):
     def __init__(self, *, deny_code: str, message: str) -> None:
         super().__init__(f"{deny_code}: {message}")
@@ -242,8 +249,7 @@ def _cap_rows(
 
 def execute_candidate_sql(
     *,
-    canonical_sql: NonEmptyTrimmedString,
-    candidate_source: SourceBoundCandidateMetadata,
+    candidate: ExecutableCandidateRecord,
     selection: ExecutionConnectorSelection,
     business_mssql_connection_string: NonEmptyTrimmedString | None = None,
     business_postgres_url: NonEmptyTrimmedString | None = None,
@@ -251,7 +257,7 @@ def execute_candidate_sql(
     cancellation_probe: CancellationProbe | None = None,
 ) -> ExecutionResult:
     _require_matching_selection(
-        candidate_source=candidate_source,
+        candidate_source=candidate.source,
         selection=selection,
     )
 
@@ -282,7 +288,7 @@ def execute_candidate_sql(
             query_runner=effective_query_runner,
             runtime_controls=runtime_controls,
             connection_string=business_mssql_connection_string,
-            canonical_sql=canonical_sql,
+            canonical_sql=candidate.canonical_sql,
         )
     elif selection.connector_id == "postgresql_readonly":
         if business_postgres_url is None:
@@ -296,7 +302,7 @@ def execute_candidate_sql(
             query_runner=effective_query_runner,
             runtime_controls=runtime_controls,
             database_url=business_postgres_url,
-            canonical_sql=canonical_sql,
+            canonical_sql=candidate.canonical_sql,
         )
     else:
         raise ExecutionConnectorSelectionError(

--- a/backend/tests/test_execution_runtime_controls.py
+++ b/backend/tests/test_execution_runtime_controls.py
@@ -9,6 +9,7 @@ from app.features.execution.connector_selection import ExecutionConnectorSelecti
 from app.features.execution.runtime import (
     DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY,
     DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY,
+    ExecutableCandidateRecord,
     ExecutionRuntimeCancelledError,
     ExecutionRuntimeControls,
     _default_mssql_query_runner,
@@ -47,6 +48,23 @@ def _selection(
     )
 
 
+def _candidate(
+    *,
+    canonical_sql: str,
+    source_id: str,
+    source_family: str,
+    source_flavor: str | None,
+) -> ExecutableCandidateRecord:
+    return ExecutableCandidateRecord(
+        canonical_sql=canonical_sql,
+        source=_candidate_source(
+            source_id=source_id,
+            source_family=source_family,
+            source_flavor=source_flavor,
+        ),
+    )
+
+
 def test_execute_candidate_sql_passes_source_aware_controls_to_mssql_runner() -> None:
     from app.features.execution import execute_candidate_sql
 
@@ -64,8 +82,8 @@ def test_execute_candidate_sql_passes_source_aware_controls_to_mssql_runner() ->
         return [{"vendor_name": "Northwind"}]
 
     execute_candidate_sql(
-        canonical_sql="SELECT TOP 1 vendor_name FROM dbo.approved_vendor_spend",
-        candidate_source=_candidate_source(
+        candidate=_candidate(
+            canonical_sql="SELECT TOP 1 vendor_name FROM dbo.approved_vendor_spend",
             source_id="business-mssql-source",
             source_family="mssql",
             source_flavor="sqlserver",
@@ -111,11 +129,11 @@ def test_execute_candidate_sql_passes_source_aware_controls_to_postgresql_runner
         return [{"vendor_name": "Northwind"}]
 
     execute_candidate_sql(
-        canonical_sql=(
-            "SELECT vendor_name FROM finance.approved_vendor_spend "
-            "ORDER BY approved_spend DESC LIMIT 1"
-        ),
-        candidate_source=_candidate_source(
+        candidate=_candidate(
+            canonical_sql=(
+                "SELECT vendor_name FROM finance.approved_vendor_spend "
+                "ORDER BY approved_spend DESC LIMIT 1"
+            ),
             source_id="approved-spend",
             source_family="postgresql",
             source_flavor="warehouse",
@@ -152,8 +170,8 @@ def test_execute_candidate_sql_blocks_pre_cancelled_execution_fail_closed() -> N
         match=r"Execution canceled before the backend-owned query runner started\.",
     ):
         execute_candidate_sql(
-            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
-            candidate_source=_candidate_source(
+            candidate=_candidate(
+                canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
                 source_id="approved-spend",
                 source_family="postgresql",
                 source_flavor="warehouse",
@@ -176,8 +194,8 @@ def test_execute_candidate_sql_caps_rows_to_source_bound_maximum() -> None:
     from app.features.execution import execute_candidate_sql
 
     result = execute_candidate_sql(
-        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend",
-        candidate_source=_candidate_source(
+        candidate=_candidate(
+            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend",
             source_id="approved-spend",
             source_family="postgresql",
             source_flavor="warehouse",

--- a/backend/tests/test_mssql_execution_connector.py
+++ b/backend/tests/test_mssql_execution_connector.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.features.execution.connector_selection import ExecutionConnectorSelection
 from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
+from app.features.execution.runtime import ExecutableCandidateRecord
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 
@@ -40,6 +41,23 @@ def _selection(
     )
 
 
+def _candidate(
+    *,
+    canonical_sql: str,
+    source_id: str = "business-mssql-source",
+    source_family: str = "mssql",
+    source_flavor: str | None = "sqlserver",
+) -> ExecutableCandidateRecord:
+    return ExecutableCandidateRecord(
+        canonical_sql=canonical_sql,
+        source=_candidate_source(
+            source_id=source_id,
+            source_family=source_family,
+            source_flavor=source_flavor,
+        ),
+    )
+
+
 def test_execute_mssql_connector_uses_backend_owned_connection_path() -> None:
     from app.features.execution import execute_candidate_sql
 
@@ -56,8 +74,9 @@ def test_execute_mssql_connector_uses_backend_owned_connection_path() -> None:
         ]
 
     result = execute_candidate_sql(
-        canonical_sql="SELECT TOP 1 vendor_name, approved_spend FROM dbo.approved_vendor_spend",
-        candidate_source=_candidate_source(),
+        candidate=_candidate(
+            canonical_sql="SELECT TOP 1 vendor_name, approved_spend FROM dbo.approved_vendor_spend"
+        ),
         selection=_selection(),
         business_mssql_connection_string=(
             "Driver={ODBC Driver 18 for SQL Server};"
@@ -107,8 +126,9 @@ def test_execute_mssql_connector_rejects_selection_binding_mismatch_fail_closed(
         match="candidate-bound source metadata does not match the selected connector binding",
     ) as exc_info:
         execute_candidate_sql(
-            canonical_sql="SELECT TOP 1 vendor_name FROM dbo.approved_vendor_spend",
-            candidate_source=_candidate_source(),
+            candidate=_candidate(
+                canonical_sql="SELECT TOP 1 vendor_name FROM dbo.approved_vendor_spend"
+            ),
             selection=_selection(source_id="other-source"),
             business_mssql_connection_string=(
                 "Driver={ODBC Driver 18 for SQL Server};"

--- a/backend/tests/test_postgresql_execution_connector.py
+++ b/backend/tests/test_postgresql_execution_connector.py
@@ -8,6 +8,7 @@ import pytest
 from app.features.execution.connector_selection import ExecutionConnectorSelection
 from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
 from app.features.execution.runtime import (
+    ExecutableCandidateRecord,
     ExecutionRuntimeControls,
     _default_postgresql_query_runner,
 )
@@ -45,6 +46,23 @@ def _selection(
     )
 
 
+def _candidate(
+    *,
+    canonical_sql: str,
+    source_id: str = "approved-spend",
+    source_family: str = "postgresql",
+    source_flavor: str | None = "warehouse",
+) -> ExecutableCandidateRecord:
+    return ExecutableCandidateRecord(
+        canonical_sql=canonical_sql,
+        source=_candidate_source(
+            source_id=source_id,
+            source_family=source_family,
+            source_flavor=source_flavor,
+        ),
+    )
+
+
 def test_execute_postgresql_connector_uses_backend_owned_connection_path() -> None:
     from app.features.execution import execute_candidate_sql
 
@@ -61,12 +79,13 @@ def test_execute_postgresql_connector_uses_backend_owned_connection_path() -> No
         ]
 
     result = execute_candidate_sql(
-        canonical_sql=(
-            "SELECT vendor_name, approved_spend "
-            "FROM finance.approved_vendor_spend "
-            "ORDER BY approved_spend DESC LIMIT 1"
+        candidate=_candidate(
+            canonical_sql=(
+                "SELECT vendor_name, approved_spend "
+                "FROM finance.approved_vendor_spend "
+                "ORDER BY approved_spend DESC LIMIT 1"
+            )
         ),
-        candidate_source=_candidate_source(),
         selection=_selection(),
         business_postgres_url=(
             "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
@@ -108,8 +127,9 @@ def test_execute_postgresql_connector_rejects_selection_binding_mismatch_fail_cl
         match="candidate-bound source metadata does not match the selected connector binding",
     ) as exc_info:
         execute_candidate_sql(
-            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
-            candidate_source=_candidate_source(),
+            candidate=_candidate(
+                canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"
+            ),
             selection=_selection(source_id="other-source"),
             business_postgres_url=(
                 "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.features.execution.connector_selection import ExecutionConnectorSelection
 from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
+from app.features.execution.runtime import ExecutableCandidateRecord
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 
@@ -32,13 +33,25 @@ def _selection(
     )
 
 
-def test_execute_candidate_sql_does_not_auto_select_execution_connector() -> None:
+def _candidate() -> ExecutableCandidateRecord:
+    return ExecutableCandidateRecord(
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
+        source=_candidate_source(),
+    )
+
+
+def test_execute_candidate_sql_requires_candidate_bound_record() -> None:
     from app.features.execution import execute_candidate_sql
 
     signature = inspect.signature(execute_candidate_sql)
 
     selection_parameter = signature.parameters["selection"]
+    candidate_parameter = signature.parameters["candidate"]
 
+    assert "canonical_sql" not in signature.parameters
+    assert "candidate_source" not in signature.parameters
+    assert candidate_parameter.default is inspect._empty
+    assert candidate_parameter.kind is inspect.Parameter.KEYWORD_ONLY
     assert selection_parameter.default is inspect._empty
     assert selection_parameter.kind is inspect.Parameter.KEYWORD_ONLY
 
@@ -54,8 +67,7 @@ def test_execute_candidate_sql_rejects_connector_swaps_on_bound_source() -> None
         match="candidate-bound source metadata does not match the selected connector binding",
     ) as exc_info:
         execute_candidate_sql(
-            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
-            candidate_source=_candidate_source(),
+            candidate=_candidate(),
             selection=_selection(connector_id="postgresql_readonly_shadow"),
             business_postgres_url=(
                 "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"


### PR DESCRIPTION
Closes #115
This PR was opened by codex-supervisor.
Latest Codex summary:

Changed the execution helper boundary to candidate-only. `execute_candidate_sql` now requires an `ExecutableCandidateRecord` that carries both executable `canonical_sql` and authoritative source metadata, so callers can no longer pass detached raw SQL plus separate source binding at the helper boundary. I also tightened the focused tests to assert the old detached parameters are gone from the public signature and updated the direct execution connector/runtime tests to use the bound record shape.

Focused verification passed with the issue’s requested command:
`cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_execution_runtime_controls.py`

Checkpoint commit: `a428845` (`Tighten execution helper contract`)

Summary: Tightened the backend execution helper to a candidate-only contract with focused regression coverage and committed the change.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_execution_runtime_controls.py`; also ran `cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_execution_runtime_controls.py tests/test_postgresql_execution_connector.py tests/test_mssql_execution_connector.py`
Failure signature: none
Next action: Open or update a draft PR for commit `a428845`, or continue the later vertical-slice caller adoption when that work starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the execution API to accept parameters through a unified structured record format instead of individual arguments, improving code consistency and API clarity without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->