### PR TITLE
Validate MLflow redacted sample metadata

### DIFF
--- a/backend/app/features/mlflow_export/contract.py
+++ b/backend/app/features/mlflow_export/contract.py
@@ -95,6 +95,20 @@ class MLflowRedactedSample(BaseModel):
     value: NonEmptyTrimmedString
     source_metadata: dict[str, object] = Field(default_factory=dict)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_prohibited_source_metadata(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        source_metadata = value.get("source_metadata")
+        prohibited = _prohibited_export_fields_in_mapping(source_metadata)
+        if prohibited:
+            raise ValueError(
+                "MLflow redacted sample metadata includes prohibited field(s): "
+                + ", ".join(prohibited)
+            )
+        return value
+
     @model_validator(mode="after")
     def _require_field_specific_profile(self) -> "MLflowRedactedSample":
         expected_profile = _APPROVED_PROFILE_BY_FIELD[self.source_field]
@@ -580,4 +594,27 @@ def _suppression_reasons_for_samples(
     for sample in samples:
         if any(pattern.search(sample.value) for pattern in _PROHIBITED_SAMPLE_PATTERNS):
             reasons.append(f"prohibited_pattern_detected:{sample.source_field}")
+        metadata_fields = _prohibited_export_fields_in_mapping(sample.source_metadata)
+        if metadata_fields:
+            reasons.append(
+                "prohibited_metadata_field_detected:"
+                f"{sample.source_field}:{','.join(metadata_fields)}"
+            )
     return reasons
+
+
+def _prohibited_export_fields_in_mapping(value: object) -> tuple[str, ...]:
+    prohibited: set[str] = set()
+
+    def collect(candidate: object) -> None:
+        if isinstance(candidate, dict):
+            for key, nested_value in candidate.items():
+                if isinstance(key, str) and key in PROHIBITED_EXPORT_FIELDS:
+                    prohibited.add(key)
+                collect(nested_value)
+        elif isinstance(candidate, (list, tuple)):
+            for item in candidate:
+                collect(item)
+
+    collect(value)
+    return tuple(sorted(prohibited))

--- a/backend/app/features/mlflow_export/contract.py
+++ b/backend/app/features/mlflow_export/contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from typing import Literal, Optional, Protocol
 from uuid import UUID
 
@@ -607,7 +608,7 @@ def _prohibited_export_fields_in_mapping(value: object) -> tuple[str, ...]:
     prohibited: set[str] = set()
 
     def collect(candidate: object) -> None:
-        if isinstance(candidate, dict):
+        if isinstance(candidate, Mapping):
             for key, nested_value in candidate.items():
                 if isinstance(key, str) and key in PROHIBITED_EXPORT_FIELDS:
                     prohibited.add(key)

--- a/backend/app/features/mlflow_export/contract.py
+++ b/backend/app/features/mlflow_export/contract.py
@@ -99,7 +99,7 @@ class MLflowRedactedSample(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _reject_prohibited_source_metadata(cls, value: object) -> object:
-        if not isinstance(value, dict):
+        if not isinstance(value, Mapping):
             return value
         source_metadata = value.get("source_metadata")
         prohibited = _prohibited_export_fields_in_mapping(source_metadata)

--- a/backend/tests/test_mlflow_export_contract.py
+++ b/backend/tests/test_mlflow_export_contract.py
@@ -492,6 +492,7 @@ def test_mlflow_export_preserves_safe_redacted_samples_and_source_metadata() -> 
         {"connection_string": "Server=warehouse;Password=sample"},
         {"identity_claims": {"subject": "user:alice"}},
         {"credentials": {"api_key": "sample-key"}},
+        {"samples": [{"connection_string": "Server=warehouse;Password=sample"}]},
         {"query": {"canonical_sql": "SELECT * FROM payroll"}},
         {"control_plane": {"candidate_lifecycle_state": "approved"}},
         {"metadata": MappingProxyType({"connection_string": "Server=warehouse"})},
@@ -510,6 +511,25 @@ def test_mlflow_redacted_sample_rejects_prohibited_source_metadata(
 
     assert "MLflow redacted sample metadata includes prohibited field(s):" in str(
         exc_info.value
+    )
+
+
+def test_mlflow_redacted_sample_rejects_mapping_model_input_source_metadata() -> None:
+    sample = MappingProxyType(
+        {
+            "source_field": "sql_snippet",
+            "redaction_profile": "sql_snippet_v1",
+            "value": "SELECT vendor_name FROM approved_vendor_spend LIMIT 10",
+            "source_metadata": {"connection_string": "Server=warehouse"},
+        }
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        MLflowRedactedSample.model_validate(sample)
+
+    assert (
+        "MLflow redacted sample metadata includes prohibited field(s): connection_string"
+        in str(exc_info.value)
     )
 
 

--- a/backend/tests/test_mlflow_export_contract.py
+++ b/backend/tests/test_mlflow_export_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime, timezone
+from types import MappingProxyType
 from uuid import UUID, uuid4
 
 import pytest
@@ -493,6 +494,7 @@ def test_mlflow_export_preserves_safe_redacted_samples_and_source_metadata() -> 
         {"credentials": {"api_key": "sample-key"}},
         {"query": {"canonical_sql": "SELECT * FROM payroll"}},
         {"control_plane": {"candidate_lifecycle_state": "approved"}},
+        {"metadata": MappingProxyType({"connection_string": "Server=warehouse"})},
     ],
 )
 def test_mlflow_redacted_sample_rejects_prohibited_source_metadata(
@@ -575,7 +577,9 @@ def test_mlflow_export_suppresses_unsafe_sample_metadata_without_blocking_audit(
         source_field="sql_snippet",
         redaction_profile="sql_snippet_v1",
         value="SELECT vendor_name FROM approved_vendor_spend LIMIT 10",
-        source_metadata={"metadata": {"connection_string": "Server=warehouse"}},
+        source_metadata={
+            "metadata": MappingProxyType({"connection_string": "Server=warehouse"})
+        },
     )
 
     decision = prepare_mlflow_export_from_audit_event(

--- a/backend/tests/test_mlflow_export_contract.py
+++ b/backend/tests/test_mlflow_export_contract.py
@@ -461,7 +461,9 @@ def test_mlflow_export_preserves_safe_redacted_samples_and_source_metadata() -> 
                 value="SELECT vendor_name FROM approved_vendor_spend LIMIT 10",
                 source_metadata={
                     "source_id": audit_event.source_id,
+                    "scenario_id": "scenario-123",
                     "schema_snapshot_version": audit_event.schema_snapshot_version,
+                    "dataset_contract_version": audit_event.dataset_contract_version,
                     "column_count": 1,
                 },
             ),
@@ -475,10 +477,38 @@ def test_mlflow_export_preserves_safe_redacted_samples_and_source_metadata() -> 
         "value": "SELECT vendor_name FROM approved_vendor_spend LIMIT 10",
         "source_metadata": {
             "source_id": "business-mssql-source",
+            "scenario_id": "scenario-123",
             "schema_snapshot_version": 7,
+            "dataset_contract_version": 3,
             "column_count": 1,
         },
     }
+
+
+@pytest.mark.parametrize(
+    "source_metadata",
+    [
+        {"connection_string": "Server=warehouse;Password=sample"},
+        {"identity_claims": {"subject": "user:alice"}},
+        {"credentials": {"api_key": "sample-key"}},
+        {"query": {"canonical_sql": "SELECT * FROM payroll"}},
+        {"control_plane": {"candidate_lifecycle_state": "approved"}},
+    ],
+)
+def test_mlflow_redacted_sample_rejects_prohibited_source_metadata(
+    source_metadata: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        MLflowRedactedSample(
+            source_field="sql_snippet",
+            redaction_profile="sql_snippet_v1",
+            value="SELECT vendor_name FROM approved_vendor_spend LIMIT 10",
+            source_metadata=source_metadata,
+        )
+
+    assert "MLflow redacted sample metadata includes prohibited field(s):" in str(
+        exc_info.value
+    )
 
 
 @pytest.mark.parametrize(
@@ -539,6 +569,30 @@ def test_mlflow_export_suppresses_unredacted_sample_without_blocking_audit() -> 
     assert decision.request_id == audit_event.request_id
 
 
+def test_mlflow_export_suppresses_unsafe_sample_metadata_without_blocking_audit() -> None:
+    audit_event = _execution_audit_event()
+    sample = MLflowRedactedSample.model_construct(
+        source_field="sql_snippet",
+        redaction_profile="sql_snippet_v1",
+        value="SELECT vendor_name FROM approved_vendor_spend LIMIT 10",
+        source_metadata={"metadata": {"connection_string": "Server=warehouse"}},
+    )
+
+    decision = prepare_mlflow_export_from_audit_event(
+        audit_event,
+        enabled=True,
+        redacted_samples=(sample,),
+    )
+
+    assert decision.payload is None
+    assert decision.suppressed is True
+    assert decision.reasons == (
+        "prohibited_metadata_field_detected:sql_snippet:connection_string",
+    )
+    assert decision.safequery_audit_event_id == audit_event.event_id
+    assert decision.request_id == audit_event.request_id
+
+
 def test_mlflow_export_suppresses_unsafe_evaluation_diagnostic() -> None:
     scenario = list_mssql_evaluation_scenarios()[0]
 
@@ -558,6 +612,30 @@ def test_mlflow_export_suppresses_unsafe_evaluation_diagnostic() -> None:
     assert decision.payload is None
     assert decision.suppressed is True
     assert decision.reasons == ("prohibited_pattern_detected:evaluation_diagnostic",)
+    assert decision.evaluation_scenario_id == scenario.scenario_id
+
+
+def test_mlflow_export_suppresses_unsafe_evaluation_metadata() -> None:
+    scenario = list_mssql_evaluation_scenarios()[0]
+    sample = MLflowRedactedSample.model_construct(
+        source_field="evaluation_diagnostic",
+        redaction_profile="evaluation_diagnostic_v1",
+        value="evaluation completed without unsafe sample text",
+        source_metadata={"control_plane": {"release_gate_status": "passed"}},
+    )
+
+    decision = prepare_mlflow_export_from_evaluation_scenario(
+        scenario,
+        enabled=True,
+        redacted_samples=(sample,),
+    )
+
+    assert decision.payload is None
+    assert decision.suppressed is True
+    assert decision.reasons == (
+        "prohibited_metadata_field_detected:"
+        "evaluation_diagnostic:release_gate_status",
+    )
     assert decision.evaluation_scenario_id == scenario.scenario_id
 
 


### PR DESCRIPTION
## Summary
- reject prohibited MLflow export field names inside redacted sample source metadata, including obvious nested mappings and lists
- suppress bypassed/legacy unsafe sample metadata in non-throwing prepare helpers with machine-readable reasons
- preserve safe source-aware metadata such as source_id, scenario_id, schema_snapshot_version, dataset_contract_version, and counters

## Verification
- cd backend && python3 -m pytest tests/test_mlflow_export_contract.py -q
- cd backend && python3 -m pytest -q

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened MLflow export validation to reject source metadata containing prohibited fields, preventing unsafe data exports.
  * Enhanced suppression detection to report exactly which prohibited metadata fields were found and suppress the export.
  * Ensured audit/evaluation identifiers remain intact when exports are suppressed, preserving traceability.
  * Verified safe exports preserve scenario and dataset contract identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->