### PR TITLE
[H-4] Define source-aware analyst response schema

### DIFF
--- a/backend/app/features/analyst_response/__init__.py
+++ b/backend/app/features/analyst_response/__init__.py
@@ -1,0 +1,13 @@
+"""Source-aware analyst response payload contracts."""
+
+from app.features.analyst_response.schema import (
+    AnalystResponsePayload,
+    AnalystResponseSourceSummary,
+    OperatorHistoryHooks,
+)
+
+__all__ = [
+    "AnalystResponsePayload",
+    "AnalystResponseSourceSummary",
+    "OperatorHistoryHooks",
+]

--- a/backend/app/features/analyst_response/schema.py
+++ b/backend/app/features/analyst_response/schema.py
@@ -65,7 +65,6 @@ class AnalystResponsePayload(BaseModel):
                 item.source_flavor,
                 item.dataset_contract_version,
                 item.schema_snapshot_version,
-                getattr(item, "execution_policy_version", None),
             )
             for item in [*self.retrieval_citations, *self.executed_evidence]
         }
@@ -76,7 +75,6 @@ class AnalystResponsePayload(BaseModel):
                 item.source_flavor,
                 item.dataset_contract_version,
                 item.schema_snapshot_version,
-                item.execution_policy_version,
             )
             for item in self.source_summaries
         }

--- a/backend/app/features/analyst_response/schema.py
+++ b/backend/app/features/analyst_response/schema.py
@@ -23,8 +23,8 @@ class AnalystResponseSourceSummary(BaseModel):
     source_id: SourceIdentifier
     source_family: SourceFamily
     source_flavor: Optional[SourceFlavor] = None
-    dataset_contract_version: Optional[PositiveInt] = None
-    schema_snapshot_version: Optional[PositiveInt] = None
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
     execution_policy_version: Optional[PositiveInt] = None
 
 

--- a/backend/app/features/analyst_response/schema.py
+++ b/backend/app/features/analyst_response/schema.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
+
+from app.features.audit.event_model import (
+    ExecutedEvidenceAuditPayload,
+    NonEmptyTrimmedString,
+    RetrievalCitationAuditPayload,
+    SourceFamily,
+    SourceFlavor,
+    SourceIdentifier,
+)
+
+AnalystConfidence = Literal["low", "medium", "high", "unknown"]
+
+
+class AnalystResponseSourceSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    dataset_contract_version: Optional[PositiveInt] = None
+    schema_snapshot_version: Optional[PositiveInt] = None
+    execution_policy_version: Optional[PositiveInt] = None
+
+
+class OperatorHistoryHooks(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    audit_event_id: Optional[UUID] = None
+    history_record_ids: list[NonEmptyTrimmedString] = Field(default_factory=list)
+
+
+class AnalystResponsePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    response_id: NonEmptyTrimmedString
+    request_id: NonEmptyTrimmedString
+    narrative: NonEmptyTrimmedString
+    advisory_only: Literal[True] = True
+    can_authorize_execution: Literal[False] = False
+    analyst_mode_version: NonEmptyTrimmedString
+    confidence: AnalystConfidence = "unknown"
+    caveats: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    source_summaries: list[AnalystResponseSourceSummary] = Field(default_factory=list)
+    retrieval_citations: list[RetrievalCitationAuditPayload] = Field(default_factory=list)
+    executed_evidence: list[ExecutedEvidenceAuditPayload] = Field(default_factory=list)
+    operator_history_hooks: OperatorHistoryHooks = Field(default_factory=OperatorHistoryHooks)
+
+    @model_validator(mode="after")
+    def validate_source_summaries(self) -> "AnalystResponsePayload":
+        if not self.retrieval_citations and not self.executed_evidence:
+            raise ValueError(
+                "Analyst responses must cite retrieval context or executed evidence."
+            )
+
+        expected = {
+            (
+                item.source_id,
+                item.source_family,
+                item.source_flavor,
+                item.dataset_contract_version,
+                item.schema_snapshot_version,
+                getattr(item, "execution_policy_version", None),
+            )
+            for item in [*self.retrieval_citations, *self.executed_evidence]
+        }
+        supplied = {
+            (
+                item.source_id,
+                item.source_family,
+                item.source_flavor,
+                item.dataset_contract_version,
+                item.schema_snapshot_version,
+                item.execution_policy_version,
+            )
+            for item in self.source_summaries
+        }
+
+        if supplied and not expected.issubset(supplied):
+            raise ValueError(
+                "Source summaries must include every citation and executed evidence source."
+            )
+
+        return self

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -132,6 +132,26 @@ def test_source_summary_coverage_rejects_missing_source_identity() -> None:
         )
 
 
+def test_source_summary_requires_dataset_and_schema_versions() -> None:
+    with pytest.raises(ValidationError):
+        AnalystResponsePayload(
+            response_id="analyst-response-123",
+            request_id="request-123",
+            narrative="Source summaries must identify the concrete governed source versions.",
+            advisory_only=True,
+            can_authorize_execution=False,
+            analyst_mode_version="analyst-schema-v1",
+            source_summaries=[
+                {
+                    "source_id": "business-postgres-source",
+                    "source_family": "postgresql",
+                    "source_flavor": "warehouse",
+                }
+            ],
+            retrieval_citations=[_citation("business-postgres-source", "postgresql")],
+        )
+
+
 @pytest.mark.parametrize(
     "payload_overrides",
     [

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.analyst_response.schema import AnalystResponsePayload
+
+
+def _citation(source_id: str, source_family: str) -> dict[str, object]:
+    return {
+        "asset_id": f"{source_id}-metric-definition",
+        "asset_kind": "metric_definition",
+        "citation_label": f"{source_id} metric definition",
+        "source_id": source_id,
+        "source_family": source_family,
+        "source_flavor": "warehouse" if source_family == "postgresql" else "sqlserver",
+        "dataset_contract_version": 2,
+        "schema_snapshot_version": 5,
+        "authority": "advisory_context",
+        "can_authorize_execution": False,
+    }
+
+
+def _executed_evidence(source_id: str, source_family: str) -> dict[str, object]:
+    return {
+        "type": "executed_evidence",
+        "source_id": source_id,
+        "source_family": source_family,
+        "source_flavor": "warehouse" if source_family == "postgresql" else "sqlserver",
+        "dataset_contract_version": 2,
+        "schema_snapshot_version": 5,
+        "execution_policy_version": 3,
+        "connector_profile_version": 11,
+        "candidate_id": f"{source_id}-candidate-123",
+        "execution_audit_event_id": uuid4(),
+        "execution_audit_event_type": "execution_completed",
+        "row_count": 12,
+        "result_truncated": False,
+        "authority": "backend_execution_result",
+        "can_authorize_execution": False,
+    }
+
+
+def test_analyst_response_payload_preserves_multi_source_advisory_labels() -> None:
+    response = AnalystResponsePayload(
+        response_id="analyst-response-123",
+        request_id="request-123",
+        narrative="PostgreSQL and MSSQL advisory context differ; execution evidence stays source-labeled.",
+        advisory_only=True,
+        can_authorize_execution=False,
+        analyst_mode_version="analyst-schema-v1",
+        confidence="medium",
+        caveats=["Advisory narrative does not approve SQL execution."],
+        retrieval_citations=[
+            _citation("business-postgres-source", "postgresql"),
+            _citation("business-mssql-source", "mssql"),
+        ],
+        executed_evidence=[
+            _executed_evidence("business-postgres-source", "postgresql"),
+            _executed_evidence("business-mssql-source", "mssql"),
+        ],
+        operator_history_hooks={
+            "audit_event_id": uuid4(),
+            "history_record_ids": ["request-123", "business-postgres-source-candidate-123"],
+        },
+    )
+
+    dumped = response.model_dump()
+
+    assert dumped["advisory_only"] is True
+    assert dumped["can_authorize_execution"] is False
+    assert [item["source_id"] for item in dumped["retrieval_citations"]] == [
+        "business-postgres-source",
+        "business-mssql-source",
+    ]
+    assert [item["source_id"] for item in dumped["executed_evidence"]] == [
+        "business-postgres-source",
+        "business-mssql-source",
+    ]
+    assert "approval_status" not in dumped
+    assert "sql_execution_approved" not in dumped
+
+
+@pytest.mark.parametrize(
+    "payload_overrides",
+    [
+        {"advisory_only": False},
+        {"can_authorize_execution": True},
+        {
+            "retrieval_citations": [
+                {
+                    **_citation("business-postgres-source", "postgresql"),
+                    "source_id": " business-postgres-source ",
+                }
+            ]
+        },
+    ],
+)
+def test_analyst_response_payload_rejects_execution_authority_and_bad_source_labels(
+    payload_overrides: dict[str, object],
+) -> None:
+    payload = {
+        "response_id": "analyst-response-123",
+        "request_id": "request-123",
+        "narrative": "Advisory answer with source-labeled context.",
+        "advisory_only": True,
+        "can_authorize_execution": False,
+        "analyst_mode_version": "analyst-schema-v1",
+        "retrieval_citations": [_citation("business-postgres-source", "postgresql")],
+        "executed_evidence": [_executed_evidence("business-postgres-source", "postgresql")],
+        **payload_overrides,
+    }
+
+    with pytest.raises(ValidationError):
+        AnalystResponsePayload(**payload)

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -83,6 +83,55 @@ def test_analyst_response_payload_preserves_multi_source_advisory_labels() -> No
     assert "sql_execution_approved" not in dumped
 
 
+def test_source_summary_coverage_uses_source_identity_not_execution_policy() -> None:
+    response = AnalystResponsePayload(
+        response_id="analyst-response-123",
+        request_id="request-123",
+        narrative="A single source can have advisory citations and executed evidence.",
+        advisory_only=True,
+        can_authorize_execution=False,
+        analyst_mode_version="analyst-schema-v1",
+        source_summaries=[
+            {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+                "dataset_contract_version": 2,
+                "schema_snapshot_version": 5,
+            }
+        ],
+        retrieval_citations=[_citation("business-postgres-source", "postgresql")],
+        executed_evidence=[_executed_evidence("business-postgres-source", "postgresql")],
+    )
+
+    assert response.source_summaries[0].execution_policy_version is None
+
+
+def test_source_summary_coverage_rejects_missing_source_identity() -> None:
+    with pytest.raises(ValidationError):
+        AnalystResponsePayload(
+            response_id="analyst-response-123",
+            request_id="request-123",
+            narrative="All cited sources must be summarized when summaries are supplied.",
+            advisory_only=True,
+            can_authorize_execution=False,
+            analyst_mode_version="analyst-schema-v1",
+            source_summaries=[
+                {
+                    "source_id": "business-postgres-source",
+                    "source_family": "postgresql",
+                    "source_flavor": "warehouse",
+                    "dataset_contract_version": 2,
+                    "schema_snapshot_version": 5,
+                }
+            ],
+            retrieval_citations=[
+                _citation("business-postgres-source", "postgresql"),
+                _citation("business-mssql-source", "mssql"),
+            ],
+        )
+
+
 @pytest.mark.parametrize(
     "payload_overrides",
     [

--- a/docs/design/search-and-analyst-capabilities.md
+++ b/docs/design/search-and-analyst-capabilities.md
@@ -93,6 +93,32 @@ The application should label analyst outputs clearly:
 - executed evidence: grounded in approved SQL execution results
 - narrative guidance: explanatory text that does not itself grant execution authority
 
+## Analyst Response Schema Constraints
+
+Analyst response payloads must be advisory surfaces, not execution approval
+records. The response contract therefore keeps these fields separate:
+
+- `narrative`: human-readable guidance only
+- `retrieval_citations`: source-labeled retrieved semantic assets
+- `executed_evidence`: source-labeled references to completed backend execution
+  audit events
+- `advisory_only=true` and `can_authorize_execution=false`: invariant markers
+  that prevent analyst output from being treated as SQL execution authority
+- `confidence` and `caveats`: metadata for answer quality and known limits
+- `operator_history_hooks`: audit or history anchors for operator-facing
+  reconstruction
+
+Every retrieval citation and executed evidence reference must carry source
+identity, source family, optional source flavor, dataset contract version, and
+schema snapshot version. Executed evidence must additionally reference the
+candidate identifier and the completed execution audit event; it must not embed
+raw result rows or become an approval token.
+
+Responses may include multiple source-labeled advisory artifacts. That does not
+create cross-source execution authority: each executed evidence reference remains
+bound to its own candidate and completed execution audit event, and narrative
+text cannot merge, erase, or retarget those source labels.
+
 ## Governance Implications
 
 SafeQuery must govern not only datasets but also semantic assets used for search and analyst experiences.

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { parseAnalystResponsePayload } from "./analyst-response";
+
+function citation(sourceId: string, sourceFamily: "mssql" | "postgresql") {
+  return {
+    assetId: `${sourceId}-metric-definition`,
+    assetKind: "metric_definition",
+    citationLabel: `${sourceId} metric definition`,
+    sourceId,
+    sourceFamily,
+    sourceFlavor: sourceFamily === "postgresql" ? "warehouse" : "sqlserver",
+    datasetContractVersion: 2,
+    schemaSnapshotVersion: 5,
+    authority: "advisory_context",
+    canAuthorizeExecution: false
+  };
+}
+
+function evidence(sourceId: string, sourceFamily: "mssql" | "postgresql") {
+  return {
+    type: "executed_evidence",
+    sourceId,
+    sourceFamily,
+    sourceFlavor: sourceFamily === "postgresql" ? "warehouse" : "sqlserver",
+    datasetContractVersion: 2,
+    schemaSnapshotVersion: 5,
+    executionPolicyVersion: 3,
+    connectorProfileVersion: 11,
+    candidateId: `${sourceId}-candidate-123`,
+    executionAuditEventId: "5dbcc36c-c6d6-4755-b307-5a3af5d6ec25",
+    executionAuditEventType: "execution_completed",
+    rowCount: 12,
+    resultTruncated: false,
+    authority: "backend_execution_result",
+    canAuthorizeExecution: false
+  };
+}
+
+describe("parseAnalystResponsePayload", () => {
+  it("preserves source-labeled advisory citations and executed evidence", () => {
+    const parsed = parseAnalystResponsePayload({
+      responseId: "analyst-response-123",
+      requestId: "request-123",
+      narrative: "Compare advisory context without granting execution approval.",
+      advisoryOnly: true,
+      canAuthorizeExecution: false,
+      analystModeVersion: "analyst-schema-v1",
+      confidence: "medium",
+      caveats: ["Narrative guidance is advisory only."],
+      retrievalCitations: [
+        citation("business-postgres-source", "postgresql"),
+        citation("business-mssql-source", "mssql")
+      ],
+      executedEvidence: [
+        evidence("business-postgres-source", "postgresql"),
+        evidence("business-mssql-source", "mssql")
+      ]
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.advisoryOnly).toBe(true);
+    expect(parsed?.canAuthorizeExecution).toBe(false);
+    expect(parsed?.retrievalCitations.map((item) => item.sourceId)).toEqual([
+      "business-postgres-source",
+      "business-mssql-source"
+    ]);
+    expect(parsed?.executedEvidence.map((item) => item.sourceId)).toEqual([
+      "business-postgres-source",
+      "business-mssql-source"
+    ]);
+  });
+
+  it("rejects narrative-only or execution-authorizing payloads", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Approve this SQL.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [],
+        executedEvidence: []
+      })
+    ).toBeNull();
+
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Advisory text with one citation.",
+        advisoryOnly: true,
+        canAuthorizeExecution: true,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [citation("business-postgres-source", "postgresql")]
+      })
+    ).toBeNull();
+  });
+
+  it("rejects malformed source labels on citations and executed evidence", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Advisory text with malformed citation source.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [
+          {
+            ...citation("business-postgres-source", "postgresql"),
+            sourceId: " business-postgres-source "
+          }
+        ]
+      })
+    ).toBeNull();
+
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Advisory text with malformed evidence source.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        executedEvidence: [
+          {
+            ...evidence("business-postgres-source", "postgresql"),
+            sourceFamily: "mysql"
+          }
+        ]
+      })
+    ).toBeNull();
+  });
+});

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -119,6 +119,23 @@ describe("parseAnalystResponsePayload", () => {
       parseAnalystResponsePayload({
         responseId: "analyst-response-123",
         requestId: "request-123",
+        narrative: "Advisory text with malformed citation flavor.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [
+          {
+            ...citation("business-postgres-source", "postgresql"),
+            sourceFlavor: "warehouse east"
+          }
+        ]
+      })
+    ).toBeNull();
+
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
         narrative: "Advisory text with malformed evidence source.",
         advisoryOnly: true,
         canAuthorizeExecution: false,
@@ -129,6 +146,70 @@ describe("parseAnalystResponsePayload", () => {
             sourceFamily: "mysql"
           }
         ]
+      })
+    ).toBeNull();
+
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Advisory text with malformed evidence flavor.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        executedEvidence: [
+          {
+            ...evidence("business-postgres-source", "postgresql"),
+            sourceFlavor: "warehouse east"
+          }
+        ]
+      })
+    ).toBeNull();
+  });
+
+  it("rejects malformed executed evidence audit event identifiers", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Executed evidence must reference a real audit event.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        executedEvidence: [
+          {
+            ...evidence("business-postgres-source", "postgresql"),
+            executionAuditEventId: "not-an-audit-event-id"
+          }
+        ]
+      })
+    ).toBeNull();
+  });
+
+  it("rejects malformed present arrays instead of defaulting them to empty", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Malformed caveats cannot be coerced away.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        caveats: "none",
+        retrievalCitations: [citation("business-postgres-source", "postgresql")]
+      })
+    ).toBeNull();
+
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Malformed citation arrays cannot be coerced away.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: "business-postgres-source",
+        executedEvidence: [evidence("business-postgres-source", "postgresql")]
       })
     ).toBeNull();
   });

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -47,7 +47,9 @@ export type AnalystResponsePayload = {
 
 type RawObject = Record<string, unknown>;
 
-const sourceIdPattern = /^[a-z0-9][a-z0-9._-]*$/;
+const sourceTokenPattern = /^[a-z0-9][a-z0-9._-]*$/;
+const executionAuditEventIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isObject(value: unknown): value is RawObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -61,17 +63,22 @@ function readRequiredString(value: unknown): string | null {
   return value;
 }
 
-function readOptionalString(value: unknown): string | null {
+function readSourceToken(value: unknown): string | null {
+  const token = readRequiredString(value);
+  return token !== null && sourceTokenPattern.test(token) ? token : null;
+}
+
+function readOptionalSourceToken(value: unknown): string | null | undefined {
   if (value === null || value === undefined) {
     return null;
   }
 
-  return readRequiredString(value);
+  return readSourceToken(value) ?? undefined;
 }
 
-function readSourceId(value: unknown): string | null {
-  const sourceId = readRequiredString(value);
-  return sourceId !== null && sourceIdPattern.test(sourceId) ? sourceId : null;
+function readExecutionAuditEventId(value: unknown): string | null {
+  const eventId = readRequiredString(value);
+  return eventId !== null && executionAuditEventIdPattern.test(eventId) ? eventId : null;
 }
 
 function readSourceFamily(value: unknown): SourceFamily | null {
@@ -95,8 +102,12 @@ function readConfidence(value: unknown): AnalystConfidence | null {
 }
 
 function parseCaveats(value: unknown): string[] | null {
-  if (!Array.isArray(value)) {
+  if (value === undefined) {
     return [];
+  }
+
+  if (!Array.isArray(value)) {
+    return null;
   }
 
   const caveats = value.map(readRequiredString);
@@ -111,9 +122,9 @@ function parseRetrievalCitation(value: unknown): AnalystRetrievalCitation | null
   const assetId = readRequiredString(value.assetId);
   const assetKind = readRequiredString(value.assetKind);
   const citationLabel = readRequiredString(value.citationLabel);
-  const sourceId = readSourceId(value.sourceId);
+  const sourceId = readSourceToken(value.sourceId);
   const sourceFamily = readSourceFamily(value.sourceFamily);
-  const sourceFlavor = readOptionalString(value.sourceFlavor);
+  const sourceFlavor = readOptionalSourceToken(value.sourceFlavor);
   const datasetContractVersion = readPositiveInteger(value.datasetContractVersion);
   const schemaSnapshotVersion = readPositiveInteger(value.schemaSnapshotVersion);
 
@@ -123,6 +134,7 @@ function parseRetrievalCitation(value: unknown): AnalystRetrievalCitation | null
     !citationLabel ||
     !sourceId ||
     !sourceFamily ||
+    sourceFlavor === undefined ||
     !datasetContractVersion ||
     !schemaSnapshotVersion ||
     value.authority !== "advisory_context" ||
@@ -150,21 +162,22 @@ function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
     return null;
   }
 
-  const sourceId = readSourceId(value.sourceId);
+  const sourceId = readSourceToken(value.sourceId);
   const sourceFamily = readSourceFamily(value.sourceFamily);
-  const sourceFlavor = readOptionalString(value.sourceFlavor);
+  const sourceFlavor = readOptionalSourceToken(value.sourceFlavor);
   const datasetContractVersion = readPositiveInteger(value.datasetContractVersion);
   const schemaSnapshotVersion = readPositiveInteger(value.schemaSnapshotVersion);
   const executionPolicyVersion = readPositiveInteger(value.executionPolicyVersion);
   const connectorProfileVersion = readPositiveInteger(value.connectorProfileVersion);
   const candidateId = readRequiredString(value.candidateId);
-  const executionAuditEventId = readRequiredString(value.executionAuditEventId);
+  const executionAuditEventId = readExecutionAuditEventId(value.executionAuditEventId);
   const rowCount = readNonNegativeInteger(value.rowCount);
 
   if (
     value.type !== "executed_evidence" ||
     !sourceId ||
     !sourceFamily ||
+    sourceFlavor === undefined ||
     !datasetContractVersion ||
     !schemaSnapshotVersion ||
     !candidateId ||
@@ -198,8 +211,12 @@ function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
 }
 
 function parseArray<T>(value: unknown, parser: (item: unknown) => T | null): T[] | null {
-  if (!Array.isArray(value)) {
+  if (value === undefined) {
     return [];
+  }
+
+  if (!Array.isArray(value)) {
+    return null;
   }
 
   const parsed = value.map(parser);

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -1,0 +1,251 @@
+export type AnalystConfidence = "low" | "medium" | "high" | "unknown";
+export type SourceFamily = "mssql" | "postgresql";
+
+export type AnalystRetrievalCitation = {
+  assetId: string;
+  assetKind: string;
+  citationLabel: string;
+  sourceId: string;
+  sourceFamily: SourceFamily;
+  sourceFlavor: string | null;
+  datasetContractVersion: number;
+  schemaSnapshotVersion: number;
+  authority: "advisory_context";
+  canAuthorizeExecution: false;
+};
+
+export type AnalystExecutedEvidence = {
+  type: "executed_evidence";
+  sourceId: string;
+  sourceFamily: SourceFamily;
+  sourceFlavor: string | null;
+  datasetContractVersion: number;
+  schemaSnapshotVersion: number;
+  executionPolicyVersion: number | null;
+  connectorProfileVersion: number | null;
+  candidateId: string;
+  executionAuditEventId: string;
+  executionAuditEventType: "execution_completed";
+  rowCount: number;
+  resultTruncated: boolean;
+  authority: "backend_execution_result";
+  canAuthorizeExecution: false;
+};
+
+export type AnalystResponsePayload = {
+  responseId: string;
+  requestId: string;
+  narrative: string;
+  advisoryOnly: true;
+  canAuthorizeExecution: false;
+  analystModeVersion: string;
+  confidence: AnalystConfidence;
+  caveats: string[];
+  retrievalCitations: AnalystRetrievalCitation[];
+  executedEvidence: AnalystExecutedEvidence[];
+};
+
+type RawObject = Record<string, unknown>;
+
+const sourceIdPattern = /^[a-z0-9][a-z0-9._-]*$/;
+
+function isObject(value: unknown): value is RawObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRequiredString(value: unknown): string | null {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  return value;
+}
+
+function readOptionalString(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return readRequiredString(value);
+}
+
+function readSourceId(value: unknown): string | null {
+  const sourceId = readRequiredString(value);
+  return sourceId !== null && sourceIdPattern.test(sourceId) ? sourceId : null;
+}
+
+function readSourceFamily(value: unknown): SourceFamily | null {
+  return value === "mssql" || value === "postgresql" ? value : null;
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  return Number.isInteger(value) && typeof value === "number" && value > 0 ? value : null;
+}
+
+function readNonNegativeInteger(value: unknown): number | null {
+  return Number.isInteger(value) && typeof value === "number" && value >= 0 ? value : null;
+}
+
+function readConfidence(value: unknown): AnalystConfidence | null {
+  if (value === "low" || value === "medium" || value === "high" || value === "unknown") {
+    return value;
+  }
+
+  return null;
+}
+
+function parseCaveats(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const caveats = value.map(readRequiredString);
+  return caveats.every((item): item is string => item !== null) ? caveats : null;
+}
+
+function parseRetrievalCitation(value: unknown): AnalystRetrievalCitation | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const assetId = readRequiredString(value.assetId);
+  const assetKind = readRequiredString(value.assetKind);
+  const citationLabel = readRequiredString(value.citationLabel);
+  const sourceId = readSourceId(value.sourceId);
+  const sourceFamily = readSourceFamily(value.sourceFamily);
+  const sourceFlavor = readOptionalString(value.sourceFlavor);
+  const datasetContractVersion = readPositiveInteger(value.datasetContractVersion);
+  const schemaSnapshotVersion = readPositiveInteger(value.schemaSnapshotVersion);
+
+  if (
+    !assetId ||
+    !assetKind ||
+    !citationLabel ||
+    !sourceId ||
+    !sourceFamily ||
+    !datasetContractVersion ||
+    !schemaSnapshotVersion ||
+    value.authority !== "advisory_context" ||
+    value.canAuthorizeExecution !== false
+  ) {
+    return null;
+  }
+
+  return {
+    assetId,
+    assetKind,
+    citationLabel,
+    sourceId,
+    sourceFamily,
+    sourceFlavor,
+    datasetContractVersion,
+    schemaSnapshotVersion,
+    authority: "advisory_context",
+    canAuthorizeExecution: false
+  };
+}
+
+function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const sourceId = readSourceId(value.sourceId);
+  const sourceFamily = readSourceFamily(value.sourceFamily);
+  const sourceFlavor = readOptionalString(value.sourceFlavor);
+  const datasetContractVersion = readPositiveInteger(value.datasetContractVersion);
+  const schemaSnapshotVersion = readPositiveInteger(value.schemaSnapshotVersion);
+  const executionPolicyVersion = readPositiveInteger(value.executionPolicyVersion);
+  const connectorProfileVersion = readPositiveInteger(value.connectorProfileVersion);
+  const candidateId = readRequiredString(value.candidateId);
+  const executionAuditEventId = readRequiredString(value.executionAuditEventId);
+  const rowCount = readNonNegativeInteger(value.rowCount);
+
+  if (
+    value.type !== "executed_evidence" ||
+    !sourceId ||
+    !sourceFamily ||
+    !datasetContractVersion ||
+    !schemaSnapshotVersion ||
+    !candidateId ||
+    !executionAuditEventId ||
+    value.executionAuditEventType !== "execution_completed" ||
+    rowCount === null ||
+    typeof value.resultTruncated !== "boolean" ||
+    value.authority !== "backend_execution_result" ||
+    value.canAuthorizeExecution !== false
+  ) {
+    return null;
+  }
+
+  return {
+    type: "executed_evidence",
+    sourceId,
+    sourceFamily,
+    sourceFlavor,
+    datasetContractVersion,
+    schemaSnapshotVersion,
+    executionPolicyVersion,
+    connectorProfileVersion,
+    candidateId,
+    executionAuditEventId,
+    executionAuditEventType: "execution_completed",
+    rowCount,
+    resultTruncated: value.resultTruncated,
+    authority: "backend_execution_result",
+    canAuthorizeExecution: false
+  };
+}
+
+function parseArray<T>(value: unknown, parser: (item: unknown) => T | null): T[] | null {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const parsed = value.map(parser);
+  return parsed.every((item): item is T => item !== null) ? parsed : null;
+}
+
+export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayload | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const responseId = readRequiredString(value.responseId);
+  const requestId = readRequiredString(value.requestId);
+  const narrative = readRequiredString(value.narrative);
+  const analystModeVersion = readRequiredString(value.analystModeVersion);
+  const confidence = readConfidence(value.confidence ?? "unknown");
+  const caveats = parseCaveats(value.caveats);
+  const retrievalCitations = parseArray(value.retrievalCitations, parseRetrievalCitation);
+  const executedEvidence = parseArray(value.executedEvidence, parseExecutedEvidence);
+
+  if (
+    !responseId ||
+    !requestId ||
+    !narrative ||
+    value.advisoryOnly !== true ||
+    value.canAuthorizeExecution !== false ||
+    !analystModeVersion ||
+    !confidence ||
+    caveats === null ||
+    retrievalCitations === null ||
+    executedEvidence === null ||
+    (retrievalCitations.length === 0 && executedEvidence.length === 0)
+  ) {
+    return null;
+  }
+
+  return {
+    responseId,
+    requestId,
+    narrative,
+    advisoryOnly: true,
+    canAuthorizeExecution: false,
+    analystModeVersion,
+    confidence,
+    caveats,
+    retrievalCitations,
+    executedEvidence
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a backend source-aware analyst response schema that keeps narrative advisory and separates retrieval citations from executed evidence.
- Adds a frontend parser for operator-facing analyst response payloads with fail-closed validation.
- Documents schema constraints for analyst-style UI consumers.

## Tests
- python3 -m pytest tests/test_analyst_response_schema.py tests/test_audit_event_model.py
- npm test -- analyst-response.test.ts
- python3 scripts/ci/check_repository_hygiene.py

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend: formal immutable analyst response schema with strict confidence/caveat handling, required source/version coverage, and validation of citation/evidence consistency
  * Frontend: runtime parser and types enforcing advisory-only responses, disallowing execution authorization, and validating citations/executed evidence

* **Tests**
  * Comprehensive unit tests covering valid preservation, missing/invalid sources, malformed fields, and advisory-only enforcement

* **Documentation**
  * Design doc clarifying governance and schema constraints for analyst responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->