### PR TITLE
Require audit artifacts in release gate

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -18,6 +18,7 @@ from app.features.evaluation.harness import (
     list_postgresql_evaluation_scenarios,
 )
 from app.features.evaluation.release_gate import (
+    ReleaseGateAuditArtifact,
     ReleaseGateDecision,
     ReleaseGateFailure,
     reconstruct_release_gate,
@@ -34,6 +35,7 @@ __all__ = [
     "EvaluationSourceProfile",
     "MSSQLEvaluationScenario",
     "PostgreSQLEvaluationScenario",
+    "ReleaseGateAuditArtifact",
     "ReleaseGateDecision",
     "ReleaseGateFailure",
     "compare_evaluation_outcomes",

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable as TypingIterable, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, ValidationError
 
+from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.evaluation.comparison import (
     EvaluationComparisonRow,
     EvaluationObservedOutcome,
@@ -45,6 +46,13 @@ class ReleaseGateFailure(BaseModel):
     detail: str
 
 
+class ReleaseGateAuditArtifact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: str
+    event: SourceAwareAuditEvent
+
+
 class ReleaseGateDecision(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -57,8 +65,10 @@ class ReleaseGateDecision(BaseModel):
 def reconstruct_release_gate(
     *,
     observed_artifacts: TypingIterable[Union[EvaluationOutcomeRecord, Mapping[str, Any]]],
+    audit_artifacts: TypingIterable[Union[ReleaseGateAuditArtifact, Mapping[str, Any]]] = (),
 ) -> ReleaseGateDecision:
     normalized_records: list[EvaluationOutcomeRecord] = []
+    normalized_audit_artifacts: list[ReleaseGateAuditArtifact] = []
     failures: list[ReleaseGateFailure] = []
 
     for artifact in observed_artifacts:
@@ -70,6 +80,16 @@ def reconstruct_release_gate(
             normalized_records.append(EvaluationOutcomeRecord.model_validate(artifact))
         except ValidationError as exc:
             failures.append(_validation_failure_for(artifact=artifact, error=exc))
+
+    for artifact in audit_artifacts:
+        if isinstance(artifact, ReleaseGateAuditArtifact):
+            normalized_audit_artifacts.append(artifact)
+            continue
+
+        try:
+            normalized_audit_artifacts.append(ReleaseGateAuditArtifact.model_validate(artifact))
+        except ValidationError as exc:
+            failures.append(_audit_validation_failure_for(artifact=artifact, error=exc))
 
     if failures:
         return ReleaseGateDecision(
@@ -84,6 +104,16 @@ def reconstruct_release_gate(
         candidate=tuple(normalized_records),
     )
     failures = [failure for row in comparison for failure in _failures_for_row(row)]
+    failures.extend(
+        _audit_failures_for_scenario(
+            scenario=scenario,
+            audit_artifacts=tuple(normalized_audit_artifacts),
+        )
+        for scenario in (
+            list_mssql_evaluation_scenarios() + list_postgresql_evaluation_scenarios()
+        )
+    )
+    failures = [failure for failure in failures if failure is not None]
 
     return ReleaseGateDecision(
         status="pass" if not failures else "fail",
@@ -144,6 +174,110 @@ def _validation_failure_for(
             f"{_error_location(validation_error['loc'])}: {validation_error['msg']}"
             for validation_error in errors
         ),
+    )
+
+
+def _audit_validation_failure_for(
+    *,
+    artifact: Any,
+    error: ValidationError,
+) -> ReleaseGateFailure:
+    errors = error.errors()
+    artifact_map = artifact if isinstance(artifact, Mapping) else {}
+    event = artifact_map.get("event")
+    event_map = event if isinstance(event, Mapping) else {}
+    source_id = event_map.get("source_id")
+    source_family = event_map.get("source_family")
+
+    return ReleaseGateFailure(
+        deny_code="DENY_MALFORMED_AUDIT_ARTIFACT",
+        source_id=source_id if isinstance(source_id, str) else None,
+        source_family=source_family if isinstance(source_family, str) else None,
+        scenario_id=_string_or_none(artifact_map.get("scenario_id")),
+        scenario_category=None,
+        detail="; ".join(
+            f"{_error_location(validation_error['loc'])}: {validation_error['msg']}"
+            for validation_error in errors
+        ),
+    )
+
+
+def _audit_failures_for_scenario(
+    *,
+    scenario: ScenarioArtifact,
+    audit_artifacts: tuple[ReleaseGateAuditArtifact, ...],
+) -> ReleaseGateFailure | None:
+    candidates = [
+        artifact.event
+        for artifact in audit_artifacts
+        if artifact.scenario_id == scenario.scenario_id
+    ]
+    if not candidates:
+        return ReleaseGateFailure(
+            deny_code="DENY_MISSING_AUDIT_COVERAGE",
+            source_id=scenario.source.source_id,
+            source_family=scenario.source.source_family,
+            scenario_id=scenario.scenario_id,
+            scenario_category=scenario.kind,
+            detail="Missing authoritative source-aware audit artifact for required scenario.",
+        )
+
+    expected_event_type = _expected_audit_event_type_for(scenario)
+    expected_primary_code = scenario.expected.primary_code
+    for event in candidates:
+        mismatches = _audit_mismatches_for_scenario(
+            scenario=scenario,
+            event=event,
+            expected_event_type=expected_event_type,
+            expected_primary_code=expected_primary_code,
+        )
+        if not mismatches:
+            return None
+
+    return ReleaseGateFailure(
+        deny_code="DENY_STALE_AUDIT_COVERAGE",
+        source_id=scenario.source.source_id,
+        source_family=scenario.source.source_family,
+        scenario_id=scenario.scenario_id,
+        scenario_category=scenario.kind,
+        detail=(
+            "No authoritative audit artifact matched the required source-aware "
+            f"scenario evidence: {', '.join(mismatches)}."
+        ),
+    )
+
+
+def _expected_audit_event_type_for(scenario: ScenarioArtifact) -> str:
+    if scenario.evaluation_boundary == "guard":
+        return "guard_evaluated"
+    if scenario.expected.decision == "allow":
+        return "execution_completed"
+    return "execution_denied"
+
+
+def _audit_mismatches_for_scenario(
+    *,
+    scenario: ScenarioArtifact,
+    event: SourceAwareAuditEvent,
+    expected_event_type: str,
+    expected_primary_code: str | None,
+) -> tuple[str, ...]:
+    expected_values = {
+        "event_type": expected_event_type,
+        "source_id": scenario.source.source_id,
+        "source_family": scenario.source.source_family,
+        "source_flavor": scenario.source.source_flavor,
+        "dialect_profile_version": scenario.source.dialect_profile_version,
+        "dataset_contract_version": scenario.source.dataset_contract_version,
+        "schema_snapshot_version": scenario.source.schema_snapshot_version,
+        "execution_policy_version": scenario.source.execution_policy_version,
+        "connector_profile_version": scenario.source.connector_profile_version,
+        "primary_deny_code": expected_primary_code,
+    }
+    return tuple(
+        field
+        for field, expected in expected_values.items()
+        if getattr(event, field) != expected
     )
 
 

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Union
+from uuid import uuid4
 
 from app.features.evaluation import (
     EvaluationOutcomeRecord,
@@ -33,12 +35,110 @@ def _observed_records_from_harness() -> tuple[EvaluationOutcomeRecord, ...]:
     )
 
 
+def _audit_artifacts_from_harness() -> tuple[dict[str, object], ...]:
+    artifacts: list[dict[str, object]] = []
+    for scenario in _all_scenarios():
+        if scenario.evaluation_boundary == "guard":
+            event_type = "guard_evaluated"
+        elif scenario.expected.decision == "allow":
+            event_type = "execution_completed"
+        else:
+            event_type = "execution_denied"
+
+        artifacts.append(
+            {
+                "scenario_id": scenario.scenario_id,
+                "event": {
+                    "event_id": uuid4(),
+                    "event_type": event_type,
+                    "occurred_at": datetime.now(timezone.utc),
+                    "request_id": f"request-{scenario.scenario_id}",
+                    "correlation_id": f"correlation-{scenario.scenario_id}",
+                    "user_subject": "user:release-gate",
+                    "session_id": "session-release-gate",
+                    "source_id": scenario.source.source_id,
+                    "source_family": scenario.source.source_family,
+                    "source_flavor": scenario.source.source_flavor,
+                    "dialect_profile_version": scenario.source.dialect_profile_version,
+                    "dataset_contract_version": scenario.source.dataset_contract_version,
+                    "schema_snapshot_version": scenario.source.schema_snapshot_version,
+                    "execution_policy_version": scenario.source.execution_policy_version,
+                    "connector_profile_version": scenario.source.connector_profile_version,
+                    "primary_deny_code": scenario.expected.primary_code,
+                },
+            }
+        )
+    return tuple(artifacts)
+
+
 def test_release_gate_passes_when_authoritative_records_match_harness() -> None:
-    decision = reconstruct_release_gate(observed_artifacts=_observed_records_from_harness())
+    decision = reconstruct_release_gate(
+        observed_artifacts=_observed_records_from_harness(),
+        audit_artifacts=_audit_artifacts_from_harness(),
+    )
 
     assert decision.status == "pass"
     assert decision.failure_count == 0
     assert decision.failures == ()
+
+
+def test_release_gate_fails_closed_when_evaluations_have_no_audit_artifacts() -> None:
+    decision = reconstruct_release_gate(observed_artifacts=_observed_records_from_harness())
+
+    assert decision.status == "fail"
+    assert decision.failure_count == len(_all_scenarios())
+    assert decision.failures[0].deny_code == "DENY_MISSING_AUDIT_COVERAGE"
+    assert decision.failures[0].source_id is not None
+    assert decision.failures[0].scenario_id is not None
+
+
+def test_release_gate_reports_missing_audit_coverage_by_source_and_scenario() -> None:
+    audit_artifacts = tuple(
+        artifact
+        for artifact in _audit_artifacts_from_harness()
+        if artifact["scenario_id"] != "postgresql-safety-stale-policy-denied"
+    )
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=_observed_records_from_harness(),
+        audit_artifacts=audit_artifacts,
+    )
+
+    assert decision.status == "fail"
+    assert decision.failure_count == 1
+    assert decision.failures[0].deny_code == "DENY_MISSING_AUDIT_COVERAGE"
+    assert decision.failures[0].source_id == "business-postgres-source"
+    assert decision.failures[0].source_family == "postgresql"
+    assert decision.failures[0].scenario_id == "postgresql-safety-stale-policy-denied"
+    assert decision.failures[0].scenario_category == "safety"
+
+
+def test_release_gate_reports_stale_audit_coverage_by_source_and_scenario() -> None:
+    audit_artifacts = list(_audit_artifacts_from_harness())
+    target_index = next(
+        index
+        for index, artifact in enumerate(audit_artifacts)
+        if artifact["scenario_id"] == "mssql-positive-approved-vendor-spend-top-vendors"
+    )
+    event = dict(audit_artifacts[target_index]["event"])
+    event["source_id"] = "business-mssql-legacy-source"
+    audit_artifacts[target_index] = {
+        **audit_artifacts[target_index],
+        "event": event,
+    }
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=_observed_records_from_harness(),
+        audit_artifacts=tuple(audit_artifacts),
+    )
+
+    assert decision.status == "fail"
+    assert decision.failure_count == 1
+    assert decision.failures[0].deny_code == "DENY_STALE_AUDIT_COVERAGE"
+    assert decision.failures[0].source_id == "business-mssql-source"
+    assert decision.failures[0].source_family == "mssql"
+    assert decision.failures[0].scenario_id == "mssql-positive-approved-vendor-spend-top-vendors"
+    assert "source_id" in decision.failures[0].detail
 
 
 def test_release_gate_fails_closed_for_safety_regression() -> None:
@@ -57,7 +157,10 @@ def test_release_gate_fails_closed_for_safety_regression() -> None:
         }
     )
 
-    decision = reconstruct_release_gate(observed_artifacts=tuple(mutated_records))
+    decision = reconstruct_release_gate(
+        observed_artifacts=tuple(mutated_records),
+        audit_artifacts=_audit_artifacts_from_harness(),
+    )
 
     assert decision.status == "fail"
     assert decision.failure_count == 1
@@ -74,7 +177,10 @@ def test_release_gate_fails_closed_for_missing_evaluation_coverage() -> None:
         if record.scenario_id != "postgresql-positive-approved-vendor-count-by-region"
     )
 
-    decision = reconstruct_release_gate(observed_artifacts=observed_records)
+    decision = reconstruct_release_gate(
+        observed_artifacts=observed_records,
+        audit_artifacts=_audit_artifacts_from_harness(),
+    )
 
     assert decision.status == "fail"
     assert decision.failure_count == 1
@@ -103,7 +209,10 @@ def test_release_gate_reports_missing_source_aware_audit_fields() -> None:
         },
     )
 
-    decision = reconstruct_release_gate(observed_artifacts=observed_artifacts)
+    decision = reconstruct_release_gate(
+        observed_artifacts=observed_artifacts,
+        audit_artifacts=_audit_artifacts_from_harness(),
+    )
 
     assert decision.status == "fail"
     assert decision.failure_count == 1


### PR DESCRIPTION
## Summary
- require scenario-bound source-aware audit artifacts during release gate reconstruction
- report missing and stale audit coverage with source_id and scenario_id failure details
- keep evaluation regression checks intact while failing closed when audit evidence is absent

## Verification
- cd backend && python3 -m pytest tests/test_release_gate.py tests/test_audit_event_model.py tests/test_evaluation_harness.py -q

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced release gate validation with audit artifact checks
  * Added audit coverage completeness verification for release gate decisions
  * Implemented audit freshness validation to ensure audit events meet source and version requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->