### PR TITLE
Complete PostgreSQL business-source vertical slice

### DIFF
--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent, SourceFamily
+from app.features.auth.context import AuthenticatedSubject
+from app.features.execution import execute_candidate_sql, select_execution_connector
+from app.features.execution.runtime import (
+    ExecutableCandidateRecord,
+    ExecutionAuditContext,
+    ExecutionResult,
+    NonEmptyTrimmedString,
+    QueryRunner,
+)
+from app.features.guard import SQLGuardEvaluation, evaluate_postgresql_sql_guard
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+from app.services.generation_context import prepare_generation_context
+from app.services.request_preview import (
+    PreviewAuditContext,
+    PreviewSubmissionRequest,
+    PreviewSubmissionResponse,
+    submit_preview_request,
+)
+from app.services.sql_generation_adapter import (
+    SQLGenerationAdapter,
+    SQLGenerationAdapterRequest,
+    build_sql_generation_adapter_request,
+)
+
+
+POSTGRESQL_DIALECT_PROFILE_VERSION = 1
+POSTGRESQL_EXECUTION_POLICY_VERSION = 3
+POSTGRESQL_CONNECTOR_PROFILE_VERSION = 1
+
+
+def _normalize_business_postgres_url(
+    database_url: str,
+) -> NonEmptyTrimmedString:
+    normalized = database_url.strip()
+    if not normalized:
+        raise RuntimeError(
+            "A non-empty backend-owned business PostgreSQL URL is required before "
+            "the PostgreSQL vertical slice can execute."
+        )
+
+    return cast(NonEmptyTrimmedString, normalized)
+
+
+def _normalize_application_postgres_url(
+    database_url: str,
+) -> NonEmptyTrimmedString:
+    normalized = database_url.strip()
+    if not normalized:
+        raise RuntimeError(
+            "A non-empty application PostgreSQL URL is required before the "
+            "PostgreSQL vertical slice can prove source separation."
+        )
+
+    return cast(NonEmptyTrimmedString, normalized)
+
+
+class GeneratedPostgreSQLCandidate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_sql: str
+    source: SourceBoundCandidateMetadata
+
+
+class PostgreSQLCoreVerticalSliceResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    preview: PreviewSubmissionResponse
+    adapter_request: SQLGenerationAdapterRequest
+    generated: GeneratedPostgreSQLCandidate
+    guard: SQLGuardEvaluation
+    execution: ExecutionResult
+    audit_events: list[SourceAwareAuditEvent]
+
+
+class PostgreSQLVerticalSliceDenied(PermissionError):
+    def __init__(
+        self,
+        *,
+        deny_code: str,
+        message: str,
+        guard: SQLGuardEvaluation,
+        audit_events: list[SourceAwareAuditEvent],
+    ) -> None:
+        super().__init__(f"{deny_code}: {message}")
+        self.deny_code = deny_code
+        self.guard = guard
+        self.audit_events = list(audit_events)
+        self.audit_event = self.audit_events[-1] if self.audit_events else None
+
+
+def _source_metadata_from_preview(
+    preview: PreviewSubmissionResponse,
+) -> SourceBoundCandidateMetadata:
+    return SourceBoundCandidateMetadata(
+        source_id=preview.candidate.source_id,
+        source_family=preview.candidate.source_family,
+        source_flavor=preview.candidate.source_flavor,
+        dataset_contract_version=preview.candidate.dataset_contract_version,
+        schema_snapshot_version=preview.candidate.schema_snapshot_version,
+        execution_policy_version=POSTGRESQL_EXECUTION_POLICY_VERSION,
+        connector_profile_version=POSTGRESQL_CONNECTOR_PROFILE_VERSION,
+    )
+
+
+def _audit_base(
+    *,
+    audit_context: PreviewAuditContext,
+    candidate_source: SourceBoundCandidateMetadata,
+    event_type: AuditEventType,
+    causation_event_id: UUID | None,
+    primary_deny_code: str | None = None,
+    candidate_state: str | None = None,
+    execution_row_count: int | None = None,
+    result_truncated: bool | None = None,
+) -> SourceAwareAuditEvent:
+    return SourceAwareAuditEvent(
+        event_id=uuid4(),
+        event_type=event_type,
+        occurred_at=audit_context.occurred_at,
+        request_id=audit_context.request_id,
+        correlation_id=audit_context.correlation_id,
+        causation_event_id=causation_event_id,
+        user_subject=audit_context.user_subject,
+        session_id=audit_context.session_id,
+        query_candidate_id=(
+            audit_context.query_candidate_id
+            if event_type
+            in {
+                "generation_completed",
+                "guard_evaluated",
+                "execution_requested",
+                "execution_started",
+                "execution_completed",
+                "execution_denied",
+            }
+            else None
+        ),
+        candidate_owner_subject=(
+            audit_context.candidate_owner_subject
+            if event_type
+            in {
+                "generation_completed",
+                "guard_evaluated",
+                "execution_requested",
+                "execution_started",
+                "execution_completed",
+                "execution_denied",
+            }
+            else None
+        ),
+        guard_version=(
+            audit_context.guard_version if event_type == "guard_evaluated" else None
+        ),
+        application_version=audit_context.application_version,
+        source_id=candidate_source.source_id,
+        source_family=cast(SourceFamily, candidate_source.source_family),
+        source_flavor=candidate_source.source_flavor,
+        dialect_profile_version=POSTGRESQL_DIALECT_PROFILE_VERSION,
+        dataset_contract_version=candidate_source.dataset_contract_version,
+        schema_snapshot_version=candidate_source.schema_snapshot_version,
+        execution_policy_version=candidate_source.execution_policy_version,
+        connector_profile_version=candidate_source.connector_profile_version,
+        primary_deny_code=primary_deny_code,
+        denial_cause="guard_rejected" if primary_deny_code is not None else None,
+        candidate_state=candidate_state,
+        execution_row_count=execution_row_count,
+        result_truncated=result_truncated,
+    )
+
+
+def _append_audit_event(
+    events: list[SourceAwareAuditEvent],
+    *,
+    audit_context: PreviewAuditContext,
+    candidate_source: SourceBoundCandidateMetadata,
+    event_type: AuditEventType,
+    primary_deny_code: str | None = None,
+    candidate_state: str | None = None,
+    execution_row_count: int | None = None,
+    result_truncated: bool | None = None,
+) -> None:
+    events.append(
+        _audit_base(
+            audit_context=audit_context,
+            candidate_source=candidate_source,
+            event_type=event_type,
+            causation_event_id=events[-1].event_id if events else None,
+            primary_deny_code=primary_deny_code,
+            candidate_state=candidate_state,
+            execution_row_count=execution_row_count,
+            result_truncated=result_truncated,
+        )
+    )
+
+
+def _build_execution_audit_context(
+    *,
+    audit_context: PreviewAuditContext,
+    previous_event_id: UUID,
+) -> ExecutionAuditContext:
+    return ExecutionAuditContext(
+        event_id=uuid4(),
+        causation_event_id=previous_event_id,
+        occurred_at=audit_context.occurred_at,
+        request_id=audit_context.request_id,
+        correlation_id=audit_context.correlation_id,
+        user_subject=audit_context.user_subject,
+        session_id=audit_context.session_id,
+        query_candidate_id=audit_context.query_candidate_id,
+        candidate_owner_subject=audit_context.candidate_owner_subject,
+        execution_policy_version=POSTGRESQL_EXECUTION_POLICY_VERSION,
+        connector_profile_version=POSTGRESQL_CONNECTOR_PROFILE_VERSION,
+    )
+
+
+def run_postgresql_core_vertical_slice(
+    *,
+    payload: PreviewSubmissionRequest,
+    authenticated_subject: AuthenticatedSubject,
+    session: Session,
+    sql_generation_adapter: SQLGenerationAdapter,
+    business_postgres_url: NonEmptyTrimmedString,
+    application_postgres_url: NonEmptyTrimmedString,
+    query_runner: QueryRunner | None = None,
+    audit_context: PreviewAuditContext,
+) -> PostgreSQLCoreVerticalSliceResult:
+    normalized_business_postgres_url = _normalize_business_postgres_url(
+        business_postgres_url
+    )
+    normalized_application_postgres_url = _normalize_application_postgres_url(
+        application_postgres_url
+    )
+
+    preview = submit_preview_request(
+        payload,
+        authenticated_subject,
+        session,
+        audit_context=None,
+    )
+    candidate_source = _source_metadata_from_preview(preview)
+    if candidate_source.source_family != "postgresql":
+        raise ValueError(
+            "The PostgreSQL core vertical slice requires a PostgreSQL source."
+        )
+
+    audit_events: list[SourceAwareAuditEvent] = []
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="query_submitted",
+    )
+
+    prepared_context = prepare_generation_context(
+        request_id=audit_context.request_id,
+        question=payload.question,
+        source_id=candidate_source.source_id,
+        authenticated_subject=authenticated_subject,
+        session=session,
+    )
+    adapter_request = build_sql_generation_adapter_request(prepared_context)
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="generation_requested",
+    )
+
+    canonical_sql = sql_generation_adapter.generate_sql(adapter_request)
+    generated = GeneratedPostgreSQLCandidate(
+        canonical_sql=canonical_sql,
+        source=candidate_source,
+    )
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="generation_completed",
+        candidate_state="generated",
+    )
+
+    guard = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": canonical_sql,
+            "source": {
+                "source_id": candidate_source.source_id,
+                "source_family": candidate_source.source_family,
+                "source_flavor": candidate_source.source_flavor,
+            },
+        }
+    )
+    if guard.decision != "allow":
+        primary_deny_code = guard.rejections[0].code if guard.rejections else "guard_rejected"
+        _append_audit_event(
+            audit_events,
+            audit_context=audit_context,
+            candidate_source=candidate_source,
+            event_type="guard_evaluated",
+            primary_deny_code=primary_deny_code,
+            candidate_state="denied",
+        )
+        raise PostgreSQLVerticalSliceDenied(
+            deny_code=primary_deny_code,
+            message="PostgreSQL guard rejected the generated candidate.",
+            guard=guard,
+            audit_events=audit_events,
+        )
+
+    _append_audit_event(
+        audit_events,
+        audit_context=audit_context,
+        candidate_source=candidate_source,
+        event_type="guard_evaluated",
+        candidate_state="preview_ready",
+    )
+
+    selection = select_execution_connector(candidate_source=candidate_source)
+    execution = execute_candidate_sql(
+        candidate=ExecutableCandidateRecord(
+            canonical_sql=canonical_sql,
+            source=candidate_source,
+        ),
+        selection=selection,
+        business_postgres_url=normalized_business_postgres_url,
+        application_postgres_url=normalized_application_postgres_url,
+        query_runner=query_runner,
+        audit_context=_build_execution_audit_context(
+            audit_context=audit_context,
+            previous_event_id=audit_events[-1].event_id,
+        ),
+    )
+    audit_events.extend(execution.audit_events)
+
+    return PostgreSQLCoreVerticalSliceResult(
+        preview=preview,
+        adapter_request=adapter_request,
+        generated=generated,
+        guard=guard,
+        execution=execution,
+        audit_events=audit_events,
+    )

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -171,6 +171,68 @@ def _seed_mssql_source(
     session.commit()
 
 
+def _seed_postgresql_source(
+    session: Session,
+    *,
+    scenario: PostgreSQLEvaluationScenario,
+    contract_version: int | None = None,
+    snapshot_version: int | None = None,
+) -> None:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id=scenario.source.source_id,
+        display_label=f"{scenario.source.source_id} display",
+        source_family=scenario.source.source_family,
+        source_flavor=scenario.source.source_flavor,
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{scenario.source.source_id}",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=snapshot_version or scenario.source.schema_snapshot_version,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=contract_version or scenario.source.dataset_contract_version,
+        display_name=f"{scenario.source.source_id} contract",
+        owner_binding="group:finance-analysts",
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    session.add(
+        DatasetContractDataset(
+            id=uuid4(),
+            dataset_contract_id=contract.id,
+            schema_name="finance",
+            dataset_name="approved_vendor_spend",
+            dataset_kind=DatasetContractDatasetKind.TABLE,
+        )
+    )
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.commit()
+
+
 def _lifecycle_candidate(
     *,
     scenario: MSSQLEvaluationScenario,
@@ -591,6 +653,172 @@ def test_postgresql_positive_evaluation_scenarios_allow_and_shape_execution_evid
     assert result.connector_id == evidence.connector_id
     assert result.ownership == evidence.ownership
     assert tuple(result.rows[0]) == evidence.row_shape
+
+
+def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_audits() -> None:
+    from app.services.postgresql_vertical_slice import run_postgresql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-positive-approved-vendor-spend-top-vendors"
+    ]
+    captured: dict[str, object] = {}
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            captured["adapter_request"] = request
+            return scenario.expected.canonical_sql
+
+    def fake_query_runner(
+        *,
+        database_url: str,
+        canonical_sql: str,
+    ) -> list[dict[str, object]]:
+        captured["database_url"] = database_url
+        captured["canonical_sql"] = canonical_sql
+        return [{"vendor_name": "Northwind", "approved_amount": 4200}]
+
+    with _session_scope() as session:
+        _seed_postgresql_source(session, scenario=scenario)
+
+        result = run_postgresql_core_vertical_slice(
+            payload=PreviewSubmissionRequest(
+                question=scenario.prompt,
+                source_id=scenario.source.source_id,
+            ),
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session=session,
+            sql_generation_adapter=RecordingAdapter(),
+            business_postgres_url=POSTGRESQL_TEST_URL,
+            application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+            query_runner=fake_query_runner,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime.now(timezone.utc),
+                request_id="request-142",
+                correlation_id="correlation-142",
+                user_subject="user:alice",
+                session_id="session-142",
+                query_candidate_id="candidate-142",
+                candidate_owner_subject="user:alice",
+                guard_version="postgresql-guard-v1",
+                application_version="safequery-test",
+            ),
+        )
+
+    adapter_request = captured["adapter_request"]
+    adapter_payload = adapter_request.model_dump()
+    assert "connection_reference" not in str(adapter_payload)
+    assert "database_url" not in str(adapter_payload)
+    assert adapter_payload["source"] == {
+        "source_id": scenario.source.source_id,
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+    }
+    assert captured["database_url"] == POSTGRESQL_TEST_URL
+    assert captured["canonical_sql"] == scenario.expected.canonical_sql
+
+    assert result.preview.candidate.source_id == scenario.source.source_id
+    assert result.generated.canonical_sql == scenario.expected.canonical_sql
+    assert result.guard.decision == "allow"
+    assert result.execution.rows == [
+        {"vendor_name": "Northwind", "approved_amount": 4200}
+    ]
+    assert [event.event_type for event in result.audit_events] == [
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+        "execution_requested",
+        "execution_started",
+        "execution_completed",
+    ]
+    for index, event in enumerate(result.audit_events):
+        expected_causation_event_id = (
+            None if index == 0 else result.audit_events[index - 1].event_id
+        )
+        assert event.causation_event_id == expected_causation_event_id
+
+    for event in result.audit_events:
+        dumped = event.model_dump(exclude_none=True)
+        assert {
+            "source_id": scenario.source.source_id,
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+            "dataset_contract_version": scenario.source.dataset_contract_version,
+            "schema_snapshot_version": scenario.source.schema_snapshot_version,
+            "execution_policy_version": scenario.source.execution_policy_version,
+            "connector_profile_version": scenario.source.connector_profile_version,
+        }.items() <= dumped.items()
+
+
+def test_postgresql_core_vertical_slice_denies_application_postgres_reuse_before_query() -> None:
+    from app.services.postgresql_vertical_slice import run_postgresql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-positive-approved-vendor-spend-top-vendors"
+    ]
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            return scenario.expected.canonical_sql
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("PostgreSQL execution must not run for application reuse")
+
+    with _session_scope() as session:
+        _seed_postgresql_source(session, scenario=scenario)
+
+        with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
+            run_postgresql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=RecordingAdapter(),
+                business_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+                application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+                query_runner=fake_query_runner,
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-142-application-reuse",
+                    correlation_id="correlation-142-application-reuse",
+                    user_subject="user:alice",
+                    session_id="session-142-application-reuse",
+                    query_candidate_id="candidate-142-application-reuse",
+                    candidate_owner_subject="user:alice",
+                    guard_version="postgresql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+    assert exc_info.value.deny_code == DENY_APPLICATION_POSTGRES_REUSE
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "execution_requested",
+        "execution_denied",
+    ]
+    denial_event = exc_info.value.audit_event.model_dump(exclude_none=True)
+    assert {
+        "event_type": "execution_denied",
+        "source_id": scenario.source.source_id,
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": scenario.source.dataset_contract_version,
+        "schema_snapshot_version": scenario.source.schema_snapshot_version,
+        "execution_policy_version": scenario.source.execution_policy_version,
+        "connector_profile_version": scenario.source.connector_profile_version,
+        "primary_deny_code": DENY_APPLICATION_POSTGRES_REUSE,
+        "denial_cause": "application_postgresql_reuse",
+        "candidate_state": "denied",
+    }.items() <= denial_event.items()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add PostgreSQL core vertical-slice service from preview submission through generation, guard, execution, and audit output
- keep business PostgreSQL and application PostgreSQL URLs separated at the execution boundary
- add focused PostgreSQL vertical-slice tests for success and application PostgreSQL reuse denial

## Verification
- cd backend && python3 -m pytest tests/test_evaluation_harness.py::test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_audits -q
- cd backend && python3 -m pytest tests/test_evaluation_harness.py::test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_audits tests/test_evaluation_harness.py::test_postgresql_core_vertical_slice_denies_application_postgres_reuse_before_query -q
- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_source_bound_execute_path.py tests/test_postgresql_execution_connector.py tests/test_application_postgres_guard.py tests/test_audit_event_model.py -q
- cd backend && python3 -m pytest -q

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL query generation and execution workflow with integrated security evaluation, denial handling, and comprehensive audit event tracking for operation accountability.

* **Tests**
  * Comprehensive test coverage for PostgreSQL operations including query generation, security validation, and end-to-end execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->