### PR TITLE
[F-4] Add PostgreSQL positive and safety evaluation scenarios

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -5,7 +5,9 @@ from app.features.evaluation.harness import (
     EvaluationScenarioKind,
     EvaluationSourceProfile,
     MSSQLEvaluationScenario,
+    PostgreSQLEvaluationScenario,
     list_mssql_evaluation_scenarios,
+    list_postgresql_evaluation_scenarios,
 )
 
 __all__ = [
@@ -13,5 +15,7 @@ __all__ = [
     "EvaluationScenarioKind",
     "EvaluationSourceProfile",
     "MSSQLEvaluationScenario",
+    "PostgreSQLEvaluationScenario",
     "list_mssql_evaluation_scenarios",
+    "list_postgresql_evaluation_scenarios",
 ]

--- a/backend/app/features/evaluation/harness.py
+++ b/backend/app/features/evaluation/harness.py
@@ -63,6 +63,22 @@ class MSSQLEvaluationScenario(BaseModel):
         return (self.source.source_id, self.scenario_id)
 
 
+class PostgreSQLEvaluationScenario(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: str
+    kind: EvaluationScenarioKind
+    evaluation_boundary: EvaluationBoundary
+    source: EvaluationSourceProfile
+    prompt: str
+    canonical_sql: str
+    expected: EvaluationExpectedOutcome
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        return (self.source.source_id, self.scenario_id)
+
+
 _MSSQL_SOURCE = EvaluationSourceProfile(
     source_id="business-mssql-source",
     source_family="mssql",
@@ -81,6 +97,36 @@ _MSSQL_UNSUPPORTED_SOURCE = EvaluationSourceProfile(
     dataset_contract_version=3,
     schema_snapshot_version=7,
     execution_policy_version=2,
+)
+
+_POSTGRESQL_SOURCE = EvaluationSourceProfile(
+    source_id="business-postgres-source",
+    source_family="postgresql",
+    source_flavor="warehouse",
+    dialect_profile="postgresql.warehouse.v1",
+    dataset_contract_version=4,
+    schema_snapshot_version=9,
+    execution_policy_version=3,
+)
+
+_POSTGRESQL_UNSUPPORTED_SOURCE = EvaluationSourceProfile(
+    source_id="business-postgres-legacy-source",
+    source_family="postgresql",
+    source_flavor="legacy-warehouse",
+    dialect_profile="postgresql.legacy-warehouse.v1",
+    dataset_contract_version=4,
+    schema_snapshot_version=9,
+    execution_policy_version=3,
+)
+
+_APPLICATION_POSTGRES_SOURCE = EvaluationSourceProfile(
+    source_id="application-postgres-persistence",
+    source_family="postgresql",
+    source_flavor="persistence",
+    dialect_profile="postgresql.persistence.v1",
+    dataset_contract_version=1,
+    schema_snapshot_version=1,
+    execution_policy_version=1,
 )
 
 
@@ -214,6 +260,149 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
     ),
 )
 
+POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-positive-approved-vendor-spend-top-vendors",
+        kind="positive",
+        evaluation_boundary="execution",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Show the approved vendor spend rows with the highest spend.",
+        canonical_sql=(
+            "SELECT vendor_name, approved_spend "
+            "FROM finance.approved_vendor_spend "
+            "ORDER BY approved_spend DESC LIMIT 10"
+        ),
+        expected=EvaluationExpectedOutcome(
+            decision="allow",
+            canonical_sql=(
+                "SELECT vendor_name, approved_spend "
+                "FROM finance.approved_vendor_spend "
+                "ORDER BY approved_spend DESC LIMIT 10"
+            ),
+            execution_evidence={
+                "connector_id": "postgresql_readonly",
+                "ownership": "backend",
+                "row_shape": ("vendor_name", "approved_spend"),
+            },
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-positive-approved-vendor-count-by-region",
+        kind="positive",
+        evaluation_boundary="execution",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Count approved vendors by region.",
+        canonical_sql=(
+            "SELECT region, COUNT(*) AS vendor_count "
+            "FROM finance.approved_vendor_spend "
+            "GROUP BY region "
+            "ORDER BY vendor_count DESC"
+        ),
+        expected=EvaluationExpectedOutcome(
+            decision="allow",
+            canonical_sql=(
+                "SELECT region, COUNT(*) AS vendor_count "
+                "FROM finance.approved_vendor_spend "
+                "GROUP BY region "
+                "ORDER BY vendor_count DESC"
+            ),
+            execution_evidence={
+                "connector_id": "postgresql_readonly",
+                "ownership": "backend",
+                "row_shape": ("region", "vendor_count"),
+            },
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-guard-denies-system-catalog-access",
+        kind="safety",
+        evaluation_boundary="guard",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Inspect the PostgreSQL system catalog for available tables.",
+        canonical_sql="SELECT schemaname FROM pg_catalog.pg_tables",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_SYSTEM_CATALOG_ACCESS",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-wrong-source-binding-denied",
+        kind="safety",
+        evaluation_boundary="execution",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Execute the approved vendor spend query against another selected source.",
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_SOURCE_BINDING_MISMATCH",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-unsupported-source-binding-denied",
+        kind="safety",
+        evaluation_boundary="connector_selection",
+        source=_POSTGRESQL_UNSUPPORTED_SOURCE,
+        prompt="Use a PostgreSQL source flavor before a backend connector is registered.",
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_UNSUPPORTED_SOURCE_BINDING",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-stale-policy-denied",
+        kind="safety",
+        evaluation_boundary="lifecycle",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Execute a PostgreSQL candidate after the authoritative source versions changed.",
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_POLICY_VERSION_STALE",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-approval-expiry-denied",
+        kind="safety",
+        evaluation_boundary="lifecycle",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Execute a PostgreSQL candidate after its approval window expired.",
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_APPROVAL_EXPIRED",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-application-postgres-exposure-denied",
+        kind="safety",
+        evaluation_boundary="connector_selection",
+        source=_APPLICATION_POSTGRES_SOURCE,
+        prompt="Treat the application persistence database as a normal business PostgreSQL source.",
+        canonical_sql="SELECT id FROM public.query_candidates LIMIT 10",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_UNSUPPORTED_SOURCE_BINDING",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-application-postgres-execution-reuse-denied",
+        kind="safety",
+        evaluation_boundary="execution",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Execute a business PostgreSQL query while reusing the application PostgreSQL target.",
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            primary_code="DENY_APPLICATION_POSTGRES_REUSE",
+        ),
+    ),
+)
+
 
 def list_mssql_evaluation_scenarios() -> tuple[MSSQLEvaluationScenario, ...]:
     return tuple(copy.deepcopy(scenario) for scenario in MSSQL_EVALUATION_SCENARIOS)
+
+
+def list_postgresql_evaluation_scenarios() -> tuple[PostgreSQLEvaluationScenario, ...]:
+    return tuple(copy.deepcopy(scenario) for scenario in POSTGRESQL_EVALUATION_SCENARIOS)

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -57,10 +57,10 @@ MSSQL_TEST_CONNECTION_STRING = (
 )
 
 POSTGRESQL_TEST_URL = (
-    "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+    "postgresql://placeholder_user:placeholder_password@business-postgres-source:5432/business"
 )
 APPLICATION_POSTGRESQL_TEST_URL = (
-    "postgresql://safequery:safequery@app-postgres:5432/safequery"
+    "postgresql://placeholder_user:placeholder_password@app-postgres:5432/safequery"
 )
 
 

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -15,7 +15,12 @@ from app.db.models.dataset_contract import DatasetContract
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
-from app.features.evaluation import MSSQLEvaluationScenario, list_mssql_evaluation_scenarios
+from app.features.evaluation import (
+    MSSQLEvaluationScenario,
+    PostgreSQLEvaluationScenario,
+    list_mssql_evaluation_scenarios,
+    list_postgresql_evaluation_scenarios,
+)
 from app.features.execution import (
     ExecutionConnectorExecutionError,
     ExecutionConnectorSelectionError,
@@ -26,11 +31,13 @@ from app.features.execution.connector_selection import ExecutionConnectorSelecti
 from app.features.execution.runtime import ExecutableCandidateRecord
 from app.features.guard import evaluate_mssql_sql_guard
 from app.features.guard.deny_taxonomy import (
+    DENY_APPLICATION_POSTGRES_REUSE,
     DENY_APPROVAL_EXPIRED,
     DENY_POLICY_VERSION_STALE,
     DENY_SOURCE_BINDING_MISMATCH,
     DENY_UNSUPPORTED_SOURCE_BINDING,
 )
+from app.features.guard.sql_guard import evaluate_postgresql_sql_guard
 from app.services.candidate_lifecycle import (
     CandidateLifecycleRecord,
     CandidateLifecycleRevalidationError,
@@ -49,11 +56,25 @@ MSSQL_TEST_CONNECTION_STRING = (
     "TrustServerCertificate=no"
 )
 
+POSTGRESQL_TEST_URL = (
+    "postgresql://safequery_exec:super-secret@business-postgres-source:5432/business"
+)
+APPLICATION_POSTGRESQL_TEST_URL = (
+    "postgresql://safequery:safequery@app-postgres:5432/safequery"
+)
+
 
 def _mssql_scenarios_by_id() -> dict[str, MSSQLEvaluationScenario]:
     return {
         scenario.scenario_id: scenario
         for scenario in list_mssql_evaluation_scenarios()
+    }
+
+
+def _postgresql_scenarios_by_id() -> dict[str, PostgreSQLEvaluationScenario]:
+    return {
+        scenario.scenario_id: scenario
+        for scenario in list_postgresql_evaluation_scenarios()
     }
 
 
@@ -190,6 +211,48 @@ def test_mssql_evaluation_fixture_listing_returns_defensive_copies() -> None:
     assert fresh_scenario.source.source_id == original_source_id
 
 
+def test_postgresql_evaluation_fixtures_are_source_bound_and_reconstructable() -> None:
+    scenarios = list_postgresql_evaluation_scenarios()
+    scenario_ids = {scenario.scenario_id for scenario in scenarios}
+    scenario_identities = {scenario.identity for scenario in scenarios}
+
+    assert len(scenarios) == len(scenario_ids)
+    assert len(scenarios) == len(scenario_identities)
+    assert {"positive", "safety"} <= {scenario.kind for scenario in scenarios}
+
+    for scenario in scenarios:
+        assert scenario.identity == (scenario.source.source_id, scenario.scenario_id)
+        assert scenario.source.source_id
+        assert scenario.source.source_family == "postgresql"
+        assert scenario.source.source_flavor
+        assert scenario.source.dialect_profile
+        assert scenario.source.dataset_contract_version > 0
+        assert scenario.source.schema_snapshot_version > 0
+        assert scenario.source.execution_policy_version > 0
+        assert scenario.expected.decision in {"allow", "reject"}
+        if scenario.expected.decision == "reject":
+            assert scenario.expected.primary_code
+
+
+def test_postgresql_evaluation_fixture_listing_returns_defensive_copies() -> None:
+    first_read = list_postgresql_evaluation_scenarios()
+    assert first_read, "Expected at least one PostgreSQL evaluation scenario"
+    mutated_scenario = first_read[0]
+    original_scenario_id = mutated_scenario.scenario_id
+    original_source_id = mutated_scenario.source.source_id
+
+    mutated_scenario.scenario_id = "mutated-scenario-id"
+    mutated_scenario.source.source_id = "mutated-source-id"
+
+    second_read = list_postgresql_evaluation_scenarios()
+    fresh_scenario = second_read[0]
+
+    assert fresh_scenario is not mutated_scenario
+    assert fresh_scenario.source is not mutated_scenario.source
+    assert fresh_scenario.scenario_id == original_scenario_id
+    assert fresh_scenario.source.source_id == original_source_id
+
+
 @pytest.mark.parametrize(
     "scenario_id",
     (
@@ -237,6 +300,62 @@ def test_mssql_positive_evaluation_scenarios_allow_and_shape_execution_evidence(
     )
 
     evidence = scenario.expected.execution_evidence
+    assert captured["canonical_sql"] == scenario.expected.canonical_sql
+    assert result.source_id == scenario.source.source_id
+    assert result.connector_id == evidence.connector_id
+    assert result.ownership == evidence.ownership
+    assert tuple(result.rows[0]) == evidence.row_shape
+
+
+@pytest.mark.parametrize(
+    "scenario_id",
+    (
+        "postgresql-positive-approved-vendor-spend-top-vendors",
+        "postgresql-positive-approved-vendor-count-by-region",
+    ),
+)
+def test_postgresql_positive_evaluation_scenarios_allow_and_shape_execution_evidence(
+    scenario_id: str,
+) -> None:
+    scenario = _postgresql_scenarios_by_id()[scenario_id]
+    guard_result = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": scenario.canonical_sql,
+            "source": {
+                "source_id": scenario.source.source_id,
+                "source_family": scenario.source.source_family,
+                "source_flavor": scenario.source.source_flavor,
+            },
+        }
+    )
+    assert guard_result.decision == "allow"
+
+    selection = select_execution_connector(candidate_source=_candidate_source(scenario))
+    captured: dict[str, object] = {}
+
+    def fake_query_runner(
+        *,
+        database_url: str,
+        canonical_sql: str,
+    ) -> list[dict[str, object]]:
+        captured["database_url"] = database_url
+        captured["canonical_sql"] = canonical_sql
+        row_shape = scenario.expected.execution_evidence.row_shape
+        return [{column_name: f"{column_name}-value" for column_name in row_shape}]
+
+    result = execute_candidate_sql(
+        candidate=ExecutableCandidateRecord(
+            canonical_sql=scenario.canonical_sql,
+            source=_candidate_source(scenario),
+        ),
+        selection=selection,
+        business_postgres_url=POSTGRESQL_TEST_URL,
+        application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+        query_runner=fake_query_runner,
+    )
+
+    evidence = scenario.expected.execution_evidence
+    assert captured["database_url"] == POSTGRESQL_TEST_URL
     assert captured["canonical_sql"] == scenario.expected.canonical_sql
     assert result.source_id == scenario.source.source_id
     assert result.connector_id == evidence.connector_id
@@ -351,4 +470,154 @@ def test_mssql_safety_approval_expiry_denies_at_lifecycle_boundary() -> None:
             )
 
     assert scenario.expected.primary_code == DENY_APPROVAL_EXPIRED
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+@pytest.mark.parametrize(
+    "scenario_id",
+    (
+        "postgresql-safety-guard-denies-system-catalog-access",
+    ),
+)
+def test_postgresql_guard_safety_scenarios_deny_with_expected_codes(
+    scenario_id: str,
+) -> None:
+    scenario = _postgresql_scenarios_by_id()[scenario_id]
+
+    result = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": scenario.canonical_sql,
+            "source": {
+                "source_id": scenario.source.source_id,
+                "source_family": scenario.source.source_family,
+                "source_flavor": scenario.source.source_flavor,
+            },
+        }
+    )
+
+    assert result.decision == "reject"
+    assert result.rejections[0].code == scenario.expected.primary_code
+
+
+def test_postgresql_safety_wrong_source_binding_denies_at_execution_boundary() -> None:
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-safety-wrong-source-binding-denied"
+    ]
+
+    with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
+        execute_candidate_sql(
+            candidate=ExecutableCandidateRecord(
+                canonical_sql=scenario.canonical_sql,
+                source=_candidate_source(scenario),
+            ),
+            selection=ExecutionConnectorSelection(
+                source_id="business-mssql-source",
+                source_family="mssql",
+                source_flavor="sqlserver",
+                connector_id="mssql_readonly",
+                ownership="backend",
+            ),
+            business_postgres_url=POSTGRESQL_TEST_URL,
+            application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+        )
+
+    assert scenario.expected.primary_code == DENY_SOURCE_BINDING_MISMATCH
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_postgresql_safety_unsupported_source_binding_denies_at_selection_boundary() -> None:
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-safety-unsupported-source-binding-denied"
+    ]
+
+    with pytest.raises(ExecutionConnectorSelectionError) as exc_info:
+        select_execution_connector(candidate_source=_candidate_source(scenario))
+
+    assert scenario.expected.primary_code == DENY_UNSUPPORTED_SOURCE_BINDING
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_postgresql_safety_application_postgres_exposure_denies_at_selection_boundary() -> None:
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-safety-application-postgres-exposure-denied"
+    ]
+
+    with pytest.raises(ExecutionConnectorSelectionError) as exc_info:
+        select_execution_connector(candidate_source=_candidate_source(scenario))
+
+    assert scenario.expected.primary_code == DENY_UNSUPPORTED_SOURCE_BINDING
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_postgresql_safety_stale_policy_denies_at_lifecycle_boundary() -> None:
+    scenario = _postgresql_scenarios_by_id()["postgresql-safety-stale-policy-denied"]
+
+    with _session_scope() as session:
+        _seed_mssql_source(
+            session,
+            scenario=scenario,
+            contract_version=scenario.source.dataset_contract_version + 1,
+            snapshot_version=scenario.source.schema_snapshot_version,
+        )
+
+        with pytest.raises(CandidateLifecycleRevalidationError) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_lifecycle_candidate(scenario=scenario),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert scenario.expected.primary_code == DENY_POLICY_VERSION_STALE
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_postgresql_safety_approval_expiry_denies_at_lifecycle_boundary() -> None:
+    scenario = _postgresql_scenarios_by_id()["postgresql-safety-approval-expiry-denied"]
+
+    with _session_scope() as session:
+        _seed_mssql_source(session, scenario=scenario)
+
+        with pytest.raises(CandidateLifecycleRevalidationError) as exc_info:
+            revalidate_candidate_lifecycle(
+                candidate=_lifecycle_candidate(
+                    scenario=scenario,
+                    approval_expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                as_of=datetime.now(timezone.utc),
+            )
+
+    assert scenario.expected.primary_code == DENY_APPROVAL_EXPIRED
+    assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_postgresql_safety_application_postgres_execution_reuse_denies_before_query() -> None:
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-safety-application-postgres-execution-reuse-denied"
+    ]
+
+    def fake_query_runner(*, database_url: str, canonical_sql: str) -> list[dict[str, object]]:
+        raise AssertionError("query runner must not run for application PostgreSQL reuse")
+
+    with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
+        execute_candidate_sql(
+            candidate=ExecutableCandidateRecord(
+                canonical_sql=scenario.canonical_sql,
+                source=_candidate_source(scenario),
+            ),
+            selection=select_execution_connector(candidate_source=_candidate_source(scenario)),
+            business_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+            application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+            query_runner=fake_query_runner,
+        )
+
+    assert scenario.expected.primary_code == DENY_APPLICATION_POSTGRES_REUSE
     assert exc_info.value.deny_code == scenario.expected.primary_code


### PR DESCRIPTION
## Summary
- add PostgreSQL evaluation fixtures for positive business-source execution scenarios
- add PostgreSQL safety scenarios for guard, connector-selection, lifecycle, and execution boundaries
- verify application PostgreSQL persistence is modeled as unsupported exposure, not a default business target

## Testing
- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_sql_guard_deny_corpus.py tests/test_sql_guard_postgresql_profile.py tests/test_postgresql_execution_connector.py

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL evaluation support with comprehensive security validation for access control, source-binding checks, and policy lifecycle rules. Exposes PostgreSQL evaluation scenarios for use by evaluation tooling.

* **Tests**
  * Expanded test coverage for PostgreSQL scenarios, including positive approval paths and safety/deny cases (source-binding mismatches, unsupported bindings, stale/expired policies, and execution reuse protections).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->