### PR TITLE
[F-7] Define operator history summary payloads for workflow surfaces (#126)

### DIFF
--- a/backend/app/features/operator_history/__init__.py
+++ b/backend/app/features/operator_history/__init__.py
@@ -1,0 +1,17 @@
+from app.features.operator_history.payloads import (
+    OperatorHistoryCandidateSummary,
+    OperatorHistoryDenialSummary,
+    OperatorHistoryInvalidationSummary,
+    OperatorHistoryRequestSummary,
+    OperatorHistoryResultSummary,
+    OperatorHistoryRunSummary,
+)
+
+__all__ = [
+    "OperatorHistoryRequestSummary",
+    "OperatorHistoryCandidateSummary",
+    "OperatorHistoryRunSummary",
+    "OperatorHistoryDenialSummary",
+    "OperatorHistoryInvalidationSummary",
+    "OperatorHistoryResultSummary",
+]

--- a/backend/app/features/operator_history/__init__.py
+++ b/backend/app/features/operator_history/__init__.py
@@ -8,10 +8,10 @@ from app.features.operator_history.payloads import (
 )
 
 __all__ = [
-    "OperatorHistoryRequestSummary",
     "OperatorHistoryCandidateSummary",
-    "OperatorHistoryRunSummary",
     "OperatorHistoryDenialSummary",
     "OperatorHistoryInvalidationSummary",
+    "OperatorHistoryRequestSummary",
     "OperatorHistoryResultSummary",
+    "OperatorHistoryRunSummary",
 ]

--- a/backend/app/features/operator_history/payloads.py
+++ b/backend/app/features/operator_history/payloads.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, NonNegativeInt, model_validator
+
+from app.features.audit.event_model import (
+    NonEmptyTrimmedString,
+    SourceFamily,
+    SourceFlavor,
+    SourceIdentifier,
+)
+
+RequestState = Literal["drafting", "submitted", "previewed", "blocked", "superseded"]
+CandidateState = Literal[
+    "pending_generation",
+    "preview_ready",
+    "blocked",
+    "expired",
+    "invalidated",
+    "approved_for_execution",
+    "stale",
+    "superseded",
+]
+GuardStatus = Literal[
+    "pending",
+    "allow",
+    "blocked",
+    "expired",
+    "invalidated",
+    "requires_revalidation",
+]
+ExecutionStatus = Literal[
+    "executing",
+    "execution_denied",
+    "failed",
+    "canceled",
+    "empty",
+    "completed",
+]
+TerminalState = Literal[
+    "review_denied",
+    "execution_denied",
+    "failed",
+    "canceled",
+    "empty",
+    "completed",
+]
+ResultState = Literal["execution_denied", "failed", "canceled", "empty", "completed"]
+
+
+class _SourceAwareHistoryPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    occurred_at: datetime
+    audit_event_id: Optional[UUID] = None
+
+
+class OperatorHistoryRequestSummary(_SourceAwareHistoryPayload):
+    request_id: NonEmptyTrimmedString
+    request_state: RequestState
+    summary_label: NonEmptyTrimmedString
+
+
+class OperatorHistoryCandidateSummary(_SourceAwareHistoryPayload):
+    request_id: NonEmptyTrimmedString
+    candidate_id: NonEmptyTrimmedString
+    candidate_state: CandidateState
+    guard_status: GuardStatus
+    sql_review_anchor: NonEmptyTrimmedString
+    primary_deny_code: Optional[NonEmptyTrimmedString] = None
+    reopened_draft_source_id: Optional[SourceIdentifier] = None
+
+    @model_validator(mode="after")
+    def validate_reopened_draft_source_id(self) -> "OperatorHistoryCandidateSummary":
+        if (
+            self.reopened_draft_source_id is not None
+            and self.reopened_draft_source_id != self.source_id
+        ):
+            raise ValueError(
+                "A reopened draft source binding must match the candidate-bound source."
+            )
+        return self
+
+
+class OperatorHistoryRunSummary(_SourceAwareHistoryPayload):
+    request_id: NonEmptyTrimmedString
+    candidate_id: NonEmptyTrimmedString
+    run_id: NonEmptyTrimmedString
+    execution_status: ExecutionStatus
+    row_count: Optional[NonNegativeInt] = None
+    result_truncated: Optional[bool] = None
+    primary_deny_code: Optional[NonEmptyTrimmedString] = None
+
+
+class OperatorHistoryDenialSummary(_SourceAwareHistoryPayload):
+    request_id: NonEmptyTrimmedString
+    candidate_id: NonEmptyTrimmedString
+    run_id: Optional[NonEmptyTrimmedString] = None
+    terminal_state: Literal["review_denied", "execution_denied"]
+    candidate_state: CandidateState
+    guard_status: Literal["blocked", "invalidated", "requires_revalidation"]
+    primary_deny_code: NonEmptyTrimmedString
+
+    @model_validator(mode="after")
+    def validate_terminal_anchor(self) -> "OperatorHistoryDenialSummary":
+        if self.terminal_state == "review_denied" and self.run_id is not None:
+            raise ValueError("review_denied must stay candidate-anchored without a run_id.")
+        if self.terminal_state == "execution_denied" and self.run_id is None:
+            raise ValueError("execution_denied must stay run-anchored with a run_id.")
+        return self
+
+
+class OperatorHistoryInvalidationSummary(_SourceAwareHistoryPayload):
+    request_id: NonEmptyTrimmedString
+    candidate_id: NonEmptyTrimmedString
+    candidate_state: Literal["invalidated"]
+    guard_status: Literal["invalidated"]
+    primary_deny_code: NonEmptyTrimmedString
+
+
+class OperatorHistoryResultSummary(_SourceAwareHistoryPayload):
+    request_id: NonEmptyTrimmedString
+    candidate_id: NonEmptyTrimmedString
+    run_id: NonEmptyTrimmedString
+    result_state: ResultState
+    execution_status: ResultState
+    row_count: Optional[NonNegativeInt] = None
+    result_truncated: Optional[bool] = None
+    primary_deny_code: Optional[NonEmptyTrimmedString] = None
+
+    @model_validator(mode="after")
+    def validate_result_summary(self) -> "OperatorHistoryResultSummary":
+        if self.execution_status != self.result_state:
+            raise ValueError("Result state must match the authoritative execution status.")
+        if self.execution_status in {"empty", "completed"} and self.row_count is None:
+            raise ValueError(
+                "Completed and empty result summaries must include a row_count summary."
+            )
+        if self.execution_status == "empty" and self.row_count != 0:
+            raise ValueError("Empty result summaries must report row_count=0.")
+        if self.execution_status in {"execution_denied", "failed", "canceled"}:
+            if self.row_count is not None:
+                raise ValueError(
+                    "Terminal non-result outcomes must not expose a synthesized row_count."
+                )
+            if self.result_truncated is not None:
+                raise ValueError(
+                    "Terminal non-result outcomes must not expose truncation posture."
+                )
+        return self

--- a/backend/app/features/operator_history/payloads.py
+++ b/backend/app/features/operator_history/payloads.py
@@ -142,8 +142,14 @@ class OperatorHistoryResultSummary(_SourceAwareHistoryPayload):
             raise ValueError(
                 "Completed and empty result summaries must include a row_count summary."
             )
+        if self.execution_status in {"empty", "completed"} and self.result_truncated is None:
+            raise ValueError(
+                "Completed and empty result summaries must include truncation posture."
+            )
         if self.execution_status == "empty" and self.row_count != 0:
             raise ValueError("Empty result summaries must report row_count=0.")
+        if self.execution_status == "empty" and self.result_truncated is not False:
+            raise ValueError("Empty result summaries must set result_truncated=False.")
         if self.execution_status in {"execution_denied", "failed", "canceled"}:
             if self.row_count is not None:
                 raise ValueError(

--- a/backend/app/features/operator_history/payloads.py
+++ b/backend/app/features/operator_history/payloads.py
@@ -52,7 +52,7 @@ ResultState = Literal["execution_denied", "failed", "canceled", "empty", "comple
 
 
 class _SourceAwareHistoryPayload(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
     source_id: SourceIdentifier
     source_family: SourceFamily
@@ -96,6 +96,14 @@ class OperatorHistoryRunSummary(_SourceAwareHistoryPayload):
     row_count: Optional[NonNegativeInt] = None
     result_truncated: Optional[bool] = None
     primary_deny_code: Optional[NonEmptyTrimmedString] = None
+
+    @model_validator(mode="after")
+    def validate_run_summary(self) -> "OperatorHistoryRunSummary":
+        if self.execution_status == "execution_denied" and self.primary_deny_code is None:
+            raise ValueError(
+                "Execution-denied run summaries must include a primary_deny_code."
+            )
+        return self
 
 
 class OperatorHistoryDenialSummary(_SourceAwareHistoryPayload):

--- a/backend/app/features/operator_history/payloads.py
+++ b/backend/app/features/operator_history/payloads.py
@@ -138,6 +138,10 @@ class OperatorHistoryResultSummary(_SourceAwareHistoryPayload):
     def validate_result_summary(self) -> "OperatorHistoryResultSummary":
         if self.execution_status != self.result_state:
             raise ValueError("Result state must match the authoritative execution status.")
+        if self.execution_status == "execution_denied" and self.primary_deny_code is None:
+            raise ValueError(
+                "Execution-denied result summaries must include a primary_deny_code."
+            )
         if self.execution_status in {"empty", "completed"} and self.row_count is None:
             raise ValueError(
                 "Completed and empty result summaries must include a row_count summary."

--- a/backend/tests/test_operator_history_payloads.py
+++ b/backend/tests/test_operator_history_payloads.py
@@ -144,6 +144,13 @@ def test_operator_history_result_summary_rejects_raw_result_rows() -> None:
     ("payload_overrides", "message"),
     [
         (
+            {
+                "result_state": "execution_denied",
+                "execution_status": "execution_denied",
+            },
+            "include a primary_deny_code",
+        ),
+        (
             {"result_state": "completed", "execution_status": "completed", "row_count": 1},
             "include truncation posture",
         ),

--- a/backend/tests/test_operator_history_payloads.py
+++ b/backend/tests/test_operator_history_payloads.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.operator_history.payloads import (
+    OperatorHistoryCandidateSummary,
+    OperatorHistoryDenialSummary,
+    OperatorHistoryInvalidationSummary,
+    OperatorHistoryRequestSummary,
+    OperatorHistoryResultSummary,
+    OperatorHistoryRunSummary,
+)
+
+
+def _source_fields() -> dict[str, object]:
+    return {
+        "source_id": "approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+    }
+
+
+def test_operator_history_summary_payloads_are_source_aware_and_minimized() -> None:
+    request = OperatorHistoryRequestSummary(
+        request_id="request-123",
+        request_state="previewed",
+        summary_label="Approved vendor spend",
+        occurred_at=datetime.now(timezone.utc),
+        **_source_fields(),
+    )
+    candidate = OperatorHistoryCandidateSummary(
+        request_id="request-123",
+        candidate_id="candidate-123",
+        candidate_state="preview_ready",
+        guard_status="allow",
+        sql_review_anchor="sha256:preview-123",
+        occurred_at=datetime.now(timezone.utc),
+        audit_event_id=uuid4(),
+        **_source_fields(),
+    )
+    run = OperatorHistoryRunSummary(
+        request_id="request-123",
+        candidate_id="candidate-123",
+        run_id="run-123",
+        execution_status="completed",
+        row_count=12,
+        result_truncated=True,
+        occurred_at=datetime.now(timezone.utc),
+        audit_event_id=uuid4(),
+        **_source_fields(),
+    )
+
+    request_dump = request.model_dump(exclude_none=True)
+    candidate_dump = candidate.model_dump(exclude_none=True)
+    run_dump = run.model_dump(exclude_none=True)
+
+    assert request_dump["source_id"] == "approved-spend"
+    assert candidate_dump["guard_status"] == "allow"
+    assert run_dump["execution_status"] == "completed"
+    assert run_dump["row_count"] == 12
+    assert run_dump["result_truncated"] is True
+    assert "question" not in request_dump
+    assert "canonical_sql" not in candidate_dump
+    assert "rows" not in run_dump
+
+
+def test_operator_history_candidate_summary_rejects_reopen_source_retargeting() -> None:
+    with pytest.raises(ValidationError, match="reopened draft source binding"):
+        OperatorHistoryCandidateSummary(
+            request_id="request-123",
+            candidate_id="candidate-123",
+            candidate_state="preview_ready",
+            guard_status="allow",
+            sql_review_anchor="sha256:preview-123",
+            occurred_at=datetime.now(timezone.utc),
+            reopened_draft_source_id="marketing-spend",
+            **_source_fields(),
+        )
+
+
+def test_operator_history_terminal_summaries_preserve_authoritative_state_mapping() -> None:
+    denial = OperatorHistoryDenialSummary(
+        request_id="request-123",
+        candidate_id="candidate-123",
+        terminal_state="review_denied",
+        candidate_state="invalidated",
+        guard_status="blocked",
+        primary_deny_code="DENY_CANDIDATE_INVALIDATED",
+        occurred_at=datetime.now(timezone.utc),
+        audit_event_id=uuid4(),
+        **_source_fields(),
+    )
+    invalidation = OperatorHistoryInvalidationSummary(
+        request_id="request-123",
+        candidate_id="candidate-123",
+        candidate_state="invalidated",
+        guard_status="invalidated",
+        primary_deny_code="DENY_CANDIDATE_INVALIDATED",
+        occurred_at=datetime.now(timezone.utc),
+        audit_event_id=uuid4(),
+        **_source_fields(),
+    )
+    result = OperatorHistoryResultSummary(
+        request_id="request-123",
+        candidate_id="candidate-123",
+        run_id="run-123",
+        result_state="empty",
+        execution_status="empty",
+        row_count=0,
+        result_truncated=False,
+        occurred_at=datetime.now(timezone.utc),
+        audit_event_id=uuid4(),
+        **_source_fields(),
+    )
+
+    assert denial.terminal_state == "review_denied"
+    assert denial.run_id is None
+    assert invalidation.guard_status == "invalidated"
+    assert result.execution_status == "empty"
+    assert result.row_count == 0
+
+
+def test_operator_history_result_summary_rejects_raw_result_rows() -> None:
+    with pytest.raises(ValidationError):
+        OperatorHistoryResultSummary(
+            request_id="request-123",
+            candidate_id="candidate-123",
+            run_id="run-123",
+            result_state="completed",
+            execution_status="completed",
+            row_count=1,
+            result_truncated=False,
+            occurred_at=datetime.now(timezone.utc),
+            rows=[{"vendor_name": "Acme"}],
+            **_source_fields(),
+        )

--- a/backend/tests/test_operator_history_payloads.py
+++ b/backend/tests/test_operator_history_payloads.py
@@ -138,3 +138,36 @@ def test_operator_history_result_summary_rejects_raw_result_rows() -> None:
             rows=[{"vendor_name": "Acme"}],
             **_source_fields(),
         )
+
+
+@pytest.mark.parametrize(
+    ("payload_overrides", "message"),
+    [
+        (
+            {"result_state": "completed", "execution_status": "completed", "row_count": 1},
+            "include truncation posture",
+        ),
+        (
+            {
+                "result_state": "empty",
+                "execution_status": "empty",
+                "row_count": 0,
+                "result_truncated": True,
+            },
+            "set result_truncated=False",
+        ),
+    ],
+)
+def test_operator_history_result_summary_enforces_explicit_truncation_posture(
+    payload_overrides: dict[str, object], message: str
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        OperatorHistoryResultSummary(
+            request_id="request-123",
+            candidate_id="candidate-123",
+            run_id="run-123",
+            occurred_at=datetime.now(timezone.utc),
+            audit_event_id=uuid4(),
+            **_source_fields(),
+            **payload_overrides,
+        )

--- a/backend/tests/test_operator_history_payloads.py
+++ b/backend/tests/test_operator_history_payloads.py
@@ -82,6 +82,24 @@ def test_operator_history_candidate_summary_rejects_reopen_source_retargeting() 
         )
 
 
+def test_operator_history_summary_payloads_are_immutable() -> None:
+    candidate = OperatorHistoryCandidateSummary(
+        request_id="request-123",
+        candidate_id="candidate-123",
+        candidate_state="preview_ready",
+        guard_status="allow",
+        sql_review_anchor="sha256:preview-123",
+        occurred_at=datetime.now(timezone.utc),
+        **_source_fields(),
+    )
+
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        candidate.source_id = "marketing-spend"
+
+    with pytest.raises(ValidationError, match="Instance is frozen"):
+        candidate.reopened_draft_source_id = "marketing-spend"
+
+
 def test_operator_history_terminal_summaries_preserve_authoritative_state_mapping() -> None:
     denial = OperatorHistoryDenialSummary(
         request_id="request-123",
@@ -122,6 +140,19 @@ def test_operator_history_terminal_summaries_preserve_authoritative_state_mappin
     assert invalidation.guard_status == "invalidated"
     assert result.execution_status == "empty"
     assert result.row_count == 0
+
+
+def test_operator_history_run_summary_requires_primary_deny_code_when_execution_denied() -> None:
+    with pytest.raises(ValidationError, match="include a primary_deny_code"):
+        OperatorHistoryRunSummary(
+            request_id="request-123",
+            candidate_id="candidate-123",
+            run_id="run-123",
+            execution_status="execution_denied",
+            occurred_at=datetime.now(timezone.utc),
+            audit_event_id=uuid4(),
+            **_source_fields(),
+        )
 
 
 def test_operator_history_result_summary_rejects_raw_result_rows() -> None:


### PR DESCRIPTION
Closes #126
This PR was opened by codex-supervisor.
Latest Codex summary:

Added a focused operator-history contract layer in [payloads.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-126/backend/app/features/operator_history/payloads.py:1) and exported it from [__init__.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-126/backend/app/features/operator_history/__init__.py:1). The new DTOs cover request, candidate, run, denial, invalidation, and result summaries with strict source-aware fields, audit-event linkage, terminal-state anchoring, minimized result summaries, and a fail-closed check that rejects reopened-draft source retargeting.

I reproduced the gap first by adding [test_operator_history_payloads.py](/Users/tsinfra/Dev/SafeQuery/SafeQuery-worktrees/issue-126/backend/tests/test_operator_history_payloads.py:1), then implemented only the missing model layer. The work is committed as `ff46a89` with message `Add operator history summary payload contracts`.

Summary: Added source-aware operator history summary DTOs and focused tests; committed as `ff46a89`.
State hint: implementing
Blocked reason: none
Tests: `cd backend && python3 -m pytest tests/test_operator_history_payloads.py tests/test_audit_event_model.py`
Failure signature: none
Next action: Open or update a draft PR from this committed checkpoint, then wire any downstream workflow surface usage to the new payload contracts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator history summary schemas for requests, candidates, runs, denials, invalidations, and results, including source metadata and validation rules that enforce consistent field/state relationships.

* **Tests**
  * Added tests covering serialization, source-aware outputs, and validation invariants (reopened-draft rules, terminal-state constraints, result/truncation consistency).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->