### PR TITLE
[H-3] Add source-labeled executed evidence

### DIFF
--- a/backend/app/features/audit/__init__.py
+++ b/backend/app/features/audit/__init__.py
@@ -1,5 +1,8 @@
 """Audit event schema and reserved persistence seams."""
 
-from app.features.audit.event_model import SourceAwareAuditEvent
+from app.features.audit.event_model import (
+    ExecutedEvidenceAuditPayload,
+    SourceAwareAuditEvent,
+)
 
-__all__ = ["SourceAwareAuditEvent"]
+__all__ = ["ExecutedEvidenceAuditPayload", "SourceAwareAuditEvent"]

--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, PositiveInt, StringConstraints
+from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, StringConstraints
 from typing_extensions import Annotated
 
 
@@ -63,6 +63,26 @@ class RetrievalCitationAuditPayload(BaseModel):
     can_authorize_execution: Literal[False] = False
 
 
+class ExecutedEvidenceAuditPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["executed_evidence"] = "executed_evidence"
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
+    execution_policy_version: Optional[PositiveInt] = None
+    connector_profile_version: Optional[PositiveInt] = None
+    candidate_id: NonEmptyTrimmedString
+    execution_audit_event_id: UUID
+    execution_audit_event_type: Literal["execution_completed"] = "execution_completed"
+    row_count: NonNegativeInt
+    result_truncated: bool
+    authority: Literal["backend_execution_result"] = "backend_execution_result"
+    can_authorize_execution: Literal[False] = False
+
+
 class SourceAwareAuditEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -83,6 +103,7 @@ class SourceAwareAuditEvent(BaseModel):
     retrieval_corpus_version: Optional[NonEmptyTrimmedString] = None
     retrieved_asset_ids: Optional[list[NonEmptyTrimmedString]] = None
     retrieved_citations: Optional[list[RetrievalCitationAuditPayload]] = None
+    executed_evidence: Optional[list[ExecutedEvidenceAuditPayload]] = None
     analyst_mode_version: Optional[NonEmptyTrimmedString] = None
 
     source_id: SourceIdentifier

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -108,6 +108,7 @@ class ExecutionResult(BaseModel):
             or audit_event.dataset_contract_version is None
             or audit_event.schema_snapshot_version is None
             or audit_event.execution_row_count is None
+            or audit_event.execution_row_count < 0
             or audit_event.result_truncated is None
         ):
             return None

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -11,7 +11,10 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, ConfigDict, PrivateAttr, StringConstraints
 from typing_extensions import Annotated
 
-from app.features.audit.event_model import SourceAwareAuditEvent
+from app.features.audit.event_model import (
+    ExecutedEvidenceAuditPayload,
+    SourceAwareAuditEvent,
+)
 from app.features.execution.connector_selection import (
     ExecutionConnectorSelection,
     ExecutionConnectorSelectionError,
@@ -93,6 +96,35 @@ class ExecutionResult(BaseModel):
     @property
     def audit_events(self) -> list[SourceAwareAuditEvent]:
         return list(self._audit_events)
+
+    @property
+    def executed_evidence(self) -> Optional[ExecutedEvidenceAuditPayload]:
+        audit_event = self.audit_event
+        if (
+            audit_event is None
+            or audit_event.event_type != "execution_completed"
+            or self.ownership != "backend"
+            or audit_event.query_candidate_id is None
+            or audit_event.dataset_contract_version is None
+            or audit_event.schema_snapshot_version is None
+            or audit_event.execution_row_count is None
+            or audit_event.result_truncated is None
+        ):
+            return None
+
+        return ExecutedEvidenceAuditPayload(
+            source_id=audit_event.source_id,
+            source_family=audit_event.source_family,
+            source_flavor=audit_event.source_flavor,
+            dataset_contract_version=audit_event.dataset_contract_version,
+            schema_snapshot_version=audit_event.schema_snapshot_version,
+            execution_policy_version=audit_event.execution_policy_version,
+            connector_profile_version=audit_event.connector_profile_version,
+            candidate_id=audit_event.query_candidate_id,
+            execution_audit_event_id=audit_event.event_id,
+            row_count=audit_event.execution_row_count,
+            result_truncated=audit_event.result_truncated,
+        )
 
 
 class ExecutableCandidateRecord(BaseModel):

--- a/backend/tests/test_audit_event_model.py
+++ b/backend/tests/test_audit_event_model.py
@@ -140,6 +140,58 @@ def test_retrieval_completed_audit_event_preserves_source_labeled_citations() ->
     assert event.model_dump()["retrieved_citations"] == payload["retrieved_citations"]
 
 
+def test_analyst_response_audit_event_keeps_executed_evidence_separate_from_citations() -> None:
+    payload = _source_aware_payload()
+    execution_audit_event_id = uuid4()
+    payload.update(
+        {
+            "event_type": "analyst_response_rendered",
+            "retrieved_citations": [
+                {
+                    "asset_id": "metric_definition",
+                    "asset_kind": "metric_definition",
+                    "citation_label": "business-postgres-source metric definition",
+                    "source_id": "business-postgres-source",
+                    "source_family": "postgresql",
+                    "source_flavor": "postgresql-16",
+                    "dataset_contract_version": 2,
+                    "schema_snapshot_version": 5,
+                    "authority": "advisory_context",
+                    "can_authorize_execution": False,
+                }
+            ],
+            "executed_evidence": [
+                {
+                    "type": "executed_evidence",
+                    "source_id": "business-postgres-source",
+                    "source_family": "postgresql",
+                    "source_flavor": "warehouse",
+                    "dataset_contract_version": 2,
+                    "schema_snapshot_version": 5,
+                    "execution_policy_version": 3,
+                    "connector_profile_version": 11,
+                    "candidate_id": "candidate-123",
+                    "execution_audit_event_id": execution_audit_event_id,
+                    "execution_audit_event_type": "execution_completed",
+                    "row_count": 12,
+                    "result_truncated": False,
+                    "authority": "backend_execution_result",
+                    "can_authorize_execution": False,
+                }
+            ],
+        }
+    )
+
+    event = SourceAwareAuditEvent(**payload)
+    dumped = event.model_dump()
+
+    assert dumped["retrieved_citations"][0]["authority"] == "advisory_context"
+    assert dumped["executed_evidence"][0]["type"] == "executed_evidence"
+    assert dumped["executed_evidence"][0]["authority"] == "backend_execution_result"
+    assert "citation_label" not in dumped["executed_evidence"][0]
+    assert "rows" not in dumped["executed_evidence"][0]
+
+
 @pytest.mark.parametrize(
     ("authority", "can_authorize_execution"),
     [
@@ -168,6 +220,36 @@ def test_retrieval_citation_audit_payload_rejects_execution_authority(
                     "authority": authority,
                     "can_authorize_execution": can_authorize_execution,
                 },
+            ],
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        SourceAwareAuditEvent(**payload)
+
+
+def test_executed_evidence_rejects_retrieval_citation_shape() -> None:
+    payload = _source_aware_payload()
+    payload.update(
+        {
+            "event_type": "analyst_response_rendered",
+            "executed_evidence": [
+                {
+                    "type": "retrieval_citation",
+                    "asset_id": "metric_definition",
+                    "asset_kind": "metric_definition",
+                    "citation_label": "business-postgres-source metric definition",
+                    "source_id": "business-postgres-source",
+                    "source_family": "postgresql",
+                    "dataset_contract_version": 2,
+                    "schema_snapshot_version": 5,
+                    "candidate_id": "candidate-123",
+                    "execution_audit_event_id": uuid4(),
+                    "row_count": 12,
+                    "result_truncated": False,
+                    "authority": "advisory_context",
+                    "can_authorize_execution": False,
+                }
             ],
         }
     )

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -5,6 +5,7 @@ import inspect
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from app.features.execution.connector_selection import ExecutionConnectorSelection
 from app.features.guard.deny_taxonomy import (
@@ -15,6 +16,7 @@ from app.features.guard.deny_taxonomy import (
 from app.features.execution.runtime import (
     ExecutableCandidateRecord,
     ExecutionAuditContext,
+    ExecutionResult,
     ExecutionRuntimeSafetyState,
 )
 from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
@@ -219,6 +221,121 @@ def test_execute_candidate_sql_returns_source_aware_completion_audit_event() -> 
         "result_truncated": False,
     }.items() <= result.audit_event.model_dump(exclude_none=True).items()
     assert result.audit_event.model_dump(exclude_none=True).get("rows") is None
+
+
+@pytest.mark.parametrize(
+    (
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "connector_id",
+        "execution_kwargs",
+    ),
+    [
+        (
+            "approved-spend",
+            "postgresql",
+            "warehouse",
+            "postgresql_readonly",
+            {
+                "business_postgres_url": BUSINESS_POSTGRES_URL,
+                "application_postgres_url": APPLICATION_POSTGRES_URL,
+            },
+        ),
+        (
+            "orders-ledger",
+            "mssql",
+            "sqlserver",
+            "mssql_readonly",
+            {
+                "business_mssql_connection_string": (
+                    "Driver={ODBC Driver 18 for SQL Server};"
+                    "Server=business-mssql-source;"
+                    "Database=orders;"
+                    "Authentication=ActiveDirectoryMsi;"
+                ),
+            },
+        ),
+    ],
+)
+def test_execute_candidate_sql_derives_source_labeled_executed_evidence(
+    source_id: str,
+    source_family: str,
+    source_flavor: str,
+    connector_id: str,
+    execution_kwargs: dict[str, str],
+) -> None:
+    from app.features.execution import execute_candidate_sql
+
+    candidate = ExecutableCandidateRecord(
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
+        source=SourceBoundCandidateMetadata(
+            source_id=source_id,
+            source_family=source_family,
+            source_flavor=source_flavor,
+            dataset_contract_version=3,
+            schema_snapshot_version=7,
+        ),
+    )
+    selection = ExecutionConnectorSelection(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        connector_id=connector_id,
+        ownership="backend",
+    )
+    result = execute_candidate_sql(
+        candidate=candidate,
+        selection=selection,
+        query_runner=lambda **_: [{"vendor_name": "Acme"}],
+        audit_context=_audit_context(),
+        **execution_kwargs,
+    )
+
+    assert result.executed_evidence is not None
+    assert result.executed_evidence.model_dump(exclude_none=True) == {
+        "type": "executed_evidence",
+        "source_id": source_id,
+        "source_family": source_family,
+        "source_flavor": source_flavor,
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "connector_profile_version": 11,
+        "candidate_id": "candidate-123",
+        "execution_audit_event_id": result.audit_event.event_id,
+        "execution_audit_event_type": "execution_completed",
+        "row_count": 1,
+        "result_truncated": False,
+        "authority": "backend_execution_result",
+        "can_authorize_execution": False,
+    }
+    assert "retrieved_citations" not in result.executed_evidence.model_dump(
+        exclude_none=True
+    )
+    assert "rows" not in result.executed_evidence.model_dump(exclude_none=True)
+
+
+def test_execution_result_rejects_client_supplied_executed_evidence() -> None:
+    with pytest.raises(ValidationError):
+        ExecutionResult(
+            source_id="approved-spend",
+            connector_id="postgresql_readonly",
+            ownership="backend",
+            rows=[],
+            executed_evidence={
+                "type": "executed_evidence",
+                "source_id": "approved-spend",
+                "source_family": "postgresql",
+                "dataset_contract_version": 3,
+                "schema_snapshot_version": 7,
+                "candidate_id": "candidate-123",
+                "execution_audit_event_id": uuid4(),
+                "row_count": 0,
+                "result_truncated": False,
+                "authority": "backend_execution_result",
+                "can_authorize_execution": False,
+            },
+        )
 
 
 def test_execute_candidate_sql_returns_source_aware_runtime_denial_audit_event() -> None:

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -315,6 +315,26 @@ def test_execute_candidate_sql_derives_source_labeled_executed_evidence(
     assert "rows" not in result.executed_evidence.model_dump(exclude_none=True)
 
 
+def test_execution_result_omits_executed_evidence_for_negative_audit_row_count() -> None:
+    from app.features.execution import execute_candidate_sql
+
+    result = execute_candidate_sql(
+        candidate=_candidate(),
+        selection=_selection(),
+        query_runner=lambda **_: [{"vendor_name": "Acme"}],
+        audit_context=_audit_context(),
+        business_postgres_url=BUSINESS_POSTGRES_URL,
+        application_postgres_url=APPLICATION_POSTGRES_URL,
+    )
+
+    assert result.audit_event is not None
+    result._audit_event = result.audit_event.model_copy(
+        update={"execution_row_count": -1}
+    )
+
+    assert result.executed_evidence is None
+
+
 def test_execution_result_rejects_client_supplied_executed_evidence() -> None:
     with pytest.raises(ValidationError):
         ExecutionResult(


### PR DESCRIPTION
## Summary
- add a distinct executed evidence audit payload shape for analyst composition
- derive executed evidence from backend-owned completed execution results and audit metadata
- cover PostgreSQL and MSSQL source labeling, citation separation, and forged client evidence rejection

## Verification
- cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_audit_event_model.py -q
- cd backend && python3 -m pytest tests -q

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit captures and surfaces executed-evidence for completed executions (includes execution status, non-negative row counts, truncation flag, and related execution metadata) and exposes it via the execution result API.

* **Tests**
  * Added tests verifying serialization, validation, conditional omission, and integration of executed-evidence during execution flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->