### PR TITLE
Define source-aware MLflow export contract

### DIFF
--- a/backend/app/features/mlflow_export/__init__.py
+++ b/backend/app/features/mlflow_export/__init__.py
@@ -1,0 +1,13 @@
+"""Optional MLflow export contract for engineering observability records."""
+
+from app.features.mlflow_export.contract import (
+    MLflowExportPayload,
+    build_mlflow_export_from_audit_event,
+    build_mlflow_export_from_evaluation_scenario,
+)
+
+__all__ = [
+    "MLflowExportPayload",
+    "build_mlflow_export_from_audit_event",
+    "build_mlflow_export_from_evaluation_scenario",
+]

--- a/backend/app/features/mlflow_export/contract.py
+++ b/backend/app/features/mlflow_export/contract.py
@@ -120,6 +120,20 @@ def build_mlflow_export_from_audit_event(
 ) -> Optional[MLflowExportPayload]:
     if not enabled:
         return None
+    missing_required = [
+        field_name
+        for field_name, field_value in (
+            ("dataset_contract_version", audit_event.dataset_contract_version),
+            ("schema_snapshot_version", audit_event.schema_snapshot_version),
+            ("execution_policy_version", audit_event.execution_policy_version),
+        )
+        if field_value is None
+    ]
+    if missing_required:
+        raise ValueError(
+            "Cannot build MLflow audit export without required source version fields: "
+            + ", ".join(missing_required)
+        )
     return MLflowExportPayload(
         export_kind="audit_trace",
         safequery_audit_event_id=audit_event.event_id,

--- a/backend/app/features/mlflow_export/contract.py
+++ b/backend/app/features/mlflow_export/contract.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from typing import Literal, Optional, Protocol
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt, model_validator
+
+from app.features.audit.event_model import (
+    NonEmptyTrimmedString,
+    SourceAwareAuditEvent,
+    SourceFamily,
+    SourceFlavor,
+    SourceIdentifier,
+)
+from app.features.evaluation.harness import EvaluationBoundary, EvaluationScenarioKind
+
+
+PROHIBITED_EXPORT_FIELDS = frozenset(
+    {
+        "credentials",
+        "connection_string",
+        "connection_strings",
+        "raw_result_set",
+        "raw_result_sets",
+        "result_rows",
+        "controlled_corpus_body",
+        "controlled_corpus_bodies",
+        "natural_language_request",
+        "unredacted_natural_language_request",
+        "canonical_sql",
+        "identity_claims",
+        "user_subject",
+        "session_cookie",
+        "token",
+    }
+)
+
+
+class MLflowExportPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    export_schema_version: Literal[1] = 1
+    export_kind: Literal["audit_trace", "evaluation_record"]
+    authority: Literal["engineering_observability"] = "engineering_observability"
+    can_authorize_or_mutate_audit: Literal[False] = False
+
+    safequery_audit_event_id: Optional[UUID] = None
+    mlflow_run_id: Optional[NonEmptyTrimmedString] = None
+    evaluation_run_id: Optional[NonEmptyTrimmedString] = None
+
+    request_id: Optional[NonEmptyTrimmedString] = None
+    candidate_id: Optional[NonEmptyTrimmedString] = None
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
+    execution_policy_version: PositiveInt
+    connector_profile_version: Optional[PositiveInt] = None
+
+    deny_code: Optional[NonEmptyTrimmedString] = None
+    latency_ms: Optional[NonNegativeInt] = None
+    row_count: Optional[NonNegativeInt] = None
+    result_truncated: Optional[bool] = None
+
+    prompt_version: Optional[NonEmptyTrimmedString] = None
+    model_version: Optional[NonEmptyTrimmedString] = None
+    application_version: Optional[NonEmptyTrimmedString] = None
+    adapter_version: Optional[NonEmptyTrimmedString] = None
+
+    evaluation_scenario_id: Optional[NonEmptyTrimmedString] = None
+    evaluation_kind: Optional[EvaluationScenarioKind] = None
+    evaluation_boundary: Optional[EvaluationBoundary] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_prohibited_export_fields(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        prohibited = sorted(PROHIBITED_EXPORT_FIELDS.intersection(value))
+        if prohibited:
+            raise ValueError(
+                "MLflow export payload includes prohibited field(s): "
+                + ", ".join(prohibited)
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _require_kind_specific_identifiers(self) -> "MLflowExportPayload":
+        if self.export_kind == "audit_trace":
+            if self.safequery_audit_event_id is None:
+                raise ValueError("Audit trace exports must reference a SafeQuery audit event.")
+            if self.request_id is None:
+                raise ValueError("Audit trace exports must include a request identifier.")
+        if self.export_kind == "evaluation_record":
+            if self.evaluation_scenario_id is None:
+                raise ValueError("Evaluation exports must include an evaluation scenario id.")
+            if self.evaluation_kind is None:
+                raise ValueError("Evaluation exports must include an evaluation kind.")
+            if self.evaluation_boundary is None:
+                raise ValueError("Evaluation exports must include an evaluation boundary.")
+        return self
+
+
+class _EvaluationScenario(Protocol):
+    scenario_id: str
+    kind: EvaluationScenarioKind
+    evaluation_boundary: EvaluationBoundary
+    source: object
+
+
+def build_mlflow_export_from_audit_event(
+    audit_event: SourceAwareAuditEvent,
+    *,
+    enabled: bool,
+    latency_ms: Optional[int] = None,
+    mlflow_run_id: Optional[str] = None,
+    prompt_version: Optional[str] = None,
+    model_version: Optional[str] = None,
+) -> Optional[MLflowExportPayload]:
+    if not enabled:
+        return None
+    return MLflowExportPayload(
+        export_kind="audit_trace",
+        safequery_audit_event_id=audit_event.event_id,
+        mlflow_run_id=mlflow_run_id,
+        request_id=audit_event.request_id,
+        candidate_id=audit_event.query_candidate_id,
+        source_id=audit_event.source_id,
+        source_family=audit_event.source_family,
+        source_flavor=audit_event.source_flavor,
+        dataset_contract_version=audit_event.dataset_contract_version,
+        schema_snapshot_version=audit_event.schema_snapshot_version,
+        execution_policy_version=audit_event.execution_policy_version,
+        connector_profile_version=audit_event.connector_profile_version,
+        deny_code=audit_event.primary_deny_code,
+        latency_ms=latency_ms,
+        row_count=audit_event.execution_row_count,
+        result_truncated=audit_event.result_truncated,
+        prompt_version=prompt_version,
+        model_version=model_version,
+        application_version=audit_event.application_version,
+        adapter_version=audit_event.adapter_version,
+    )
+
+
+def build_mlflow_export_from_evaluation_scenario(
+    scenario: _EvaluationScenario,
+    *,
+    enabled: bool,
+    evaluation_run_id: Optional[str] = None,
+    deny_code: Optional[str] = None,
+    latency_ms: Optional[int] = None,
+    row_count: Optional[int] = None,
+    result_truncated: Optional[bool] = None,
+    prompt_version: Optional[str] = None,
+    model_version: Optional[str] = None,
+) -> Optional[MLflowExportPayload]:
+    if not enabled:
+        return None
+    source = scenario.source
+    return MLflowExportPayload(
+        export_kind="evaluation_record",
+        evaluation_run_id=evaluation_run_id,
+        source_id=source.source_id,
+        source_family=source.source_family,
+        source_flavor=source.source_flavor,
+        dataset_contract_version=source.dataset_contract_version,
+        schema_snapshot_version=source.schema_snapshot_version,
+        execution_policy_version=source.execution_policy_version,
+        connector_profile_version=source.connector_profile_version,
+        deny_code=deny_code,
+        latency_ms=latency_ms,
+        row_count=row_count,
+        result_truncated=result_truncated,
+        prompt_version=prompt_version,
+        model_version=model_version,
+        evaluation_scenario_id=scenario.scenario_id,
+        evaluation_kind=scenario.kind,
+        evaluation_boundary=scenario.evaluation_boundary,
+    )

--- a/backend/tests/test_mlflow_export_contract.py
+++ b/backend/tests/test_mlflow_export_contract.py
@@ -89,6 +89,22 @@ def test_mlflow_export_payload_serializes_source_aware_audit_metadata() -> None:
     assert serialized["safequery_audit_event_id"] != serialized["mlflow_run_id"]
 
 
+def test_mlflow_export_audit_builder_rejects_missing_source_versions() -> None:
+    audit_event = _execution_audit_event(
+        dataset_contract_version=None,
+        schema_snapshot_version=None,
+        execution_policy_version=None,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        build_mlflow_export_from_audit_event(audit_event, enabled=True)
+
+    assert str(exc_info.value) == (
+        "Cannot build MLflow audit export without required source version fields: "
+        "dataset_contract_version, schema_snapshot_version, execution_policy_version"
+    )
+
+
 def test_mlflow_export_payload_serializes_mssql_and_postgresql_evaluation_metadata() -> None:
     mssql_scenario = list_mssql_evaluation_scenarios()[0]
     postgresql_scenario = list_postgresql_evaluation_scenarios()[0]

--- a/backend/tests/test_mlflow_export_contract.py
+++ b/backend/tests/test_mlflow_export_contract.py
@@ -198,15 +198,20 @@ def test_mlflow_export_payload_rejects_prohibited_data_classes(
         prohibited_field: "blocked",
     }
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         MLflowExportPayload(**payload)
+
+    assert (
+        f"MLflow export payload includes prohibited field(s): {prohibited_field}"
+        in str(exc_info.value)
+    )
 
 
 def test_mlflow_export_payload_rejects_mlflow_as_audit_authority() -> None:
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         MLflowExportPayload(
             export_kind="audit_trace",
-            authority="authoritative_audit",
+            authority="engineering_observability",
             can_authorize_or_mutate_audit=True,
             safequery_audit_event_id=uuid4(),
             request_id="request-123",
@@ -217,6 +222,11 @@ def test_mlflow_export_payload_rejects_mlflow_as_audit_authority() -> None:
             schema_snapshot_version=7,
             execution_policy_version=2,
         )
+
+    assert any(
+        error["loc"] == ("can_authorize_or_mutate_audit",)
+        for error in exc_info.value.errors()
+    )
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_mlflow_export_contract.py
+++ b/backend/tests/test_mlflow_export_contract.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.audit import SourceAwareAuditEvent
+from app.features.evaluation import (
+    list_mssql_evaluation_scenarios,
+    list_postgresql_evaluation_scenarios,
+)
+from app.features.mlflow_export import (
+    MLflowExportPayload,
+    build_mlflow_export_from_audit_event,
+    build_mlflow_export_from_evaluation_scenario,
+)
+
+
+def _execution_audit_event(**overrides: object) -> SourceAwareAuditEvent:
+    payload: dict[str, object] = {
+        "event_id": uuid4(),
+        "event_type": "execution_completed",
+        "occurred_at": datetime.now(timezone.utc),
+        "request_id": "request-123",
+        "correlation_id": "correlation-123",
+        "user_subject": "user:alice",
+        "session_id": "session-123",
+        "query_candidate_id": "candidate-123",
+        "adapter_version": "adapter-v1",
+        "application_version": "app-v1",
+        "source_id": "business-mssql-source",
+        "source_family": "mssql",
+        "source_flavor": "sqlserver",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "execution_policy_version": 2,
+        "connector_profile_version": 1,
+        "execution_row_count": 10,
+        "result_truncated": False,
+    }
+    payload.update(overrides)
+    return SourceAwareAuditEvent(**payload)
+
+
+def test_mlflow_export_payload_serializes_source_aware_audit_metadata() -> None:
+    audit_event = _execution_audit_event()
+
+    payload = build_mlflow_export_from_audit_event(
+        audit_event,
+        enabled=True,
+        latency_ms=42,
+        mlflow_run_id="mlflow-run-123",
+        prompt_version="prompt-v1",
+        model_version="model-v1",
+    )
+
+    assert payload is not None
+    serialized = payload.model_dump(exclude_none=True)
+    assert serialized == {
+        "export_schema_version": 1,
+        "export_kind": "audit_trace",
+        "authority": "engineering_observability",
+        "can_authorize_or_mutate_audit": False,
+        "safequery_audit_event_id": audit_event.event_id,
+        "mlflow_run_id": "mlflow-run-123",
+        "request_id": "request-123",
+        "candidate_id": "candidate-123",
+        "source_id": "business-mssql-source",
+        "source_family": "mssql",
+        "source_flavor": "sqlserver",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "execution_policy_version": 2,
+        "connector_profile_version": 1,
+        "latency_ms": 42,
+        "row_count": 10,
+        "result_truncated": False,
+        "prompt_version": "prompt-v1",
+        "model_version": "model-v1",
+        "application_version": "app-v1",
+        "adapter_version": "adapter-v1",
+    }
+    assert "canonical_sql" not in serialized
+    assert "raw_result_set" not in serialized
+    assert "user_subject" not in serialized
+    assert serialized["safequery_audit_event_id"] != serialized["mlflow_run_id"]
+
+
+def test_mlflow_export_payload_serializes_mssql_and_postgresql_evaluation_metadata() -> None:
+    mssql_scenario = list_mssql_evaluation_scenarios()[0]
+    postgresql_scenario = list_postgresql_evaluation_scenarios()[0]
+
+    mssql_payload = build_mlflow_export_from_evaluation_scenario(
+        mssql_scenario,
+        enabled=True,
+        evaluation_run_id="evaluation-run-123",
+        latency_ms=55,
+        row_count=10,
+        result_truncated=False,
+    )
+    postgresql_payload = build_mlflow_export_from_evaluation_scenario(
+        postgresql_scenario,
+        enabled=True,
+        evaluation_run_id="evaluation-run-123",
+        deny_code="DENY_TEST",
+        latency_ms=20,
+        result_truncated=True,
+    )
+
+    assert mssql_payload is not None
+    assert postgresql_payload is not None
+    assert mssql_payload.model_dump(exclude_none=True) == {
+        "export_schema_version": 1,
+        "export_kind": "evaluation_record",
+        "authority": "engineering_observability",
+        "can_authorize_or_mutate_audit": False,
+        "evaluation_run_id": "evaluation-run-123",
+        "source_id": "business-mssql-source",
+        "source_family": "mssql",
+        "source_flavor": "sqlserver",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "execution_policy_version": 2,
+        "connector_profile_version": 1,
+        "latency_ms": 55,
+        "row_count": 10,
+        "result_truncated": False,
+        "evaluation_scenario_id": mssql_scenario.scenario_id,
+        "evaluation_kind": "positive",
+        "evaluation_boundary": "execution",
+    }
+    assert postgresql_payload.model_dump(exclude_none=True) == {
+        "export_schema_version": 1,
+        "export_kind": "evaluation_record",
+        "authority": "engineering_observability",
+        "can_authorize_or_mutate_audit": False,
+        "evaluation_run_id": "evaluation-run-123",
+        "source_id": "business-postgres-source",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": 4,
+        "schema_snapshot_version": 9,
+        "execution_policy_version": 3,
+        "connector_profile_version": 1,
+        "deny_code": "DENY_TEST",
+        "latency_ms": 20,
+        "result_truncated": True,
+        "evaluation_scenario_id": postgresql_scenario.scenario_id,
+        "evaluation_kind": "positive",
+        "evaluation_boundary": "execution",
+    }
+
+
+@pytest.mark.parametrize(
+    "prohibited_field",
+    [
+        "credentials",
+        "connection_string",
+        "raw_result_set",
+        "controlled_corpus_body",
+        "natural_language_request",
+        "canonical_sql",
+        "identity_claims",
+    ],
+)
+def test_mlflow_export_payload_rejects_prohibited_data_classes(
+    prohibited_field: str,
+) -> None:
+    payload = {
+        "export_kind": "audit_trace",
+        "safequery_audit_event_id": uuid4(),
+        "request_id": "request-123",
+        "source_id": "business-mssql-source",
+        "source_family": "mssql",
+        "source_flavor": "sqlserver",
+        "dataset_contract_version": 3,
+        "schema_snapshot_version": 7,
+        "execution_policy_version": 2,
+        prohibited_field: "blocked",
+    }
+
+    with pytest.raises(ValidationError):
+        MLflowExportPayload(**payload)
+
+
+def test_mlflow_export_payload_rejects_mlflow_as_audit_authority() -> None:
+    with pytest.raises(ValidationError):
+        MLflowExportPayload(
+            export_kind="audit_trace",
+            authority="authoritative_audit",
+            can_authorize_or_mutate_audit=True,
+            safequery_audit_event_id=uuid4(),
+            request_id="request-123",
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver",
+            dataset_contract_version=3,
+            schema_snapshot_version=7,
+            execution_policy_version=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "builder",
+    [
+        lambda: build_mlflow_export_from_audit_event(_execution_audit_event(), enabled=False),
+        lambda: build_mlflow_export_from_evaluation_scenario(
+            list_mssql_evaluation_scenarios()[0],
+            enabled=False,
+        ),
+    ],
+)
+def test_mlflow_export_can_be_disabled_without_creating_payload(
+    builder: Callable[[], object],
+) -> None:
+    assert builder() is None
+
+
+def test_mlflow_export_payload_keeps_audit_reference_typed() -> None:
+    audit_event_id = uuid4()
+
+    payload = MLflowExportPayload(
+        export_kind="audit_trace",
+        safequery_audit_event_id=audit_event_id,
+        request_id="request-123",
+        source_id="business-postgres-source",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        dataset_contract_version=4,
+        schema_snapshot_version=9,
+        execution_policy_version=3,
+    )
+
+    assert isinstance(payload.safequery_audit_event_id, UUID)
+    assert payload.safequery_audit_event_id == audit_event_id


### PR DESCRIPTION
## Summary
- Add an optional typed MLflow export payload for SafeQuery engineering observability records
- Add builders for source-aware audit traces and evaluation records without wiring MLflow into core paths
- Reject prohibited export data classes and keep MLflow run IDs separate from authoritative audit references

## Verification
- cd backend && python3 -m pytest tests/test_mlflow_export_contract.py
- cd backend && python3 -m pytest tests/test_mlflow_export_contract.py tests/test_audit_event_model.py tests/test_evaluation_harness.py tests/test_release_gate.py
- cd backend && python3 -m pytest
- rg -n -e '/Users/' -e '/home/' -e 'C:\Users\' -e '\\Users\' backend/app/features/mlflow_export backend/tests/test_mlflow_export_contract.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MLflow export payload support with strict schema validation, prohibited-field guards, and an enable/disable flag; enforces required identifiers per export type and preserves typed IDs.

* **Tests**
  * Added comprehensive tests validating payload serialization, prohibited-field rejection, required-field validation, behavior when disabled, and handling across evaluation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->