### PR TITLE
[H-F1] Align analyst response payload field naming

### DIFF
--- a/backend/app/features/analyst_response/schema.py
+++ b/backend/app/features/analyst_response/schema.py
@@ -13,6 +13,7 @@ from app.features.audit.event_model import (
     SourceFamily,
     SourceFlavor,
     SourceIdentifier,
+    to_camel,
 )
 
 AnalystConfidence = Literal["low", "medium", "high", "unknown"]
@@ -58,7 +59,12 @@ _CROSS_SOURCE_EXECUTION_PATTERN = re.compile(
 
 
 class AnalystResponseSourceSummary(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        frozen=True,
+        populate_by_name=True,
+    )
 
     source_id: SourceIdentifier
     source_family: SourceFamily
@@ -69,14 +75,24 @@ class AnalystResponseSourceSummary(BaseModel):
 
 
 class OperatorHistoryHooks(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        frozen=True,
+        populate_by_name=True,
+    )
 
     audit_event_id: Optional[UUID] = None
     history_record_ids: list[NonEmptyTrimmedString] = Field(default_factory=list)
 
 
 class AnalystResponseValidationOutcome(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        frozen=True,
+        populate_by_name=True,
+    )
 
     status: Literal["safe"] = "safe"
     checks: list[AnalystValidationCheck] = Field(
@@ -92,7 +108,12 @@ class AnalystResponseValidationOutcome(BaseModel):
 
 
 class AnalystResponsePayload(BaseModel):
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        frozen=True,
+        populate_by_name=True,
+    )
 
     response_id: NonEmptyTrimmedString
     request_id: NonEmptyTrimmedString
@@ -109,6 +130,9 @@ class AnalystResponsePayload(BaseModel):
     validation_outcome: AnalystResponseValidationOutcome = Field(
         default_factory=AnalystResponseValidationOutcome
     )
+
+    def to_wire_payload(self) -> dict[str, object]:
+        return self.model_dump(mode="json", by_alias=True)
 
     @model_validator(mode="after")
     def validate_source_summaries(self) -> "AnalystResponsePayload":

--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -8,6 +8,11 @@ from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, StringC
 from typing_extensions import Annotated
 
 
+def to_camel(value: str) -> str:
+    head, *tail = value.split("_")
+    return head + "".join(item.capitalize() for item in tail)
+
+
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 SourceIdentifier = Annotated[
     str,
@@ -49,7 +54,11 @@ SourceFamily = Literal["mssql", "postgresql"]
 
 
 class RetrievalCitationAuditPayload(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
+    )
 
     asset_id: NonEmptyTrimmedString
     asset_kind: NonEmptyTrimmedString
@@ -64,7 +73,11 @@ class RetrievalCitationAuditPayload(BaseModel):
 
 
 class ExecutedEvidenceAuditPayload(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
+    )
 
     type: Literal["executed_evidence"] = "executed_evidence"
     source_id: SourceIdentifier

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -83,6 +83,53 @@ def test_analyst_response_payload_preserves_multi_source_advisory_labels() -> No
     assert "sql_execution_approved" not in dumped
 
 
+def test_analyst_response_payload_serializes_camel_case_wire_contract() -> None:
+    response = AnalystResponsePayload(
+        response_id="analyst-response-123",
+        request_id="request-123",
+        narrative="Backend-produced advisory response keeps source-labeled evidence intact.",
+        advisory_only=True,
+        can_authorize_execution=False,
+        analyst_mode_version="analyst-schema-v1",
+        confidence="medium",
+        caveats=["Narrative guidance is advisory only."],
+        source_summaries=[
+            {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+                "dataset_contract_version": 2,
+                "schema_snapshot_version": 5,
+                "execution_policy_version": 3,
+            }
+        ],
+        retrieval_citations=[_citation("business-postgres-source", "postgresql")],
+        executed_evidence=[_executed_evidence("business-postgres-source", "postgresql")],
+        operator_history_hooks={
+            "audit_event_id": uuid4(),
+            "history_record_ids": ["request-123", "business-postgres-source-candidate-123"],
+        },
+    )
+
+    wire_payload = response.to_wire_payload()
+
+    assert wire_payload["responseId"] == "analyst-response-123"
+    assert wire_payload["advisoryOnly"] is True
+    assert wire_payload["canAuthorizeExecution"] is False
+    assert wire_payload["analystModeVersion"] == "analyst-schema-v1"
+    assert wire_payload["sourceSummaries"][0]["executionPolicyVersion"] == 3
+    assert wire_payload["retrievalCitations"][0]["sourceId"] == "business-postgres-source"
+    assert wire_payload["retrievalCitations"][0]["canAuthorizeExecution"] is False
+    assert wire_payload["executedEvidence"][0]["executionAuditEventType"] == "execution_completed"
+    assert wire_payload["operatorHistoryHooks"]["historyRecordIds"] == [
+        "request-123",
+        "business-postgres-source-candidate-123",
+    ]
+    assert wire_payload["validationOutcome"]["unsafeReasons"] == []
+    assert "response_id" not in wire_payload
+    assert "retrieval_citations" not in wire_payload
+
+
 def test_source_summary_coverage_uses_source_identity_not_execution_policy() -> None:
     response = AnalystResponsePayload(
         response_id="analyst-response-123",

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -37,6 +37,56 @@ function evidence(sourceId: string, sourceFamily: "mssql" | "postgresql") {
 }
 
 describe("parseAnalystResponsePayload", () => {
+  it("parses backend-produced analyst response payload field names", () => {
+    const parsed = parseAnalystResponsePayload({
+      responseId: "analyst-response-123",
+      requestId: "request-123",
+      narrative: "Backend-produced advisory response keeps source-labeled evidence intact.",
+      advisoryOnly: true,
+      canAuthorizeExecution: false,
+      analystModeVersion: "analyst-schema-v1",
+      confidence: "medium",
+      caveats: ["Narrative guidance is advisory only."],
+      sourceSummaries: [
+        {
+          sourceId: "business-postgres-source",
+          sourceFamily: "postgresql",
+          sourceFlavor: "warehouse",
+          datasetContractVersion: 2,
+          schemaSnapshotVersion: 5,
+          executionPolicyVersion: 3
+        }
+      ],
+      retrievalCitations: [citation("business-postgres-source", "postgresql")],
+      executedEvidence: [evidence("business-postgres-source", "postgresql")],
+      operatorHistoryHooks: {
+        auditEventId: "5dbcc36c-c6d6-4755-b307-5a3af5d6ec25",
+        historyRecordIds: ["request-123", "business-postgres-source-candidate-123"]
+      },
+      validationOutcome: {
+        status: "safe",
+        checks: [
+          "source_labeled_evidence_present",
+          "source_summary_coverage",
+          "narrative_execution_authority",
+          "narrative_execution_grounding",
+          "narrative_cross_source_execution"
+        ],
+        unsafeReasons: ["Manual review remains required before execution."]
+      }
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.responseId).toBe("analyst-response-123");
+    expect(parsed?.sourceSummaries[0]?.executionPolicyVersion).toBe(3);
+    expect(parsed?.retrievalCitations[0]?.sourceId).toBe("business-postgres-source");
+    expect(parsed?.executedEvidence[0]?.executionAuditEventType).toBe("execution_completed");
+    expect(parsed?.operatorHistoryHooks.historyRecordIds).toContain("request-123");
+    expect(parsed?.validationOutcome.unsafeReasons).toEqual([
+      "Manual review remains required before execution."
+    ]);
+  });
+
   it("preserves source-labeled advisory citations and executed evidence", () => {
     const parsed = parseAnalystResponsePayload({
       responseId: "analyst-response-123",

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -32,6 +32,20 @@ export type AnalystExecutedEvidence = {
   canAuthorizeExecution: false;
 };
 
+export type AnalystSourceSummary = {
+  sourceId: string;
+  sourceFamily: SourceFamily;
+  sourceFlavor: string | null;
+  datasetContractVersion: number;
+  schemaSnapshotVersion: number;
+  executionPolicyVersion: number | null;
+};
+
+export type AnalystOperatorHistoryHooks = {
+  auditEventId: string | null;
+  historyRecordIds: string[];
+};
+
 export type AnalystValidationOutcome = {
   status: "safe";
   checks: [
@@ -53,8 +67,10 @@ export type AnalystResponsePayload = {
   analystModeVersion: string;
   confidence: AnalystConfidence;
   caveats: string[];
+  sourceSummaries: AnalystSourceSummary[];
   retrievalCitations: AnalystRetrievalCitation[];
   executedEvidence: AnalystExecutedEvidence[];
+  operatorHistoryHooks: AnalystOperatorHistoryHooks;
   validationOutcome: AnalystValidationOutcome;
 };
 
@@ -100,12 +116,28 @@ function readExecutionAuditEventId(value: unknown): string | null {
   return eventId !== null && executionAuditEventIdPattern.test(eventId) ? eventId : null;
 }
 
+function readOptionalAuditEventId(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return readExecutionAuditEventId(value) ?? undefined;
+}
+
 function readSourceFamily(value: unknown): SourceFamily | null {
   return value === "mssql" || value === "postgresql" ? value : null;
 }
 
 function readPositiveInteger(value: unknown): number | null {
   return Number.isInteger(value) && typeof value === "number" && value > 0 ? value : null;
+}
+
+function readOptionalPositiveInteger(value: unknown): number | null | undefined {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return readPositiveInteger(value) ?? undefined;
 }
 
 function readNonNegativeInteger(value: unknown): number | null {
@@ -131,6 +163,48 @@ function parseCaveats(value: unknown): string[] | null {
 
   const caveats = value.map(readRequiredString);
   return caveats.every((item): item is string => item !== null) ? caveats : null;
+}
+
+function parseStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const parsed = value.map(readRequiredString);
+  return parsed.every((item): item is string => item !== null) ? parsed : null;
+}
+
+function parseSourceSummary(value: unknown): AnalystSourceSummary | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const sourceId = readSourceToken(value.sourceId);
+  const sourceFamily = readSourceFamily(value.sourceFamily);
+  const sourceFlavor = readOptionalSourceToken(value.sourceFlavor);
+  const datasetContractVersion = readPositiveInteger(value.datasetContractVersion);
+  const schemaSnapshotVersion = readPositiveInteger(value.schemaSnapshotVersion);
+  const executionPolicyVersion = readOptionalPositiveInteger(value.executionPolicyVersion);
+
+  if (
+    !sourceId ||
+    !sourceFamily ||
+    sourceFlavor === undefined ||
+    !datasetContractVersion ||
+    !schemaSnapshotVersion ||
+    executionPolicyVersion === undefined
+  ) {
+    return null;
+  }
+
+  return {
+    sourceId,
+    sourceFamily,
+    sourceFlavor,
+    datasetContractVersion,
+    schemaSnapshotVersion,
+    executionPolicyVersion
+  };
 }
 
 function parseRetrievalCitation(value: unknown): AnalystRetrievalCitation | null {
@@ -186,8 +260,8 @@ function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
   const sourceFlavor = readOptionalSourceToken(value.sourceFlavor);
   const datasetContractVersion = readPositiveInteger(value.datasetContractVersion);
   const schemaSnapshotVersion = readPositiveInteger(value.schemaSnapshotVersion);
-  const executionPolicyVersion = readPositiveInteger(value.executionPolicyVersion);
-  const connectorProfileVersion = readPositiveInteger(value.connectorProfileVersion);
+  const executionPolicyVersion = readOptionalPositiveInteger(value.executionPolicyVersion);
+  const connectorProfileVersion = readOptionalPositiveInteger(value.connectorProfileVersion);
   const candidateId = readRequiredString(value.candidateId);
   const executionAuditEventId = readExecutionAuditEventId(value.executionAuditEventId);
   const rowCount = readNonNegativeInteger(value.rowCount);
@@ -199,6 +273,8 @@ function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
     sourceFlavor === undefined ||
     !datasetContractVersion ||
     !schemaSnapshotVersion ||
+    executionPolicyVersion === undefined ||
+    connectorProfileVersion === undefined ||
     !candidateId ||
     !executionAuditEventId ||
     value.executionAuditEventType !== "execution_completed" ||
@@ -242,6 +318,31 @@ function parseArray<T>(value: unknown, parser: (item: unknown) => T | null): T[]
   return parsed.every((item): item is T => item !== null) ? parsed : null;
 }
 
+function parseOperatorHistoryHooks(value: unknown): AnalystOperatorHistoryHooks | null {
+  if (value === undefined) {
+    return {
+      auditEventId: null,
+      historyRecordIds: []
+    };
+  }
+
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const auditEventId = readOptionalAuditEventId(value.auditEventId);
+  const historyRecordIds = parseStringArray(value.historyRecordIds);
+
+  if (auditEventId === undefined || historyRecordIds === null) {
+    return null;
+  }
+
+  return {
+    auditEventId,
+    historyRecordIds
+  };
+}
+
 function sourceKey(item: AnalystRetrievalCitation | AnalystExecutedEvidence): string {
   return `${item.sourceFamily}:${item.sourceId}`;
 }
@@ -268,7 +369,7 @@ function validateNarrativeAuthority(
   return true;
 }
 
-function validationOutcome(): AnalystValidationOutcome {
+function defaultValidationOutcome(): AnalystValidationOutcome {
   return {
     status: "safe",
     checks: [
@@ -279,6 +380,42 @@ function validationOutcome(): AnalystValidationOutcome {
       "narrative_cross_source_execution"
     ],
     unsafeReasons: []
+  };
+}
+
+function parseValidationOutcome(value: unknown): AnalystValidationOutcome | null {
+  if (value === undefined) {
+    return defaultValidationOutcome();
+  }
+
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const expectedChecks: AnalystValidationOutcome["checks"] = [
+    "source_labeled_evidence_present",
+    "source_summary_coverage",
+    "narrative_execution_authority",
+    "narrative_execution_grounding",
+    "narrative_cross_source_execution"
+  ];
+  const checks = Array.isArray(value.checks) ? value.checks : null;
+  const unsafeReasons = parseStringArray(value.unsafeReasons);
+
+  if (
+    value.status !== "safe" ||
+    checks === null ||
+    checks.length !== expectedChecks.length ||
+    !expectedChecks.every((check, index) => checks[index] === check) ||
+    unsafeReasons === null
+  ) {
+    return null;
+  }
+
+  return {
+    status: "safe",
+    checks: expectedChecks,
+    unsafeReasons
   };
 }
 
@@ -293,8 +430,11 @@ export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayl
   const analystModeVersion = readRequiredString(value.analystModeVersion);
   const confidence = readConfidence(value.confidence ?? "unknown");
   const caveats = parseCaveats(value.caveats);
+  const sourceSummaries = parseArray(value.sourceSummaries, parseSourceSummary);
   const retrievalCitations = parseArray(value.retrievalCitations, parseRetrievalCitation);
   const executedEvidence = parseArray(value.executedEvidence, parseExecutedEvidence);
+  const operatorHistoryHooks = parseOperatorHistoryHooks(value.operatorHistoryHooks);
+  const validationOutcome = parseValidationOutcome(value.validationOutcome);
 
   if (
     !responseId ||
@@ -305,8 +445,11 @@ export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayl
     !analystModeVersion ||
     !confidence ||
     caveats === null ||
+    sourceSummaries === null ||
     retrievalCitations === null ||
     executedEvidence === null ||
+    operatorHistoryHooks === null ||
+    validationOutcome === null ||
     (retrievalCitations.length === 0 && executedEvidence.length === 0) ||
     !validateNarrativeAuthority(narrative, retrievalCitations, executedEvidence)
   ) {
@@ -322,8 +465,10 @@ export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayl
     analystModeVersion,
     confidence,
     caveats,
+    sourceSummaries,
     retrievalCitations,
     executedEvidence,
-    validationOutcome: validationOutcome()
+    operatorHistoryHooks,
+    validationOutcome
   };
 }


### PR DESCRIPTION
## Summary
- define the analyst response wire payload as camelCase via backend serialization aliases and an explicit to_wire_payload entrypoint
- preserve frontend parsing for source summaries, retrieval citations, executed evidence, operator history hooks, and validation outcomes
- add focused backend/frontend regression coverage for the payload boundary

## Verification
- PYTHONPATH=. python3 -m pytest tests/test_audit_event_model.py tests/test_analyst_response_schema.py
- npm test -- lib/analyst-response.test.ts
- npx tsc --noEmit

Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analyst responses now include source summaries with version tracking.
  * Added operator history hooks to track audit events and execution records.
  * Enhanced validation outcomes with detailed status checks and safety assessments.

* **Tests**
  * Comprehensive test coverage added for response payload handling and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->