### PR TITLE
Make retrieval corpus source-aware and governed

### DIFF
--- a/backend/alembic/versions/0005_retrieval_corpus_scaffold.py
+++ b/backend/alembic/versions/0005_retrieval_corpus_scaffold.py
@@ -1,0 +1,106 @@
+"""Add source-aware retrieval corpus assets.
+
+This revision adds application-owned retrieval corpus records. The records are
+bound to one registered source, one active dataset contract version, and one
+schema snapshot version so governed search can return advisory context without
+becoming SQL execution authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_retrieval_corpus_scaffold"
+down_revision: str | None = "0004_schema_snapshot_linkage"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+retrieval_corpus_asset_kind = sa.Enum(
+    "glossary_term",
+    "metric_definition",
+    "question_exemplar",
+    "analytic_playbook",
+    "schema_context",
+    name="retrieval_corpus_asset_kind",
+    native_enum=False,
+    create_constraint=True,
+)
+
+retrieval_corpus_asset_status = sa.Enum(
+    "approved",
+    "withdrawn",
+    name="retrieval_corpus_asset_status",
+    native_enum=False,
+    create_constraint=True,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "retrieval_corpus_assets",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("asset_id", sa.String(length=255), nullable=False),
+        sa.Column("registered_source_id", sa.Uuid(), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("source_family", sa.String(length=64), nullable=False),
+        sa.Column("source_flavor", sa.String(length=64), nullable=True),
+        sa.Column("dataset_contract_id", sa.Uuid(), nullable=False),
+        sa.Column("dataset_contract_version", sa.Integer(), nullable=False),
+        sa.Column("schema_snapshot_id", sa.Uuid(), nullable=False),
+        sa.Column("schema_snapshot_version", sa.Integer(), nullable=False),
+        sa.Column("asset_kind", retrieval_corpus_asset_kind, nullable=False),
+        sa.Column(
+            "status",
+            retrieval_corpus_asset_status,
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("citation_label", sa.String(length=255), nullable=False),
+        sa.Column("owner_binding", sa.String(length=255), nullable=False),
+        sa.Column("visibility_binding", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["registered_source_id"],
+            ["registered_sources.id"],
+            name=op.f("fk_retrieval_corpus_assets_registered_source_id_registered_sources"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["dataset_contract_id"],
+            ["dataset_contracts.id"],
+            name=op.f("fk_retrieval_corpus_assets_dataset_contract_id_dataset_contracts"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["schema_snapshot_id"],
+            ["schema_snapshots.id"],
+            name=op.f("fk_retrieval_corpus_assets_schema_snapshot_id_schema_snapshots"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_retrieval_corpus_assets")),
+        sa.UniqueConstraint(
+            "asset_id",
+            name=op.f("uq_retrieval_corpus_assets_asset_id"),
+        ),
+        sa.UniqueConstraint(
+            "registered_source_id",
+            "asset_id",
+            name=op.f("uq_retrieval_corpus_assets_registered_source_id"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("retrieval_corpus_assets")

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,4 +1,5 @@
 from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
+from app.db.models.retrieval_corpus import RetrievalCorpusAsset
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
 
@@ -6,5 +7,6 @@ __all__ = [
     "DatasetContract",
     "DatasetContractDataset",
     "RegisteredSource",
+    "RetrievalCorpusAsset",
     "SchemaSnapshot",
 ]

--- a/backend/app/db/models/retrieval_corpus.py
+++ b/backend/app/db/models/retrieval_corpus.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import (
+    DateTime,
+    Enum as SqlEnum,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy import Uuid as SqlAlchemyUuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class RetrievalCorpusAssetKind(str, Enum):
+    GLOSSARY_TERM = "glossary_term"
+    METRIC_DEFINITION = "metric_definition"
+    QUESTION_EXEMPLAR = "question_exemplar"
+    ANALYTIC_PLAYBOOK = "analytic_playbook"
+    SCHEMA_CONTEXT = "schema_context"
+
+
+class RetrievalCorpusAssetStatus(str, Enum):
+    APPROVED = "approved"
+    WITHDRAWN = "withdrawn"
+
+
+class RetrievalCorpusAsset(Base):
+    __tablename__ = "retrieval_corpus_assets"
+    __table_args__ = (
+        UniqueConstraint("asset_id"),
+        UniqueConstraint("registered_source_id", "asset_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    asset_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    registered_source_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("registered_sources.id"),
+        nullable=False,
+    )
+    source_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_family: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    dataset_contract_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("dataset_contracts.id"),
+        nullable=False,
+    )
+    dataset_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    schema_snapshot_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("schema_snapshots.id"),
+        nullable=False,
+    )
+    schema_snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    asset_kind: Mapped[RetrievalCorpusAssetKind] = mapped_column(
+        SqlEnum(
+            RetrievalCorpusAssetKind,
+            name="retrieval_corpus_asset_kind",
+            native_enum=False,
+            create_constraint=True,
+            validate_strings=True,
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
+        nullable=False,
+    )
+    status: Mapped[RetrievalCorpusAssetStatus] = mapped_column(
+        SqlEnum(
+            RetrievalCorpusAssetStatus,
+            name="retrieval_corpus_asset_status",
+            native_enum=False,
+            create_constraint=True,
+            validate_strings=True,
+            values_callable=lambda enum_cls: [member.value for member in enum_cls],
+        ),
+        nullable=False,
+        default=RetrievalCorpusAssetStatus.APPROVED,
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    citation_label: Mapped[str] = mapped_column(String(255), nullable=False)
+    owner_binding: Mapped[str] = mapped_column(String(255), nullable=False)
+    visibility_binding: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/services/retrieval_corpus.py
+++ b/backend/app/services/retrieval_corpus.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, StringConstraints
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from typing_extensions import Annotated
+
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.retrieval_corpus import (
+    RetrievalCorpusAsset,
+    RetrievalCorpusAssetStatus,
+)
+from app.db.models.schema_snapshot import SchemaSnapshot
+from app.db.models.source_registry import RegisteredSource
+from app.features.auth.context import AuthenticatedSubject
+from app.services.source_entitlements import (
+    SourceEntitlementError,
+    ensure_subject_is_entitled_for_source,
+)
+from app.services.source_governance import (
+    SourceGovernanceResolutionError,
+    resolve_authoritative_source_governance,
+)
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class RetrievedAssetSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: NonEmptyTrimmedString
+    source_family: NonEmptyTrimmedString
+    source_flavor: Optional[NonEmptyTrimmedString] = None
+    dataset_contract_version: int
+    schema_snapshot_version: int
+
+
+class RetrievedCorpusAsset(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asset_id: NonEmptyTrimmedString
+    asset_kind: NonEmptyTrimmedString
+    title: NonEmptyTrimmedString
+    body: NonEmptyTrimmedString
+    citation_label: NonEmptyTrimmedString
+    source: RetrievedAssetSource
+    authority: Literal["advisory_context"] = "advisory_context"
+    can_authorize_execution: Literal[False] = False
+
+
+class RetrievalCorpusAuditHook(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    corpus_version: NonEmptyTrimmedString
+    retrieved_asset_ids: list[NonEmptyTrimmedString]
+
+
+class GovernedRetrievalResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    query_text: NonEmptyTrimmedString
+    assets: list[RetrievedCorpusAsset]
+    audit: RetrievalCorpusAuditHook
+
+
+class RetrievalCorpusGovernanceError(ValueError):
+    """Raised when retrieval cannot be governed by source-scoped authority."""
+
+
+def _normalized_binding(binding: str | None) -> str | None:
+    if binding is None:
+        return None
+    normalized = binding.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _asset_matches_authoritative_source(
+    asset: RetrievalCorpusAsset,
+    source: RegisteredSource,
+    dataset_contract: DatasetContract,
+    schema_snapshot: SchemaSnapshot,
+) -> bool:
+    return (
+        asset.registered_source_id == source.id
+        and asset.source_id == source.source_id
+        and asset.source_family == source.source_family
+        and asset.source_flavor == source.source_flavor
+        and asset.dataset_contract_id == dataset_contract.id
+        and asset.dataset_contract_version == dataset_contract.contract_version
+        and asset.schema_snapshot_id == schema_snapshot.id
+        and asset.schema_snapshot_version == schema_snapshot.snapshot_version
+        and _normalized_binding(asset.owner_binding)
+        == _normalized_binding(dataset_contract.owner_binding)
+    )
+
+
+def _subject_can_see_asset(
+    subject: AuthenticatedSubject,
+    asset: RetrievalCorpusAsset,
+) -> bool:
+    subject_bindings = subject.normalized_governance_bindings()
+    visibility_binding = _normalized_binding(asset.visibility_binding)
+    owner_binding = _normalized_binding(asset.owner_binding)
+    if visibility_binding is None or owner_binding is None:
+        return False
+    return visibility_binding in subject_bindings
+
+
+def _to_retrieved_asset(asset: RetrievalCorpusAsset) -> RetrievedCorpusAsset:
+    return RetrievedCorpusAsset(
+        asset_id=asset.asset_id,
+        asset_kind=asset.asset_kind.value,
+        title=asset.title,
+        body=asset.body,
+        citation_label=asset.citation_label,
+        source=RetrievedAssetSource(
+            source_id=asset.source_id,
+            source_family=asset.source_family,
+            source_flavor=asset.source_flavor,
+            dataset_contract_version=asset.dataset_contract_version,
+            schema_snapshot_version=asset.schema_snapshot_version,
+        ),
+    )
+
+
+def _load_governed_source(
+    *,
+    session: Session,
+    source_id: str,
+    authenticated_subject: AuthenticatedSubject,
+) -> tuple[RegisteredSource, DatasetContract, SchemaSnapshot]:
+    try:
+        source, dataset_contract, schema_snapshot = resolve_authoritative_source_governance(
+            session,
+            source_id=source_id,
+        )
+        ensure_subject_is_entitled_for_source(
+            authenticated_subject,
+            source,
+            dataset_contract,
+        )
+    except (SourceGovernanceResolutionError, SourceEntitlementError) as exc:
+        raise RetrievalCorpusGovernanceError(str(exc)) from exc
+    return source, dataset_contract, schema_snapshot
+
+
+def retrieve_governed_corpus_assets(
+    *,
+    query_text: str,
+    authenticated_subject: AuthenticatedSubject,
+    session: Session,
+    source_id: str | None = None,
+) -> GovernedRetrievalResult:
+    normalized_query = query_text.strip()
+    if not normalized_query:
+        raise RetrievalCorpusGovernanceError("Retrieval query text is required.")
+
+    statement = (
+        select(RetrievalCorpusAsset)
+        .where(RetrievalCorpusAsset.status == RetrievalCorpusAssetStatus.APPROVED)
+        .order_by(RetrievalCorpusAsset.asset_id.asc())
+    )
+
+    governed_sources: dict[str, tuple[RegisteredSource, DatasetContract, SchemaSnapshot]] = {}
+    if source_id is not None:
+        normalized_source_id = source_id.strip()
+        if not normalized_source_id:
+            raise RetrievalCorpusGovernanceError("Retrieval source_id is required when provided.")
+        governed_sources[normalized_source_id] = _load_governed_source(
+            session=session,
+            source_id=normalized_source_id,
+            authenticated_subject=authenticated_subject,
+        )
+        statement = statement.where(RetrievalCorpusAsset.source_id == normalized_source_id)
+
+    retrieved_assets: list[RetrievedCorpusAsset] = []
+    for asset in session.execute(statement).scalars():
+        if asset.source_id not in governed_sources:
+            try:
+                governed_sources[asset.source_id] = _load_governed_source(
+                    session=session,
+                    source_id=asset.source_id,
+                    authenticated_subject=authenticated_subject,
+                )
+            except RetrievalCorpusGovernanceError:
+                continue
+
+        source, dataset_contract, schema_snapshot = governed_sources[asset.source_id]
+        if not _asset_matches_authoritative_source(
+            asset,
+            source,
+            dataset_contract,
+            schema_snapshot,
+        ):
+            continue
+        if not _subject_can_see_asset(authenticated_subject, asset):
+            continue
+        retrieved_assets.append(_to_retrieved_asset(asset))
+
+    retrieved_asset_ids = [asset.asset_id for asset in retrieved_assets]
+    return GovernedRetrievalResult(
+        query_text=normalized_query,
+        assets=retrieved_assets,
+        audit=RetrievalCorpusAuditHook(
+            corpus_version="source-aware-v1",
+            retrieved_asset_ids=retrieved_asset_ids,
+        ),
+    )

--- a/backend/tests/test_retrieval_corpus_governance.py
+++ b/backend/tests/test_retrieval_corpus_governance.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.retrieval_corpus import (
+    RetrievalCorpusAsset,
+    RetrievalCorpusAssetKind,
+)
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.services.retrieval_corpus import (
+    RetrievalCorpusGovernanceError,
+    retrieve_governed_corpus_assets,
+)
+
+
+@contextmanager
+def _session_scope() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def _seed_source(
+    session: Session,
+    *,
+    source_id: str,
+    source_family: str,
+    source_flavor: str,
+    owner_binding: str,
+    contract_version: int,
+    snapshot_version: int,
+) -> tuple[RegisteredSource, DatasetContract, SchemaSnapshot]:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id=source_id,
+        display_label=f"{source_id} display",
+        source_family=source_family,
+        source_flavor=source_flavor,
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{source_id}",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=snapshot_version,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=contract_version,
+        display_name=f"{source_id} contract",
+        owner_binding=owner_binding,
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.flush()
+    return source, contract, snapshot
+
+
+def _seed_asset(
+    session: Session,
+    *,
+    asset_id: str,
+    source: RegisteredSource,
+    contract: DatasetContract,
+    snapshot: SchemaSnapshot,
+    visibility_binding: str,
+    text: str,
+) -> RetrievalCorpusAsset:
+    asset = RetrievalCorpusAsset(
+        id=uuid4(),
+        asset_id=asset_id,
+        registered_source_id=source.id,
+        source_id=source.source_id,
+        source_family=source.source_family,
+        source_flavor=source.source_flavor,
+        dataset_contract_id=contract.id,
+        dataset_contract_version=contract.contract_version,
+        schema_snapshot_id=snapshot.id,
+        schema_snapshot_version=snapshot.snapshot_version,
+        asset_kind=RetrievalCorpusAssetKind.METRIC_DEFINITION,
+        title=f"{source.source_id} metric",
+        body=text,
+        citation_label=f"{source.source_id} metric definition",
+        owner_binding=contract.owner_binding,
+        visibility_binding=visibility_binding,
+    )
+    session.add(asset)
+    return asset
+
+
+def test_retrieval_corpus_assets_are_source_labeled_filtered_and_advisory_only() -> None:
+    with _session_scope() as session:
+        mssql_source, mssql_contract, mssql_snapshot = _seed_source(
+            session,
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver-2022",
+            owner_binding="group:finance-analysts",
+            contract_version=7,
+            snapshot_version=3,
+        )
+        postgres_source, postgres_contract, postgres_snapshot = _seed_source(
+            session,
+            source_id="business-postgres-source",
+            source_family="postgresql",
+            source_flavor="postgresql-16",
+            owner_binding="group:people-ops",
+            contract_version=2,
+            snapshot_version=5,
+        )
+        _seed_asset(
+            session,
+            asset_id="asset_finance_margin",
+            source=mssql_source,
+            contract=mssql_contract,
+            snapshot=mssql_snapshot,
+            visibility_binding="group:finance-analysts",
+            text="Gross margin uses net revenue minus cost of goods sold.",
+        )
+        _seed_asset(
+            session,
+            asset_id="asset_people_headcount",
+            source=postgres_source,
+            contract=postgres_contract,
+            snapshot=postgres_snapshot,
+            visibility_binding="group:people-ops",
+            text="Headcount is measured from the active employee roster.",
+        )
+        session.commit()
+
+        retrieved = retrieve_governed_corpus_assets(
+            query_text="show gross margin by quarter",
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session=session,
+            source_id="business-mssql-source",
+        )
+
+    assert [asset.asset_id for asset in retrieved.assets] == ["asset_finance_margin"]
+    assert retrieved.audit.retrieved_asset_ids == ["asset_finance_margin"]
+    assert retrieved.assets[0].source.model_dump() == {
+        "source_id": "business-mssql-source",
+        "source_family": "mssql",
+        "source_flavor": "sqlserver-2022",
+        "dataset_contract_version": 7,
+        "schema_snapshot_version": 3,
+    }
+    assert retrieved.assets[0].authority == "advisory_context"
+    assert retrieved.assets[0].can_authorize_execution is False
+    assert "asset_people_headcount" not in str(retrieved.model_dump())
+
+
+def test_retrieval_corpus_rejects_explicit_source_without_entitlement() -> None:
+    with _session_scope() as session:
+        postgres_source, postgres_contract, postgres_snapshot = _seed_source(
+            session,
+            source_id="business-postgres-source",
+            source_family="postgresql",
+            source_flavor="postgresql-16",
+            owner_binding="group:people-ops",
+            contract_version=2,
+            snapshot_version=5,
+        )
+        _seed_asset(
+            session,
+            asset_id="asset_people_headcount",
+            source=postgres_source,
+            contract=postgres_contract,
+            snapshot=postgres_snapshot,
+            visibility_binding="group:people-ops",
+            text="Headcount is measured from the active employee roster.",
+        )
+        session.commit()
+
+        with pytest.raises(
+            RetrievalCorpusGovernanceError,
+            match=(
+                "Authenticated subject 'user:alice' is not entitled to use "
+                "registered source 'business-postgres-source'"
+            ),
+        ):
+            retrieve_governed_corpus_assets(
+                query_text="show headcount",
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                source_id="business-postgres-source",
+            )


### PR DESCRIPTION
## Summary
- add source-aware retrieval corpus asset persistence and migration scaffold
- add governed retrieval service that resolves authoritative source governance and subject entitlement before returning approved assets
- return retrieval results as advisory-only context with audit asset IDs

## Tests
- cd backend && python3 -m pytest tests/test_retrieval_corpus_governance.py -q
- cd backend && python3 -m pytest -q

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retrieve curated assets from the retrieval corpus with integrated governance enforcement.
  * Asset access is validated through approval workflows, visibility controls, and entitlement verification.
  * Assets can be filtered by source for targeted queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->