### PR TITLE
[codex] Add MSSQL evaluation scenarios

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -1,0 +1,17 @@
+"""Application-owned evaluation scenarios and harness helpers."""
+
+from app.features.evaluation.harness import (
+    EvaluationExpectedOutcome,
+    EvaluationScenarioKind,
+    EvaluationSourceProfile,
+    MSSQLEvaluationScenario,
+    list_mssql_evaluation_scenarios,
+)
+
+__all__ = [
+    "EvaluationExpectedOutcome",
+    "EvaluationScenarioKind",
+    "EvaluationSourceProfile",
+    "MSSQLEvaluationScenario",
+    "list_mssql_evaluation_scenarios",
+]

--- a/backend/app/features/evaluation/harness.py
+++ b/backend/app/features/evaluation/harness.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, PositiveInt, model_validator
+
+
+EvaluationScenarioKind = Literal["positive", "safety", "regression"]
+EvaluationBoundary = Literal["guard", "connector_selection", "lifecycle", "execution"]
+
+
+class EvaluationSourceProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str
+    source_family: str
+    source_flavor: str
+    dialect_profile: str
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
+    execution_policy_version: PositiveInt
+
+
+class EvaluationExecutionEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    connector_id: str
+    ownership: Literal["backend"]
+    row_shape: tuple[str, ...]
+
+
+class EvaluationExpectedOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Literal["allow", "reject"]
+    primary_code: Optional[str] = None
+    canonical_sql: Optional[str] = None
+    execution_evidence: Optional[EvaluationExecutionEvidence] = None
+
+    @model_validator(mode="after")
+    def _require_machine_readable_reject_code(self) -> "EvaluationExpectedOutcome":
+        if self.decision == "reject" and self.primary_code is None:
+            raise ValueError("Reject scenarios must include a machine-readable primary code.")
+        if self.decision == "allow" and self.primary_code is not None:
+            raise ValueError("Allow scenarios must not include a primary deny code.")
+        return self
+
+
+class MSSQLEvaluationScenario(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: str
+    kind: EvaluationScenarioKind
+    evaluation_boundary: EvaluationBoundary
+    source: EvaluationSourceProfile
+    prompt: str
+    canonical_sql: str
+    expected: EvaluationExpectedOutcome
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        return (self.source.source_id, self.scenario_id)
+
+
+_MSSQL_SOURCE = EvaluationSourceProfile(
+    source_id="business-mssql-source",
+    source_family="mssql",
+    source_flavor="sqlserver",
+    dialect_profile="mssql.sqlserver.v1",
+    dataset_contract_version=3,
+    schema_snapshot_version=7,
+    execution_policy_version=2,
+)
+
+_MSSQL_UNSUPPORTED_SOURCE = EvaluationSourceProfile(
+    source_id="business-mssql-legacy-source",
+    source_family="mssql",
+    source_flavor="legacy-sqlserver",
+    dialect_profile="mssql.legacy-sqlserver.v1",
+    dataset_contract_version=3,
+    schema_snapshot_version=7,
+    execution_policy_version=2,
+)
+
+
+MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-positive-approved-vendor-spend-top-vendors",
+        kind="positive",
+        evaluation_boundary="execution",
+        source=_MSSQL_SOURCE,
+        prompt="Show the top approved vendor spend records.",
+        canonical_sql=(
+            "SELECT TOP 10 vendor_name, approved_amount "
+            "FROM dbo.approved_vendor_spend "
+            "ORDER BY approved_amount DESC"
+        ),
+        expected=EvaluationExpectedOutcome(
+            decision="allow",
+            canonical_sql=(
+                "SELECT TOP 10 vendor_name, approved_amount "
+                "FROM dbo.approved_vendor_spend "
+                "ORDER BY approved_amount DESC"
+            ),
+            execution_evidence={
+                "connector_id": "mssql_readonly",
+                "ownership": "backend",
+                "row_shape": ("vendor_name", "approved_amount"),
+            },
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-positive-approved-vendor-count-by-region",
+        kind="positive",
+        evaluation_boundary="execution",
+        source=_MSSQL_SOURCE,
+        prompt="Count approved vendors by region.",
+        canonical_sql=(
+            "SELECT region, COUNT(*) AS vendor_count "
+            "FROM dbo.approved_vendor_spend "
+            "GROUP BY region "
+            "ORDER BY vendor_count DESC"
+        ),
+        expected=EvaluationExpectedOutcome(
+            decision="allow",
+            canonical_sql=(
+                "SELECT region, COUNT(*) AS vendor_count "
+                "FROM dbo.approved_vendor_spend "
+                "GROUP BY region "
+                "ORDER BY vendor_count DESC"
+            ),
+            execution_evidence={
+                "connector_id": "mssql_readonly",
+                "ownership": "backend",
+                "row_shape": ("region", "vendor_count"),
+            },
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-safety-guard-denies-waitfor-delay",
+        kind="safety",
+        evaluation_boundary="guard",
+        source=_MSSQL_SOURCE,
+        prompt="Run a slow query to check whether the database is responsive.",
+        canonical_sql=(
+            "SELECT vendor_name FROM dbo.approved_vendor_spend "
+            "WAITFOR DELAY '00:00:05'"
+        ),
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_RESOURCE_ABUSE",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-safety-wrong-source-binding-denied",
+        kind="safety",
+        evaluation_boundary="execution",
+        source=_MSSQL_SOURCE,
+        prompt="Execute the approved spend query against another selected source.",
+        canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_SOURCE_BINDING_MISMATCH",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-safety-unsupported-source-binding-denied",
+        kind="safety",
+        evaluation_boundary="connector_selection",
+        source=_MSSQL_UNSUPPORTED_SOURCE,
+        prompt="Use the legacy SQL Server source before a backend connector is registered.",
+        canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_UNSUPPORTED_SOURCE_BINDING",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-safety-stale-policy-denied",
+        kind="safety",
+        evaluation_boundary="lifecycle",
+        source=_MSSQL_SOURCE,
+        prompt="Execute a candidate after its source-scoped policy versions changed.",
+        canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_POLICY_VERSION_STALE",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-safety-approval-expiry-denied",
+        kind="safety",
+        evaluation_boundary="lifecycle",
+        source=_MSSQL_SOURCE,
+        prompt="Execute a candidate after its approval window expired.",
+        canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_APPROVAL_EXPIRED",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-regression-linked-server-denied",
+        kind="regression",
+        evaluation_boundary="guard",
+        source=_MSSQL_SOURCE,
+        prompt="Join approved spend to a linked server vendor table.",
+        canonical_sql="SELECT vendor_name FROM [remote].[sales].[dbo].[vendors]",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_LINKED_SERVER",
+        ),
+    ),
+)
+
+
+def list_mssql_evaluation_scenarios() -> tuple[MSSQLEvaluationScenario, ...]:
+    return MSSQL_EVALUATION_SCENARIOS

--- a/backend/app/features/evaluation/harness.py
+++ b/backend/app/features/evaluation/harness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, PositiveInt, model_validator
@@ -215,4 +216,4 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
 
 
 def list_mssql_evaluation_scenarios() -> tuple[MSSQLEvaluationScenario, ...]:
-    return MSSQL_EVALUATION_SCENARIOS
+    return tuple(copy.deepcopy(scenario) for scenario in MSSQL_EVALUATION_SCENARIOS)

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.features.evaluation import MSSQLEvaluationScenario, list_mssql_evaluation_scenarios
+from app.features.execution import (
+    ExecutionConnectorExecutionError,
+    ExecutionConnectorSelectionError,
+    execute_candidate_sql,
+    select_execution_connector,
+)
+from app.features.execution.connector_selection import ExecutionConnectorSelection
+from app.features.execution.runtime import ExecutableCandidateRecord
+from app.features.guard import evaluate_mssql_sql_guard
+from app.features.guard.deny_taxonomy import (
+    DENY_APPROVAL_EXPIRED,
+    DENY_POLICY_VERSION_STALE,
+    DENY_SOURCE_BINDING_MISMATCH,
+    DENY_UNSUPPORTED_SOURCE_BINDING,
+)
+from app.services.candidate_lifecycle import (
+    CandidateLifecycleRecord,
+    CandidateLifecycleRevalidationError,
+    SourceBoundCandidateMetadata,
+    revalidate_candidate_lifecycle,
+)
+
+
+MSSQL_TEST_CONNECTION_STRING = (
+    "Driver={ODBC Driver 18 for SQL Server};"
+    "Server=tcp:business-mssql-source,1433;"
+    "Database=business;"
+    "Uid=svc_safequery_exec;"
+    "Pwd=unused-test-password;"
+    "Encrypt=yes;"
+    "TrustServerCertificate=no"
+)
+
+
+def _mssql_scenarios_by_id() -> dict[str, MSSQLEvaluationScenario]:
+    return {
+        scenario.scenario_id: scenario
+        for scenario in list_mssql_evaluation_scenarios()
+    }
+
+
+def _candidate_source(scenario: MSSQLEvaluationScenario) -> SourceBoundCandidateMetadata:
+    return SourceBoundCandidateMetadata(
+        source_id=scenario.source.source_id,
+        source_family=scenario.source.source_family,
+        source_flavor=scenario.source.source_flavor,
+        dataset_contract_version=scenario.source.dataset_contract_version,
+        schema_snapshot_version=scenario.source.schema_snapshot_version,
+    )
+
+
+@contextmanager
+def _session_scope() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_mssql_source(
+    session: Session,
+    *,
+    scenario: MSSQLEvaluationScenario,
+    contract_version: int | None = None,
+    snapshot_version: int | None = None,
+) -> None:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id=scenario.source.source_id,
+        display_label=f"{scenario.source.source_id} display",
+        source_family=scenario.source.source_family,
+        source_flavor=scenario.source.source_flavor,
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{scenario.source.source_id}",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=snapshot_version or scenario.source.schema_snapshot_version,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=contract_version or scenario.source.dataset_contract_version,
+        display_name=f"{scenario.source.source_id} contract",
+        owner_binding="group:finance-analysts",
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.commit()
+
+
+def _lifecycle_candidate(
+    *,
+    scenario: MSSQLEvaluationScenario,
+    approval_expires_at: datetime | None = None,
+) -> CandidateLifecycleRecord:
+    now = datetime.now(timezone.utc)
+    return CandidateLifecycleRecord(
+        owner_subject_id="user:alice",
+        approved_at=now - timedelta(minutes=5),
+        approval_expires_at=approval_expires_at or (now + timedelta(minutes=10)),
+        invalidated_at=None,
+        source=_candidate_source(scenario),
+    )
+
+
+def test_mssql_evaluation_fixtures_are_source_bound_and_reconstructable() -> None:
+    scenarios = list_mssql_evaluation_scenarios()
+    scenario_ids = {scenario.scenario_id for scenario in scenarios}
+    scenario_identities = {scenario.identity for scenario in scenarios}
+
+    assert len(scenarios) == len(scenario_ids)
+    assert len(scenarios) == len(scenario_identities)
+    assert {"positive", "safety", "regression"} <= {
+        scenario.kind for scenario in scenarios
+    }
+
+    for scenario in scenarios:
+        assert scenario.identity == (scenario.source.source_id, scenario.scenario_id)
+        assert scenario.source.source_id
+        assert scenario.source.source_family == "mssql"
+        assert scenario.source.source_flavor
+        assert scenario.source.dialect_profile
+        assert scenario.source.dataset_contract_version > 0
+        assert scenario.source.schema_snapshot_version > 0
+        assert scenario.source.execution_policy_version > 0
+        assert scenario.expected.decision in {"allow", "reject"}
+        if scenario.expected.decision == "reject":
+            assert scenario.expected.primary_code
+
+
+@pytest.mark.parametrize(
+    "scenario_id",
+    (
+        "mssql-positive-approved-vendor-spend-top-vendors",
+        "mssql-positive-approved-vendor-count-by-region",
+    ),
+)
+def test_mssql_positive_evaluation_scenarios_allow_and_shape_execution_evidence(
+    scenario_id: str,
+) -> None:
+    scenario = _mssql_scenarios_by_id()[scenario_id]
+    guard_result = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": scenario.canonical_sql,
+            "source": {
+                "source_id": scenario.source.source_id,
+                "source_family": scenario.source.source_family,
+                "source_flavor": scenario.source.source_flavor,
+            },
+        }
+    )
+    assert guard_result.decision == "allow"
+
+    selection = select_execution_connector(candidate_source=_candidate_source(scenario))
+    captured: dict[str, object] = {}
+
+    def fake_query_runner(
+        *,
+        connection_string: str,
+        canonical_sql: str,
+    ) -> list[dict[str, object]]:
+        del connection_string
+        captured["canonical_sql"] = canonical_sql
+        row_shape = scenario.expected.execution_evidence.row_shape
+        return [{column_name: f"{column_name}-value" for column_name in row_shape}]
+
+    result = execute_candidate_sql(
+        candidate=ExecutableCandidateRecord(
+            canonical_sql=scenario.canonical_sql,
+            source=_candidate_source(scenario),
+        ),
+        selection=selection,
+        business_mssql_connection_string=MSSQL_TEST_CONNECTION_STRING,
+        query_runner=fake_query_runner,
+    )
+
+    evidence = scenario.expected.execution_evidence
+    assert captured["canonical_sql"] == scenario.expected.canonical_sql
+    assert result.source_id == scenario.source.source_id
+    assert result.connector_id == evidence.connector_id
+    assert result.ownership == evidence.ownership
+    assert tuple(result.rows[0]) == evidence.row_shape
+
+
+@pytest.mark.parametrize(
+    "scenario_id",
+    (
+        "mssql-safety-guard-denies-waitfor-delay",
+        "mssql-regression-linked-server-denied",
+    ),
+)
+def test_mssql_guard_safety_scenarios_deny_with_expected_codes(
+    scenario_id: str,
+) -> None:
+    scenario = _mssql_scenarios_by_id()[scenario_id]
+
+    result = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": scenario.canonical_sql,
+            "source": {
+                "source_id": scenario.source.source_id,
+                "source_family": scenario.source.source_family,
+                "source_flavor": scenario.source.source_flavor,
+            },
+        }
+    )
+
+    assert result.decision == "reject"
+    assert result.rejections[0].code == scenario.expected.primary_code
+
+
+def test_mssql_safety_wrong_source_binding_denies_at_execution_boundary() -> None:
+    scenario = _mssql_scenarios_by_id()["mssql-safety-wrong-source-binding-denied"]
+
+    with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
+        execute_candidate_sql(
+            candidate=ExecutableCandidateRecord(
+                canonical_sql=scenario.canonical_sql,
+                source=_candidate_source(scenario),
+            ),
+            selection=ExecutionConnectorSelection(
+                source_id="business-postgres-source",
+                source_family="postgresql",
+                source_flavor="warehouse",
+                connector_id="postgresql_readonly",
+                ownership="backend",
+            ),
+            business_mssql_connection_string=MSSQL_TEST_CONNECTION_STRING,
+        )
+
+    assert scenario.expected.primary_code == DENY_SOURCE_BINDING_MISMATCH
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_mssql_safety_unsupported_source_binding_denies_at_selection_boundary() -> None:
+    scenario = _mssql_scenarios_by_id()["mssql-safety-unsupported-source-binding-denied"]
+
+    with pytest.raises(ExecutionConnectorSelectionError) as exc_info:
+        select_execution_connector(candidate_source=_candidate_source(scenario))
+
+    assert scenario.expected.primary_code == DENY_UNSUPPORTED_SOURCE_BINDING
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_mssql_safety_stale_policy_denies_at_lifecycle_boundary() -> None:
+    scenario = _mssql_scenarios_by_id()["mssql-safety-stale-policy-denied"]
+
+    with _session_scope() as session:
+        _seed_mssql_source(
+            session,
+            scenario=scenario,
+            contract_version=scenario.source.dataset_contract_version + 1,
+            snapshot_version=scenario.source.schema_snapshot_version,
+        )
+
+        with pytest.raises(CandidateLifecycleRevalidationError) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_lifecycle_candidate(scenario=scenario),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert scenario.expected.primary_code == DENY_POLICY_VERSION_STALE
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_mssql_safety_approval_expiry_denies_at_lifecycle_boundary() -> None:
+    scenario = _mssql_scenarios_by_id()["mssql-safety-approval-expiry-denied"]
+
+    with _session_scope() as session:
+        _seed_mssql_source(session, scenario=scenario)
+
+        with pytest.raises(CandidateLifecycleRevalidationError) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_lifecycle_candidate(
+                    scenario=scenario,
+                    approval_expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert scenario.expected.primary_code == DENY_APPROVAL_EXPIRED
+    assert exc_info.value.deny_code == scenario.expected.primary_code

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -173,6 +173,7 @@ def test_mssql_evaluation_fixtures_are_source_bound_and_reconstructable() -> Non
 
 def test_mssql_evaluation_fixture_listing_returns_defensive_copies() -> None:
     first_read = list_mssql_evaluation_scenarios()
+    assert first_read, "Expected at least one MSSQL evaluation scenario"
     mutated_scenario = first_read[0]
     original_scenario_id = mutated_scenario.scenario_id
     original_source_id = mutated_scenario.source.source_id

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -171,6 +171,24 @@ def test_mssql_evaluation_fixtures_are_source_bound_and_reconstructable() -> Non
             assert scenario.expected.primary_code
 
 
+def test_mssql_evaluation_fixture_listing_returns_defensive_copies() -> None:
+    first_read = list_mssql_evaluation_scenarios()
+    mutated_scenario = first_read[0]
+    original_scenario_id = mutated_scenario.scenario_id
+    original_source_id = mutated_scenario.source.source_id
+
+    mutated_scenario.scenario_id = "mutated-scenario-id"
+    mutated_scenario.source.source_id = "mutated-source-id"
+
+    second_read = list_mssql_evaluation_scenarios()
+    fresh_scenario = second_read[0]
+
+    assert fresh_scenario is not mutated_scenario
+    assert fresh_scenario.source is not mutated_scenario.source
+    assert fresh_scenario.scenario_id == original_scenario_id
+    assert fresh_scenario.source.source_id == original_source_id
+
+
 @pytest.mark.parametrize(
     "scenario_id",
     (


### PR DESCRIPTION
## Summary

Adds application-owned MSSQL evaluation fixtures for issue #122. The scenarios distinguish positive, safety, and regression coverage and bind each case to source metadata: source ID, source family/flavor, dialect profile, dataset contract version, schema snapshot version, and execution policy version.

## Details

- Adds `app.features.evaluation` with reconstructable MSSQL scenarios that do not depend on MLflow.
- Covers representative allowed read-only MSSQL requests with expected canonical SQL and execution evidence shape.
- Covers safety and regression denials for guard rejection, wrong-source binding, unsupported source binding, stale policy, approval expiry, and linked-server regression.
- Adds focused tests that exercise the real guard, connector selection, lifecycle, and execution boundaries for expected machine-readable codes.

## Verification

- `cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_sql_guard_deny_corpus.py tests/test_sql_guard_mssql_profile.py`

Closes #122.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MSSQL evaluation harness with predefined evaluation scenarios and an API to retrieve them; scenarios include strict validation of expected outcomes and source profiles.

* **Tests**
  * Added end-to-end tests covering positive execution, safety/regression denies, connector selection/execution behavior, defensive copying of scenarios, and lifecycle revalidation deny cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->