### PR TITLE
[F-5] Add source-aware evaluation comparison

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -1,5 +1,13 @@
 """Application-owned evaluation scenarios and harness helpers."""
 
+from app.features.evaluation.comparison import (
+    EvaluationComparisonRow,
+    EvaluationComparisonKey,
+    EvaluationObservedOutcome,
+    EvaluationOutcomeRecord,
+    EvaluationOutcomeSnapshot,
+    compare_evaluation_outcomes,
+)
 from app.features.evaluation.harness import (
     EvaluationExpectedOutcome,
     EvaluationScenarioKind,
@@ -11,11 +19,17 @@ from app.features.evaluation.harness import (
 )
 
 __all__ = [
+    "EvaluationComparisonKey",
+    "EvaluationComparisonRow",
     "EvaluationExpectedOutcome",
+    "EvaluationObservedOutcome",
     "EvaluationScenarioKind",
+    "EvaluationOutcomeRecord",
+    "EvaluationOutcomeSnapshot",
     "EvaluationSourceProfile",
     "MSSQLEvaluationScenario",
     "PostgreSQLEvaluationScenario",
+    "compare_evaluation_outcomes",
     "list_mssql_evaluation_scenarios",
     "list_postgresql_evaluation_scenarios",
 ]

--- a/backend/app/features/evaluation/comparison.py
+++ b/backend/app/features/evaluation/comparison.py
@@ -22,7 +22,9 @@ class EvaluationObservedOutcome(BaseModel):
 
     @model_validator(mode="after")
     def _validate_primary_code(self) -> "EvaluationObservedOutcome":
-        if self.decision == "reject" and self.primary_code is None:
+        if self.decision == "reject" and (
+            self.primary_code is None or not self.primary_code.strip()
+        ):
             raise ValueError("Reject outcomes must include a machine-readable primary code.")
         if self.decision == "allow" and self.primary_code is not None:
             raise ValueError("Allow outcomes must not include a primary deny code.")

--- a/backend/app/features/evaluation/comparison.py
+++ b/backend/app/features/evaluation/comparison.py
@@ -73,8 +73,8 @@ def compare_evaluation_outcomes(
     baseline: tuple[EvaluationOutcomeRecord, ...],
     candidate: tuple[EvaluationOutcomeRecord, ...],
 ) -> tuple[EvaluationComparisonRow, ...]:
-    baseline_index = {record.comparison_identity: record for record in baseline}
-    candidate_index = {record.comparison_identity: record for record in candidate}
+    baseline_index = _index_outcomes_by_identity(baseline, side="baseline")
+    candidate_index = _index_outcomes_by_identity(candidate, side="candidate")
     identities = sorted(set(baseline_index) | set(candidate_index))
 
     return tuple(
@@ -84,6 +84,20 @@ def compare_evaluation_outcomes(
         )
         for identity in identities
     )
+
+
+def _index_outcomes_by_identity(
+    records: tuple[EvaluationOutcomeRecord, ...],
+    *,
+    side: str,
+) -> dict[tuple[str, str], EvaluationOutcomeRecord]:
+    index: dict[tuple[str, str], EvaluationOutcomeRecord] = {}
+    for record in records:
+        identity = record.comparison_identity
+        if identity in index:
+            raise ValueError(f"Duplicate {side} evaluation outcome identity: {identity!r}")
+        index[identity] = record
+    return index
 
 
 def _build_comparison_row(

--- a/backend/app/features/evaluation/comparison.py
+++ b/backend/app/features/evaluation/comparison.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, PositiveInt, model_validator
+
+from app.features.evaluation.harness import EvaluationScenarioKind, EvaluationSourceProfile
+
+
+ComparisonStatus = Literal["pass", "fail", "regression"]
+
+
+class EvaluationOutcomeSnapshot(EvaluationSourceProfile):
+    model_config = ConfigDict(extra="forbid")
+
+
+class EvaluationObservedOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: Literal["allow", "reject"]
+    primary_code: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_primary_code(self) -> "EvaluationObservedOutcome":
+        if self.decision == "reject" and self.primary_code is None:
+            raise ValueError("Reject outcomes must include a machine-readable primary code.")
+        if self.decision == "allow" and self.primary_code is not None:
+            raise ValueError("Allow outcomes must not include a primary deny code.")
+        return self
+
+
+class EvaluationOutcomeRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: str
+    kind: EvaluationScenarioKind
+    source: EvaluationOutcomeSnapshot
+    outcome: EvaluationObservedOutcome
+
+    @property
+    def comparison_identity(self) -> tuple[str, str]:
+        return (self.source.source_id, self.scenario_id)
+
+
+class EvaluationComparisonKey(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: str
+    source_id: str
+    source_family: str
+    source_flavor: str
+    dialect_profile: str
+    dialect_profile_version: Optional[PositiveInt] = None
+    connector_profile_version: Optional[PositiveInt] = None
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
+    execution_policy_version: PositiveInt
+
+
+class EvaluationComparisonRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: EvaluationComparisonKey
+    kind: EvaluationScenarioKind
+    status: ComparisonStatus
+    baseline: Optional[EvaluationOutcomeRecord] = None
+    candidate: Optional[EvaluationOutcomeRecord] = None
+    regressions: tuple[str, ...] = ()
+
+
+def compare_evaluation_outcomes(
+    *,
+    baseline: tuple[EvaluationOutcomeRecord, ...],
+    candidate: tuple[EvaluationOutcomeRecord, ...],
+) -> tuple[EvaluationComparisonRow, ...]:
+    baseline_index = {record.comparison_identity: record for record in baseline}
+    candidate_index = {record.comparison_identity: record for record in candidate}
+    identities = sorted(set(baseline_index) | set(candidate_index))
+
+    return tuple(
+        _build_comparison_row(
+            baseline=baseline_index.get(identity),
+            candidate=candidate_index.get(identity),
+        )
+        for identity in identities
+    )
+
+
+def _build_comparison_row(
+    *,
+    baseline: Optional[EvaluationOutcomeRecord],
+    candidate: Optional[EvaluationOutcomeRecord],
+) -> EvaluationComparisonRow:
+    anchor = candidate or baseline
+    assert anchor is not None
+
+    if baseline is None or candidate is None:
+        return EvaluationComparisonRow(
+            key=_comparison_key_for(anchor),
+            kind=anchor.kind,
+            status="fail",
+            baseline=baseline,
+            candidate=candidate,
+            regressions=("missing_candidate" if candidate is None else "missing_baseline",),
+        )
+
+    regressions = _collect_regressions(baseline=baseline, candidate=candidate)
+    status: ComparisonStatus = "pass" if not regressions else "regression"
+    return EvaluationComparisonRow(
+        key=_comparison_key_for(candidate),
+        kind=candidate.kind,
+        status=status,
+        baseline=baseline,
+        candidate=candidate,
+        regressions=tuple(regressions),
+    )
+
+
+def _comparison_key_for(record: EvaluationOutcomeRecord) -> EvaluationComparisonKey:
+    source = record.source
+    return EvaluationComparisonKey(
+        scenario_id=record.scenario_id,
+        source_id=source.source_id,
+        source_family=source.source_family,
+        source_flavor=source.source_flavor,
+        dialect_profile=source.dialect_profile,
+        dialect_profile_version=source.dialect_profile_version,
+        connector_profile_version=source.connector_profile_version,
+        dataset_contract_version=source.dataset_contract_version,
+        schema_snapshot_version=source.schema_snapshot_version,
+        execution_policy_version=source.execution_policy_version,
+    )
+
+
+def _collect_regressions(
+    *,
+    baseline: EvaluationOutcomeRecord,
+    candidate: EvaluationOutcomeRecord,
+) -> list[str]:
+    regressions: list[str] = []
+    source_fields = (
+        "source_family",
+        "source_flavor",
+        "dialect_profile",
+        "dialect_profile_version",
+        "connector_profile_version",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+    )
+
+    if baseline.kind != candidate.kind:
+        regressions.append("kind")
+    for field_name in source_fields:
+        if getattr(baseline.source, field_name) != getattr(candidate.source, field_name):
+            regressions.append(field_name)
+    if baseline.outcome.decision != candidate.outcome.decision:
+        regressions.append("decision")
+    if baseline.outcome.primary_code != candidate.outcome.primary_code:
+        regressions.append("primary_code")
+
+    return regressions

--- a/backend/app/features/evaluation/harness.py
+++ b/backend/app/features/evaluation/harness.py
@@ -17,6 +17,8 @@ class EvaluationSourceProfile(BaseModel):
     source_family: str
     source_flavor: str
     dialect_profile: str
+    dialect_profile_version: Optional[PositiveInt] = None
+    connector_profile_version: Optional[PositiveInt] = None
     dataset_contract_version: PositiveInt
     schema_snapshot_version: PositiveInt
     execution_policy_version: PositiveInt
@@ -84,6 +86,8 @@ _MSSQL_SOURCE = EvaluationSourceProfile(
     source_family="mssql",
     source_flavor="sqlserver",
     dialect_profile="mssql.sqlserver.v1",
+    dialect_profile_version=1,
+    connector_profile_version=1,
     dataset_contract_version=3,
     schema_snapshot_version=7,
     execution_policy_version=2,
@@ -94,6 +98,7 @@ _MSSQL_UNSUPPORTED_SOURCE = EvaluationSourceProfile(
     source_family="mssql",
     source_flavor="legacy-sqlserver",
     dialect_profile="mssql.legacy-sqlserver.v1",
+    dialect_profile_version=1,
     dataset_contract_version=3,
     schema_snapshot_version=7,
     execution_policy_version=2,
@@ -104,6 +109,8 @@ _POSTGRESQL_SOURCE = EvaluationSourceProfile(
     source_family="postgresql",
     source_flavor="warehouse",
     dialect_profile="postgresql.warehouse.v1",
+    dialect_profile_version=1,
+    connector_profile_version=1,
     dataset_contract_version=4,
     schema_snapshot_version=9,
     execution_policy_version=3,
@@ -114,6 +121,7 @@ _POSTGRESQL_UNSUPPORTED_SOURCE = EvaluationSourceProfile(
     source_family="postgresql",
     source_flavor="legacy-warehouse",
     dialect_profile="postgresql.legacy-warehouse.v1",
+    dialect_profile_version=1,
     dataset_contract_version=4,
     schema_snapshot_version=9,
     execution_policy_version=3,
@@ -124,6 +132,8 @@ _APPLICATION_POSTGRES_SOURCE = EvaluationSourceProfile(
     source_family="postgresql",
     source_flavor="persistence",
     dialect_profile="postgresql.persistence.v1",
+    dialect_profile_version=1,
+    connector_profile_version=1,
     dataset_contract_version=1,
     schema_snapshot_version=1,
     execution_policy_version=1,

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -16,8 +16,12 @@ from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewSt
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
 from app.features.evaluation import (
+    EvaluationComparisonRow,
+    EvaluationOutcomeRecord,
+    EvaluationOutcomeSnapshot,
     MSSQLEvaluationScenario,
     PostgreSQLEvaluationScenario,
+    compare_evaluation_outcomes,
     list_mssql_evaluation_scenarios,
     list_postgresql_evaluation_scenarios,
 )
@@ -621,3 +625,106 @@ def test_postgresql_safety_application_postgres_execution_reuse_denies_before_qu
 
     assert scenario.expected.primary_code == DENY_APPLICATION_POSTGRES_REUSE
     assert exc_info.value.deny_code == scenario.expected.primary_code
+
+
+def test_evaluation_comparison_keeps_same_family_different_sources_separate() -> None:
+    baseline = (
+        EvaluationOutcomeRecord(
+            scenario_id="postgresql-positive-approved-vendor-spend-top-vendors",
+            kind="positive",
+            source=EvaluationOutcomeSnapshot(
+                source_id="business-postgres-source-a",
+                source_family="postgresql",
+                source_flavor="warehouse",
+                dialect_profile="postgresql.warehouse.v1",
+                dialect_profile_version=1,
+                connector_profile_version=2,
+                dataset_contract_version=4,
+                schema_snapshot_version=9,
+                execution_policy_version=3,
+            ),
+            outcome={"decision": "allow"},
+        ),
+    )
+    candidate = (
+        EvaluationOutcomeRecord(
+            scenario_id="postgresql-positive-approved-vendor-spend-top-vendors",
+            kind="positive",
+            source=EvaluationOutcomeSnapshot(
+                source_id="business-postgres-source-b",
+                source_family="postgresql",
+                source_flavor="warehouse",
+                dialect_profile="postgresql.warehouse.v1",
+                dialect_profile_version=1,
+                connector_profile_version=2,
+                dataset_contract_version=4,
+                schema_snapshot_version=9,
+                execution_policy_version=3,
+            ),
+            outcome={"decision": "allow"},
+        ),
+    )
+
+    comparison = compare_evaluation_outcomes(baseline=baseline, candidate=candidate)
+
+    assert tuple(row.status for row in comparison) == ("fail", "fail")
+    assert {row.key.source_id for row in comparison} == {
+        "business-postgres-source-a",
+        "business-postgres-source-b",
+    }
+    assert all(row.key.source_family == "postgresql" for row in comparison)
+    assert all(row.kind == "positive" for row in comparison)
+
+
+def test_evaluation_comparison_marks_profile_version_drift_as_regression() -> None:
+    baseline = EvaluationOutcomeRecord(
+        scenario_id="mssql-positive-approved-vendor-spend-top-vendors",
+        kind="positive",
+        source=EvaluationOutcomeSnapshot(
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver",
+            dialect_profile="mssql.sqlserver.v1",
+            dialect_profile_version=1,
+            connector_profile_version=4,
+            dataset_contract_version=3,
+            schema_snapshot_version=7,
+            execution_policy_version=2,
+        ),
+        outcome={"decision": "allow"},
+    )
+    candidate = EvaluationOutcomeRecord(
+        scenario_id="mssql-positive-approved-vendor-spend-top-vendors",
+        kind="positive",
+        source=EvaluationOutcomeSnapshot(
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver",
+            dialect_profile="mssql.sqlserver.v1",
+            dialect_profile_version=2,
+            connector_profile_version=5,
+            dataset_contract_version=3,
+            schema_snapshot_version=7,
+            execution_policy_version=2,
+        ),
+        outcome={"decision": "allow"},
+    )
+
+    comparison = compare_evaluation_outcomes(
+        baseline=(baseline,),
+        candidate=(candidate,),
+    )
+
+    assert len(comparison) == 1
+    row = comparison[0]
+    assert isinstance(row, EvaluationComparisonRow)
+    assert row.status == "regression"
+    assert row.key.source_id == "business-mssql-source"
+    assert row.baseline.source.dialect_profile_version == 1
+    assert row.candidate.source.dialect_profile_version == 2
+    assert row.baseline.source.connector_profile_version == 4
+    assert row.candidate.source.connector_profile_version == 5
+    assert row.regressions == (
+        "dialect_profile_version",
+        "connector_profile_version",
+    )

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -728,3 +728,36 @@ def test_evaluation_comparison_marks_profile_version_drift_as_regression() -> No
         "dialect_profile_version",
         "connector_profile_version",
     )
+
+
+@pytest.mark.parametrize("duplicate_side", ("baseline", "candidate"))
+def test_evaluation_comparison_rejects_duplicate_comparison_identity(
+    duplicate_side: str,
+) -> None:
+    record = EvaluationOutcomeRecord(
+        scenario_id="postgresql-positive-approved-vendor-spend-top-vendors",
+        kind="positive",
+        source=EvaluationOutcomeSnapshot(
+            source_id="business-postgres-source-a",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            dialect_profile="postgresql.warehouse.v1",
+            dialect_profile_version=1,
+            connector_profile_version=2,
+            dataset_contract_version=4,
+            schema_snapshot_version=9,
+            execution_policy_version=3,
+        ),
+        outcome={"decision": "allow"},
+    )
+    baseline = (record, record) if duplicate_side == "baseline" else (record,)
+    candidate = (record, record) if duplicate_side == "candidate" else (record,)
+
+    with pytest.raises(ValueError) as exc_info:
+        compare_evaluation_outcomes(baseline=baseline, candidate=candidate)
+
+    assert str(exc_info.value) == (
+        "Duplicate "
+        f"{duplicate_side} evaluation outcome identity: "
+        "('business-postgres-source-a', 'postgresql-positive-approved-vendor-spend-top-vendors')"
+    )

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -17,6 +17,7 @@ from app.db.models.source_registry import RegisteredSource, SourceActivationPost
 from app.features.auth.context import AuthenticatedSubject
 from app.features.evaluation import (
     EvaluationComparisonRow,
+    EvaluationObservedOutcome,
     EvaluationOutcomeRecord,
     EvaluationOutcomeSnapshot,
     MSSQLEvaluationScenario,
@@ -728,6 +729,17 @@ def test_evaluation_comparison_marks_profile_version_drift_as_regression() -> No
         "dialect_profile_version",
         "connector_profile_version",
     )
+
+
+@pytest.mark.parametrize("primary_code", ("", "   "))
+def test_evaluation_observed_outcome_reject_requires_non_blank_primary_code(
+    primary_code: str,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="Reject outcomes must include a machine-readable primary code.",
+    ):
+        EvaluationObservedOutcome(decision="reject", primary_code=primary_code)
 
 
 @pytest.mark.parametrize("duplicate_side", ("baseline", "candidate"))


### PR DESCRIPTION
## Summary
- add an evaluation comparison model that keys regressions by source_id and scenario
- report profile-version drift as a regression instead of collapsing same-family sources
- add focused regression tests for same-family multi-source separation and profile drift

## Testing
- cd backend && python3 -m pytest tests/test_evaluation_harness.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outcome comparison to identify regressions and mismatches between baseline and candidate evaluation runs.
  * Added numeric version metadata for dialect and connector profiles to detect version drift.
* **Tests**
  * Added coverage for comparison behavior, version-drift reporting, and duplicate-identity validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->