### PR TITLE
[F-6] Add MLflow-independent release gate reconstruction (#125)

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -17,6 +17,11 @@ from app.features.evaluation.harness import (
     list_mssql_evaluation_scenarios,
     list_postgresql_evaluation_scenarios,
 )
+from app.features.evaluation.release_gate import (
+    ReleaseGateDecision,
+    ReleaseGateFailure,
+    reconstruct_release_gate,
+)
 
 __all__ = [
     "EvaluationComparisonKey",
@@ -29,7 +34,10 @@ __all__ = [
     "EvaluationSourceProfile",
     "MSSQLEvaluationScenario",
     "PostgreSQLEvaluationScenario",
+    "ReleaseGateDecision",
+    "ReleaseGateFailure",
     "compare_evaluation_outcomes",
     "list_mssql_evaluation_scenarios",
     "list_postgresql_evaluation_scenarios",
+    "reconstruct_release_gate",
 ]

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, Iterable as TypingIterable, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from app.features.evaluation.comparison import (
+    EvaluationComparisonRow,
+    EvaluationObservedOutcome,
+    EvaluationOutcomeRecord,
+    EvaluationOutcomeSnapshot,
+    compare_evaluation_outcomes,
+)
+from app.features.evaluation.harness import (
+    MSSQLEvaluationScenario,
+    PostgreSQLEvaluationScenario,
+    list_mssql_evaluation_scenarios,
+    list_postgresql_evaluation_scenarios,
+)
+
+
+ReleaseGateStatus = Literal["pass", "fail"]
+ScenarioArtifact = Union[MSSQLEvaluationScenario, PostgreSQLEvaluationScenario]
+
+_SOURCE_REQUIRED_FIELDS = {
+    "source.source_id",
+    "source.source_family",
+    "source.source_flavor",
+    "source.dialect_profile",
+    "source.dataset_contract_version",
+    "source.schema_snapshot_version",
+    "source.execution_policy_version",
+}
+
+
+class ReleaseGateFailure(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    deny_code: str
+    source_id: Optional[str] = None
+    source_family: Optional[str] = None
+    scenario_id: Optional[str] = None
+    scenario_category: Optional[str] = None
+    detail: str
+
+
+class ReleaseGateDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: ReleaseGateStatus
+    evaluated_scenario_count: int
+    failure_count: int
+    failures: tuple[ReleaseGateFailure, ...]
+
+
+def reconstruct_release_gate(
+    *,
+    observed_artifacts: TypingIterable[Union[EvaluationOutcomeRecord, Mapping[str, Any]]],
+) -> ReleaseGateDecision:
+    normalized_records: list[EvaluationOutcomeRecord] = []
+    failures: list[ReleaseGateFailure] = []
+
+    for artifact in observed_artifacts:
+        if isinstance(artifact, EvaluationOutcomeRecord):
+            normalized_records.append(artifact)
+            continue
+
+        try:
+            normalized_records.append(EvaluationOutcomeRecord.model_validate(artifact))
+        except ValidationError as exc:
+            failures.append(_validation_failure_for(artifact=artifact, error=exc))
+
+    if failures:
+        return ReleaseGateDecision(
+            status="fail",
+            evaluated_scenario_count=len(normalized_records),
+            failure_count=len(failures),
+            failures=tuple(failures),
+        )
+
+    comparison = compare_evaluation_outcomes(
+        baseline=_baseline_records_from_harness(),
+        candidate=tuple(normalized_records),
+    )
+    failures = [failure for row in comparison for failure in _failures_for_row(row)]
+
+    return ReleaseGateDecision(
+        status="pass" if not failures else "fail",
+        evaluated_scenario_count=len(comparison),
+        failure_count=len(failures),
+        failures=tuple(failures),
+    )
+
+
+def _baseline_records_from_harness() -> tuple[EvaluationOutcomeRecord, ...]:
+    return tuple(
+        _record_from_scenario(scenario)
+        for scenario in (
+            list_mssql_evaluation_scenarios() + list_postgresql_evaluation_scenarios()
+        )
+    )
+
+
+def _record_from_scenario(scenario: ScenarioArtifact) -> EvaluationOutcomeRecord:
+    return EvaluationOutcomeRecord(
+        scenario_id=scenario.scenario_id,
+        kind=scenario.kind,
+        source=EvaluationOutcomeSnapshot.model_validate(scenario.source.model_dump()),
+        outcome=EvaluationObservedOutcome(
+            decision=scenario.expected.decision,
+            primary_code=scenario.expected.primary_code,
+        ),
+    )
+
+
+def _validation_failure_for(
+    *,
+    artifact: Mapping[str, Any],
+    error: ValidationError,
+) -> ReleaseGateFailure:
+    errors = error.errors()
+    error_paths = {
+        ".".join(str(part) for part in validation_error["loc"])
+        for validation_error in errors
+    }
+    source = artifact.get("source")
+    source_id = source.get("source_id") if isinstance(source, Mapping) else None
+    source_family = source.get("source_family") if isinstance(source, Mapping) else None
+    deny_code = (
+        "DENY_MISSING_SOURCE_AWARE_AUDIT_FIELDS"
+        if error_paths & _SOURCE_REQUIRED_FIELDS
+        else "DENY_MALFORMED_EVALUATION_ARTIFACT"
+    )
+
+    return ReleaseGateFailure(
+        deny_code=deny_code,
+        source_id=source_id if isinstance(source_id, str) else None,
+        source_family=source_family if isinstance(source_family, str) else None,
+        scenario_id=_string_or_none(artifact.get("scenario_id")),
+        scenario_category=_string_or_none(artifact.get("kind")),
+        detail="; ".join(validation_error["msg"] for validation_error in errors),
+    )
+
+
+def _failures_for_row(row: EvaluationComparisonRow) -> tuple[ReleaseGateFailure, ...]:
+    if row.status == "pass":
+        return ()
+
+    if "missing_candidate" in row.regressions:
+        return (
+            ReleaseGateFailure(
+                deny_code="DENY_MISSING_EVALUATION_COVERAGE",
+                source_id=row.key.source_id,
+                source_family=row.key.source_family,
+                scenario_id=row.key.scenario_id,
+                scenario_category=row.kind,
+                detail="Missing authoritative evaluation outcome for required scenario.",
+            ),
+        )
+
+    if row.status == "regression":
+        deny_code = (
+            "DENY_SAFETY_SCENARIO_REGRESSION"
+            if row.kind in {"safety", "regression"}
+            else "DENY_EVALUATION_REGRESSION"
+        )
+        detail = _regression_detail(row)
+        return (
+            ReleaseGateFailure(
+                deny_code=deny_code,
+                source_id=row.key.source_id,
+                source_family=row.key.source_family,
+                scenario_id=row.key.scenario_id,
+                scenario_category=row.kind,
+                detail=detail,
+            ),
+        )
+
+    return (
+        ReleaseGateFailure(
+            deny_code="DENY_BASELINE_RECONSTRUCTION_GAP",
+            source_id=row.key.source_id,
+            source_family=row.key.source_family,
+            scenario_id=row.key.scenario_id,
+            scenario_category=row.kind,
+            detail="Baseline reconstruction was incomplete for a required scenario.",
+        ),
+    )
+
+
+def _regression_detail(row: EvaluationComparisonRow) -> str:
+    if "decision" in row.regressions or "primary_code" in row.regressions:
+        baseline_outcome = row.baseline.outcome if row.baseline is not None else None
+        candidate_outcome = row.candidate.outcome if row.candidate is not None else None
+        expected_decision = baseline_outcome.decision if baseline_outcome is not None else None
+        observed_decision = candidate_outcome.decision if candidate_outcome is not None else None
+        expected_code = baseline_outcome.primary_code if baseline_outcome is not None else None
+        observed_code = candidate_outcome.primary_code if candidate_outcome is not None else None
+        return (
+            "Observed decision does not match the authoritative scenario expectation: "
+            f"expected decision={expected_decision!r}, observed decision={observed_decision!r}, "
+            f"expected deny code={expected_code!r}, observed deny code={observed_code!r}."
+        )
+
+    return (
+        "Observed source profile does not match the authoritative scenario metadata: "
+        f"{', '.join(row.regressions)}."
+    )
+
+
+def _string_or_none(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) else None

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -116,7 +116,7 @@ def _record_from_scenario(scenario: ScenarioArtifact) -> EvaluationOutcomeRecord
 
 def _validation_failure_for(
     *,
-    artifact: Mapping[str, Any],
+    artifact: Any,
     error: ValidationError,
 ) -> ReleaseGateFailure:
     errors = error.errors()
@@ -124,7 +124,8 @@ def _validation_failure_for(
         ".".join(str(part) for part in validation_error["loc"])
         for validation_error in errors
     }
-    source = artifact.get("source")
+    artifact_map = artifact if isinstance(artifact, Mapping) else {}
+    source = artifact_map.get("source")
     source_id = source.get("source_id") if isinstance(source, Mapping) else None
     source_family = source.get("source_family") if isinstance(source, Mapping) else None
     deny_code = (
@@ -137,9 +138,12 @@ def _validation_failure_for(
         deny_code=deny_code,
         source_id=source_id if isinstance(source_id, str) else None,
         source_family=source_family if isinstance(source_family, str) else None,
-        scenario_id=_string_or_none(artifact.get("scenario_id")),
-        scenario_category=_string_or_none(artifact.get("kind")),
-        detail="; ".join(validation_error["msg"] for validation_error in errors),
+        scenario_id=_string_or_none(artifact_map.get("scenario_id")),
+        scenario_category=_string_or_none(artifact_map.get("kind")),
+        detail="; ".join(
+            f"{_error_location(validation_error['loc'])}: {validation_error['msg']}"
+            for validation_error in errors
+        ),
     )
 
 
@@ -211,3 +215,9 @@ def _regression_detail(row: EvaluationComparisonRow) -> str:
 
 def _string_or_none(value: Any) -> Optional[str]:
     return value if isinstance(value, str) else None
+
+
+def _error_location(location: tuple[Any, ...]) -> str:
+    if not location:
+        return "<root>"
+    return ".".join(str(part) for part in location)

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Union
+
+from app.features.evaluation import (
+    EvaluationOutcomeRecord,
+    reconstruct_release_gate,
+)
+from app.features.evaluation.harness import (
+    MSSQLEvaluationScenario,
+    PostgreSQLEvaluationScenario,
+    list_mssql_evaluation_scenarios,
+    list_postgresql_evaluation_scenarios,
+)
+
+
+def _all_scenarios() -> tuple[Union[MSSQLEvaluationScenario, PostgreSQLEvaluationScenario], ...]:
+    return list_mssql_evaluation_scenarios() + list_postgresql_evaluation_scenarios()
+
+
+def _observed_records_from_harness() -> tuple[EvaluationOutcomeRecord, ...]:
+    return tuple(
+        EvaluationOutcomeRecord(
+            scenario_id=scenario.scenario_id,
+            kind=scenario.kind,
+            source=scenario.source.model_dump(),
+            outcome={
+                "decision": scenario.expected.decision,
+                "primary_code": scenario.expected.primary_code,
+            },
+        )
+        for scenario in _all_scenarios()
+    )
+
+
+def test_release_gate_passes_when_authoritative_records_match_harness() -> None:
+    decision = reconstruct_release_gate(observed_artifacts=_observed_records_from_harness())
+
+    assert decision.status == "pass"
+    assert decision.failure_count == 0
+    assert decision.failures == ()
+
+
+def test_release_gate_fails_closed_for_safety_regression() -> None:
+    mutated_records = list(_observed_records_from_harness())
+    target_index = next(
+        index
+        for index, record in enumerate(mutated_records)
+        if record.scenario_id == "mssql-safety-guard-denies-waitfor-delay"
+    )
+    target = mutated_records[target_index]
+    mutated_records[target_index] = target.model_copy(
+        update={
+            "outcome": target.outcome.model_copy(
+                update={"decision": "allow", "primary_code": None}
+            )
+        }
+    )
+
+    decision = reconstruct_release_gate(observed_artifacts=tuple(mutated_records))
+
+    assert decision.status == "fail"
+    assert decision.failure_count == 1
+    assert decision.failures[0].deny_code == "DENY_SAFETY_SCENARIO_REGRESSION"
+    assert decision.failures[0].source_id == "business-mssql-source"
+    assert decision.failures[0].source_family == "mssql"
+    assert decision.failures[0].scenario_category == "safety"
+
+
+def test_release_gate_fails_closed_for_missing_evaluation_coverage() -> None:
+    observed_records = tuple(
+        record
+        for record in _observed_records_from_harness()
+        if record.scenario_id != "postgresql-positive-approved-vendor-count-by-region"
+    )
+
+    decision = reconstruct_release_gate(observed_artifacts=observed_records)
+
+    assert decision.status == "fail"
+    assert decision.failure_count == 1
+    assert decision.failures[0].deny_code == "DENY_MISSING_EVALUATION_COVERAGE"
+    assert decision.failures[0].source_id == "business-postgres-source"
+    assert decision.failures[0].source_family == "postgresql"
+    assert decision.failures[0].scenario_category == "positive"
+
+
+def test_release_gate_reports_missing_source_aware_audit_fields() -> None:
+    observed_artifacts = (
+        {
+            "scenario_id": "mssql-positive-approved-vendor-spend-top-vendors",
+            "kind": "positive",
+            "source": {
+                "source_id": "business-mssql-source",
+                "source_flavor": "sqlserver",
+                "dialect_profile": "mssql.sqlserver.v1",
+                "dialect_profile_version": 1,
+                "connector_profile_version": 1,
+                "dataset_contract_version": 3,
+                "schema_snapshot_version": 7,
+                "execution_policy_version": 2,
+            },
+            "outcome": {"decision": "allow"},
+        },
+    )
+
+    decision = reconstruct_release_gate(observed_artifacts=observed_artifacts)
+
+    assert decision.status == "fail"
+    assert decision.failure_count == 1
+    assert decision.failures[0].deny_code == "DENY_MISSING_SOURCE_AWARE_AUDIT_FIELDS"
+    assert decision.failures[0].source_id == "business-mssql-source"
+    assert decision.failures[0].source_family is None
+    assert decision.failures[0].scenario_category == "positive"

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -111,3 +111,17 @@ def test_release_gate_reports_missing_source_aware_audit_fields() -> None:
     assert decision.failures[0].source_id == "business-mssql-source"
     assert decision.failures[0].source_family is None
     assert decision.failures[0].scenario_category == "positive"
+    assert "source.source_family" in decision.failures[0].detail
+
+
+def test_release_gate_reports_structured_failure_for_non_mapping_artifact() -> None:
+    decision = reconstruct_release_gate(observed_artifacts=("not-a-mapping",))
+
+    assert decision.status == "fail"
+    assert decision.failure_count == 1
+    assert decision.failures[0].deny_code == "DENY_MALFORMED_EVALUATION_ARTIFACT"
+    assert decision.failures[0].source_id is None
+    assert decision.failures[0].source_family is None
+    assert decision.failures[0].scenario_id is None
+    assert decision.failures[0].scenario_category is None
+    assert "<root>" in decision.failures[0].detail


### PR DESCRIPTION
Closes #125
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented an application-owned release gate in [backend/app/features/evaluation/release_gate.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-125/backend/app/features/evaluation/release_gate.py) and exported it via [backend/app/features/evaluation/__init__.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-125/backend/app/features/evaluation/__init__.py). It reconstructs release decisions from SafeQuery’s authoritative evaluation scenarios plus observed outcome artifacts, with fail-closed handling for missing source-aware audit fields, missing coverage, and safety/regression mismatches. No MLflow dependency was added.

Added focused coverage in [backend/tests/test_release_gate.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-125/backend/tests/test_release_gate.py) for pass, safety regression, missing coverage, and malformed source metadata. The exact issue verification command now passes, and I recorded the work in the local issue journal before committing `9da2c4b` on `codex/issue-125`.

Summary: Added MLflow-independent release gate reconstruction and focused release-gate tests; committed as `9da2c4b`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_release_gate.py`
Failure signature: none
Next action: Open or update the draft PR for commit `9da2c4b` and move to the next supervisor phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release gate evaluation module with decision reconstruction capabilities from evaluation outcomes.

* **Tests**
  * Added comprehensive test coverage for release gate scenarios, including safety regression detection, evaluation coverage validation, and audit field verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->