### PR TITLE
Expose runtime controls through vertical slices

### DIFF
--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -136,7 +136,15 @@ class ExecutionConnectorExecutionError(PermissionError):
 
 
 class ExecutionRuntimeCancelledError(RuntimeError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        audit_events: list[SourceAwareAuditEvent] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.audit_events = list(audit_events or [])
+        self.audit_event = self.audit_events[-1] if self.audit_events else None
 
 
 def _source_flavor_matches(
@@ -166,6 +174,7 @@ def _build_execution_audit_event(
     candidate_source: SourceBoundCandidateMetadata,
     audit_context: ExecutionAuditContext | None,
     primary_deny_code: str | None = None,
+    candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
 ) -> SourceAwareAuditEvent | None:
@@ -205,7 +214,11 @@ def _build_execution_audit_event(
             if primary_deny_code is not None
             else None
         ),
-        candidate_state="denied" if primary_deny_code is not None else None,
+        candidate_state=(
+            candidate_state
+            if candidate_state is not None
+            else "denied" if primary_deny_code is not None else None
+        ),
         execution_row_count=execution_row_count,
         result_truncated=result_truncated,
     )
@@ -217,6 +230,7 @@ def _build_execution_audit_events(
     candidate_source: SourceBoundCandidateMetadata,
     audit_context: ExecutionAuditContext | None,
     primary_deny_code: str | None = None,
+    candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
 ) -> list[SourceAwareAuditEvent]:
@@ -235,6 +249,9 @@ def _build_execution_audit_events(
                 if event_type
                 in {"execution_denied", "request_rate_limited", "concurrency_rejected"}
                 else None
+            ),
+            candidate_state=(
+                candidate_state if event_type == "execution_failed" else None
             ),
             execution_row_count=(
                 execution_row_count if event_type == "execution_completed" else None
@@ -269,6 +286,25 @@ def _attach_execution_denial_audit_event(
             candidate_source=candidate_source,
             audit_context=audit_context,
             primary_deny_code=error.deny_code,
+        ),
+    )
+
+
+def _attach_cancellation_audit_event(
+    *,
+    error: ExecutionRuntimeCancelledError,
+    candidate_source: SourceBoundCandidateMetadata,
+    audit_context: ExecutionAuditContext | None,
+) -> ExecutionRuntimeCancelledError:
+    if error.audit_event is not None or audit_context is None:
+        return error
+    return ExecutionRuntimeCancelledError(
+        str(error),
+        audit_events=_build_execution_audit_events(
+            event_types=["execution_requested", "execution_failed"],
+            candidate_source=candidate_source,
+            audit_context=audit_context,
+            candidate_state="canceled",
         ),
     )
 
@@ -680,6 +716,12 @@ def execute_candidate_sql(
                     f"'{selection.connector_id}'."
                 ),
             )
+    except ExecutionRuntimeCancelledError as exc:
+        raise _attach_cancellation_audit_event(
+            error=exc,
+            candidate_source=candidate.source,
+            audit_context=audit_context,
+        ) from exc
     except (ExecutionConnectorExecutionError, ExecutionConnectorSelectionError) as exc:
         raise _attach_execution_denial_audit_event(
             error=exc,

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -11,9 +11,11 @@ from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent
 from app.features.auth.context import AuthenticatedSubject
 from app.features.execution import execute_candidate_sql, select_execution_connector
 from app.features.execution.runtime import (
+    CancellationProbe,
     ExecutableCandidateRecord,
     ExecutionAuditContext,
     ExecutionResult,
+    ExecutionRuntimeSafetyState,
     NonEmptyTrimmedString,
     QueryRunner,
 )
@@ -255,6 +257,8 @@ def run_mssql_core_vertical_slice(
     sql_generation_adapter: SQLGenerationAdapter,
     business_mssql_connection_string: NonEmptyTrimmedString,
     query_runner: QueryRunner | None = None,
+    cancellation_probe: CancellationProbe | None = None,
+    runtime_safety_state: ExecutionRuntimeSafetyState | None = None,
     audit_context: PreviewAuditContext,
     candidate_lifecycle: CandidateLifecycleRecord | None = None,
 ) -> MSSQLCoreVerticalSliceResult:
@@ -378,6 +382,8 @@ def run_mssql_core_vertical_slice(
         selection=selection,
         business_mssql_connection_string=normalized_business_mssql_connection_string,
         query_runner=query_runner,
+        cancellation_probe=cancellation_probe,
+        runtime_safety_state=runtime_safety_state,
         audit_context=_build_execution_audit_context(
             audit_context=audit_context,
             previous_event_id=audit_events[-1].event_id,

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -11,9 +11,11 @@ from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent
 from app.features.auth.context import AuthenticatedSubject
 from app.features.execution import execute_candidate_sql, select_execution_connector
 from app.features.execution.runtime import (
+    CancellationProbe,
     ExecutableCandidateRecord,
     ExecutionAuditContext,
     ExecutionResult,
+    ExecutionRuntimeSafetyState,
     NonEmptyTrimmedString,
     QueryRunner,
 )
@@ -269,6 +271,8 @@ def run_postgresql_core_vertical_slice(
     business_postgres_url: NonEmptyTrimmedString,
     application_postgres_url: NonEmptyTrimmedString,
     query_runner: QueryRunner | None = None,
+    cancellation_probe: CancellationProbe | None = None,
+    runtime_safety_state: ExecutionRuntimeSafetyState | None = None,
     audit_context: PreviewAuditContext,
     candidate_lifecycle: CandidateLifecycleRecord | None = None,
 ) -> PostgreSQLCoreVerticalSliceResult:
@@ -398,6 +402,8 @@ def run_postgresql_core_vertical_slice(
         business_postgres_url=normalized_business_postgres_url,
         application_postgres_url=normalized_application_postgres_url,
         query_runner=query_runner,
+        cancellation_probe=cancellation_probe,
+        runtime_safety_state=runtime_safety_state,
         audit_context=_build_execution_audit_context(
             audit_context=audit_context,
             previous_event_id=audit_events[-1].event_id,

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -33,16 +33,22 @@ from app.features.evaluation import (
 from app.features.execution import (
     ExecutionConnectorExecutionError,
     ExecutionConnectorSelectionError,
+    ExecutionRuntimeCancelledError,
     execute_candidate_sql,
     select_execution_connector,
 )
 from app.features.execution.connector_selection import ExecutionConnectorSelection
-from app.features.execution.runtime import ExecutableCandidateRecord
+from app.features.execution.runtime import (
+    ExecutableCandidateRecord,
+    ExecutionRuntimeSafetyState,
+)
 from app.features.guard import evaluate_mssql_sql_guard
 from app.features.guard.deny_taxonomy import (
     DENY_APPLICATION_POSTGRES_REUSE,
     DENY_APPROVAL_EXPIRED,
     DENY_POLICY_VERSION_STALE,
+    DENY_RUNTIME_KILL_SWITCH,
+    DENY_RUNTIME_RATE_LIMIT,
     DENY_SOURCE_BINDING_MISMATCH,
     DENY_UNSUPPORTED_SOURCE_BINDING,
 )
@@ -599,6 +605,128 @@ def test_mssql_core_vertical_slice_denies_guard_rejection_before_execution() -> 
     }.items() <= guard_event.items()
 
 
+def test_mssql_core_vertical_slice_applies_runtime_kill_switch_before_execution() -> None:
+    from app.services.mssql_vertical_slice import run_mssql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _mssql_scenarios_by_id()["mssql-positive-approved-vendor-spend-top-vendors"]
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            return scenario.expected.canonical_sql
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("MSSQL execution must not run after runtime denial")
+
+    with _session_scope() as session:
+        _seed_mssql_source(session, scenario=scenario)
+
+        with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
+            run_mssql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=RecordingAdapter(),
+                business_mssql_connection_string=MSSQL_TEST_CONNECTION_STRING,
+                query_runner=fake_query_runner,
+                runtime_safety_state=ExecutionRuntimeSafetyState(
+                    disabled_source_families=frozenset({"mssql"})
+                ),
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-141-runtime-denied",
+                    correlation_id="correlation-141-runtime-denied",
+                    user_subject="user:alice",
+                    session_id="session-141-runtime-denied",
+                    query_candidate_id="candidate-141-runtime-denied",
+                    candidate_owner_subject="user:alice",
+                    guard_version="mssql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+    assert exc_info.value.deny_code == DENY_RUNTIME_KILL_SWITCH
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "execution_requested",
+        "execution_denied",
+    ]
+    denial_event = exc_info.value.audit_event.model_dump(exclude_none=True)
+    assert {
+        "event_type": "execution_denied",
+        "source_id": scenario.source.source_id,
+        "source_family": "mssql",
+        "primary_deny_code": DENY_RUNTIME_KILL_SWITCH,
+        "denial_cause": "runtime_kill_switch",
+        "candidate_state": "denied",
+    }.items() <= denial_event.items()
+
+
+def test_mssql_core_vertical_slice_cancellation_probe_blocks_before_execution() -> None:
+    from app.services.mssql_vertical_slice import run_mssql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _mssql_scenarios_by_id()["mssql-positive-approved-vendor-spend-top-vendors"]
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            return scenario.expected.canonical_sql
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("MSSQL execution must not run after cancellation")
+
+    with _session_scope() as session:
+        _seed_mssql_source(session, scenario=scenario)
+
+        with pytest.raises(
+            ExecutionRuntimeCancelledError,
+            match=r"Execution canceled before the backend-owned query runner started\.",
+        ) as exc_info:
+            run_mssql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=RecordingAdapter(),
+                business_mssql_connection_string=MSSQL_TEST_CONNECTION_STRING,
+                query_runner=fake_query_runner,
+                cancellation_probe=lambda: True,
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-141-canceled",
+                    correlation_id="correlation-141-canceled",
+                    user_subject="user:alice",
+                    session_id="session-141-canceled",
+                    query_candidate_id="candidate-141-canceled",
+                    candidate_owner_subject="user:alice",
+                    guard_version="mssql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "execution_requested",
+        "execution_failed",
+    ]
+    canceled_event = exc_info.value.audit_event.model_dump(exclude_none=True)
+    assert {
+        "event_type": "execution_failed",
+        "source_id": scenario.source.source_id,
+        "source_family": "mssql",
+        "candidate_state": "canceled",
+    }.items() <= canceled_event.items()
+
+
 @pytest.mark.parametrize(
     "scenario_id",
     (
@@ -819,6 +947,134 @@ def test_postgresql_core_vertical_slice_denies_application_postgres_reuse_before
         "denial_cause": "application_postgresql_reuse",
         "candidate_state": "denied",
     }.items() <= denial_event.items()
+
+
+def test_postgresql_core_vertical_slice_applies_runtime_rate_limit_before_execution() -> None:
+    from app.services.postgresql_vertical_slice import run_postgresql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-positive-approved-vendor-spend-top-vendors"
+    ]
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            return scenario.expected.canonical_sql
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("PostgreSQL execution must not run after runtime denial")
+
+    with _session_scope() as session:
+        _seed_postgresql_source(session, scenario=scenario)
+
+        with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
+            run_postgresql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=RecordingAdapter(),
+                business_postgres_url=POSTGRESQL_TEST_URL,
+                application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+                query_runner=fake_query_runner,
+                runtime_safety_state=ExecutionRuntimeSafetyState(
+                    rate_limited_source_ids=frozenset({scenario.source.source_id})
+                ),
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-142-runtime-denied",
+                    correlation_id="correlation-142-runtime-denied",
+                    user_subject="user:alice",
+                    session_id="session-142-runtime-denied",
+                    query_candidate_id="candidate-142-runtime-denied",
+                    candidate_owner_subject="user:alice",
+                    guard_version="postgresql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+    assert exc_info.value.deny_code == DENY_RUNTIME_RATE_LIMIT
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "execution_requested",
+        "execution_denied",
+    ]
+    denial_event = exc_info.value.audit_event.model_dump(exclude_none=True)
+    assert {
+        "event_type": "execution_denied",
+        "source_id": scenario.source.source_id,
+        "source_family": "postgresql",
+        "primary_deny_code": DENY_RUNTIME_RATE_LIMIT,
+        "denial_cause": "runtime_rate_limit",
+        "candidate_state": "denied",
+    }.items() <= denial_event.items()
+
+
+def test_postgresql_core_vertical_slice_cancellation_probe_blocks_before_execution() -> None:
+    from app.services.postgresql_vertical_slice import run_postgresql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-positive-approved-vendor-spend-top-vendors"
+    ]
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            return scenario.expected.canonical_sql
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("PostgreSQL execution must not run after cancellation")
+
+    with _session_scope() as session:
+        _seed_postgresql_source(session, scenario=scenario)
+
+        with pytest.raises(
+            ExecutionRuntimeCancelledError,
+            match=r"Execution canceled before the backend-owned query runner started\.",
+        ) as exc_info:
+            run_postgresql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=RecordingAdapter(),
+                business_postgres_url=POSTGRESQL_TEST_URL,
+                application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+                query_runner=fake_query_runner,
+                cancellation_probe=lambda: True,
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-142-canceled",
+                    correlation_id="correlation-142-canceled",
+                    user_subject="user:alice",
+                    session_id="session-142-canceled",
+                    query_candidate_id="candidate-142-canceled",
+                    candidate_owner_subject="user:alice",
+                    guard_version="postgresql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+    assert [event.event_type for event in exc_info.value.audit_events] == [
+        "execution_requested",
+        "execution_failed",
+    ]
+    canceled_event = exc_info.value.audit_event.model_dump(exclude_none=True)
+    assert {
+        "event_type": "execution_failed",
+        "source_id": scenario.source.source_id,
+        "source_family": "postgresql",
+        "candidate_state": "canceled",
+    }.items() <= canceled_event.items()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Exposes cancellation probes and runtime safety state on both MSSQL and PostgreSQL core vertical slice services.
- Passes those controls into execute_candidate_sql so runtime kill switch, rate-limit, concurrency, and cancellation checks apply through the completed vertical slice path.
- Adds source-bound audit metadata to runtime cancellation errors and focused vertical-slice tests for runtime denial and cancellation.

## Verification
- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_execution_runtime_controls.py tests/test_source_bound_execute_path.py tests/test_operator_history_payloads.py -q

Closes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Execution cancellations now tracked with full audit event history.
  * Runtime safety controls (kill switches and rate limits) now properly enforced during query execution.
  * Enhanced audit trails capture execution lifecycle events including cancellation and denial reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->