### PR TITLE
Emit source-aware lifecycle audit events

### DIFF
--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -77,3 +77,8 @@ class SourceAwareAuditEvent(BaseModel):
     schema_snapshot_version: Optional[PositiveInt] = None
     execution_policy_version: Optional[PositiveInt] = None
     connector_profile_version: Optional[PositiveInt] = None
+    primary_deny_code: Optional[NonEmptyTrimmedString] = None
+    denial_cause: Optional[NonEmptyTrimmedString] = None
+    candidate_state: Optional[NonEmptyTrimmedString] = None
+    execution_row_count: Optional[int] = None
+    result_truncated: Optional[bool] = None

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
-from typing import Any, Callable
+from datetime import datetime
+from typing import Any, Callable, Optional
 from urllib.parse import unquote, urlsplit
+from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from pydantic import BaseModel, ConfigDict, PrivateAttr, StringConstraints
 from typing_extensions import Annotated
 
+from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.execution.connector_selection import (
     ExecutionConnectorSelection,
     ExecutionConnectorSelectionError,
@@ -57,11 +60,16 @@ class _PostgresConnectionIdentity:
 
 class ExecutionResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
+    _audit_event: Optional[SourceAwareAuditEvent] = PrivateAttr(default=None)
 
     source_id: NonEmptyTrimmedString
     connector_id: NonEmptyTrimmedString
     ownership: str
     rows: list[dict[str, Any]]
+
+    @property
+    def audit_event(self) -> Optional[SourceAwareAuditEvent]:
+        return self._audit_event
 
 
 class ExecutableCandidateRecord(BaseModel):
@@ -71,10 +79,31 @@ class ExecutableCandidateRecord(BaseModel):
     source: SourceBoundCandidateMetadata
 
 
+class ExecutionAuditContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: UUID
+    occurred_at: datetime
+    request_id: str
+    correlation_id: str
+    user_subject: str
+    session_id: str
+    query_candidate_id: Optional[str] = None
+    candidate_owner_subject: Optional[str] = None
+    connector_profile_version: Optional[int] = None
+
+
 class ExecutionConnectorExecutionError(PermissionError):
-    def __init__(self, *, deny_code: str, message: str) -> None:
+    def __init__(
+        self,
+        *,
+        deny_code: str,
+        message: str,
+        audit_event: SourceAwareAuditEvent | None = None,
+    ) -> None:
         super().__init__(f"{deny_code}: {message}")
         self.deny_code = deny_code
+        self.audit_event = audit_event
 
 
 class ExecutionRuntimeCancelledError(RuntimeError):
@@ -91,10 +120,80 @@ def _source_flavor_matches(
     return candidate_flavor == selection_flavor
 
 
+def _execution_denial_cause_for_code(deny_code: str) -> str:
+    return {
+        DENY_APPLICATION_POSTGRES_REUSE: "application_postgresql_reuse",
+        DENY_SOURCE_BINDING_MISMATCH: "source_binding_mismatch",
+        DENY_UNSUPPORTED_SOURCE_BINDING: "unsupported_source_binding",
+    }.get(deny_code, "execution_denied")
+
+
+def _build_execution_audit_event(
+    *,
+    event_type: str,
+    candidate_source: SourceBoundCandidateMetadata,
+    audit_context: ExecutionAuditContext | None,
+    primary_deny_code: str | None = None,
+    execution_row_count: int | None = None,
+    result_truncated: bool | None = None,
+) -> SourceAwareAuditEvent | None:
+    if audit_context is None:
+        return None
+
+    return SourceAwareAuditEvent(
+        event_id=audit_context.event_id,
+        event_type=event_type,
+        occurred_at=audit_context.occurred_at,
+        request_id=audit_context.request_id,
+        correlation_id=audit_context.correlation_id,
+        user_subject=audit_context.user_subject,
+        session_id=audit_context.session_id,
+        query_candidate_id=audit_context.query_candidate_id,
+        candidate_owner_subject=audit_context.candidate_owner_subject,
+        source_id=candidate_source.source_id,
+        source_family=candidate_source.source_family,
+        source_flavor=candidate_source.source_flavor,
+        dataset_contract_version=candidate_source.dataset_contract_version,
+        schema_snapshot_version=candidate_source.schema_snapshot_version,
+        connector_profile_version=audit_context.connector_profile_version,
+        primary_deny_code=primary_deny_code,
+        denial_cause=(
+            _execution_denial_cause_for_code(primary_deny_code)
+            if primary_deny_code is not None
+            else None
+        ),
+        candidate_state="denied" if primary_deny_code is not None else None,
+        execution_row_count=execution_row_count,
+        result_truncated=result_truncated,
+    )
+
+
+def _attach_execution_denial_audit_event(
+    *,
+    error: ExecutionConnectorExecutionError,
+    candidate_source: SourceBoundCandidateMetadata,
+    audit_context: ExecutionAuditContext | None,
+) -> ExecutionConnectorExecutionError:
+    if error.audit_event is not None or audit_context is None:
+        return error
+    message = str(error).split(": ", 1)[1] if ": " in str(error) else str(error)
+    return ExecutionConnectorExecutionError(
+        deny_code=error.deny_code,
+        message=message,
+        audit_event=_build_execution_audit_event(
+            event_type="execution_denied",
+            candidate_source=candidate_source,
+            audit_context=audit_context,
+            primary_deny_code=error.deny_code,
+        ),
+    )
+
+
 def _require_matching_selection(
     *,
     candidate_source: SourceBoundCandidateMetadata,
     selection: ExecutionConnectorSelection,
+    audit_context: ExecutionAuditContext | None = None,
 ) -> None:
     expected_selection = select_execution_connector(candidate_source=candidate_source)
     if (
@@ -112,6 +211,12 @@ def _require_matching_selection(
             message=(
                 "The candidate-bound source metadata does not match the selected "
                 "connector binding."
+            ),
+            audit_event=_build_execution_audit_event(
+                event_type="execution_denied",
+                candidate_source=candidate_source,
+                audit_context=audit_context,
+                primary_deny_code=DENY_SOURCE_BINDING_MISMATCH,
             ),
         )
 
@@ -343,77 +448,96 @@ def execute_candidate_sql(
     application_postgres_url: NonEmptyTrimmedString | None = None,
     query_runner: QueryRunner | None = None,
     cancellation_probe: CancellationProbe | None = None,
+    audit_context: ExecutionAuditContext | None = None,
 ) -> ExecutionResult:
-    _require_matching_selection(
-        candidate_source=candidate.source,
-        selection=selection,
-    )
-
-    if selection.ownership != "backend":
-        raise ExecutionConnectorExecutionError(
-            deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
-            message="Execution connectors must remain backend-owned.",
+    try:
+        _require_matching_selection(
+            candidate_source=candidate.source,
+            selection=selection,
+            audit_context=audit_context,
         )
 
-    runtime_controls = _resolve_runtime_controls(
-        selection=selection,
-        cancellation_probe=cancellation_probe,
-    )
-    _raise_if_cancelled(
-        runtime_controls=runtime_controls,
-        message="Execution canceled before the backend-owned query runner started.",
-    )
-
-    if selection.connector_id == "mssql_readonly":
-        if business_mssql_connection_string is None:
-            raise RuntimeError(
-                "A backend-owned business MSSQL connection string is required before "
-                "the MSSQL execution connector can run."
+        if selection.ownership != "backend":
+            raise ExecutionConnectorExecutionError(
+                deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
+                message="Execution connectors must remain backend-owned.",
             )
 
-        effective_query_runner = query_runner or _default_mssql_query_runner
-        rows = _execute_query_runner(
-            query_runner=effective_query_runner,
-            runtime_controls=runtime_controls,
-            connection_string=business_mssql_connection_string,
-            canonical_sql=candidate.canonical_sql,
+        runtime_controls = _resolve_runtime_controls(
+            selection=selection,
+            cancellation_probe=cancellation_probe,
         )
-    elif selection.connector_id == "postgresql_readonly":
-        if business_postgres_url is None:
-            raise RuntimeError(
-                "A backend-owned business PostgreSQL URL is required before the "
-                "PostgreSQL execution connector can run."
+        _raise_if_cancelled(
+            runtime_controls=runtime_controls,
+            message="Execution canceled before the backend-owned query runner started.",
+        )
+
+        if selection.connector_id == "mssql_readonly":
+            if business_mssql_connection_string is None:
+                raise RuntimeError(
+                    "A backend-owned business MSSQL connection string is required before "
+                    "the MSSQL execution connector can run."
+                )
+
+            effective_query_runner = query_runner or _default_mssql_query_runner
+            rows = _execute_query_runner(
+                query_runner=effective_query_runner,
+                runtime_controls=runtime_controls,
+                connection_string=business_mssql_connection_string,
+                canonical_sql=candidate.canonical_sql,
+            )
+        elif selection.connector_id == "postgresql_readonly":
+            if business_postgres_url is None:
+                raise RuntimeError(
+                    "A backend-owned business PostgreSQL URL is required before the "
+                    "PostgreSQL execution connector can run."
+                )
+
+            if application_postgres_url is None:
+                from app.core.config import get_settings
+
+                application_postgres_url = str(get_settings().app_postgres_url)
+
+            _require_separate_postgresql_execution_target(
+                business_postgres_url=business_postgres_url,
+                application_postgres_url=application_postgres_url,
             )
 
-        if application_postgres_url is None:
-            from app.core.config import get_settings
+            effective_query_runner = query_runner or _default_postgresql_query_runner
+            rows = _execute_query_runner(
+                query_runner=effective_query_runner,
+                runtime_controls=runtime_controls,
+                database_url=business_postgres_url,
+                canonical_sql=candidate.canonical_sql,
+            )
+        else:
+            raise ExecutionConnectorSelectionError(
+                deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
+                message=(
+                    "No backend-owned execution runtime is registered for connector "
+                    f"'{selection.connector_id}'."
+                ),
+            )
+    except ExecutionConnectorExecutionError as exc:
+        raise _attach_execution_denial_audit_event(
+            error=exc,
+            candidate_source=candidate.source,
+            audit_context=audit_context,
+        ) from exc
 
-            application_postgres_url = str(get_settings().app_postgres_url)
+    capped_rows = _cap_rows(rows, runtime_controls=runtime_controls)
 
-        _require_separate_postgresql_execution_target(
-            business_postgres_url=business_postgres_url,
-            application_postgres_url=application_postgres_url,
-        )
-
-        effective_query_runner = query_runner or _default_postgresql_query_runner
-        rows = _execute_query_runner(
-            query_runner=effective_query_runner,
-            runtime_controls=runtime_controls,
-            database_url=business_postgres_url,
-            canonical_sql=candidate.canonical_sql,
-        )
-    else:
-        raise ExecutionConnectorSelectionError(
-            deny_code=DENY_UNSUPPORTED_SOURCE_BINDING,
-            message=(
-                "No backend-owned execution runtime is registered for connector "
-                f"'{selection.connector_id}'."
-            ),
-        )
-
-    return ExecutionResult(
+    result = ExecutionResult(
         source_id=selection.source_id,
         connector_id=selection.connector_id,
         ownership=selection.ownership,
-        rows=_cap_rows(rows, runtime_controls=runtime_controls),
+        rows=capped_rows,
     )
+    result._audit_event = _build_execution_audit_event(
+        event_type="execution_completed",
+        candidate_source=candidate.source,
+        audit_context=audit_context,
+        execution_row_count=len(capped_rows),
+        result_truncated=len(rows) > len(capped_rows),
+    )
+    return result

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Literal, Optional
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
+from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.auth.context import AuthenticatedSubject
 from app.features.guard.deny_taxonomy import (
     DENY_APPROVAL_EXPIRED,
@@ -46,6 +48,19 @@ class CandidateLifecycleRecord(BaseModel):
     source: SourceBoundCandidateMetadata
 
 
+class CandidateLifecycleAuditContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: UUID
+    occurred_at: datetime
+    request_id: str
+    correlation_id: str
+    user_subject: str
+    session_id: str
+    query_candidate_id: Optional[str] = None
+    candidate_owner_subject: Optional[str] = None
+
+
 class CandidateLifecycleRevalidationResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -54,9 +69,65 @@ class CandidateLifecycleRevalidationResult(BaseModel):
 
 
 class CandidateLifecycleRevalidationError(PermissionError):
-    def __init__(self, *, deny_code: str, message: str) -> None:
+    def __init__(
+        self,
+        *,
+        deny_code: str,
+        message: str,
+        audit_event: SourceAwareAuditEvent | None = None,
+    ) -> None:
         super().__init__(f"{deny_code}: {message}")
         self.deny_code = deny_code
+        self.audit_event = audit_event
+
+
+def _denial_cause_for_code(deny_code: str) -> str:
+    return {
+        DENY_APPROVAL_EXPIRED: "approval_expired",
+        DENY_CANDIDATE_INVALIDATED: "candidate_invalidated",
+        DENY_ENTITLEMENT_CHANGED: "entitlement_changed",
+        DENY_POLICY_VERSION_STALE: "policy_stale",
+        DENY_SOURCE_BINDING_MISMATCH: "source_binding_mismatch",
+        DENY_SUBJECT_MISMATCH: "subject_mismatch",
+    }.get(deny_code, "execution_denied")
+
+
+def _build_revalidation_audit_event(
+    *,
+    deny_code: str,
+    candidate: CandidateLifecycleRecord,
+    audit_context: CandidateLifecycleAuditContext | None,
+) -> SourceAwareAuditEvent | None:
+    if audit_context is None:
+        return None
+
+    event_type = (
+        "candidate_invalidated"
+        if deny_code == DENY_CANDIDATE_INVALIDATED
+        else "execution_denied"
+    )
+    candidate_state = "invalidated" if event_type == "candidate_invalidated" else "denied"
+    return SourceAwareAuditEvent(
+        event_id=audit_context.event_id,
+        event_type=event_type,
+        occurred_at=audit_context.occurred_at,
+        request_id=audit_context.request_id,
+        correlation_id=audit_context.correlation_id,
+        user_subject=audit_context.user_subject,
+        session_id=audit_context.session_id,
+        query_candidate_id=audit_context.query_candidate_id,
+        candidate_owner_subject=(
+            audit_context.candidate_owner_subject or candidate.owner_subject_id
+        ),
+        source_id=candidate.source.source_id,
+        source_family=candidate.source.source_family,
+        source_flavor=candidate.source.source_flavor,
+        dataset_contract_version=candidate.source.dataset_contract_version,
+        schema_snapshot_version=candidate.source.schema_snapshot_version,
+        primary_deny_code=deny_code,
+        denial_cause=_denial_cause_for_code(deny_code),
+        candidate_state=candidate_state,
+    )
 
 
 def _require_aware_datetime(value: datetime, *, field_name: str) -> datetime:
@@ -68,10 +139,21 @@ def _require_aware_datetime(value: datetime, *, field_name: str) -> datetime:
     return value
 
 
-def _raise_revalidation_error(*, deny_code: str, message: str) -> None:
+def _raise_revalidation_error(
+    *,
+    deny_code: str,
+    message: str,
+    candidate: CandidateLifecycleRecord,
+    audit_context: CandidateLifecycleAuditContext | None,
+) -> None:
     raise CandidateLifecycleRevalidationError(
         deny_code=deny_code,
         message=message,
+        audit_event=_build_revalidation_audit_event(
+            deny_code=deny_code,
+            candidate=candidate,
+            audit_context=audit_context,
+        ),
     )
 
 
@@ -82,6 +164,7 @@ def revalidate_candidate_lifecycle(
     session: Session,
     as_of: datetime,
     selected_source_id: str | None = None,
+    audit_context: CandidateLifecycleAuditContext | None = None,
 ) -> CandidateLifecycleRevalidationResult:
     effective_as_of = _require_aware_datetime(as_of, field_name="as_of")
     approval_expires_at = _require_aware_datetime(
@@ -96,6 +179,8 @@ def revalidate_candidate_lifecycle(
                 "Candidate source binding does not match the selected source. "
                 f"Expected '{candidate.source.source_id}' and received '{selected_source_id}'."
             ),
+            candidate=candidate,
+            audit_context=audit_context,
         )
 
     normalized_subject_id = authenticated_subject.normalized_subject_id()
@@ -106,6 +191,8 @@ def revalidate_candidate_lifecycle(
                 f"Candidate owner '{candidate.owner_subject_id}' does not match "
                 f"authenticated subject '{normalized_subject_id}'."
             ),
+            candidate=candidate,
+            audit_context=audit_context,
         )
 
     if approval_expires_at <= effective_as_of:
@@ -115,6 +202,8 @@ def revalidate_candidate_lifecycle(
                 f"Candidate approval for source '{candidate.source.source_id}' expired "
                 "before lifecycle revalidation completed."
             ),
+            candidate=candidate,
+            audit_context=audit_context,
         )
 
     if candidate.invalidated_at is not None:
@@ -129,6 +218,8 @@ def revalidate_candidate_lifecycle(
                     f"Candidate for source '{candidate.source.source_id}' was invalidated "
                     "before lifecycle revalidation completed."
                 ),
+                candidate=candidate,
+                audit_context=audit_context,
             )
 
     try:
@@ -140,6 +231,8 @@ def revalidate_candidate_lifecycle(
         _raise_revalidation_error(
             deny_code=DENY_POLICY_VERSION_STALE,
             message=str(exc),
+            candidate=candidate,
+            audit_context=audit_context,
         )
 
     if source.source_family != candidate.source.source_family:
@@ -149,6 +242,8 @@ def revalidate_candidate_lifecycle(
                 f"Candidate source family '{candidate.source.source_family}' no longer "
                 f"matches authoritative source '{source.source_family}'."
             ),
+            candidate=candidate,
+            audit_context=audit_context,
         )
     if source.source_flavor != candidate.source.source_flavor:
         _raise_revalidation_error(
@@ -157,6 +252,8 @@ def revalidate_candidate_lifecycle(
                 f"Candidate source flavor '{candidate.source.source_flavor}' no longer "
                 "matches the authoritative source posture."
             ),
+            candidate=candidate,
+            audit_context=audit_context,
         )
     if dataset_contract.contract_version != candidate.source.dataset_contract_version:
         _raise_revalidation_error(
@@ -165,6 +262,8 @@ def revalidate_candidate_lifecycle(
                 "Candidate dataset contract version is stale against the "
                 "authoritative source-scoped governance record."
             ),
+            candidate=candidate,
+            audit_context=audit_context,
         )
     if schema_snapshot.snapshot_version != candidate.source.schema_snapshot_version:
         _raise_revalidation_error(
@@ -173,6 +272,8 @@ def revalidate_candidate_lifecycle(
                 "Candidate schema snapshot version is stale against the "
                 "authoritative source-scoped governance record."
             ),
+            candidate=candidate,
+            audit_context=audit_context,
         )
 
     try:
@@ -192,6 +293,8 @@ def revalidate_candidate_lifecycle(
         _raise_revalidation_error(
             deny_code=deny_code,
             message=message,
+            candidate=candidate,
+            audit_context=audit_context,
         )
 
     return CandidateLifecycleRevalidationResult(

--- a/backend/tests/test_candidate_lifecycle_revalidation.py
+++ b/backend/tests/test_candidate_lifecycle_revalidation.py
@@ -16,6 +16,7 @@ from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewSt
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
 from app.services.candidate_lifecycle import (
+    CandidateLifecycleAuditContext,
     CandidateLifecycleRecord,
     CandidateLifecycleRevalidationError,
     SourceBoundCandidateMetadata,
@@ -115,6 +116,19 @@ def _candidate(
     )
 
 
+def _audit_context() -> CandidateLifecycleAuditContext:
+    return CandidateLifecycleAuditContext(
+        event_id=uuid4(),
+        occurred_at=datetime.now(timezone.utc),
+        request_id="request-123",
+        correlation_id="correlation-123",
+        user_subject="user:alice",
+        session_id="session-123",
+        query_candidate_id="candidate-123",
+        candidate_owner_subject="user:alice",
+    )
+
+
 def test_revalidate_candidate_lifecycle_accepts_current_source_bound_candidate() -> None:
     with _session_scope() as session:
         _seed_source(session, source_id="sap-approved-spend")
@@ -156,6 +170,44 @@ def test_revalidate_candidate_lifecycle_rejects_expired_approval() -> None:
     assert exc_info.value.deny_code == "DENY_APPROVAL_EXPIRED"
 
 
+def test_revalidate_candidate_lifecycle_attaches_source_aware_expiry_audit_event() -> None:
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
+
+        with pytest.raises(CandidateLifecycleRevalidationError) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(
+                    approval_expires_at=datetime.now(timezone.utc) - timedelta(seconds=1)
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+                audit_context=_audit_context(),
+            )
+
+    audit_event = exc_info.value.audit_event
+    assert audit_event is not None
+    assert {
+        "event_type": "execution_denied",
+        "request_id": "request-123",
+        "correlation_id": "correlation-123",
+        "user_subject": "user:alice",
+        "session_id": "session-123",
+        "query_candidate_id": "candidate-123",
+        "candidate_owner_subject": "user:alice",
+        "source_id": "sap-approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "primary_deny_code": "DENY_APPROVAL_EXPIRED",
+        "denial_cause": "approval_expired",
+    }.items() <= audit_event.model_dump(exclude_none=True).items()
+
+
 def test_revalidate_candidate_lifecycle_rejects_invalidated_candidate() -> None:
     with _session_scope() as session:
         _seed_source(session, source_id="sap-approved-spend")
@@ -175,6 +227,37 @@ def test_revalidate_candidate_lifecycle_rejects_invalidated_candidate() -> None:
             )
 
     assert exc_info.value.deny_code == "DENY_CANDIDATE_INVALIDATED"
+
+
+def test_revalidate_candidate_lifecycle_attaches_source_aware_invalidation_audit_event() -> None:
+    with _session_scope() as session:
+        _seed_source(session, source_id="sap-approved-spend")
+
+        with pytest.raises(CandidateLifecycleRevalidationError) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_candidate(invalidated_at=datetime.now(timezone.utc)),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+                audit_context=_audit_context(),
+            )
+
+    audit_event = exc_info.value.audit_event
+    assert audit_event is not None
+    assert {
+        "event_type": "candidate_invalidated",
+        "source_id": "sap-approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "primary_deny_code": "DENY_CANDIDATE_INVALIDATED",
+        "denial_cause": "candidate_invalidated",
+        "candidate_state": "invalidated",
+    }.items() <= audit_event.model_dump(exclude_none=True).items()
 
 
 def test_revalidate_candidate_lifecycle_allows_future_dated_invalidation() -> None:

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import inspect
+from uuid import uuid4
 
 import pytest
 
 from app.features.execution.connector_selection import ExecutionConnectorSelection
 from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
-from app.features.execution.runtime import ExecutableCandidateRecord
+from app.features.execution.runtime import ExecutableCandidateRecord, ExecutionAuditContext
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 
@@ -46,6 +48,20 @@ def _candidate() -> ExecutableCandidateRecord:
     )
 
 
+def _audit_context() -> ExecutionAuditContext:
+    return ExecutionAuditContext(
+        event_id=uuid4(),
+        occurred_at=datetime.now(timezone.utc),
+        request_id="request-123",
+        correlation_id="correlation-123",
+        user_subject="user:alice",
+        session_id="session-123",
+        query_candidate_id="candidate-123",
+        candidate_owner_subject="user:alice",
+        connector_profile_version=11,
+    )
+
+
 def test_execute_candidate_sql_requires_candidate_bound_record() -> None:
     from app.features.execution import execute_candidate_sql
 
@@ -77,6 +93,52 @@ def test_execute_candidate_sql_rejects_connector_swaps_on_bound_source() -> None
             selection=_selection(connector_id="postgresql_readonly_shadow"),
             business_postgres_url=BUSINESS_POSTGRES_URL,
             application_postgres_url=APPLICATION_POSTGRES_URL,
+            audit_context=_audit_context(),
         )
 
     assert exc_info.value.deny_code == DENY_SOURCE_BINDING_MISMATCH
+    assert exc_info.value.audit_event is not None
+    assert {
+        "event_type": "execution_denied",
+        "request_id": "request-123",
+        "correlation_id": "correlation-123",
+        "user_subject": "user:alice",
+        "session_id": "session-123",
+        "query_candidate_id": "candidate-123",
+        "candidate_owner_subject": "user:alice",
+        "source_id": "approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "connector_profile_version": 11,
+        "primary_deny_code": DENY_SOURCE_BINDING_MISMATCH,
+        "denial_cause": "source_binding_mismatch",
+    }.items() <= exc_info.value.audit_event.model_dump(exclude_none=True).items()
+
+
+def test_execute_candidate_sql_returns_source_aware_completion_audit_event() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    result = execute_candidate_sql(
+        candidate=_candidate(),
+        selection=_selection(),
+        business_postgres_url=BUSINESS_POSTGRES_URL,
+        application_postgres_url=APPLICATION_POSTGRES_URL,
+        query_runner=lambda **_: [{"vendor_name": "Acme"}],
+        audit_context=_audit_context(),
+    )
+
+    assert result.audit_event is not None
+    assert {
+        "event_type": "execution_completed",
+        "source_id": "approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "connector_profile_version": 11,
+        "execution_row_count": 1,
+        "result_truncated": False,
+    }.items() <= result.audit_event.model_dump(exclude_none=True).items()
+    assert result.audit_event.model_dump(exclude_none=True).get("rows") is None


### PR DESCRIPTION
## Summary
- add source-aware audit payload fields for deny causes, candidate state, row count, and truncation
- assemble validated lifecycle audit events for candidate expiry/invalidation and execution denial/completion
- keep execution result serialization stable by storing audit events as private runtime metadata

## Verification
- cd backend && python3 -m pytest tests/test_audit_event_model.py tests/test_candidate_lifecycle_revalidation.py tests/test_source_bound_execute_path.py
- cd backend && python3 -m pytest

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audit logging with detailed capture of execution events, denial metadata, and result metrics.
  * Improved tracking of candidate validation denials with cause information and candidate state details.
  * Added execution completion metrics to audit events, including row counts and result truncation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->