### PR TITLE
Expand source-aware lifecycle audit coverage

### DIFF
--- a/backend/app/features/execution/connector_selection.py
+++ b/backend/app/features/execution/connector_selection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, StringConstraints
 from typing_extensions import Annotated
@@ -23,9 +23,20 @@ class ExecutionConnectorSelection(BaseModel):
 
 
 class ExecutionConnectorSelectionError(PermissionError):
-    def __init__(self, *, deny_code: str, message: str) -> None:
+    def __init__(
+        self,
+        *,
+        deny_code: str,
+        message: str,
+        audit_event: Any | None = None,
+        audit_events: list[Any] | None = None,
+    ) -> None:
         super().__init__(f"{deny_code}: {message}")
         self.deny_code = deny_code
+        self.audit_events = list(audit_events or ([audit_event] if audit_event else []))
+        self.audit_event = audit_event or (
+            self.audit_events[-1] if self.audit_events else None
+        )
 
 
 _EXACT_CONNECTOR_BINDINGS: dict[tuple[str, str], str] = {

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Optional
 from urllib.parse import unquote, urlsplit
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, StringConstraints
 from typing_extensions import Annotated
@@ -61,6 +61,7 @@ class _PostgresConnectionIdentity:
 class ExecutionResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
     _audit_event: Optional[SourceAwareAuditEvent] = PrivateAttr(default=None)
+    _audit_events: list[SourceAwareAuditEvent] = PrivateAttr(default_factory=list)
 
     source_id: NonEmptyTrimmedString
     connector_id: NonEmptyTrimmedString
@@ -70,6 +71,10 @@ class ExecutionResult(BaseModel):
     @property
     def audit_event(self) -> Optional[SourceAwareAuditEvent]:
         return self._audit_event
+
+    @property
+    def audit_events(self) -> list[SourceAwareAuditEvent]:
+        return list(self._audit_events)
 
 
 class ExecutableCandidateRecord(BaseModel):
@@ -100,10 +105,14 @@ class ExecutionConnectorExecutionError(PermissionError):
         deny_code: str,
         message: str,
         audit_event: SourceAwareAuditEvent | None = None,
+        audit_events: list[SourceAwareAuditEvent] | None = None,
     ) -> None:
         super().__init__(f"{deny_code}: {message}")
         self.deny_code = deny_code
-        self.audit_event = audit_event
+        self.audit_events = list(audit_events or ([audit_event] if audit_event else []))
+        self.audit_event = audit_event or (
+            self.audit_events[-1] if self.audit_events else None
+        )
 
 
 class ExecutionRuntimeCancelledError(RuntimeError):
@@ -141,7 +150,11 @@ def _build_execution_audit_event(
         return None
 
     return SourceAwareAuditEvent(
-        event_id=audit_context.event_id,
+        event_id=(
+            audit_context.event_id
+            if event_type in {"execution_completed", "execution_denied"}
+            else uuid4()
+        ),
         event_type=event_type,
         occurred_at=audit_context.occurred_at,
         request_id=audit_context.request_id,
@@ -168,6 +181,44 @@ def _build_execution_audit_event(
     )
 
 
+def _build_execution_audit_events(
+    *,
+    event_types: list[str],
+    candidate_source: SourceBoundCandidateMetadata,
+    audit_context: ExecutionAuditContext | None,
+    primary_deny_code: str | None = None,
+    execution_row_count: int | None = None,
+    result_truncated: bool | None = None,
+) -> list[SourceAwareAuditEvent]:
+    if audit_context is None:
+        return []
+
+    events: list[SourceAwareAuditEvent] = []
+    causation_event_id: UUID | None = None
+    for event_type in event_types:
+        event = _build_execution_audit_event(
+            event_type=event_type,
+            candidate_source=candidate_source,
+            audit_context=audit_context,
+            primary_deny_code=(
+                primary_deny_code if event_type == "execution_denied" else None
+            ),
+            execution_row_count=(
+                execution_row_count if event_type == "execution_completed" else None
+            ),
+            result_truncated=(
+                result_truncated if event_type == "execution_completed" else None
+            ),
+        )
+        if event is None:
+            continue
+        if causation_event_id is not None:
+            event.causation_event_id = causation_event_id
+        causation_event_id = event.event_id
+        events.append(event)
+    return events
+
+
 def _attach_execution_denial_audit_event(
     *,
     error: ExecutionConnectorExecutionError,
@@ -180,8 +231,8 @@ def _attach_execution_denial_audit_event(
     return ExecutionConnectorExecutionError(
         deny_code=error.deny_code,
         message=message,
-        audit_event=_build_execution_audit_event(
-            event_type="execution_denied",
+        audit_events=_build_execution_audit_events(
+            event_types=["execution_requested", "execution_denied"],
             candidate_source=candidate_source,
             audit_context=audit_context,
             primary_deny_code=error.deny_code,
@@ -211,12 +262,6 @@ def _require_matching_selection(
             message=(
                 "The candidate-bound source metadata does not match the selected "
                 "connector binding."
-            ),
-            audit_event=_build_execution_audit_event(
-                event_type="execution_denied",
-                candidate_source=candidate_source,
-                audit_context=audit_context,
-                primary_deny_code=DENY_SOURCE_BINDING_MISMATCH,
             ),
         )
 
@@ -533,11 +578,12 @@ def execute_candidate_sql(
         ownership=selection.ownership,
         rows=capped_rows,
     )
-    result._audit_event = _build_execution_audit_event(
-        event_type="execution_completed",
+    result._audit_events = _build_execution_audit_events(
+        event_types=["execution_requested", "execution_started", "execution_completed"],
         candidate_source=candidate.source,
         audit_context=audit_context,
         execution_row_count=len(capped_rows),
         result_truncated=len(rows) > len(capped_rows),
     )
+    result._audit_event = result._audit_events[-1] if result._audit_events else None
     return result

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -221,14 +221,14 @@ def _build_execution_audit_events(
 
 def _attach_execution_denial_audit_event(
     *,
-    error: ExecutionConnectorExecutionError,
+    error: ExecutionConnectorExecutionError | ExecutionConnectorSelectionError,
     candidate_source: SourceBoundCandidateMetadata,
     audit_context: ExecutionAuditContext | None,
-) -> ExecutionConnectorExecutionError:
+) -> ExecutionConnectorExecutionError | ExecutionConnectorSelectionError:
     if error.audit_event is not None or audit_context is None:
         return error
     message = str(error).split(": ", 1)[1] if ": " in str(error) else str(error)
-    return ExecutionConnectorExecutionError(
+    return type(error)(
         deny_code=error.deny_code,
         message=message,
         audit_events=_build_execution_audit_events(
@@ -563,7 +563,7 @@ def execute_candidate_sql(
                     f"'{selection.connector_id}'."
                 ),
             )
-    except ExecutionConnectorExecutionError as exc:
+    except (ExecutionConnectorExecutionError, ExecutionConnectorSelectionError) as exc:
         raise _attach_execution_denial_audit_event(
             error=exc,
             candidate_source=candidate.source,

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,11 +1,16 @@
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict, PrivateAttr, StringConstraints
 from sqlalchemy.orm import Session
 from typing import Optional
 from typing_extensions import Annotated
+from uuid import UUID, uuid4
 
 from app.db.models.dataset_contract import DatasetContract
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
+from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.auth.context import AuthenticatedSubject
 from app.services.source_entitlements import (
     SourceEntitlementError,
@@ -45,6 +50,11 @@ class CandidateRecord(BaseModel):
 class AuditRecord(BaseModel):
     source_id: str
     state: str
+    _events: list[SourceAwareAuditEvent] = PrivateAttr(default_factory=list)
+
+    @property
+    def events(self) -> list[SourceAwareAuditEvent]:
+        return list(self._events)
 
 
 class EvaluationRecord(BaseModel):
@@ -63,6 +73,20 @@ class PreviewSubmissionContractError(ValueError):
     """Raised when a preview submission does not carry an executable source binding."""
 
 
+class PreviewAuditContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    occurred_at: datetime
+    request_id: str
+    correlation_id: str
+    user_subject: str
+    session_id: str
+    query_candidate_id: Optional[str] = None
+    candidate_owner_subject: Optional[str] = None
+    guard_version: Optional[str] = None
+    application_version: Optional[str] = None
+
+
 def _resolve_authoritative_source_governance(
     session: Session,
     *,
@@ -79,10 +103,65 @@ def _resolve_authoritative_source_governance(
     return source, dataset_contract, schema_snapshot
 
 
+def _build_preview_lifecycle_audit_events(
+    *,
+    resolved_source: RegisteredSource,
+    dataset_contract: DatasetContract,
+    schema_snapshot: SchemaSnapshot,
+    audit_context: PreviewAuditContext | None,
+) -> list[SourceAwareAuditEvent]:
+    if audit_context is None:
+        return []
+
+    events: list[SourceAwareAuditEvent] = []
+    causation_event_id: UUID | None = None
+    for event_type in (
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+    ):
+        event = SourceAwareAuditEvent(
+            event_id=uuid4(),
+            event_type=event_type,
+            occurred_at=audit_context.occurred_at,
+            request_id=audit_context.request_id,
+            correlation_id=audit_context.correlation_id,
+            causation_event_id=causation_event_id,
+            user_subject=audit_context.user_subject,
+            session_id=audit_context.session_id,
+            query_candidate_id=(
+                audit_context.query_candidate_id
+                if event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
+            candidate_owner_subject=(
+                audit_context.candidate_owner_subject
+                if event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
+            guard_version=(
+                audit_context.guard_version if event_type == "guard_evaluated" else None
+            ),
+            application_version=audit_context.application_version,
+            source_id=resolved_source.source_id,
+            source_family=resolved_source.source_family,
+            source_flavor=resolved_source.source_flavor,
+            dataset_contract_version=dataset_contract.contract_version,
+            schema_snapshot_version=schema_snapshot.snapshot_version,
+            candidate_state="preview_ready" if event_type == "guard_evaluated" else None,
+        )
+        causation_event_id = event.event_id
+        events.append(event)
+
+    return events
+
+
 def submit_preview_request(
     payload: PreviewSubmissionRequest,
     authenticated_subject: AuthenticatedSubject,
     session: Session,
+    audit_context: PreviewAuditContext | None = None,
 ) -> PreviewSubmissionResponse:
     source, dataset_contract, schema_snapshot = _resolve_authoritative_source_governance(
         session,
@@ -98,6 +177,17 @@ def submit_preview_request(
     except SourceEntitlementError as exc:
         raise PreviewSubmissionContractError(str(exc)) from exc
 
+    audit = AuditRecord(
+        source_id=resolved_source.source_id,
+        state="recorded",
+    )
+    audit._events = _build_preview_lifecycle_audit_events(
+        resolved_source=resolved_source,
+        dataset_contract=dataset_contract,
+        schema_snapshot=schema_snapshot,
+        audit_context=audit_context,
+    )
+
     return PreviewSubmissionResponse(
         request=RequestRecord(
             question=payload.question,
@@ -112,10 +202,7 @@ def submit_preview_request(
             schema_snapshot_version=schema_snapshot.snapshot_version,
             state="preview_ready",
         ),
-        audit=AuditRecord(
-            source_id=resolved_source.source_id,
-            state="recorded",
-        ),
+        audit=audit,
         evaluation=EvaluationRecord(
             source_id=resolved_source.source_id,
             state="pending",

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, PrivateAttr, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy.orm import Session
 from typing import Optional
 from typing_extensions import Annotated
@@ -50,11 +50,7 @@ class CandidateRecord(BaseModel):
 class AuditRecord(BaseModel):
     source_id: str
     state: str
-    _events: list[SourceAwareAuditEvent] = PrivateAttr(default_factory=list)
-
-    @property
-    def events(self) -> list[SourceAwareAuditEvent]:
-        return list(self._events)
+    events: list[SourceAwareAuditEvent] = Field(default_factory=list)
 
 
 class EvaluationRecord(BaseModel):
@@ -180,12 +176,12 @@ def submit_preview_request(
     audit = AuditRecord(
         source_id=resolved_source.source_id,
         state="recorded",
-    )
-    audit._events = _build_preview_lifecycle_audit_events(
-        resolved_source=resolved_source,
-        dataset_contract=dataset_contract,
-        schema_snapshot=schema_snapshot,
-        audit_context=audit_context,
+        events=_build_preview_lifecycle_audit_events(
+            resolved_source=resolved_source,
+            dataset_contract=dataset_contract,
+            schema_snapshot=schema_snapshot,
+            audit_context=audit_context,
+        ),
     )
 
     return PreviewSubmissionResponse(

--- a/backend/tests/test_audit_event_model.py
+++ b/backend/tests/test_audit_event_model.py
@@ -33,9 +33,12 @@ def _source_aware_payload() -> dict[str, object]:
     "event_type",
     [
         "query_submitted",
+        "generation_requested",
         "generation_completed",
         "guard_evaluated",
         "execution_requested",
+        "execution_started",
+        "execution_completed",
         "execution_denied",
         "candidate_invalidated",
     ],

--- a/backend/tests/test_preview_source_governance_resolution.py
+++ b/backend/tests/test_preview_source_governance_resolution.py
@@ -14,6 +14,7 @@ from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewSt
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
 from app.services.request_preview import (
+    PreviewAuditContext,
     PreviewSubmissionContractError,
     PreviewSubmissionRequest,
     submit_preview_request,
@@ -121,6 +122,66 @@ def test_preview_submission_resolves_persisted_source_governance_records() -> No
         )
 
     assert response.model_dump()["candidate"]["source_id"] == "persisted-approved-spend"
+
+
+def test_preview_submission_emits_source_aware_lifecycle_audit_events() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(
+            session,
+            source_id="persisted-approved-spend",
+        )
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="persisted-approved-spend",
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime.now(timezone.utc),
+                request_id="request-123",
+                correlation_id="correlation-123",
+                user_subject="user:alice",
+                session_id="session-123",
+                query_candidate_id="candidate-123",
+                candidate_owner_subject="user:alice",
+                guard_version="guard-profile-v1",
+                application_version="safequery-test",
+            ),
+        )
+
+    assert [event.event_type for event in response.audit.events] == [
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+    ]
+    for event in response.audit.events:
+        assert {
+            "request_id": "request-123",
+            "correlation_id": "correlation-123",
+            "user_subject": "user:alice",
+            "session_id": "session-123",
+            "source_id": "persisted-approved-spend",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+            "dataset_contract_version": 1,
+            "schema_snapshot_version": 1,
+            "application_version": "safequery-test",
+        }.items() <= event.model_dump(exclude_none=True).items()
+
+    guard_event = response.audit.events[-1].model_dump(exclude_none=True)
+    assert {
+        "event_type": "guard_evaluated",
+        "query_candidate_id": "candidate-123",
+        "candidate_owner_subject": "user:alice",
+        "guard_version": "guard-profile-v1",
+        "candidate_state": "preview_ready",
+    }.items() <= guard_event.items()
 
 
 def test_preview_submission_rejects_missing_active_contract_linkage() -> None:

--- a/backend/tests/test_preview_source_governance_resolution.py
+++ b/backend/tests/test_preview_source_governance_resolution.py
@@ -160,6 +160,13 @@ def test_preview_submission_emits_source_aware_lifecycle_audit_events() -> None:
         "generation_completed",
         "guard_evaluated",
     ]
+    serialized_audit = response.model_dump()["audit"]
+    assert [event["event_type"] for event in serialized_audit["events"]] == [
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+    ]
     for event in response.audit.events:
         assert {
             "request_id": "request-123",

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -286,6 +286,7 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                 "audit": {
                     "source_id": "sap-approved-spend",
                     "state": "recorded",
+                    "events": [],
                 },
                 "evaluation": {
                     "source_id": "sap-approved-spend",

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -7,7 +7,10 @@ from uuid import uuid4
 import pytest
 
 from app.features.execution.connector_selection import ExecutionConnectorSelection
-from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
+from app.features.guard.deny_taxonomy import (
+    DENY_SOURCE_BINDING_MISMATCH,
+    DENY_UNSUPPORTED_SOURCE_BINDING,
+)
 from app.features.execution.runtime import ExecutableCandidateRecord, ExecutionAuditContext
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
@@ -45,6 +48,19 @@ def _candidate() -> ExecutableCandidateRecord:
     return ExecutableCandidateRecord(
         canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
         source=_candidate_source(),
+    )
+
+
+def _unsupported_flavor_candidate() -> ExecutableCandidateRecord:
+    return ExecutableCandidateRecord(
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
+        source=SourceBoundCandidateMetadata(
+            source_id="approved-spend",
+            source_family="postgresql",
+            source_flavor="analytics",
+            dataset_contract_version=3,
+            schema_snapshot_version=7,
+        ),
     )
 
 
@@ -118,6 +134,48 @@ def test_execute_candidate_sql_rejects_connector_swaps_on_bound_source() -> None
         "connector_profile_version": 11,
         "primary_deny_code": DENY_SOURCE_BINDING_MISMATCH,
         "denial_cause": "source_binding_mismatch",
+    }.items() <= exc_info.value.audit_event.model_dump(exclude_none=True).items()
+
+
+def test_execute_candidate_sql_attaches_audit_events_to_selection_denials() -> None:
+    from app.features.execution import (
+        ExecutionConnectorSelectionError,
+        execute_candidate_sql,
+    )
+
+    with pytest.raises(
+        ExecutionConnectorSelectionError,
+        match="No backend-owned execution connector is registered",
+    ) as exc_info:
+        execute_candidate_sql(
+            candidate=_unsupported_flavor_candidate(),
+            selection=ExecutionConnectorSelection(
+                source_id="approved-spend",
+                source_family="postgresql",
+                source_flavor="analytics",
+                connector_id="postgresql_readonly",
+                ownership="backend",
+            ),
+            business_postgres_url=BUSINESS_POSTGRES_URL,
+            application_postgres_url=APPLICATION_POSTGRES_URL,
+            audit_context=_audit_context(),
+        )
+
+    assert exc_info.value.deny_code == DENY_UNSUPPORTED_SOURCE_BINDING
+    assert exc_info.value.audit_event is not None
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "execution_requested",
+        "execution_denied",
+    ]
+    assert {
+        "event_type": "execution_denied",
+        "source_id": "approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "analytics",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "primary_deny_code": DENY_UNSUPPORTED_SOURCE_BINDING,
+        "denial_cause": "unsupported_source_binding",
     }.items() <= exc_info.value.audit_event.model_dump(exclude_none=True).items()
 
 

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -98,6 +98,10 @@ def test_execute_candidate_sql_rejects_connector_swaps_on_bound_source() -> None
 
     assert exc_info.value.deny_code == DENY_SOURCE_BINDING_MISMATCH
     assert exc_info.value.audit_event is not None
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "execution_requested",
+        "execution_denied",
+    ]
     assert {
         "event_type": "execution_denied",
         "request_id": "request-123",
@@ -130,6 +134,11 @@ def test_execute_candidate_sql_returns_source_aware_completion_audit_event() -> 
     )
 
     assert result.audit_event is not None
+    assert [event.event_type for event in result.audit_events] == [
+        "execution_requested",
+        "execution_started",
+        "execution_completed",
+    ]
     assert {
         "event_type": "execution_completed",
         "source_id": "approved-spend",

--- a/backend/tests/test_source_bound_records.py
+++ b/backend/tests/test_source_bound_records.py
@@ -107,6 +107,7 @@ def test_preview_submission_binds_all_records_to_authoritative_source_id() -> No
         "audit": {
             "source_id": "sap-approved-spend",
             "state": "recorded",
+            "events": [],
         },
         "evaluation": {
             "source_id": "sap-approved-spend",


### PR DESCRIPTION
## Summary
- emit ordered source-aware preview lifecycle audit events for query submission, generation, and guard evaluation
- emit ordered source-aware execution audit event sequences for success and denial while preserving terminal audit_event compatibility
- tighten focused lifecycle audit tests for preview, execute, deny, and schema event coverage

## Verification
- cd backend && python3 -m pytest tests/test_audit_event_model.py tests/test_candidate_lifecycle_revalidation.py tests/test_source_bound_execute_path.py tests/test_preview_source_governance_resolution.py
- cd backend && python3 -m pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit events are now stored and returned as ordered sequences with causation links and richer metadata.
  * Preview requests can emit a lifecycle of audit events (submission → generation → guard evaluation).
  * Execution requests produce multi-event trails for requested/started/completed and two-step denial chains.

* **Tests**
  * Tests updated to assert audit event sequences and presence of audit.events in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->