### PR TITLE
Add source-aware audit event schema

### DIFF
--- a/backend/app/features/audit/__init__.py
+++ b/backend/app/features/audit/__init__.py
@@ -1,1 +1,5 @@
-"""Reserved package for audit event persistence and retrieval."""
+"""Audit event schema and reserved persistence seams."""
+
+from app.features.audit.event_model import SourceAwareAuditEvent
+
+__all__ = ["SourceAwareAuditEvent"]

--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, PositiveInt, StringConstraints
+from typing_extensions import Annotated
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+SourceIdentifier = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=255,
+        pattern=r"^[a-z0-9][a-z0-9._-]*$",
+    ),
+]
+SourceFlavor = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9][a-z0-9._-]*$",
+    ),
+]
+
+AuditEventType = Literal[
+    "query_submitted",
+    "retrieval_requested",
+    "retrieval_completed",
+    "generation_requested",
+    "generation_completed",
+    "generation_failed",
+    "guard_evaluated",
+    "execution_requested",
+    "execution_started",
+    "execution_completed",
+    "execution_denied",
+    "execution_failed",
+    "analyst_response_rendered",
+    "request_rate_limited",
+    "concurrency_rejected",
+    "candidate_invalidated",
+]
+
+SourceFamily = Literal["mssql", "postgresql"]
+
+
+class SourceAwareAuditEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: UUID
+    event_type: AuditEventType
+    occurred_at: datetime
+    request_id: NonEmptyTrimmedString
+    correlation_id: NonEmptyTrimmedString
+    causation_event_id: Optional[UUID] = None
+    user_subject: NonEmptyTrimmedString
+    session_id: NonEmptyTrimmedString
+    claim_or_role_snapshot: Optional[dict[str, object]] = None
+    query_candidate_id: Optional[NonEmptyTrimmedString] = None
+    candidate_owner_subject: Optional[NonEmptyTrimmedString] = None
+    adapter_version: Optional[NonEmptyTrimmedString] = None
+    guard_version: Optional[NonEmptyTrimmedString] = None
+    application_version: Optional[NonEmptyTrimmedString] = None
+    retrieval_corpus_version: Optional[NonEmptyTrimmedString] = None
+    retrieved_asset_ids: Optional[list[NonEmptyTrimmedString]] = None
+    analyst_mode_version: Optional[NonEmptyTrimmedString] = None
+
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    dialect_profile_version: Optional[PositiveInt] = None
+    dataset_contract_version: Optional[PositiveInt] = None
+    schema_snapshot_version: Optional[PositiveInt] = None
+    execution_policy_version: Optional[PositiveInt] = None
+    connector_profile_version: Optional[PositiveInt] = None

--- a/backend/tests/test_audit_event_model.py
+++ b/backend/tests/test_audit_event_model.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.audit.event_model import SourceAwareAuditEvent
+
+
+def _source_aware_payload() -> dict[str, object]:
+    return {
+        "event_id": uuid4(),
+        "event_type": "guard_evaluated",
+        "occurred_at": datetime.now(timezone.utc),
+        "request_id": "request-123",
+        "correlation_id": "correlation-123",
+        "user_subject": "user:alice",
+        "session_id": "session-123",
+        "source_id": "sap-approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dialect_profile_version": 2,
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "execution_policy_version": 5,
+        "connector_profile_version": 11,
+    }
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "query_submitted",
+        "generation_completed",
+        "guard_evaluated",
+        "execution_requested",
+        "execution_denied",
+        "candidate_invalidated",
+    ],
+)
+def test_source_aware_audit_event_accepts_relevant_lifecycle_events(
+    event_type: str,
+) -> None:
+    payload = _source_aware_payload()
+    payload["event_type"] = event_type
+
+    event = SourceAwareAuditEvent(**payload)
+
+    dumped = event.model_dump(exclude_none=True)
+    assert dumped == payload
+    assert set(SourceAwareAuditEvent.model_fields) >= {
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dialect_profile_version",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_id", " sap-approved-spend "),
+        ("source_id", "sap/approved/spend"),
+        ("source_family", "mysql"),
+        ("dataset_contract_version", 0),
+        ("connector_profile_version", -1),
+    ],
+)
+def test_source_aware_audit_event_rejects_invalid_source_metadata(
+    field: str,
+    value: object,
+) -> None:
+    payload = _source_aware_payload()
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        SourceAwareAuditEvent(**payload)
+
+
+@pytest.mark.parametrize("field", ["source_id", "source_family"])
+def test_source_aware_audit_event_rejects_missing_required_source_metadata(
+    field: str,
+) -> None:
+    payload = _source_aware_payload()
+    del payload[field]
+
+    with pytest.raises(ValidationError):
+        SourceAwareAuditEvent(**payload)


### PR DESCRIPTION
## Summary
- add a source-aware audit event schema with first-class source metadata fields
- validate supported source families, source identifier shape, and positive profile/contract version fields
- add focused audit event model tests for valid lifecycle payloads and fail-closed invalid metadata

## Verification
- cd backend && python3 -m pytest tests/test_audit_event_model.py

Closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented new audit event schema with source-aware tracking, capturing detailed event metadata including user, session, request context, and version information with robust validation.

* **Tests**
  * Added extensive test coverage for audit events, validating correct event processing and error handling for invalid source metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->