### PR TITLE
[codex] Connect operator workflow to live source data

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,10 @@ from app.services.request_preview import (
     PreviewSubmissionResponse,
     submit_preview_request,
 )
+from app.services.operator_workflow import (
+    OperatorWorkflowSnapshot,
+    get_operator_workflow_snapshot,
+)
 
 configure_logging()
 
@@ -196,6 +200,12 @@ def create_app() -> FastAPI:
             )
         except PreviewSubmissionContractError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    @app.get("/operator/workflow", response_model=OperatorWorkflowSnapshot)
+    def read_operator_workflow(
+        session: Session = Depends(require_preview_submission_session),
+    ) -> OperatorWorkflowSnapshot:
+        return get_operator_workflow_snapshot(session)
 
     return app
 

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.source_registry import RegisteredSource
+
+
+class OperatorWorkflowSourceOption(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(serialization_alias="sourceId")
+    display_label: str = Field(serialization_alias="displayLabel")
+    description: str
+    activation_posture: str = Field(serialization_alias="activationPosture")
+    source_family: str = Field(serialization_alias="sourceFamily")
+    source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+
+
+class OperatorWorkflowHistoryItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    item_type: Literal["request", "candidate", "run"] = Field(serialization_alias="itemType")
+    record_id: str = Field(serialization_alias="recordId")
+    label: str
+    source_id: str = Field(serialization_alias="sourceId")
+    source_label: str = Field(serialization_alias="sourceLabel")
+    lifecycle_state: str = Field(serialization_alias="lifecycleState")
+    occurred_at: datetime = Field(serialization_alias="occurredAt")
+    guard_status: Optional[str] = Field(default=None, serialization_alias="guardStatus")
+    run_state: Optional[str] = Field(default=None, serialization_alias="runState")
+
+
+class OperatorWorkflowSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    sources: list[OperatorWorkflowSourceOption]
+    history: list[OperatorWorkflowHistoryItem] = Field(default_factory=list)
+
+
+def _source_description(source: RegisteredSource) -> str:
+    flavor = f" / {source.source_flavor}" if source.source_flavor else ""
+    return (
+        f"{source.source_family}{flavor} source with "
+        f"{source.activation_posture.value} activation posture."
+    )
+
+
+def get_operator_workflow_snapshot(session: Session) -> OperatorWorkflowSnapshot:
+    sources = (
+        session.execute(select(RegisteredSource).order_by(RegisteredSource.source_id))
+        .scalars()
+        .all()
+    )
+
+    source_options = [
+        OperatorWorkflowSourceOption(
+            source_id=source.source_id,
+            display_label=source.display_label,
+            description=_source_description(source),
+            activation_posture=source.activation_posture.value,
+            source_family=source.source_family,
+            source_flavor=source.source_flavor,
+        )
+        for source in sources
+    ]
+
+    return OperatorWorkflowSnapshot(sources=source_options, history=[])

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -340,6 +340,46 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         self.assertEqual(audit["events"][3]["candidate_owner_subject"], "user:alice")
         self.assertEqual(audit["events"][3]["candidate_state"], "preview_ready")
 
+    def test_operator_workflow_snapshot_exposes_live_source_options_without_secrets(self) -> None:
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+        )
+        self._seed_authoritative_source_governance(
+            source_id="legacy-finance-archive",
+            source_posture=SourceActivationPosture.PAUSED,
+        )
+
+        response = self.client.get("/operator/workflow")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            [
+                {
+                    "sourceId": source["sourceId"],
+                    "displayLabel": source["displayLabel"],
+                    "activationPosture": source["activationPosture"],
+                }
+                for source in payload["sources"]
+            ],
+            [
+                {
+                    "sourceId": "legacy-finance-archive",
+                    "displayLabel": "legacy-finance-archive display",
+                    "activationPosture": "paused",
+                },
+                {
+                    "sourceId": "sap-approved-spend",
+                    "displayLabel": "sap-approved-spend display",
+                    "activationPosture": "active",
+                },
+            ],
+        )
+        self.assertEqual(payload["history"], [])
+        self.assertNotIn("connection_reference", response.text)
+        self.assertNotIn("vault:", response.text)
+
     def test_preview_submission_rejects_subject_matching_only_security_review_binding(self) -> None:
         self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(
             subject_id="user:alice",

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -51,6 +51,7 @@ a {
 
 button,
 input,
+select,
 textarea {
   font: inherit;
 }
@@ -207,11 +208,12 @@ button:focus-visible {
 
 .workspace-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.65fr) minmax(320px, 0.95fr);
+  grid-template-columns: minmax(240px, 0.75fr) minmax(0, 1.65fr) minmax(320px, 0.95fr);
   gap: 24px;
   margin-top: 24px;
 }
 
+.history-column,
 .primary-column,
 .support-column {
   display: grid;
@@ -292,10 +294,33 @@ button:focus-visible {
 .signin-actions,
 .action-row,
 .guard-list,
+.history-list,
 .result-table,
 .placeholder-block {
   display: grid;
   gap: 12px;
+}
+
+.history-item {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: rgba(7, 11, 20, 0.38);
+  color: var(--text-secondary);
+}
+
+.history-item strong {
+  color: var(--text-primary);
+}
+
+.history-type {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .action-row,
@@ -361,10 +386,9 @@ button {
   font-weight: 600;
 }
 
+select,
 textarea {
   width: 100%;
-  min-height: 168px;
-  resize: vertical;
   padding: 18px;
   border: 1px solid var(--border-strong);
   border-radius: 18px;
@@ -374,10 +398,20 @@ textarea {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
+select {
+  min-height: 56px;
+}
+
+textarea {
+  min-height: 168px;
+  resize: vertical;
+}
+
 textarea::placeholder {
   color: var(--text-muted);
 }
 
+select:focus-visible,
 textarea:focus-visible,
 button:focus-visible,
 .state-nav-link:focus-visible,

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import HomePage from "./page";
 import { resolveWorkflowState } from "../components/query-workflow-shell";
@@ -123,6 +123,102 @@ describe("HomePage", () => {
       "SAP spend cube / approved_vendor_spend"
     );
     expect(screen.getByLabelText(/operator history/i)).toHaveTextContent("previewed");
+  });
+
+  it("reopens history rows into anchored non-draft workflow states", async () => {
+    render(await HomePage({}));
+
+    const historyLink = within(screen.getByLabelText(/operator history/i)).getByRole("link", {
+      name: /approved vendor spend/i
+    });
+
+    expect(historyLink).toHaveAttribute("href", expect.stringContaining("state=preview"));
+    expect(historyLink).toHaveAttribute("href", expect.stringContaining("source_id=sap-approved-spend"));
+    expect(historyLink).toHaveAttribute("href", expect.stringContaining("history_item_type=request"));
+    expect(historyLink).toHaveAttribute("href", expect.stringContaining("history_record_id=request-123"));
+    expect(historyLink).not.toHaveAttribute("href", expect.stringContaining("state=query"));
+  });
+
+  it("reopens denied candidates and terminal runs into their lifecycle states", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    guardStatus: "blocked",
+                    itemType: "candidate",
+                    label: "Blocked candidate",
+                    lifecycleState: "blocked",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-123",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
+                  {
+                    itemType: "run",
+                    label: "Failed run",
+                    lifecycleState: "failed",
+                    occurredAt: "2026-04-21T14:35:00Z",
+                    recordId: "run-123",
+                    runState: "failed",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    const history = screen.getByLabelText(/operator history/i);
+    const deniedCandidateLink = within(history).getByRole("link", { name: /blocked candidate/i });
+    const failedRunLink = within(history).getByRole("link", { name: /failed run/i });
+
+    expect(deniedCandidateLink).toHaveAttribute("href", expect.stringContaining("state=review_denied"));
+    expect(deniedCandidateLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("history_record_id=candidate-123")
+    );
+    expect(failedRunLink).toHaveAttribute("href", expect.stringContaining("state=failed"));
+    expect(failedRunLink).toHaveAttribute("href", expect.stringContaining("history_record_id=run-123"));
+  });
+
+  it("reports malformed workflow payloads separately from unavailable transport", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.reject(new SyntaxError("Unexpected token < in JSON"))
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(screen.getByLabelText(/operator history/i)).toHaveTextContent("malformed");
+    expect(
+      screen.getByText(/backend workflow payload was malformed, so the source selector remains blocked/i)
+    ).toBeInTheDocument();
   });
 
   it("renders the shell before the health probe completes", async () => {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -3,12 +3,57 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import HomePage from "./page";
 import { resolveWorkflowState } from "../components/query-workflow-shell";
 
+function workflowPayload(sourceLabel = "SAP spend cube / approved_vendor_spend") {
+  return {
+    history: [
+      {
+        itemType: "request",
+        label: "Approved vendor spend",
+        lifecycleState: "previewed",
+        occurredAt: "2026-04-21T14:18:00Z",
+        recordId: "request-123",
+        sourceId: "sap-approved-spend",
+        sourceLabel
+      }
+    ],
+    sources: [
+      {
+        activationPosture: "active",
+        description: "Approved finance spend cube for governed preview and single-source execution.",
+        displayLabel: sourceLabel,
+        sourceId: "sap-approved-spend"
+      },
+      {
+        activationPosture: "paused",
+        description: "Historical archive is visible for posture review but not executable for preview.",
+        displayLabel: "Legacy finance archive",
+        sourceId: "legacy-finance-archive"
+      }
+    ]
+  };
+}
+
+function stubWorkflowFetch() {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = input.toString();
+
+    if (url.endsWith("/operator/workflow")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(workflowPayload())
+      });
+    }
+
+    return new Promise(() => {});
+  });
+}
+
 describe("HomePage", () => {
   beforeEach(() => {
     process.env.API_INTERNAL_BASE_URL = "http://127.0.0.1:8000";
     process.env.NEXT_PUBLIC_API_BASE_URL = "http://127.0.0.1:8000";
 
-    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+    vi.stubGlobal("fetch", stubWorkflowFetch());
   });
 
   afterEach(() => {
@@ -34,8 +79,54 @@ describe("HomePage", () => {
     expect(screen.queryByText(/awaiting analyst review/i)).not.toBeInTheDocument();
   });
 
+  it("renders source options from the live operator workflow payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [],
+                sources: [
+                  {
+                    activationPosture: "active",
+                    description: "Live source returned by the backend contract.",
+                    displayLabel: "ERP approved spend / live contract",
+                    sourceId: "erp-approved-spend"
+                  }
+                ]
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(
+      screen.getByRole("option", { name: "ERP approved spend / live contract" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /SAP spend cube/i })).not.toBeInTheDocument();
+  });
+
+  it("renders source-aware history rows from the live operator workflow payload", async () => {
+    render(await HomePage({}));
+
+    expect(screen.getByLabelText(/operator history/i)).toHaveTextContent("Approved vendor spend");
+    expect(screen.getByLabelText(/operator history/i)).toHaveTextContent(
+      "SAP spend cube / approved_vendor_spend"
+    );
+    expect(screen.getByLabelText(/operator history/i)).toHaveTextContent("previewed");
+  });
+
   it("renders the shell before the health probe completes", async () => {
-    const fetchMock = vi.fn(() => new Promise(() => {}));
+    const fetchMock = stubWorkflowFetch();
     vi.stubGlobal("fetch", fetchMock);
 
     render(await HomePage({}));
@@ -46,7 +137,7 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:8000/health", expect.any(Object));
     });
   });
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 import { QueryWorkflowShell, resolveWorkflowState } from "../components/query-workflow-shell";
 import { getAppConfig } from "../lib/config";
 import { DEFAULT_HEALTH_SNAPSHOT } from "../lib/health";
+import { getOperatorWorkflowSnapshot } from "../lib/operator-workflow";
 
 type SearchParamValue = string | string[] | undefined;
 
@@ -22,11 +23,13 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const question = readParam(params.question)?.trim() || "List the top 10 approved vendors by quarterly spend.";
   const sourceId = readParam(params.source_id)?.trim();
   const state = resolveWorkflowState(readParam(params.state));
+  const operatorWorkflow = await getOperatorWorkflowSnapshot(config.apiInternalBaseUrl);
 
   return (
     <QueryWorkflowShell
       apiUrl={config.publicApiBaseUrl}
       health={DEFAULT_HEALTH_SNAPSHOT}
+      operatorWorkflow={operatorWorkflow}
       question={question}
       sourceId={sourceId}
       state={state}

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -60,6 +60,11 @@ type ResolvedSourceBinding = {
   state: CanonicalWorkflowState;
 };
 
+type WorkflowHrefContext = {
+  historyItemType?: OperatorHistoryItem["itemType"];
+  historyRecordId?: string;
+};
+
 const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
   canceled: {
     description: "Execution started from a reviewed candidate but stopped before the run completed.",
@@ -198,7 +203,10 @@ function renderHistoryItem(item: OperatorHistoryItem) {
   return (
     <a
       className="history-item"
-      href={buildStateHref("query", item.label, item.sourceId)}
+      href={buildStateHref(historyItemToState(item), item.label, item.sourceId, {
+        historyItemType: item.itemType,
+        historyRecordId: item.recordId
+      })}
       key={`${item.itemType}:${item.recordId}`}
     >
       <span className="history-type">{item.itemType}</span>
@@ -207,6 +215,48 @@ function renderHistoryItem(item: OperatorHistoryItem) {
       <span>{item.lifecycleState}</span>
     </a>
   );
+}
+
+function historyItemToState(item: OperatorHistoryItem): CanonicalWorkflowState {
+  const lifecycleState = item.lifecycleState.toLowerCase();
+  const runState = item.runState?.toLowerCase();
+  const guardStatus = item.guardStatus?.toLowerCase();
+
+  if (item.itemType === "request" || item.itemType === "candidate") {
+    if (
+      lifecycleState === "review_denied" ||
+      lifecycleState === "blocked" ||
+      lifecycleState === "invalidated" ||
+      guardStatus === "blocked" ||
+      guardStatus === "invalidated"
+    ) {
+      return "review_denied";
+    }
+
+    return "preview";
+  }
+
+  if (runState === "completed" || lifecycleState === "completed") {
+    return "completed";
+  }
+
+  if (runState === "empty" || lifecycleState === "empty") {
+    return "empty";
+  }
+
+  if (runState === "execution_denied" || lifecycleState === "execution_denied") {
+    return "execution_denied";
+  }
+
+  if (runState === "failed" || lifecycleState === "failed") {
+    return "failed";
+  }
+
+  if (runState === "canceled" || lifecycleState === "canceled") {
+    return "canceled";
+  }
+
+  return "preview";
 }
 
 function getWorkflowDataStatusCopy(status: OperatorWorkflowSnapshot["status"]): string {
@@ -224,7 +274,8 @@ function getWorkflowDataStatusCopy(status: OperatorWorkflowSnapshot["status"]): 
 function buildStateHref(
   state: CanonicalWorkflowState,
   question: string,
-  sourceId?: string
+  sourceId?: string,
+  context?: WorkflowHrefContext
 ): string {
   const params = new URLSearchParams({
     question,
@@ -233,6 +284,11 @@ function buildStateHref(
 
   if (sourceId) {
     params.set("source_id", sourceId);
+  }
+
+  if (context?.historyItemType && context.historyRecordId) {
+    params.set("history_item_type", context.historyItemType);
+    params.set("history_record_id", context.historyRecordId);
   }
 
   return `/?${params.toString()}`;

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1,5 +1,10 @@
 import { HealthStatusCard } from "./health-status-card";
 import type { HealthSnapshot } from "../lib/health";
+import type {
+  OperatorHistoryItem,
+  OperatorWorkflowSnapshot,
+  SourceOption
+} from "../lib/operator-workflow";
 
 type WorkflowState =
   | "signin"
@@ -28,6 +33,7 @@ type CanonicalWorkflowState =
 type QueryWorkflowShellProps = {
   apiUrl: string;
   health: HealthSnapshot;
+  operatorWorkflow: OperatorWorkflowSnapshot;
   question: string;
   sourceId?: string;
   state: WorkflowState;
@@ -46,13 +52,6 @@ type WorkflowContext = {
   runIdentity?: string;
   runState?: string;
   sourceIdentity: string;
-};
-
-type SourceOption = {
-  activationPosture: "active" | "paused";
-  description: string;
-  displayLabel: string;
-  sourceId: string;
 };
 
 type ResolvedSourceBinding = {
@@ -117,21 +116,6 @@ const workflowStateOrder: CanonicalWorkflowState[] = [
   "canceled"
 ];
 
-const previewSourceOptions: SourceOption[] = [
-  {
-    activationPosture: "active",
-    description: "Approved finance spend cube for governed preview and single-source execution.",
-    displayLabel: "SAP spend cube / approved_vendor_spend",
-    sourceId: "sap-approved-spend"
-  },
-  {
-    activationPosture: "paused",
-    description: "Historical archive is visible for posture review but not executable for preview.",
-    displayLabel: "Legacy finance archive",
-    sourceId: "legacy-finance-archive"
-  }
-];
-
 export function resolveWorkflowState(value?: string): CanonicalWorkflowState {
   if (!value) {
     return "query";
@@ -148,15 +132,19 @@ export function resolveWorkflowState(value?: string): CanonicalWorkflowState {
   return "query";
 }
 
-function findSourceOption(sourceId?: string): SourceOption | undefined {
-  return previewSourceOptions.find((source) => source.sourceId === sourceId);
+function findSourceOption(
+  sourceOptions: SourceOption[],
+  sourceId?: string
+): SourceOption | undefined {
+  return sourceOptions.find((source) => source.sourceId === sourceId);
 }
 
 function resolveSourceBinding(
+  sourceOptions: SourceOption[],
   state: CanonicalWorkflowState,
   sourceId?: string
 ): ResolvedSourceBinding {
-  const source = findSourceOption(sourceId);
+  const source = findSourceOption(sourceOptions, sourceId);
 
   if (state === "signin") {
     return {
@@ -166,6 +154,13 @@ function resolveSourceBinding(
   }
 
   if (state === "query") {
+    if (sourceOptions.length === 0) {
+      return {
+        blockedReason: "Live source registry data is unavailable, so preview submission remains blocked.",
+        state: "query"
+      };
+    }
+
     if (sourceId && source?.activationPosture !== "active") {
       return {
         blockedReason: "Select an executable source before preview can be requested.",
@@ -197,6 +192,33 @@ function resolveSourceBinding(
     source,
     state
   };
+}
+
+function renderHistoryItem(item: OperatorHistoryItem) {
+  return (
+    <a
+      className="history-item"
+      href={buildStateHref("query", item.label, item.sourceId)}
+      key={`${item.itemType}:${item.recordId}`}
+    >
+      <span className="history-type">{item.itemType}</span>
+      <strong>{item.label}</strong>
+      <span>{item.sourceLabel}</span>
+      <span>{item.lifecycleState}</span>
+    </a>
+  );
+}
+
+function getWorkflowDataStatusCopy(status: OperatorWorkflowSnapshot["status"]): string {
+  if (status === "live") {
+    return "Source registry and history summary loaded from the backend workflow contract.";
+  }
+
+  if (status === "malformed") {
+    return "Backend workflow payload was malformed, so the source selector remains blocked.";
+  }
+
+  return "Backend workflow payload is unavailable, so the source selector remains blocked.";
 }
 
 function buildStateHref(
@@ -665,12 +687,13 @@ function renderStatePanel(
 export function QueryWorkflowShell({
   apiUrl,
   health,
+  operatorWorkflow,
   question,
   sourceId,
   state
 }: QueryWorkflowShellProps) {
   const requestedState = resolveWorkflowState(state);
-  const sourceBinding = resolveSourceBinding(requestedState, sourceId);
+  const sourceBinding = resolveSourceBinding(operatorWorkflow.sources, requestedState, sourceId);
   const normalizedState = sourceBinding.state;
   const sqlPreview = getSqlPreview(question);
   const activeState = workflowStates[normalizedState];
@@ -723,6 +746,37 @@ export function QueryWorkflowShell({
       </header>
 
       <section className="workspace-grid">
+        <aside className="history-column" aria-label="Operator history">
+          <section className="surface surface-secondary">
+            <div className="section-header">
+              <div>
+                <p className="eyebrow">History</p>
+                <h2 className="panel-title">Source-aware workflow history</h2>
+              </div>
+              <span
+                className={`surface-badge surface-badge-${
+                  operatorWorkflow.status === "live" ? "active" : "danger"
+                }`}
+              >
+                {operatorWorkflow.status}
+              </span>
+            </div>
+            <p className="section-copy">{getWorkflowDataStatusCopy(operatorWorkflow.status)}</p>
+            <div className="history-list">
+              {operatorWorkflow.history.length > 0 ? (
+                operatorWorkflow.history.map(renderHistoryItem)
+              ) : (
+                <div className="placeholder-block">
+                  <p className="placeholder-title">No live history rows</p>
+                  <p>
+                    The shell keeps history empty until the backend returns authoritative request,
+                    candidate, or run summaries.
+                  </p>
+                </div>
+              )}
+            </div>
+          </section>
+        </aside>
         <div className="primary-column">
           <section className="surface surface-primary">
             {renderStatePanel(normalizedState, question, boundSourceId)}
@@ -748,7 +802,7 @@ export function QueryWorkflowShell({
                   </label>
                   <select defaultValue={boundSourceId ?? ""} id="source_id" name="source_id" required>
                     <option value="">Select one source</option>
-                    {previewSourceOptions.map((source) => (
+                    {operatorWorkflow.sources.map((source) => (
                       <option
                         disabled={source.activationPosture !== "active"}
                         key={source.sourceId}

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -1,0 +1,153 @@
+export type SourceActivationPosture = "active" | "paused" | "blocked" | "retired";
+
+export type SourceOption = {
+  activationPosture: SourceActivationPosture;
+  description: string;
+  displayLabel: string;
+  sourceFamily?: string;
+  sourceFlavor?: string | null;
+  sourceId: string;
+};
+
+export type OperatorHistoryItem = {
+  guardStatus?: string | null;
+  itemType: "request" | "candidate" | "run";
+  label: string;
+  lifecycleState: string;
+  occurredAt: string;
+  recordId: string;
+  runState?: string | null;
+  sourceId: string;
+  sourceLabel: string;
+};
+
+export type OperatorWorkflowSnapshot = {
+  history: OperatorHistoryItem[];
+  sources: SourceOption[];
+  status: "live" | "unavailable" | "malformed";
+};
+
+type RawObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is RawObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isActivationPosture(value: unknown): value is SourceActivationPosture {
+  return value === "active" || value === "paused" || value === "blocked" || value === "retired";
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function parseSourceOption(value: unknown): SourceOption | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const sourceId = readOptionalString(value.sourceId);
+  const displayLabel = readOptionalString(value.displayLabel);
+  const description = readOptionalString(value.description);
+
+  if (!sourceId || !displayLabel || !description || !isActivationPosture(value.activationPosture)) {
+    return null;
+  }
+
+  return {
+    activationPosture: value.activationPosture,
+    description,
+    displayLabel,
+    sourceFamily: readOptionalString(value.sourceFamily),
+    sourceFlavor: readOptionalString(value.sourceFlavor) ?? null,
+    sourceId
+  };
+}
+
+function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const itemType = value.itemType;
+  const recordId = readOptionalString(value.recordId);
+  const label = readOptionalString(value.label);
+  const sourceId = readOptionalString(value.sourceId);
+  const sourceLabel = readOptionalString(value.sourceLabel);
+  const lifecycleState = readOptionalString(value.lifecycleState);
+  const occurredAt = readOptionalString(value.occurredAt);
+
+  if (
+    (itemType !== "request" && itemType !== "candidate" && itemType !== "run") ||
+    !recordId ||
+    !label ||
+    !sourceId ||
+    !sourceLabel ||
+    !lifecycleState ||
+    !occurredAt
+  ) {
+    return null;
+  }
+
+  return {
+    guardStatus: readOptionalString(value.guardStatus) ?? null,
+    itemType,
+    label,
+    lifecycleState,
+    occurredAt,
+    recordId,
+    runState: readOptionalString(value.runState) ?? null,
+    sourceId,
+    sourceLabel
+  };
+}
+
+function unavailableSnapshot(status: OperatorWorkflowSnapshot["status"]): OperatorWorkflowSnapshot {
+  return {
+    history: [],
+    sources: [],
+    status
+  };
+}
+
+function isParsedSourceOption(value: SourceOption | null): value is SourceOption {
+  return value !== null;
+}
+
+function isParsedHistoryItem(value: OperatorHistoryItem | null): value is OperatorHistoryItem {
+  return value !== null;
+}
+
+export async function getOperatorWorkflowSnapshot(
+  apiInternalBaseUrl: string
+): Promise<OperatorWorkflowSnapshot> {
+  try {
+    const response = await fetch(`${apiInternalBaseUrl}/operator/workflow`, {
+      cache: "no-store"
+    });
+
+    if (!response.ok) {
+      return unavailableSnapshot("unavailable");
+    }
+
+    const payload = (await response.json()) as unknown;
+    if (!isObject(payload) || !Array.isArray(payload.sources) || !Array.isArray(payload.history)) {
+      return unavailableSnapshot("malformed");
+    }
+
+    const sources = payload.sources.map(parseSourceOption);
+    const history = payload.history.map(parseHistoryItem);
+
+    if (!sources.every(isParsedSourceOption) || !history.every(isParsedHistoryItem)) {
+      return unavailableSnapshot("malformed");
+    }
+
+    return {
+      history,
+      sources,
+      status: "live"
+    };
+  } catch {
+    return unavailableSnapshot("unavailable");
+  }
+}

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -130,7 +130,13 @@ export async function getOperatorWorkflowSnapshot(
       return unavailableSnapshot("unavailable");
     }
 
-    const payload = (await response.json()) as unknown;
+    let payload: unknown;
+    try {
+      payload = (await response.json()) as unknown;
+    } catch {
+      return unavailableSnapshot("malformed");
+    }
+
     if (!isObject(payload) || !Array.isArray(payload.sources) || !Array.isArray(payload.history)) {
       return unavailableSnapshot("malformed");
     }


### PR DESCRIPTION
## Summary
- add a backend `GET /operator/workflow` snapshot that exposes registered source options without connection indirection or secrets
- fetch and validate that workflow snapshot in the Next.js shell, failing closed when the payload is unavailable or malformed
- render source selector options and left-rail history from backend-provided source-aware payloads instead of baked-in shell state

## Root Cause
The redesigned operator workflow shell still carried static frontend source and history data. That meant a backend-provided source-aware workflow payload could be ignored while the UI continued to render the baked-in SAP source option.

## Notes
The backend snapshot intentionally returns an empty history list until authoritative request, candidate, or run records exist. It does not derive operator history from source registry rows.

## Verification
- `npm test -- --run app/page.test.tsx`
- `python3 -m pytest tests/test_request_source_selection.py -q`
- `npm test`
- `API_INTERNAL_BASE_URL=http://127.0.0.1:8000 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 npm run build`
- `python3 -m pytest -q`
- `python3 scripts/ci/check_repository_hygiene.py`
- `git diff --check`
- path-literal scan excluding generated dependency/build folders

Closes #145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend exposes a live operator workflow snapshot used to populate source selection and activation status in the UI.
  * Added a workflow history sidebar showing processing status and lifecycle details with links to reopen workflow states.
* **UI / Style**
  * Workspace layout updated to include a left history column and refreshed form/control styling.
* **Tests**
  * New tests covering source selection, workflow retrieval, history rendering, and malformed payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->