### PR TITLE
[G-F3] Preserve replayed candidate owner in lifecycle denials

### DIFF
--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -236,6 +236,7 @@ def _build_default_candidate_lifecycle(
 def _build_candidate_lifecycle_audit_context(
     *,
     audit_context: PreviewAuditContext,
+    lifecycle_record: CandidateLifecycleRecord,
 ) -> CandidateLifecycleAuditContext:
     return CandidateLifecycleAuditContext(
         event_id=uuid4(),
@@ -245,7 +246,7 @@ def _build_candidate_lifecycle_audit_context(
         user_subject=audit_context.user_subject,
         session_id=audit_context.session_id,
         query_candidate_id=audit_context.query_candidate_id,
-        candidate_owner_subject=audit_context.candidate_owner_subject,
+        candidate_owner_subject=lifecycle_record.owner_subject_id,
     )
 
 
@@ -361,6 +362,7 @@ def run_mssql_core_vertical_slice(
             selected_source_id=candidate_source.source_id,
             audit_context=_build_candidate_lifecycle_audit_context(
                 audit_context=audit_context,
+                lifecycle_record=lifecycle_record,
             ),
         )
     except CandidateLifecycleRevalidationError as exc:

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -249,6 +249,7 @@ def _build_default_candidate_lifecycle(
 def _build_candidate_lifecycle_audit_context(
     *,
     audit_context: PreviewAuditContext,
+    lifecycle_record: CandidateLifecycleRecord,
 ) -> CandidateLifecycleAuditContext:
     return CandidateLifecycleAuditContext(
         event_id=uuid4(),
@@ -258,7 +259,7 @@ def _build_candidate_lifecycle_audit_context(
         user_subject=audit_context.user_subject,
         session_id=audit_context.session_id,
         query_candidate_id=audit_context.query_candidate_id,
-        candidate_owner_subject=audit_context.candidate_owner_subject,
+        candidate_owner_subject=lifecycle_record.owner_subject_id,
     )
 
 
@@ -380,6 +381,7 @@ def run_postgresql_core_vertical_slice(
             selected_source_id=candidate_source.source_id,
             audit_context=_build_candidate_lifecycle_audit_context(
                 audit_context=audit_context,
+                lifecycle_record=lifecycle_record,
             ),
         )
     except CandidateLifecycleRevalidationError as exc:

--- a/backend/tests/test_vertical_slice_lifecycle_revalidation.py
+++ b/backend/tests/test_vertical_slice_lifecycle_revalidation.py
@@ -291,7 +291,8 @@ def test_mssql_vertical_slice_denies_owner_mismatch_before_execution() -> None:
     assert exc_info.value.deny_code == DENY_SUBJECT_MISMATCH
     assert {
         "event_type": "execution_denied",
-        "candidate_owner_subject": "user:alice",
+        "user_subject": "user:alice",
+        "candidate_owner_subject": "user:bob",
         "source_id": "business-mssql-source",
         "primary_deny_code": DENY_SUBJECT_MISMATCH,
         "denial_cause": "subject_mismatch",
@@ -352,6 +353,57 @@ def test_postgresql_vertical_slice_denies_invalidated_candidate_before_execution
         "primary_deny_code": DENY_CANDIDATE_INVALIDATED,
         "denial_cause": "candidate_invalidated",
         "candidate_state": "invalidated",
+    }.items() <= denial.items()
+
+
+def test_postgresql_vertical_slice_denies_owner_mismatch_before_execution() -> None:
+    with _session_scope() as session:
+        _seed_source(
+            session,
+            source_id="business-postgres-source",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            contract_version=4,
+            snapshot_version=9,
+            schema_name="finance",
+        )
+
+        with pytest.raises(PostgreSQLVerticalSliceDenied) as exc_info:
+            run_postgresql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question="Show approved vendors.",
+                    source_id="business-postgres-source",
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=_PostgreSQLAdapter(),
+                business_postgres_url=POSTGRESQL_TEST_URL,
+                application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+                query_runner=_unexpected_query_runner,
+                audit_context=_audit_context(prefix="postgres-owner"),
+                candidate_lifecycle=_candidate(
+                    source_id="business-postgres-source",
+                    source_family="postgresql",
+                    source_flavor="warehouse",
+                    contract_version=4,
+                    snapshot_version=9,
+                    execution_policy_version=3,
+                    owner_subject_id="user:bob",
+                ),
+            )
+
+    denial = exc_info.value.audit_events[-1].model_dump(exclude_none=True)
+    assert exc_info.value.deny_code == DENY_SUBJECT_MISMATCH
+    assert {
+        "event_type": "execution_denied",
+        "user_subject": "user:alice",
+        "candidate_owner_subject": "user:bob",
+        "source_id": "business-postgres-source",
+        "primary_deny_code": DENY_SUBJECT_MISMATCH,
+        "denial_cause": "subject_mismatch",
     }.items() <= denial.items()
 
 


### PR DESCRIPTION
## Summary
- Preserve the replayed candidate owner in MSSQL and PostgreSQL lifecycle revalidation audit contexts.
- Tighten MSSQL owner-mismatch coverage and add PostgreSQL owner-mismatch coverage so denial events distinguish authenticated executor from candidate owner.

## Verification
- cd backend && python3 -m pytest tests/test_vertical_slice_lifecycle_revalidation.py tests/test_evaluation_harness.py -q

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audit event tracking in lifecycle revalidation to correctly record candidate owner information in both MSSQL and PostgreSQL systems.
  * Improved enforcement of owner-subject mismatch validation with proper denial audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->