### PR TITLE
Reject single-source cross-source execution narratives

### DIFF
--- a/backend/app/features/analyst_response/schema.py
+++ b/backend/app/features/analyst_response/schema.py
@@ -172,12 +172,8 @@ class AnalystResponsePayload(BaseModel):
     @model_validator(mode="after")
     def validate_narrative_authority(self) -> "AnalystResponsePayload":
         narrative = self.narrative
-        cited_sources = {
-            (item.source_id, item.source_family)
-            for item in [*self.retrieval_citations, *self.executed_evidence]
-        }
 
-        if len(cited_sources) > 1 and _CROSS_SOURCE_EXECUTION_PATTERN.search(narrative):
+        if _CROSS_SOURCE_EXECUTION_PATTERN.search(narrative):
             raise ValueError(
                 "Analyst narrative must not imply cross-source execution authority."
             )

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -263,6 +263,35 @@ def test_analyst_response_payload_rejects_cross_source_execution_narratives(
         )
 
 
+@pytest.mark.parametrize(
+    "payload_overrides",
+    [
+        {
+            "narrative": "The PostgreSQL rows were joined across sources and executed together.",
+            "retrieval_citations": [_citation("business-postgres-source", "postgresql")],
+            "executed_evidence": [_executed_evidence("business-postgres-source", "postgresql")],
+        },
+        {
+            "narrative": "The federated query compared governed definitions across both sources.",
+            "retrieval_citations": [_citation("business-postgres-source", "postgresql")],
+            "executed_evidence": [],
+        },
+    ],
+)
+def test_analyst_response_payload_rejects_cross_source_execution_with_one_source(
+    payload_overrides: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError, match="cross-source execution"):
+        AnalystResponsePayload(
+            response_id="analyst-response-123",
+            request_id="request-123",
+            advisory_only=True,
+            can_authorize_execution=False,
+            analyst_mode_version="analyst-schema-v1",
+            **payload_overrides,
+        )
+
+
 def test_analyst_response_payload_rejects_execution_claims_without_executed_evidence() -> None:
     with pytest.raises(ValidationError, match="executed evidence"):
         AnalystResponsePayload(

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -285,6 +285,34 @@ describe("parseAnalystResponsePayload", () => {
     ).toBeNull();
   });
 
+  it("rejects cross-source execution narratives with one source or retrieval-only context", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "The PostgreSQL rows were joined across sources and executed together.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [citation("business-postgres-source", "postgresql")],
+        executedEvidence: [evidence("business-postgres-source", "postgresql")]
+      })
+    ).toBeNull();
+
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "The federated query compared governed definitions across both sources.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [citation("business-postgres-source", "postgresql")],
+        executedEvidence: []
+      })
+    ).toBeNull();
+  });
+
   it("rejects execution claims without executed evidence", () => {
     expect(
       parseAnalystResponsePayload({

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -343,18 +343,12 @@ function parseOperatorHistoryHooks(value: unknown): AnalystOperatorHistoryHooks 
   };
 }
 
-function sourceKey(item: AnalystRetrievalCitation | AnalystExecutedEvidence): string {
-  return `${item.sourceFamily}:${item.sourceId}`;
-}
-
 function validateNarrativeAuthority(
   narrative: string,
   retrievalCitations: AnalystRetrievalCitation[],
   executedEvidence: AnalystExecutedEvidence[]
 ): boolean {
-  const sourceCount = new Set([...retrievalCitations, ...executedEvidence].map(sourceKey)).size;
-
-  if (sourceCount > 1 && crossSourceExecutionPattern.test(narrative)) {
+  if (crossSourceExecutionPattern.test(narrative)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- reject cross-source execution wording unconditionally in backend analyst response validation
- mirror the unconditional guard in the frontend analyst response parser
- add regressions for one-source and retrieval-only cross-source narrative payloads

## Verification
- cd backend && python3 -m pytest tests/test_analyst_response_schema.py -q
- cd frontend && npm test -- analyst-response.test.ts
- git diff --check

Note: the issue-listed frontend command `npm test -- --run analyst-response.test.ts` hung locally because it forwards to `vitest run --run analyst-response.test.ts`; the equivalent file-targeted command above passed.

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of analyst responses to properly reject narratives claiming cross-source execution when the supporting evidence only comes from a single source, ensuring consistency between narrative claims and actual data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->