### PR TITLE
[codex] Emit preview audit events from HTTP endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from time import perf_counter
 from uuid import uuid4
 
@@ -25,6 +26,7 @@ from app.features.auth.context import (
 )
 from app.services.health import check_database_health
 from app.services.request_preview import (
+    PreviewAuditContext,
     PreviewSubmissionContractError,
     PreviewSubmissionRequest,
     PreviewSubmissionResponse,
@@ -160,6 +162,7 @@ def create_app() -> FastAPI:
 
     @app.post("/requests/preview", response_model=PreviewSubmissionResponse)
     def create_request_preview(
+        request: Request,
         payload: PreviewSubmissionRequest,
         authenticated_subject: AuthenticatedSubject = Depends(
             require_authenticated_subject
@@ -167,7 +170,30 @@ def create_app() -> FastAPI:
         session: Session = Depends(require_preview_submission_session),
     ) -> PreviewSubmissionResponse:
         try:
-            return submit_preview_request(payload, authenticated_subject, session)
+            request_id = getattr(request.state, "request_id", None)
+            if not isinstance(request_id, str) or not request_id.strip():
+                raise HTTPException(
+                    status_code=500,
+                    detail="Request audit context is unavailable.",
+                )
+
+            user_subject = authenticated_subject.normalized_subject_id()
+            audit_context = PreviewAuditContext(
+                occurred_at=datetime.now(timezone.utc),
+                request_id=request_id,
+                correlation_id=str(uuid4()),
+                user_subject=user_subject,
+                session_id=str(uuid4()),
+                query_candidate_id=str(uuid4()),
+                candidate_owner_subject=user_subject,
+                application_version=f"safequery-api/{app.version}",
+            )
+            return submit_preview_request(
+                payload,
+                authenticated_subject,
+                session,
+                audit_context=audit_context,
+            )
         except PreviewSubmissionContractError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -267,33 +267,70 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        response_body = response.json()
         self.assertEqual(
-            response.json(),
+            response_body["request"],
             {
-                "request": {
-                    "question": "Show approved vendors by quarterly spend",
-                    "source_id": "sap-approved-spend",
-                    "state": "submitted",
-                },
-                "candidate": {
-                    "source_id": "sap-approved-spend",
-                    "source_family": "postgresql",
-                    "source_flavor": "warehouse",
-                    "dataset_contract_version": 1,
-                    "schema_snapshot_version": 1,
-                    "state": "preview_ready",
-                },
-                "audit": {
-                    "source_id": "sap-approved-spend",
-                    "state": "recorded",
-                    "events": [],
-                },
-                "evaluation": {
-                    "source_id": "sap-approved-spend",
-                    "state": "pending",
-                },
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+                "state": "submitted",
             },
         )
+        self.assertEqual(
+            response_body["candidate"],
+            {
+                "source_id": "sap-approved-spend",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+                "dataset_contract_version": 1,
+                "schema_snapshot_version": 1,
+                "state": "preview_ready",
+            },
+        )
+        self.assertEqual(
+            response_body["evaluation"],
+            {
+                "source_id": "sap-approved-spend",
+                "state": "pending",
+            },
+        )
+
+        audit = response_body["audit"]
+        self.assertEqual(audit["source_id"], "sap-approved-spend")
+        self.assertEqual(audit["state"], "recorded")
+        self.assertEqual(
+            [event["event_type"] for event in audit["events"]],
+            [
+                "query_submitted",
+                "generation_requested",
+                "generation_completed",
+                "guard_evaluated",
+            ],
+        )
+        self.assertEqual(
+            audit["events"][0]["request_id"],
+            response.headers["X-Request-ID"],
+        )
+
+        for event in audit["events"]:
+            self.assertEqual(event["request_id"], response.headers["X-Request-ID"])
+            self.assertTrue(event["correlation_id"])
+            self.assertEqual(event["user_subject"], "user:alice")
+            self.assertTrue(event["session_id"])
+            self.assertEqual(event["source_id"], "sap-approved-spend")
+            self.assertEqual(event["source_family"], "postgresql")
+            self.assertEqual(event["source_flavor"], "warehouse")
+            self.assertEqual(event["dataset_contract_version"], 1)
+            self.assertEqual(event["schema_snapshot_version"], 1)
+            self.assertEqual(event["application_version"], "safequery-api/0.1.0")
+
+        self.assertEqual(
+            audit["events"][2]["query_candidate_id"],
+            audit["events"][3]["query_candidate_id"],
+        )
+        self.assertEqual(audit["events"][2]["candidate_owner_subject"], "user:alice")
+        self.assertEqual(audit["events"][3]["candidate_owner_subject"], "user:alice")
+        self.assertEqual(audit["events"][3]["candidate_state"], "preview_ready")
 
     def test_preview_submission_rejects_subject_matching_only_security_review_binding(self) -> None:
         self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -312,11 +312,15 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             response.headers["X-Request-ID"],
         )
 
+        first_event = audit["events"][0]
+        self.assertTrue(first_event["correlation_id"])
+        self.assertTrue(first_event["session_id"])
+
         for event in audit["events"]:
             self.assertEqual(event["request_id"], response.headers["X-Request-ID"])
-            self.assertTrue(event["correlation_id"])
+            self.assertEqual(event["correlation_id"], first_event["correlation_id"])
             self.assertEqual(event["user_subject"], "user:alice")
-            self.assertTrue(event["session_id"])
+            self.assertEqual(event["session_id"], first_event["session_id"])
             self.assertEqual(event["source_id"], "sap-approved-spend")
             self.assertEqual(event["source_family"], "postgresql")
             self.assertEqual(event["source_flavor"], "warehouse")
@@ -324,6 +328,10 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             self.assertEqual(event["schema_snapshot_version"], 1)
             self.assertEqual(event["application_version"], "safequery-api/0.1.0")
 
+        self.assertIsNone(audit["events"][0]["query_candidate_id"])
+        self.assertIsNone(audit["events"][1]["query_candidate_id"])
+        self.assertIsNotNone(audit["events"][2]["query_candidate_id"])
+        self.assertIsNotNone(audit["events"][3]["query_candidate_id"])
         self.assertEqual(
             audit["events"][2]["query_candidate_id"],
             audit["events"][3]["query_candidate_id"],


### PR DESCRIPTION
## Summary
- Build authoritative `PreviewAuditContext` in the `/requests/preview` HTTP endpoint before submitting previews.
- Emit ordered preview lifecycle audit events for successful source-bound HTTP preview submissions.
- Tighten endpoint-level coverage so successful previews no longer accept empty audit events.

## Root Cause
Service-level callers could emit source-aware preview audit events only when they manually passed `PreviewAuditContext`; the FastAPI endpoint did not construct one, so HTTP responses returned `audit.events: []`.

## Validation
- `cd backend && python3 -m pytest tests/test_request_source_selection.py::RequestSourceSelectionTestCase::test_preview_submission_accepts_registered_executable_source_id -q`
- `cd backend && python3 -m pytest tests/test_request_source_selection.py tests/test_preview_source_governance_resolution.py tests/test_audit_event_model.py -q`
- `cd backend && python3 -m pytest tests/test_request_source_selection.py tests/test_preview_source_governance_resolution.py tests/test_audit_event_model.py tests/test_release_gate.py -q`

Closes #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview requests now include audit context with UTC timestamps, correlation/session/candidate IDs, and application version.

* **Bug Fixes**
  * Request validation now returns HTTP 500 for missing or invalid request identifiers.

* **Tests**
  * Tests expanded to assert audit event ordering, per-event metadata consistency, matching request IDs, shared correlation/session IDs, candidate ID behavior, and final candidate state/owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->