### PR TITLE
Validate analyst narrative authority

### DIFF
--- a/backend/app/features/analyst_response/schema.py
+++ b/backend/app/features/analyst_response/schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Literal, Optional
 from uuid import UUID
 
@@ -15,6 +16,45 @@ from app.features.audit.event_model import (
 )
 
 AnalystConfidence = Literal["low", "medium", "high", "unknown"]
+AnalystValidationCheck = Literal[
+    "source_labeled_evidence_present",
+    "source_summary_coverage",
+    "narrative_execution_authority",
+    "narrative_execution_grounding",
+    "narrative_cross_source_execution",
+]
+
+_EXECUTION_APPROVAL_PATTERN = re.compile(
+    r"\b("
+    r"approv(?:e|es|ed|ing)\s+(?:sql\s+)?execution|"
+    r"execution\s+(?:is\s+)?approv(?:e|ed)|"
+    r"authori[sz](?:e|es|ed|ing)\s+(?:sql\s+)?execution|"
+    r"execution\s+(?:is\s+)?authori[sz](?:e|ed)|"
+    r"safe\s+to\s+(?:execute|run)|"
+    r"can\s+(?:execute|run)\s+(?:this\s+)?(?:sql|query|candidate)"
+    r")\b",
+    re.IGNORECASE,
+)
+_EXECUTION_CLAIM_PATTERN = re.compile(
+    r"\b("
+    r"backend\s+execution\s+(?:show(?:s|ed)?|returned|produced)|"
+    r"completed\s+backend\s+execution|"
+    r"execut(?:e|ed|ion)\s+(?:result|evidence)\s+(?:show(?:s|ed)?|returned|produced)|"
+    r"(?:query|candidate)\s+(?:ran|executed)\b|"
+    r"rows?\s+(?:were\s+)?returned"
+    r")",
+    re.IGNORECASE,
+)
+_CROSS_SOURCE_EXECUTION_PATTERN = re.compile(
+    r"\b("
+    r"cross[- ]source\s+(?:execution|query|join)|"
+    r"federated\s+(?:execution|query)|"
+    r"(?:joined|merged|combined)\s+(?:across\s+sources|execution\s+results)|"
+    r"executed\s+together|"
+    r"ran\s+across\s+(?:both|multiple)\s+sources"
+    r")\b",
+    re.IGNORECASE,
+)
 
 
 class AnalystResponseSourceSummary(BaseModel):
@@ -35,6 +75,22 @@ class OperatorHistoryHooks(BaseModel):
     history_record_ids: list[NonEmptyTrimmedString] = Field(default_factory=list)
 
 
+class AnalystResponseValidationOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    status: Literal["safe"] = "safe"
+    checks: list[AnalystValidationCheck] = Field(
+        default_factory=lambda: [
+            "source_labeled_evidence_present",
+            "source_summary_coverage",
+            "narrative_execution_authority",
+            "narrative_execution_grounding",
+            "narrative_cross_source_execution",
+        ]
+    )
+    unsafe_reasons: list[NonEmptyTrimmedString] = Field(default_factory=list)
+
+
 class AnalystResponsePayload(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -50,6 +106,9 @@ class AnalystResponsePayload(BaseModel):
     retrieval_citations: list[RetrievalCitationAuditPayload] = Field(default_factory=list)
     executed_evidence: list[ExecutedEvidenceAuditPayload] = Field(default_factory=list)
     operator_history_hooks: OperatorHistoryHooks = Field(default_factory=OperatorHistoryHooks)
+    validation_outcome: AnalystResponseValidationOutcome = Field(
+        default_factory=AnalystResponseValidationOutcome
+    )
 
     @model_validator(mode="after")
     def validate_source_summaries(self) -> "AnalystResponsePayload":
@@ -82,6 +141,31 @@ class AnalystResponsePayload(BaseModel):
         if supplied and not expected.issubset(supplied):
             raise ValueError(
                 "Source summaries must include every citation and executed evidence source."
+            )
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_narrative_authority(self) -> "AnalystResponsePayload":
+        narrative = self.narrative
+        cited_sources = {
+            (item.source_id, item.source_family)
+            for item in [*self.retrieval_citations, *self.executed_evidence]
+        }
+
+        if len(cited_sources) > 1 and _CROSS_SOURCE_EXECUTION_PATTERN.search(narrative):
+            raise ValueError(
+                "Analyst narrative must not imply cross-source execution authority."
+            )
+
+        if _EXECUTION_APPROVAL_PATTERN.search(narrative):
+            raise ValueError(
+                "Analyst narrative must not imply execution approval authority."
+            )
+
+        if not self.executed_evidence and _EXECUTION_CLAIM_PATTERN.search(narrative):
+            raise ValueError(
+                "Analyst narrative must not claim executed evidence without source-labeled executed evidence."
             )
 
         return self

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -184,3 +184,89 @@ def test_analyst_response_payload_rejects_execution_authority_and_bad_source_lab
 
     with pytest.raises(ValidationError):
         AnalystResponsePayload(**payload)
+
+
+@pytest.mark.parametrize(
+    "narrative",
+    [
+        "The PostgreSQL and MSSQL rows were joined across sources and executed together.",
+        "Merged execution results from business-postgres-source and business-mssql-source approve the answer.",
+        "The federated query ran across both sources and returned matching totals.",
+    ],
+)
+def test_analyst_response_payload_rejects_cross_source_execution_narratives(
+    narrative: str,
+) -> None:
+    with pytest.raises(ValidationError, match="cross-source execution"):
+        AnalystResponsePayload(
+            response_id="analyst-response-123",
+            request_id="request-123",
+            narrative=narrative,
+            advisory_only=True,
+            can_authorize_execution=False,
+            analyst_mode_version="analyst-schema-v1",
+            retrieval_citations=[
+                _citation("business-postgres-source", "postgresql"),
+                _citation("business-mssql-source", "mssql"),
+            ],
+            executed_evidence=[
+                _executed_evidence("business-postgres-source", "postgresql"),
+                _executed_evidence("business-mssql-source", "mssql"),
+            ],
+        )
+
+
+def test_analyst_response_payload_rejects_execution_claims_without_executed_evidence() -> None:
+    with pytest.raises(ValidationError, match="executed evidence"):
+        AnalystResponsePayload(
+            response_id="analyst-response-123",
+            request_id="request-123",
+            narrative="The completed backend execution showed 12 matching rows.",
+            advisory_only=True,
+            can_authorize_execution=False,
+            analyst_mode_version="analyst-schema-v1",
+            retrieval_citations=[_citation("business-postgres-source", "postgresql")],
+            executed_evidence=[],
+        )
+
+
+def test_analyst_response_payload_rejects_execution_approval_narratives() -> None:
+    with pytest.raises(ValidationError, match="execution approval"):
+        AnalystResponsePayload(
+            response_id="analyst-response-123",
+            request_id="request-123",
+            narrative="The analyst response approves SQL execution for this candidate.",
+            advisory_only=True,
+            can_authorize_execution=False,
+            analyst_mode_version="analyst-schema-v1",
+            retrieval_citations=[_citation("business-postgres-source", "postgresql")],
+            executed_evidence=[_executed_evidence("business-postgres-source", "postgresql")],
+        )
+
+
+def test_analyst_response_payload_accepts_safe_advisory_composition() -> None:
+    response = AnalystResponsePayload(
+        response_id="analyst-response-123",
+        request_id="request-123",
+        narrative=(
+            "PostgreSQL citation business-postgres-source metric definition and MSSQL "
+            "citation business-mssql-source metric definition provide advisory context. "
+            "Backend executed evidence remains candidate-bound per source."
+        ),
+        advisory_only=True,
+        can_authorize_execution=False,
+        analyst_mode_version="analyst-schema-v1",
+        confidence="medium",
+        caveats=["Execution still requires the normal guarded candidate flow."],
+        retrieval_citations=[
+            _citation("business-postgres-source", "postgresql"),
+            _citation("business-mssql-source", "mssql"),
+        ],
+        executed_evidence=[
+            _executed_evidence("business-postgres-source", "postgresql"),
+            _executed_evidence("business-mssql-source", "mssql"),
+        ],
+    )
+
+    assert response.validation_outcome.status == "safe"
+    assert response.validation_outcome.unsafe_reasons == []

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -285,6 +285,13 @@ describe("parseAnalystResponsePayload", () => {
     });
 
     expect(parsed?.validationOutcome.status).toBe("safe");
+    expect(parsed?.validationOutcome.checks).toEqual([
+      "source_labeled_evidence_present",
+      "source_summary_coverage",
+      "narrative_execution_authority",
+      "narrative_execution_grounding",
+      "narrative_cross_source_execution"
+    ]);
     expect(parsed?.validationOutcome.unsafeReasons).toEqual([]);
   });
 });

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -213,4 +213,78 @@ describe("parseAnalystResponsePayload", () => {
       })
     ).toBeNull();
   });
+
+  it("rejects cross-source execution narratives", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "PostgreSQL and MSSQL rows were joined across sources and executed together.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [
+          citation("business-postgres-source", "postgresql"),
+          citation("business-mssql-source", "mssql")
+        ],
+        executedEvidence: [
+          evidence("business-postgres-source", "postgresql"),
+          evidence("business-mssql-source", "mssql")
+        ]
+      })
+    ).toBeNull();
+  });
+
+  it("rejects execution claims without executed evidence", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "The completed backend execution showed 12 matching rows.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [citation("business-postgres-source", "postgresql")],
+        executedEvidence: []
+      })
+    ).toBeNull();
+  });
+
+  it("rejects execution approval narratives", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "The analyst response approves SQL execution for this candidate.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [citation("business-postgres-source", "postgresql")],
+        executedEvidence: [evidence("business-postgres-source", "postgresql")]
+      })
+    ).toBeNull();
+  });
+
+  it("exposes a safe validation outcome for advisory composition", () => {
+    const parsed = parseAnalystResponsePayload({
+      responseId: "analyst-response-123",
+      requestId: "request-123",
+      narrative:
+        "PostgreSQL citation and MSSQL citation provide advisory context. Backend executed evidence remains candidate-bound per source.",
+      advisoryOnly: true,
+      canAuthorizeExecution: false,
+      analystModeVersion: "analyst-schema-v1",
+      retrievalCitations: [
+        citation("business-postgres-source", "postgresql"),
+        citation("business-mssql-source", "mssql")
+      ],
+      executedEvidence: [
+        evidence("business-postgres-source", "postgresql"),
+        evidence("business-mssql-source", "mssql")
+      ]
+    });
+
+    expect(parsed?.validationOutcome.status).toBe("safe");
+    expect(parsed?.validationOutcome.unsafeReasons).toEqual([]);
+  });
 });

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -36,6 +36,7 @@ export type AnalystValidationOutcome = {
   status: "safe";
   checks: [
     "source_labeled_evidence_present",
+    "source_summary_coverage",
     "narrative_execution_authority",
     "narrative_execution_grounding",
     "narrative_cross_source_execution"
@@ -272,6 +273,7 @@ function validationOutcome(): AnalystValidationOutcome {
     status: "safe",
     checks: [
       "source_labeled_evidence_present",
+      "source_summary_coverage",
       "narrative_execution_authority",
       "narrative_execution_grounding",
       "narrative_cross_source_execution"

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -32,6 +32,17 @@ export type AnalystExecutedEvidence = {
   canAuthorizeExecution: false;
 };
 
+export type AnalystValidationOutcome = {
+  status: "safe";
+  checks: [
+    "source_labeled_evidence_present",
+    "narrative_execution_authority",
+    "narrative_execution_grounding",
+    "narrative_cross_source_execution"
+  ];
+  unsafeReasons: string[];
+};
+
 export type AnalystResponsePayload = {
   responseId: string;
   requestId: string;
@@ -43,6 +54,7 @@ export type AnalystResponsePayload = {
   caveats: string[];
   retrievalCitations: AnalystRetrievalCitation[];
   executedEvidence: AnalystExecutedEvidence[];
+  validationOutcome: AnalystValidationOutcome;
 };
 
 type RawObject = Record<string, unknown>;
@@ -50,6 +62,12 @@ type RawObject = Record<string, unknown>;
 const sourceTokenPattern = /^[a-z0-9][a-z0-9._-]*$/;
 const executionAuditEventIdPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const executionApprovalPattern =
+  /\b(approv(?:e|es|ed|ing)\s+(?:sql\s+)?execution|execution\s+(?:is\s+)?approv(?:e|ed)|authori[sz](?:e|es|ed|ing)\s+(?:sql\s+)?execution|execution\s+(?:is\s+)?authori[sz](?:e|ed)|safe\s+to\s+(?:execute|run)|can\s+(?:execute|run)\s+(?:this\s+)?(?:sql|query|candidate))\b/i;
+const executionClaimPattern =
+  /\b(backend\s+execution\s+(?:show(?:s|ed)?|returned|produced)|completed\s+backend\s+execution|execut(?:e|ed|ion)\s+(?:result|evidence)\s+(?:show(?:s|ed)?|returned|produced)|(?:query|candidate)\s+(?:ran|executed)\b|rows?\s+(?:were\s+)?returned)/i;
+const crossSourceExecutionPattern =
+  /\b(cross[- ]source\s+(?:execution|query|join)|federated\s+(?:execution|query)|(?:joined|merged|combined)\s+(?:across\s+sources|execution\s+results)|executed\s+together|ran\s+across\s+(?:both|multiple)\s+sources)\b/i;
 
 function isObject(value: unknown): value is RawObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -223,6 +241,45 @@ function parseArray<T>(value: unknown, parser: (item: unknown) => T | null): T[]
   return parsed.every((item): item is T => item !== null) ? parsed : null;
 }
 
+function sourceKey(item: AnalystRetrievalCitation | AnalystExecutedEvidence): string {
+  return `${item.sourceFamily}:${item.sourceId}`;
+}
+
+function validateNarrativeAuthority(
+  narrative: string,
+  retrievalCitations: AnalystRetrievalCitation[],
+  executedEvidence: AnalystExecutedEvidence[]
+): boolean {
+  const sourceCount = new Set([...retrievalCitations, ...executedEvidence].map(sourceKey)).size;
+
+  if (sourceCount > 1 && crossSourceExecutionPattern.test(narrative)) {
+    return false;
+  }
+
+  if (executionApprovalPattern.test(narrative)) {
+    return false;
+  }
+
+  if (executedEvidence.length === 0 && executionClaimPattern.test(narrative)) {
+    return false;
+  }
+
+  return true;
+}
+
+function validationOutcome(): AnalystValidationOutcome {
+  return {
+    status: "safe",
+    checks: [
+      "source_labeled_evidence_present",
+      "narrative_execution_authority",
+      "narrative_execution_grounding",
+      "narrative_cross_source_execution"
+    ],
+    unsafeReasons: []
+  };
+}
+
 export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayload | null {
   if (!isObject(value)) {
     return null;
@@ -248,7 +305,8 @@ export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayl
     caveats === null ||
     retrievalCitations === null ||
     executedEvidence === null ||
-    (retrievalCitations.length === 0 && executedEvidence.length === 0)
+    (retrievalCitations.length === 0 && executedEvidence.length === 0) ||
+    !validateNarrativeAuthority(narrative, retrievalCitations, executedEvidence)
   ) {
     return null;
   }
@@ -263,6 +321,7 @@ export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayl
     confidence,
     caveats,
     retrievalCitations,
-    executedEvidence
+    executedEvidence,
+    validationOutcome: validationOutcome()
   };
 }


### PR DESCRIPTION
## Summary
- reject analyst narratives that imply cross-source execution, execution approval, or backend execution evidence without source-labeled executed evidence
- add machine-readable safe validation outcomes for accepted analyst payloads
- mirror the validation in the frontend analyst response parser

## Verification
- cd backend && python3 -m pytest tests/test_analyst_response_schema.py tests/test_operator_history_payloads.py
- cd frontend && npm test -- analyst-response.test.ts
- cd frontend && npx tsc --noEmit

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced analyst response validation with automated checks to verify claim credibility
  * Validation outcomes now included in responses, displaying safety status and detailed rationale
  * Stricter enforcement prevents unsupported execution claims, unauthorized authority assertions, and cross-source execution statements

* **Tests**
  * Expanded test coverage for analyst response validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->