### PR TITLE
[codex] Complete MSSQL core vertical slice

### DIFF
--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -88,6 +88,7 @@ class ExecutionAuditContext(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     event_id: UUID
+    causation_event_id: Optional[UUID] = None
     occurred_at: datetime
     request_id: str
     correlation_id: str
@@ -202,7 +203,7 @@ def _build_execution_audit_events(
         return []
 
     events: list[SourceAwareAuditEvent] = []
-    causation_event_id: UUID | None = None
+    causation_event_id = audit_context.causation_event_id
     for event_type in event_types:
         event = _build_execution_audit_event(
             event_type=event_type,

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -95,6 +95,7 @@ class ExecutionAuditContext(BaseModel):
     session_id: str
     query_candidate_id: Optional[str] = None
     candidate_owner_subject: Optional[str] = None
+    execution_policy_version: Optional[int] = None
     connector_profile_version: Optional[int] = None
 
 
@@ -168,7 +169,14 @@ def _build_execution_audit_event(
         source_flavor=candidate_source.source_flavor,
         dataset_contract_version=candidate_source.dataset_contract_version,
         schema_snapshot_version=candidate_source.schema_snapshot_version,
-        connector_profile_version=audit_context.connector_profile_version,
+        execution_policy_version=(
+            audit_context.execution_policy_version
+            or candidate_source.execution_policy_version
+        ),
+        connector_profile_version=(
+            audit_context.connector_profile_version
+            or candidate_source.connector_profile_version
+        ),
         primary_deny_code=primary_deny_code,
         denial_cause=(
             _execution_denial_cause_for_code(primary_deny_code)

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -36,6 +36,8 @@ class SourceBoundCandidateMetadata(BaseModel):
     source_flavor: Optional[str] = None
     dataset_contract_version: int
     schema_snapshot_version: int
+    execution_policy_version: Optional[int] = None
+    connector_profile_version: Optional[int] = None
 
 
 class CandidateLifecycleRecord(BaseModel):

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -192,9 +192,11 @@ def _append_audit_event(
 def _build_execution_audit_context(
     *,
     audit_context: PreviewAuditContext,
+    previous_event_id: UUID,
 ) -> ExecutionAuditContext:
     return ExecutionAuditContext(
         event_id=uuid4(),
+        causation_event_id=previous_event_id,
         occurred_at=audit_context.occurred_at,
         request_id=audit_context.request_id,
         correlation_id=audit_context.correlation_id,
@@ -242,7 +244,7 @@ def run_mssql_core_vertical_slice(
     prepared_context = prepare_generation_context(
         request_id=audit_context.request_id,
         question=payload.question,
-        source_id=payload.source_id,
+        source_id=candidate_source.source_id,
         authenticated_subject=authenticated_subject,
         session=session,
     )
@@ -311,7 +313,10 @@ def run_mssql_core_vertical_slice(
         selection=selection,
         business_mssql_connection_string=normalized_business_mssql_connection_string,
         query_runner=query_runner,
-        audit_context=_build_execution_audit_context(audit_context=audit_context),
+        audit_context=_build_execution_audit_context(
+            audit_context=audit_context,
+            previous_event_id=audit_events[-1].event_id,
+        ),
     )
     audit_events.extend(execution.audit_events)
 

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -13,6 +13,7 @@ from app.features.execution.runtime import (
     ExecutableCandidateRecord,
     ExecutionAuditContext,
     ExecutionResult,
+    NonEmptyTrimmedString,
     QueryRunner,
 )
 from app.features.guard import SQLGuardEvaluation, evaluate_mssql_sql_guard
@@ -34,6 +35,19 @@ from app.services.sql_generation_adapter import (
 MSSQL_DIALECT_PROFILE_VERSION = 1
 MSSQL_EXECUTION_POLICY_VERSION = 2
 MSSQL_CONNECTOR_PROFILE_VERSION = 1
+
+
+def _normalize_business_mssql_connection_string(
+    connection_string: str,
+) -> NonEmptyTrimmedString:
+    normalized = connection_string.strip()
+    if not normalized:
+        raise RuntimeError(
+            "A non-empty backend-owned business MSSQL connection string is required "
+            "before the MSSQL vertical slice can execute."
+        )
+
+    return cast(NonEmptyTrimmedString, normalized)
 
 
 class GeneratedMSSQLCandidate(BaseModel):
@@ -199,10 +213,14 @@ def run_mssql_core_vertical_slice(
     authenticated_subject: AuthenticatedSubject,
     session: Session,
     sql_generation_adapter: SQLGenerationAdapter,
-    business_mssql_connection_string: str,
+    business_mssql_connection_string: NonEmptyTrimmedString,
     query_runner: QueryRunner | None = None,
     audit_context: PreviewAuditContext,
 ) -> MSSQLCoreVerticalSliceResult:
+    normalized_business_mssql_connection_string = (
+        _normalize_business_mssql_connection_string(business_mssql_connection_string)
+    )
+
     preview = submit_preview_request(
         payload,
         authenticated_subject,
@@ -291,7 +309,7 @@ def run_mssql_core_vertical_slice(
             source=candidate_source,
         ),
         selection=selection,
-        business_mssql_connection_string=business_mssql_connection_string,
+        business_mssql_connection_string=normalized_business_mssql_connection_string,
         query_runner=query_runner,
         audit_context=_build_execution_audit_context(audit_context=audit_context),
     )

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent
+from app.features.auth.context import AuthenticatedSubject
+from app.features.execution import execute_candidate_sql, select_execution_connector
+from app.features.execution.runtime import (
+    ExecutableCandidateRecord,
+    ExecutionAuditContext,
+    ExecutionResult,
+    QueryRunner,
+)
+from app.features.guard import SQLGuardEvaluation, evaluate_mssql_sql_guard
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+from app.services.generation_context import prepare_generation_context
+from app.services.request_preview import (
+    PreviewAuditContext,
+    PreviewSubmissionRequest,
+    PreviewSubmissionResponse,
+    submit_preview_request,
+)
+from app.services.sql_generation_adapter import (
+    SQLGenerationAdapter,
+    SQLGenerationAdapterRequest,
+    build_sql_generation_adapter_request,
+)
+
+
+MSSQL_DIALECT_PROFILE_VERSION = 1
+MSSQL_EXECUTION_POLICY_VERSION = 2
+MSSQL_CONNECTOR_PROFILE_VERSION = 1
+
+
+class GeneratedMSSQLCandidate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_sql: str
+    source: SourceBoundCandidateMetadata
+
+
+class MSSQLCoreVerticalSliceResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    preview: PreviewSubmissionResponse
+    adapter_request: SQLGenerationAdapterRequest
+    generated: GeneratedMSSQLCandidate
+    guard: SQLGuardEvaluation
+    execution: ExecutionResult
+    audit_events: list[SourceAwareAuditEvent]
+
+
+class MSSQLVerticalSliceDenied(PermissionError):
+    def __init__(
+        self,
+        *,
+        deny_code: str,
+        message: str,
+        guard: SQLGuardEvaluation,
+        audit_events: list[SourceAwareAuditEvent],
+    ) -> None:
+        super().__init__(f"{deny_code}: {message}")
+        self.deny_code = deny_code
+        self.guard = guard
+        self.audit_events = list(audit_events)
+        self.audit_event = self.audit_events[-1] if self.audit_events else None
+
+
+def _source_metadata_from_preview(
+    preview: PreviewSubmissionResponse,
+) -> SourceBoundCandidateMetadata:
+    return SourceBoundCandidateMetadata(
+        source_id=preview.candidate.source_id,
+        source_family=preview.candidate.source_family,
+        source_flavor=preview.candidate.source_flavor,
+        dataset_contract_version=preview.candidate.dataset_contract_version,
+        schema_snapshot_version=preview.candidate.schema_snapshot_version,
+        execution_policy_version=MSSQL_EXECUTION_POLICY_VERSION,
+        connector_profile_version=MSSQL_CONNECTOR_PROFILE_VERSION,
+    )
+
+
+def _audit_base(
+    *,
+    audit_context: PreviewAuditContext,
+    candidate_source: SourceBoundCandidateMetadata,
+    event_type: AuditEventType,
+    causation_event_id: UUID | None,
+    primary_deny_code: str | None = None,
+    candidate_state: str | None = None,
+    execution_row_count: int | None = None,
+    result_truncated: bool | None = None,
+) -> SourceAwareAuditEvent:
+    return SourceAwareAuditEvent(
+        event_id=uuid4(),
+        event_type=event_type,
+        occurred_at=audit_context.occurred_at,
+        request_id=audit_context.request_id,
+        correlation_id=audit_context.correlation_id,
+        causation_event_id=causation_event_id,
+        user_subject=audit_context.user_subject,
+        session_id=audit_context.session_id,
+        query_candidate_id=(
+            audit_context.query_candidate_id
+            if event_type
+            in {
+                "generation_completed",
+                "guard_evaluated",
+                "execution_requested",
+                "execution_started",
+                "execution_completed",
+                "execution_denied",
+            }
+            else None
+        ),
+        candidate_owner_subject=(
+            audit_context.candidate_owner_subject
+            if event_type
+            in {
+                "generation_completed",
+                "guard_evaluated",
+                "execution_requested",
+                "execution_started",
+                "execution_completed",
+                "execution_denied",
+            }
+            else None
+        ),
+        guard_version=(
+            audit_context.guard_version if event_type == "guard_evaluated" else None
+        ),
+        application_version=audit_context.application_version,
+        source_id=candidate_source.source_id,
+        source_family=candidate_source.source_family,  # type: ignore[arg-type]
+        source_flavor=candidate_source.source_flavor,
+        dialect_profile_version=MSSQL_DIALECT_PROFILE_VERSION,
+        dataset_contract_version=candidate_source.dataset_contract_version,
+        schema_snapshot_version=candidate_source.schema_snapshot_version,
+        execution_policy_version=candidate_source.execution_policy_version,
+        connector_profile_version=candidate_source.connector_profile_version,
+        primary_deny_code=primary_deny_code,
+        denial_cause="guard_rejected" if primary_deny_code is not None else None,
+        candidate_state=candidate_state,
+        execution_row_count=execution_row_count,
+        result_truncated=result_truncated,
+    )
+
+
+def _append_audit_event(
+    events: list[SourceAwareAuditEvent],
+    *,
+    audit_context: PreviewAuditContext,
+    candidate_source: SourceBoundCandidateMetadata,
+    event_type: AuditEventType,
+    primary_deny_code: str | None = None,
+    candidate_state: str | None = None,
+    execution_row_count: int | None = None,
+    result_truncated: bool | None = None,
+) -> None:
+    events.append(
+        _audit_base(
+            audit_context=audit_context,
+            candidate_source=candidate_source,
+            event_type=event_type,
+            causation_event_id=events[-1].event_id if events else None,
+            primary_deny_code=primary_deny_code,
+            candidate_state=candidate_state,
+            execution_row_count=execution_row_count,
+            result_truncated=result_truncated,
+        )
+    )
+
+
+def _build_execution_audit_context(
+    *,
+    audit_context: PreviewAuditContext,
+) -> ExecutionAuditContext:
+    return ExecutionAuditContext(
+        event_id=uuid4(),
+        occurred_at=audit_context.occurred_at,
+        request_id=audit_context.request_id,
+        correlation_id=audit_context.correlation_id,
+        user_subject=audit_context.user_subject,
+        session_id=audit_context.session_id,
+        query_candidate_id=audit_context.query_candidate_id,
+        candidate_owner_subject=audit_context.candidate_owner_subject,
+        execution_policy_version=MSSQL_EXECUTION_POLICY_VERSION,
+        connector_profile_version=MSSQL_CONNECTOR_PROFILE_VERSION,
+    )
+
+
+def run_mssql_core_vertical_slice(
+    *,
+    payload: PreviewSubmissionRequest,
+    authenticated_subject: AuthenticatedSubject,
+    session: Session,
+    sql_generation_adapter: SQLGenerationAdapter,
+    business_mssql_connection_string: str,
+    query_runner: QueryRunner | None = None,
+    audit_context: PreviewAuditContext,
+) -> MSSQLCoreVerticalSliceResult:
+    preview = submit_preview_request(
+        payload,
+        authenticated_subject,
+        session,
+        audit_context=None,
+    )
+    candidate_source = _source_metadata_from_preview(preview)
+    if candidate_source.source_family != "mssql":
+        raise ValueError("The MSSQL core vertical slice requires an MSSQL source.")
+
+    audit_events: list[SourceAwareAuditEvent] = []
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="query_submitted",
+    )
+
+    prepared_context = prepare_generation_context(
+        request_id=audit_context.request_id,
+        question=payload.question,
+        source_id=payload.source_id,
+        authenticated_subject=authenticated_subject,
+        session=session,
+    )
+    adapter_request = build_sql_generation_adapter_request(prepared_context)
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="generation_requested",
+    )
+
+    canonical_sql = sql_generation_adapter.generate_sql(adapter_request)
+    generated = GeneratedMSSQLCandidate(
+        canonical_sql=canonical_sql,
+        source=candidate_source,
+    )
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="generation_completed",
+        candidate_state="generated",
+    )
+
+    guard = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": canonical_sql,
+            "source": {
+                "source_id": candidate_source.source_id,
+                "source_family": candidate_source.source_family,
+                "source_flavor": candidate_source.source_flavor,
+            },
+        }
+    )
+    if guard.decision != "allow":
+        primary_deny_code = guard.rejections[0].code if guard.rejections else "guard_rejected"
+        _append_audit_event(
+            audit_events,
+            audit_context=audit_context,
+            candidate_source=candidate_source,
+            event_type="guard_evaluated",
+            primary_deny_code=primary_deny_code,
+            candidate_state="denied",
+        )
+        raise MSSQLVerticalSliceDenied(
+            deny_code=primary_deny_code,
+            message="MSSQL guard rejected the generated candidate.",
+            guard=guard,
+            audit_events=audit_events,
+        )
+
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="guard_evaluated",
+        candidate_state="preview_ready",
+    )
+
+    selection = select_execution_connector(candidate_source=candidate_source)
+    execution = execute_candidate_sql(
+        candidate=ExecutableCandidateRecord(
+            canonical_sql=canonical_sql,
+            source=candidate_source,
+        ),
+        selection=selection,
+        business_mssql_connection_string=business_mssql_connection_string,
+        query_runner=query_runner,
+        audit_context=_build_execution_audit_context(audit_context=audit_context),
+    )
+    audit_events.extend(execution.audit_events)
+
+    return MSSQLCoreVerticalSliceResult(
+        preview=preview,
+        adapter_request=adapter_request,
+        generated=generated,
+        guard=guard,
+        execution=execution,
+        audit_events=audit_events,
+    )

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from typing import cast
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
-from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent
+from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent, SourceFamily
 from app.features.auth.context import AuthenticatedSubject
 from app.features.execution import execute_candidate_sql, select_execution_connector
 from app.features.execution.runtime import (
@@ -134,7 +135,7 @@ def _audit_base(
         ),
         application_version=audit_context.application_version,
         source_id=candidate_source.source_id,
-        source_family=candidate_source.source_family,  # type: ignore[arg-type]
+        source_family=cast(SourceFamily, candidate_source.source_family),
         source_flavor=candidate_source.source_flavor,
         dialect_profile_version=MSSQL_DIALECT_PROFILE_VERSION,
         dataset_contract_version=candidate_source.dataset_contract_version,

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -11,7 +11,11 @@ from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
-from app.db.models.dataset_contract import DatasetContract
+from app.db.models.dataset_contract import (
+    DatasetContract,
+    DatasetContractDataset,
+    DatasetContractDatasetKind,
+)
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
@@ -151,6 +155,16 @@ def _seed_mssql_source(
     )
     session.add(contract)
     session.flush()
+
+    session.add(
+        DatasetContractDataset(
+            id=uuid4(),
+            dataset_contract_id=contract.id,
+            schema_name="dbo",
+            dataset_name="approved_vendor_spend",
+            dataset_kind=DatasetContractDatasetKind.TABLE,
+        )
+    )
 
     source.dataset_contract_id = contract.id
     source.schema_snapshot_id = snapshot.id
@@ -310,6 +324,163 @@ def test_mssql_positive_evaluation_scenarios_allow_and_shape_execution_evidence(
     assert result.connector_id == evidence.connector_id
     assert result.ownership == evidence.ownership
     assert tuple(result.rows[0]) == evidence.row_shape
+
+
+def test_mssql_core_vertical_slice_submits_generates_guards_executes_and_audits() -> None:
+    from app.services.mssql_vertical_slice import run_mssql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _mssql_scenarios_by_id()["mssql-positive-approved-vendor-spend-top-vendors"]
+    captured: dict[str, object] = {}
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            captured["adapter_request"] = request
+            return scenario.expected.canonical_sql
+
+    def fake_query_runner(
+        *,
+        connection_string: str,
+        canonical_sql: str,
+    ) -> list[dict[str, object]]:
+        captured["connection_string"] = connection_string
+        captured["canonical_sql"] = canonical_sql
+        return [{"vendor_name": "Northwind", "approved_amount": 4200}]
+
+    with _session_scope() as session:
+        _seed_mssql_source(session, scenario=scenario)
+
+        result = run_mssql_core_vertical_slice(
+            payload=PreviewSubmissionRequest(
+                question=scenario.prompt,
+                source_id=scenario.source.source_id,
+            ),
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session=session,
+            sql_generation_adapter=RecordingAdapter(),
+            business_mssql_connection_string=MSSQL_TEST_CONNECTION_STRING,
+            query_runner=fake_query_runner,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime.now(timezone.utc),
+                request_id="request-141",
+                correlation_id="correlation-141",
+                user_subject="user:alice",
+                session_id="session-141",
+                query_candidate_id="candidate-141",
+                candidate_owner_subject="user:alice",
+                guard_version="mssql-guard-v1",
+                application_version="safequery-test",
+            ),
+        )
+
+    adapter_request = captured["adapter_request"]
+    adapter_payload = adapter_request.model_dump()
+    assert "connection_reference" not in str(adapter_payload)
+    assert "connection_string" not in str(adapter_payload)
+    assert adapter_payload["source"] == {
+        "source_id": scenario.source.source_id,
+        "source_family": "mssql",
+        "source_flavor": "sqlserver",
+    }
+    assert captured["connection_string"] == MSSQL_TEST_CONNECTION_STRING
+    assert captured["canonical_sql"] == scenario.expected.canonical_sql
+
+    assert result.preview.candidate.source_id == scenario.source.source_id
+    assert result.generated.canonical_sql == scenario.expected.canonical_sql
+    assert result.guard.decision == "allow"
+    assert result.execution.rows == [
+        {"vendor_name": "Northwind", "approved_amount": 4200}
+    ]
+    assert [event.event_type for event in result.audit_events] == [
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+        "execution_requested",
+        "execution_started",
+        "execution_completed",
+    ]
+
+    for event in result.audit_events:
+        dumped = event.model_dump(exclude_none=True)
+        assert {
+            "source_id": scenario.source.source_id,
+            "source_family": "mssql",
+            "source_flavor": "sqlserver",
+            "dataset_contract_version": scenario.source.dataset_contract_version,
+            "schema_snapshot_version": scenario.source.schema_snapshot_version,
+            "execution_policy_version": scenario.source.execution_policy_version,
+            "connector_profile_version": scenario.source.connector_profile_version,
+        }.items() <= dumped.items()
+
+
+def test_mssql_core_vertical_slice_denies_guard_rejection_before_execution() -> None:
+    from app.features.guard.deny_taxonomy import DENY_RESOURCE_ABUSE
+    from app.services.mssql_vertical_slice import (
+        MSSQLVerticalSliceDenied,
+        run_mssql_core_vertical_slice,
+    )
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _mssql_scenarios_by_id()["mssql-safety-guard-denies-waitfor-delay"]
+
+    class DeniedAdapter:
+        def generate_sql(self, request):
+            return scenario.canonical_sql
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("MSSQL execution must not run after a guard rejection")
+
+    with _session_scope() as session:
+        _seed_mssql_source(session, scenario=scenario)
+
+        with pytest.raises(MSSQLVerticalSliceDenied) as exc_info:
+            run_mssql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=DeniedAdapter(),
+                business_mssql_connection_string=MSSQL_TEST_CONNECTION_STRING,
+                query_runner=fake_query_runner,
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-141-denied",
+                    correlation_id="correlation-141-denied",
+                    user_subject="user:alice",
+                    session_id="session-141-denied",
+                    query_candidate_id="candidate-141-denied",
+                    candidate_owner_subject="user:alice",
+                    guard_version="mssql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+    assert exc_info.value.deny_code == DENY_RESOURCE_ABUSE
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+    ]
+    guard_event = exc_info.value.audit_events[-1].model_dump(exclude_none=True)
+    assert {
+        "event_type": "guard_evaluated",
+        "primary_deny_code": DENY_RESOURCE_ABUSE,
+        "denial_cause": "guard_rejected",
+        "candidate_state": "denied",
+        "source_id": scenario.source.source_id,
+        "execution_policy_version": scenario.source.execution_policy_version,
+        "connector_profile_version": scenario.source.connector_profile_version,
+    }.items() <= guard_event.items()
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -403,6 +403,11 @@ def test_mssql_core_vertical_slice_submits_generates_guards_executes_and_audits(
         "execution_started",
         "execution_completed",
     ]
+    for index, event in enumerate(result.audit_events):
+        expected_causation_event_id = (
+            None if index == 0 else result.audit_events[index - 1].event_id
+        )
+        assert event.causation_event_id == expected_causation_event_id
 
     for event in result.audit_events:
         dumped = event.model_dump(exclude_none=True)

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -417,6 +417,55 @@ def test_mssql_core_vertical_slice_submits_generates_guards_executes_and_audits(
         }.items() <= dumped.items()
 
 
+def test_mssql_core_vertical_slice_rejects_blank_backend_connection_string_before_generation() -> None:
+    from app.services.mssql_vertical_slice import run_mssql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _mssql_scenarios_by_id()["mssql-positive-approved-vendor-spend-top-vendors"]
+
+    class UnexpectedAdapter:
+        def generate_sql(self, request):
+            raise AssertionError(
+                "SQL generation must not run without a valid backend credential"
+            )
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("MSSQL execution must not run without a valid backend credential")
+
+    with _session_scope() as session:
+        _seed_mssql_source(session, scenario=scenario)
+
+        with pytest.raises(
+            RuntimeError,
+            match="non-empty backend-owned business MSSQL connection string",
+        ):
+            run_mssql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=UnexpectedAdapter(),
+                business_mssql_connection_string=" \t\n ",
+                query_runner=fake_query_runner,
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-141-blank-credential",
+                    correlation_id="correlation-141-blank-credential",
+                    user_subject="user:alice",
+                    session_id="session-141-blank-credential",
+                    query_candidate_id="candidate-141-blank-credential",
+                    candidate_owner_subject="user:alice",
+                    guard_version="mssql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+
 def test_mssql_core_vertical_slice_denies_guard_rejection_before_execution() -> None:
     from app.features.guard.deny_taxonomy import DENY_RESOURCE_ABUSE
     from app.services.mssql_vertical_slice import (

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -78,6 +78,11 @@ def _audit_context() -> ExecutionAuditContext:
     )
 
 
+def _anchored_audit_context(previous_event_id) -> ExecutionAuditContext:
+    context = _audit_context()
+    return context.model_copy(update={"causation_event_id": previous_event_id})
+
+
 def test_execute_candidate_sql_requires_candidate_bound_record() -> None:
     from app.features.execution import execute_candidate_sql
 
@@ -209,3 +214,27 @@ def test_execute_candidate_sql_returns_source_aware_completion_audit_event() -> 
         "result_truncated": False,
     }.items() <= result.audit_event.model_dump(exclude_none=True).items()
     assert result.audit_event.model_dump(exclude_none=True).get("rows") is None
+
+
+def test_execute_candidate_sql_anchors_first_audit_event_to_previous_event() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    previous_event_id = uuid4()
+
+    result = execute_candidate_sql(
+        candidate=_candidate(),
+        selection=_selection(),
+        business_postgres_url=BUSINESS_POSTGRES_URL,
+        application_postgres_url=APPLICATION_POSTGRES_URL,
+        query_runner=lambda **_: [{"vendor_name": "Acme"}],
+        audit_context=_anchored_audit_context(previous_event_id),
+    )
+
+    assert [event.event_type for event in result.audit_events] == [
+        "execution_requested",
+        "execution_started",
+        "execution_completed",
+    ]
+    assert result.audit_events[0].causation_event_id == previous_event_id
+    assert result.audit_events[1].causation_event_id == result.audit_events[0].event_id
+    assert result.audit_events[2].causation_event_id == result.audit_events[1].event_id


### PR DESCRIPTION
## Summary
- Add a backend-owned MSSQL vertical-slice composition service for preview submission, source-scoped generation, MSSQL guard evaluation, candidate-bound execution, and source-aware audit reconstruction.
- Add focused successful and guard-denial coverage using controlled fixtures and a fake MSSQL query runner.
- Thread optional execution policy and connector profile versions through candidate-bound execution audit metadata.

## Validation
- cd backend && python3 -m pytest tests/test_evaluation_harness.py -q -k 'mssql_core_vertical_slice'\n- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_source_bound_execute_path.py tests/test_mssql_execution_connector.py tests/test_audit_event_model.py -q\n- cd backend && python3 -m pytest -q\n- cd backend && python3 -m compileall -q app tests\n- git diff --check\n\nCloses #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MSSQL vertical-slice execution service for SQL generation, guard evaluation, and execution orchestration.
  * Audit events now include execution policy and connector profile version metadata; source/candidate metadata track these version fields.

* **Tests**
  * Added MSSQL vertical-slice tests covering successful execution, validation error for invalid connection strings, and guard-denied paths with audit verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->