### PR TITLE
[H-2] Add source-labeled retrieval citations

### DIFF
--- a/backend/alembic/versions/0005_retrieval_corpus_scaffold.py
+++ b/backend/alembic/versions/0005_retrieval_corpus_scaffold.py
@@ -91,10 +91,6 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_retrieval_corpus_assets")),
         sa.UniqueConstraint(
-            "asset_id",
-            name=op.f("uq_retrieval_corpus_assets_asset_id"),
-        ),
-        sa.UniqueConstraint(
             "registered_source_id",
             "asset_id",
             name=op.f("uq_retrieval_corpus_assets_registered_source_id"),

--- a/backend/app/db/models/retrieval_corpus.py
+++ b/backend/app/db/models/retrieval_corpus.py
@@ -37,7 +37,6 @@ class RetrievalCorpusAssetStatus(str, Enum):
 class RetrievalCorpusAsset(Base):
     __tablename__ = "retrieval_corpus_assets"
     __table_args__ = (
-        UniqueConstraint("asset_id"),
         UniqueConstraint("registered_source_id", "asset_id"),
     )
 

--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -48,6 +48,21 @@ AuditEventType = Literal[
 SourceFamily = Literal["mssql", "postgresql"]
 
 
+class RetrievalCitationAuditPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asset_id: NonEmptyTrimmedString
+    asset_kind: NonEmptyTrimmedString
+    citation_label: NonEmptyTrimmedString
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
+    authority: Literal["advisory_context"] = "advisory_context"
+    can_authorize_execution: Literal[False] = False
+
+
 class SourceAwareAuditEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -67,6 +82,7 @@ class SourceAwareAuditEvent(BaseModel):
     application_version: Optional[NonEmptyTrimmedString] = None
     retrieval_corpus_version: Optional[NonEmptyTrimmedString] = None
     retrieved_asset_ids: Optional[list[NonEmptyTrimmedString]] = None
+    retrieved_citations: Optional[list[RetrievalCitationAuditPayload]] = None
     analyst_mode_version: Optional[NonEmptyTrimmedString] = None
 
     source_id: SourceIdentifier

--- a/backend/app/services/retrieval_corpus.py
+++ b/backend/app/services/retrieval_corpus.py
@@ -51,11 +51,27 @@ class RetrievedCorpusAsset(BaseModel):
     can_authorize_execution: Literal[False] = False
 
 
+class RetrievalCitation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asset_id: NonEmptyTrimmedString
+    asset_kind: NonEmptyTrimmedString
+    citation_label: NonEmptyTrimmedString
+    source_id: NonEmptyTrimmedString
+    source_family: NonEmptyTrimmedString
+    source_flavor: Optional[NonEmptyTrimmedString] = None
+    dataset_contract_version: int
+    schema_snapshot_version: int
+    authority: Literal["advisory_context"] = "advisory_context"
+    can_authorize_execution: Literal[False] = False
+
+
 class RetrievalCorpusAuditHook(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     corpus_version: NonEmptyTrimmedString
     retrieved_asset_ids: list[NonEmptyTrimmedString]
+    citations: list[RetrievalCitation]
 
 
 class GovernedRetrievalResult(BaseModel):
@@ -128,6 +144,21 @@ def _to_retrieved_asset(asset: RetrievalCorpusAsset) -> RetrievedCorpusAsset:
     )
 
 
+def _to_retrieval_citation(asset: RetrievedCorpusAsset) -> RetrievalCitation:
+    return RetrievalCitation(
+        asset_id=asset.asset_id,
+        asset_kind=asset.asset_kind,
+        citation_label=asset.citation_label,
+        source_id=asset.source.source_id,
+        source_family=asset.source.source_family,
+        source_flavor=asset.source.source_flavor,
+        dataset_contract_version=asset.source.dataset_contract_version,
+        schema_snapshot_version=asset.source.schema_snapshot_version,
+        authority=asset.authority,
+        can_authorize_execution=asset.can_authorize_execution,
+    )
+
+
 def _load_governed_source(
     *,
     session: Session,
@@ -163,7 +194,7 @@ def retrieve_governed_corpus_assets(
     statement = (
         select(RetrievalCorpusAsset)
         .where(RetrievalCorpusAsset.status == RetrievalCorpusAssetStatus.APPROVED)
-        .order_by(RetrievalCorpusAsset.asset_id.asc())
+        .order_by(RetrievalCorpusAsset.source_id.asc(), RetrievalCorpusAsset.asset_id.asc())
     )
 
     governed_sources: dict[str, tuple[RegisteredSource, DatasetContract, SchemaSnapshot]] = {}
@@ -203,11 +234,13 @@ def retrieve_governed_corpus_assets(
         retrieved_assets.append(_to_retrieved_asset(asset))
 
     retrieved_asset_ids = [asset.asset_id for asset in retrieved_assets]
+    citations = [_to_retrieval_citation(asset) for asset in retrieved_assets]
     return GovernedRetrievalResult(
         query_text=normalized_query,
         assets=retrieved_assets,
         audit=RetrievalCorpusAuditHook(
             corpus_version="source-aware-v1",
             retrieved_asset_ids=retrieved_asset_ids,
+            citations=citations,
         ),
     )

--- a/backend/app/services/retrieval_corpus.py
+++ b/backend/app/services/retrieval_corpus.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from pydantic import BaseModel, ConfigDict, PositiveInt, StringConstraints
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing_extensions import Annotated
@@ -14,6 +14,7 @@ from app.db.models.retrieval_corpus import (
 )
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
+from app.features.audit.event_model import SourceFamily, SourceFlavor, SourceIdentifier
 from app.features.auth.context import AuthenticatedSubject
 from app.services.source_entitlements import (
     SourceEntitlementError,
@@ -57,11 +58,11 @@ class RetrievalCitation(BaseModel):
     asset_id: NonEmptyTrimmedString
     asset_kind: NonEmptyTrimmedString
     citation_label: NonEmptyTrimmedString
-    source_id: NonEmptyTrimmedString
-    source_family: NonEmptyTrimmedString
-    source_flavor: Optional[NonEmptyTrimmedString] = None
-    dataset_contract_version: int
-    schema_snapshot_version: int
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
     authority: Literal["advisory_context"] = "advisory_context"
     can_authorize_execution: Literal[False] = False
 

--- a/backend/tests/test_audit_event_model.py
+++ b/backend/tests/test_audit_event_model.py
@@ -97,3 +97,70 @@ def test_source_aware_audit_event_rejects_missing_required_source_metadata(
 
     with pytest.raises(ValidationError):
         SourceAwareAuditEvent(**payload)
+
+
+def test_retrieval_completed_audit_event_preserves_source_labeled_citations() -> None:
+    payload = _source_aware_payload()
+    payload.update(
+        {
+            "event_type": "retrieval_completed",
+            "retrieval_corpus_version": "source-aware-v1",
+            "retrieved_asset_ids": ["metric_definition", "metric_definition"],
+            "retrieved_citations": [
+                {
+                    "asset_id": "metric_definition",
+                    "asset_kind": "metric_definition",
+                    "citation_label": "business-mssql-source metric definition",
+                    "source_id": "business-mssql-source",
+                    "source_family": "mssql",
+                    "source_flavor": "sqlserver-2022",
+                    "dataset_contract_version": 7,
+                    "schema_snapshot_version": 3,
+                    "authority": "advisory_context",
+                    "can_authorize_execution": False,
+                },
+                {
+                    "asset_id": "metric_definition",
+                    "asset_kind": "metric_definition",
+                    "citation_label": "business-postgres-source metric definition",
+                    "source_id": "business-postgres-source",
+                    "source_family": "postgresql",
+                    "source_flavor": "postgresql-16",
+                    "dataset_contract_version": 2,
+                    "schema_snapshot_version": 5,
+                    "authority": "advisory_context",
+                    "can_authorize_execution": False,
+                },
+            ],
+        }
+    )
+
+    event = SourceAwareAuditEvent(**payload)
+
+    assert event.model_dump()["retrieved_citations"] == payload["retrieved_citations"]
+
+
+def test_retrieval_citation_audit_payload_rejects_execution_authority() -> None:
+    payload = _source_aware_payload()
+    payload.update(
+        {
+            "event_type": "retrieval_completed",
+            "retrieved_citations": [
+                {
+                    "asset_id": "metric_definition",
+                    "asset_kind": "metric_definition",
+                    "citation_label": "business-mssql-source metric definition",
+                    "source_id": "business-mssql-source",
+                    "source_family": "mssql",
+                    "source_flavor": "sqlserver-2022",
+                    "dataset_contract_version": 7,
+                    "schema_snapshot_version": 3,
+                    "authority": "execution_evidence",
+                    "can_authorize_execution": True,
+                },
+            ],
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        SourceAwareAuditEvent(**payload)

--- a/backend/tests/test_audit_event_model.py
+++ b/backend/tests/test_audit_event_model.py
@@ -140,7 +140,17 @@ def test_retrieval_completed_audit_event_preserves_source_labeled_citations() ->
     assert event.model_dump()["retrieved_citations"] == payload["retrieved_citations"]
 
 
-def test_retrieval_citation_audit_payload_rejects_execution_authority() -> None:
+@pytest.mark.parametrize(
+    ("authority", "can_authorize_execution"),
+    [
+        ("execution_evidence", False),
+        ("advisory_context", True),
+    ],
+)
+def test_retrieval_citation_audit_payload_rejects_execution_authority(
+    authority: str,
+    can_authorize_execution: bool,
+) -> None:
     payload = _source_aware_payload()
     payload.update(
         {
@@ -155,8 +165,8 @@ def test_retrieval_citation_audit_payload_rejects_execution_authority() -> None:
                     "source_flavor": "sqlserver-2022",
                     "dataset_contract_version": 7,
                     "schema_snapshot_version": 3,
-                    "authority": "execution_evidence",
-                    "can_authorize_execution": True,
+                    "authority": authority,
+                    "can_authorize_execution": can_authorize_execution,
                 },
             ],
         }

--- a/backend/tests/test_retrieval_corpus_governance.py
+++ b/backend/tests/test_retrieval_corpus_governance.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import UniqueConstraint
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -21,6 +22,7 @@ from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewSt
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
 from app.services.retrieval_corpus import (
+    RetrievalCitation,
     RetrievalCorpusGovernanceError,
     retrieve_governed_corpus_assets,
 )
@@ -216,6 +218,36 @@ def test_retrieval_citations_preserve_source_scope_when_asset_ids_match() -> Non
             "can_authorize_execution": False,
         },
     ]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_id", "business/postgres/source"),
+        ("source_family", "mysql"),
+        ("source_flavor", "postgresql 16"),
+        ("dataset_contract_version", 0),
+        ("schema_snapshot_version", -1),
+    ],
+)
+def test_retrieval_citation_rejects_audit_incompatible_source_metadata(
+    field: str,
+    value: object,
+) -> None:
+    payload = {
+        "asset_id": "metric_definition",
+        "asset_kind": "metric_definition",
+        "citation_label": "business-postgres-source metric definition",
+        "source_id": "business-postgres-source",
+        "source_family": "postgresql",
+        "source_flavor": "postgresql-16",
+        "dataset_contract_version": 2,
+        "schema_snapshot_version": 5,
+    }
+    payload[field] = value
+
+    with pytest.raises(ValidationError):
+        RetrievalCitation(**payload)
 
 
 def test_retrieval_corpus_assets_are_source_labeled_filtered_and_advisory_only() -> None:

--- a/backend/tests/test_retrieval_corpus_governance.py
+++ b/backend/tests/test_retrieval_corpus_governance.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import UniqueConstraint
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
@@ -35,6 +36,17 @@ def _session_scope() -> Iterator[Session]:
     Base.metadata.create_all(engine)
     with Session(engine) as session:
         yield session
+
+
+def test_retrieval_corpus_asset_identifier_is_source_scoped() -> None:
+    unique_constraints = {
+        tuple(column.name for column in constraint.columns)
+        for constraint in RetrievalCorpusAsset.__table__.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+
+    assert ("registered_source_id", "asset_id") in unique_constraints
+    assert ("asset_id",) not in unique_constraints
 
 
 def _seed_source(
@@ -123,6 +135,87 @@ def _seed_asset(
     )
     session.add(asset)
     return asset
+
+
+def test_retrieval_citations_preserve_source_scope_when_asset_ids_match() -> None:
+    with _session_scope() as session:
+        mssql_source, mssql_contract, mssql_snapshot = _seed_source(
+            session,
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver-2022",
+            owner_binding="group:shared-analysts",
+            contract_version=7,
+            snapshot_version=3,
+        )
+        postgres_source, postgres_contract, postgres_snapshot = _seed_source(
+            session,
+            source_id="business-postgres-source",
+            source_family="postgresql",
+            source_flavor="postgresql-16",
+            owner_binding="group:shared-analysts",
+            contract_version=2,
+            snapshot_version=5,
+        )
+        _seed_asset(
+            session,
+            asset_id="metric_definition",
+            source=mssql_source,
+            contract=mssql_contract,
+            snapshot=mssql_snapshot,
+            visibility_binding="group:shared-analysts",
+            text="Gross margin uses net revenue minus cost of goods sold.",
+        )
+        _seed_asset(
+            session,
+            asset_id="metric_definition",
+            source=postgres_source,
+            contract=postgres_contract,
+            snapshot=postgres_snapshot,
+            visibility_binding="group:shared-analysts",
+            text="Headcount is measured from the active employee roster.",
+        )
+        session.commit()
+
+        retrieved = retrieve_governed_corpus_assets(
+            query_text="show governed metric definitions",
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:shared-analysts"}),
+            ),
+            session=session,
+        )
+
+    assert [asset.asset_id for asset in retrieved.assets] == [
+        "metric_definition",
+        "metric_definition",
+    ]
+    assert retrieved.audit.model_dump()["citations"] == [
+        {
+            "asset_id": "metric_definition",
+            "asset_kind": "metric_definition",
+            "citation_label": "business-mssql-source metric definition",
+            "source_id": "business-mssql-source",
+            "source_family": "mssql",
+            "source_flavor": "sqlserver-2022",
+            "dataset_contract_version": 7,
+            "schema_snapshot_version": 3,
+            "authority": "advisory_context",
+            "can_authorize_execution": False,
+        },
+        {
+            "asset_id": "metric_definition",
+            "asset_kind": "metric_definition",
+            "citation_label": "business-postgres-source metric definition",
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "postgresql-16",
+            "dataset_contract_version": 2,
+            "schema_snapshot_version": 5,
+            "authority": "advisory_context",
+            "can_authorize_execution": False,
+        },
+    ]
 
 
 def test_retrieval_corpus_assets_are_source_labeled_filtered_and_advisory_only() -> None:


### PR DESCRIPTION
## Summary
- add source-labeled retrieval citation payloads to governed retrieval audit output
- keep duplicate retrieval asset identifiers source-scoped instead of globally unique
- extend audit events with advisory-only retrieved citation metadata

## Verification
- cd backend && python3 -m pytest tests/test_retrieval_corpus_governance.py tests/test_audit_event_model.py -q
- cd backend && python3 -m pytest
- git diff --check

Closes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Removed overly restrictive uniqueness constraint allowing asset identifiers to be reused across different sources.

* **New Features**
  - Citation metadata is now captured and included in audit events for improved visibility into retrieved content.

* **Tests**
  - Added test coverage for citation auditing and source-scoped asset uniqueness enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->