### PR TITLE
Define planned MySQL source profile requirements

### DIFF
--- a/backend/app/services/source_family_profiles.py
+++ b/backend/app/services/source_family_profiles.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+RolloutStatus = Literal["active_baseline", "planned", "planned_flavor"]
+
+
+class ConnectorProfileRequirements(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    profile_id: str
+    owner: Literal["backend"]
+    read_only_posture: Literal["required"]
+    secret_reference_pattern: str
+    connection_identity_fields: tuple[str, ...]
+    required_controls: tuple[str, ...]
+    application_postgres_separation: str
+
+
+class DialectProfileRequirements(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    profile_id: str
+    canonicalization_requirements: tuple[str, ...]
+    identifier_quoting: str
+    row_bounding_strategy: str
+    limit_behavior: str
+    read_only_statement_allowlist: tuple[str, ...]
+    fail_closed_denies: tuple[str, ...]
+
+
+class AuditAndEvaluationRequirements(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    reconstruction_fields: tuple[str, ...]
+    preview_events: tuple[str, ...]
+    guard_events: tuple[str, ...]
+    execution_events: tuple[str, ...]
+    denial_events: tuple[str, ...]
+    release_gate_fields: tuple[str, ...]
+    evaluation_corpus_requirements: tuple[str, ...]
+
+
+class SourceFamilyProfileRequirements(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source_family: str
+    rollout_status: RolloutStatus
+    execution_enabled_by_default: bool
+    backend_selected: bool
+    adapter_inference_allowed: bool
+    permitted_source_flavors: tuple[str, ...]
+    required_registry_fields: tuple[str, ...]
+    required_version_fields: tuple[str, ...]
+    connector: ConnectorProfileRequirements
+    dialect: DialectProfileRequirements
+    audit_and_evaluation: AuditAndEvaluationRequirements
+
+
+ACTIVE_SOURCE_FAMILIES: tuple[str, ...] = ("mssql", "postgresql")
+
+MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
+    source_family="mysql",
+    rollout_status="planned",
+    execution_enabled_by_default=False,
+    backend_selected=True,
+    adapter_inference_allowed=False,
+    permitted_source_flavors=("mysql-8", "aurora-mysql"),
+    required_registry_fields=(
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+        "activation_posture",
+        "connection_reference",
+    ),
+    required_version_fields=(
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+    ),
+    connector=ConnectorProfileRequirements(
+        profile_id="mysql.readonly.planned.v1",
+        owner="backend",
+        read_only_posture="required",
+        secret_reference_pattern="safequery/business/mysql/<source_id>/reader",
+        connection_identity_fields=(
+            "host",
+            "port",
+            "database",
+            "username",
+            "tls_mode",
+        ),
+        required_controls=(
+            "connect_timeout_seconds",
+            "statement_timeout_seconds",
+            "cancellation_probe",
+        ),
+        application_postgres_separation=(
+            "mysql business source credentials and endpoints must be distinct from "
+            "the application PostgreSQL system of record"
+        ),
+    ),
+    dialect=DialectProfileRequirements(
+        profile_id="mysql.family.planned.v1",
+        canonicalization_requirements=(
+            "single_statement_select_shape",
+            "mysql_keyword_normalization",
+            "literal_preservation_before_guard",
+            "schema_qualified_identifier_normalization",
+        ),
+        identifier_quoting="backtick identifiers by default; reject unsafe sql_mode assumptions",
+        row_bounding_strategy="append_or_tighten_limit_before_guard_preview_and_execution",
+        limit_behavior=(
+            "canonical SQL must have one effective LIMIT bounded by the execution policy; "
+            "OFFSET is allowed only with an explicit bounded LIMIT"
+        ),
+        read_only_statement_allowlist=("SELECT", "WITH_SELECT"),
+        fail_closed_denies=(
+            "multi_statement",
+            "write_operation",
+            "procedure_execution",
+            "dynamic_sql",
+            "external_data_access",
+            "system_catalog_access",
+            "cross_database_reference",
+            "temporary_object_mutation",
+            "unbounded_or_unsafe_limit",
+            "unsupported_sql_syntax",
+        ),
+    ),
+    audit_and_evaluation=AuditAndEvaluationRequirements(
+        reconstruction_fields=(
+            "source_id",
+            "source_family",
+            "source_flavor",
+            "dataset_contract_version",
+            "schema_snapshot_version",
+            "execution_policy_version",
+            "connector_profile_version",
+            "dialect_profile_version",
+            "guard_version",
+            "primary_deny_code",
+        ),
+        preview_events=("query_submitted", "generation_completed"),
+        guard_events=("guard_evaluated",),
+        execution_events=("execution_requested", "execution_started", "execution_completed"),
+        denial_events=("execution_denied", "candidate_invalidated"),
+        release_gate_fields=(
+            "scenario_id",
+            "source.source_id",
+            "source.source_family",
+            "source.source_flavor",
+            "source.dialect_profile",
+            "source.dialect_profile_version",
+            "source.connector_profile_version",
+            "source.dataset_contract_version",
+            "source.schema_snapshot_version",
+            "source.execution_policy_version",
+            "expected.primary_code",
+        ),
+        evaluation_corpus_requirements=(
+            "positive_readonly_selects",
+            "row_bounding_regressions",
+            "guard_deny_corpus",
+            "connector_timeout_and_cancellation",
+            "release_gate_reconstruction",
+        ),
+    ),
+)
+
+
+PLANNED_SOURCE_FAMILY_PROFILE_REQUIREMENTS: tuple[
+    SourceFamilyProfileRequirements, ...
+] = (MYSQL_FAMILY_PROFILE_REQUIREMENTS,)
+
+
+def get_planned_source_family_profile_requirements(
+    source_family: str,
+) -> SourceFamilyProfileRequirements | None:
+    normalized_source_family = source_family.strip().lower()
+    for requirements in PLANNED_SOURCE_FAMILY_PROFILE_REQUIREMENTS:
+        if requirements.source_family == normalized_source_family:
+            return requirements
+    return None

--- a/backend/app/services/source_family_profiles.py
+++ b/backend/app/services/source_family_profiles.py
@@ -53,7 +53,7 @@ class SourceFamilyProfileRequirements(BaseModel):
     backend_selected: bool
     adapter_inference_allowed: bool
     permitted_source_flavors: tuple[str, ...]
-    required_registry_fields: tuple[str, ...]
+    required_profile_contract_fields: tuple[str, ...]
     required_version_fields: tuple[str, ...]
     connector: ConnectorProfileRequirements
     dialect: DialectProfileRequirements
@@ -69,7 +69,7 @@ MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
     backend_selected=True,
     adapter_inference_allowed=False,
     permitted_source_flavors=("mysql-8", "aurora-mysql"),
-    required_registry_fields=(
+    required_profile_contract_fields=(
         "source_id",
         "source_family",
         "source_flavor",

--- a/backend/app/services/source_family_profiles.py
+++ b/backend/app/services/source_family_profiles.py
@@ -92,7 +92,7 @@ MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
         profile_id="mysql.readonly.planned.v1",
         owner="backend",
         read_only_posture="required",
-        secret_reference_pattern="safequery/business/mysql/<source_id>/reader",
+        secret_reference_pattern="safequery/business/mysql/<source_id>/reader",  # noqa: S106 - reference template, not a credential
         connection_identity_fields=(
             "host",
             "port",

--- a/backend/tests/test_source_family_profiles.py
+++ b/backend/tests/test_source_family_profiles.py
@@ -1,0 +1,117 @@
+import pytest
+
+from app.features.execution.connector_selection import (
+    ExecutionConnectorSelectionError,
+    select_execution_connector,
+)
+from app.features.execution.runtime import (
+    DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY,
+    DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY,
+)
+from app.features.guard.deny_taxonomy import DENY_UNSUPPORTED_SOURCE_BINDING
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
+from app.services.source_family_profiles import (
+    ACTIVE_SOURCE_FAMILIES,
+    MYSQL_FAMILY_PROFILE_REQUIREMENTS,
+    get_planned_source_family_profile_requirements,
+)
+
+
+def test_mysql_family_requirements_are_planned_and_backend_selected() -> None:
+    requirements = get_planned_source_family_profile_requirements(" MySQL ")
+
+    assert requirements == MYSQL_FAMILY_PROFILE_REQUIREMENTS
+    assert requirements.source_family == "mysql"
+    assert requirements.rollout_status == "planned"
+    assert requirements.execution_enabled_by_default is False
+    assert requirements.backend_selected is True
+    assert requirements.adapter_inference_allowed is False
+    assert requirements.permitted_source_flavors == ("mysql-8", "aurora-mysql")
+    assert set(requirements.required_version_fields) == {
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+    }
+
+
+def test_mysql_family_requirements_cover_connector_dialect_guard_and_audit() -> None:
+    requirements = MYSQL_FAMILY_PROFILE_REQUIREMENTS
+
+    assert requirements.connector.model_dump() == {
+        "profile_id": "mysql.readonly.planned.v1",
+        "owner": "backend",
+        "read_only_posture": "required",
+        "secret_reference_pattern": "safequery/business/mysql/<source_id>/reader",
+        "connection_identity_fields": (
+            "host",
+            "port",
+            "database",
+            "username",
+            "tls_mode",
+        ),
+        "required_controls": (
+            "connect_timeout_seconds",
+            "statement_timeout_seconds",
+            "cancellation_probe",
+        ),
+        "application_postgres_separation": (
+            "mysql business source credentials and endpoints must be distinct from "
+            "the application PostgreSQL system of record"
+        ),
+    }
+    assert requirements.dialect.identifier_quoting.startswith("backtick identifiers")
+    assert requirements.dialect.read_only_statement_allowlist == ("SELECT", "WITH_SELECT")
+    assert {
+        "multi_statement",
+        "write_operation",
+        "procedure_execution",
+        "dynamic_sql",
+        "external_data_access",
+        "system_catalog_access",
+        "cross_database_reference",
+        "temporary_object_mutation",
+        "unbounded_or_unsafe_limit",
+        "unsupported_sql_syntax",
+    }.issubset(set(requirements.dialect.fail_closed_denies))
+    assert {
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+        "primary_deny_code",
+    }.issubset(set(requirements.audit_and_evaluation.reconstruction_fields))
+    assert {
+        "positive_readonly_selects",
+        "row_bounding_regressions",
+        "guard_deny_corpus",
+        "connector_timeout_and_cancellation",
+        "release_gate_reconstruction",
+    }.issubset(set(requirements.audit_and_evaluation.evaluation_corpus_requirements))
+
+
+def test_planned_mysql_profile_does_not_enable_active_execution_paths() -> None:
+    assert ACTIVE_SOURCE_FAMILIES == ("mssql", "postgresql")
+    assert "mysql" not in DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY
+    assert "mysql" not in DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY
+
+    with pytest.raises(
+        ExecutionConnectorSelectionError,
+        match="No backend-owned execution connector is registered",
+    ) as exc_info:
+        select_execution_connector(
+            candidate_source=SourceBoundCandidateMetadata(
+                source_id="future-mysql-source",
+                source_family="mysql",
+                source_flavor="mysql-8",
+                dataset_contract_version=1,
+                schema_snapshot_version=1,
+            )
+        )
+
+    assert exc_info.value.deny_code == DENY_UNSUPPORTED_SOURCE_BINDING

--- a/backend/tests/test_source_family_profiles.py
+++ b/backend/tests/test_source_family_profiles.py
@@ -27,6 +27,18 @@ def test_mysql_family_requirements_are_planned_and_backend_selected() -> None:
     assert requirements.backend_selected is True
     assert requirements.adapter_inference_allowed is False
     assert requirements.permitted_source_flavors == ("mysql-8", "aurora-mysql")
+    assert set(requirements.required_profile_contract_fields) == {
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+        "activation_posture",
+        "connection_reference",
+    }
     assert set(requirements.required_version_fields) == {
         "dataset_contract_version",
         "schema_snapshot_version",
@@ -34,6 +46,9 @@ def test_mysql_family_requirements_are_planned_and_backend_selected() -> None:
         "connector_profile_version",
         "dialect_profile_version",
     }
+    assert set(requirements.required_version_fields).issubset(
+        requirements.required_profile_contract_fields
+    )
 
 
 def test_mysql_family_requirements_cover_connector_dialect_guard_and_audit() -> None:
@@ -84,8 +99,22 @@ def test_mysql_family_requirements_cover_connector_dialect_guard_and_audit() -> 
         "execution_policy_version",
         "connector_profile_version",
         "dialect_profile_version",
+        "guard_version",
         "primary_deny_code",
     }.issubset(set(requirements.audit_and_evaluation.reconstruction_fields))
+    assert {
+        "scenario_id",
+        "source.source_id",
+        "source.source_family",
+        "source.source_flavor",
+        "source.dialect_profile",
+        "source.dialect_profile_version",
+        "source.connector_profile_version",
+        "source.dataset_contract_version",
+        "source.schema_snapshot_version",
+        "source.execution_policy_version",
+        "expected.primary_code",
+    }.issubset(set(requirements.audit_and_evaluation.release_gate_fields))
     assert {
         "positive_readonly_selects",
         "row_bounding_regressions",

--- a/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
+++ b/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
@@ -91,6 +91,8 @@ for:
 - `execution_policy_version`
 - `connector_profile_version`
 - `dialect_profile_version`
+- `activation_posture`
+- `connection_reference`
 
 The adapter and client must not infer MySQL eligibility from a driver name,
 hostname, connection URL, request hint, source label, or generated SQL text.

--- a/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
+++ b/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
@@ -74,6 +74,53 @@ The dialect profile defines:
 
 Future onboarding must happen by adding or approving profiles, not by redesigning the core SafeQuery control plane.
 
+### Planned MySQL Family Requirements
+
+MySQL is approved as planned source-family metadata only. Listing the family does
+not activate execution, connector selection, runtime defaults, or release-gate
+coverage.
+
+A MySQL source profile must be registered by the backend with explicit values
+for:
+
+- `source_id`
+- `source_family=mysql`
+- `source_flavor`, such as `mysql-8` or `aurora-mysql`
+- `dataset_contract_version`
+- `schema_snapshot_version`
+- `execution_policy_version`
+- `connector_profile_version`
+- `dialect_profile_version`
+
+The adapter and client must not infer MySQL eligibility from a driver name,
+hostname, connection URL, request hint, source label, or generated SQL text.
+Connector selection remains backend-owned and source-registry governed.
+
+The planned MySQL connector profile must require:
+
+- read-only database identity and privileges
+- backend-owned secret indirection such as `safequery/business/mysql/<source_id>/reader`
+- explicit connection identity fields for host, port, database, username, and TLS posture
+- connect timeout, statement timeout, and cancellation probe support
+- separation from application PostgreSQL credentials, service identity, and endpoint
+
+The planned MySQL dialect and guard profile must require:
+
+- single-statement canonical SQL before preview, guard, and execution
+- MySQL-aware keyword and identifier normalization
+- backtick identifier quoting by default, with unsafe `sql_mode` assumptions rejected
+- one effective policy-bounded `LIMIT`; `OFFSET` is allowed only with an explicit bounded `LIMIT`
+- a read-only statement allowlist for `SELECT` and `WITH`-leading SELECT queries
+- fail-closed denies for writes, multi-statement SQL, procedure execution, dynamic SQL,
+  external data access, system catalog access, cross-database references, temporary
+  object mutation, unsafe row bounds, and unsupported syntax
+
+Audit, operator-history, and release-gate reconstruction for MySQL must preserve
+the source and profile fields needed to prove which backend-selected profile was
+used: `source_id`, `source_family`, `source_flavor`, dataset contract version,
+schema snapshot version, execution policy version, connector profile version,
+dialect profile version, guard version, and primary deny code.
+
 ## Consequences
 
 Positive outcomes:

--- a/docs/design/dialect-capability-matrix.md
+++ b/docs/design/dialect-capability-matrix.md
@@ -14,7 +14,7 @@ It is a planning and review aid for connector, guard, and evaluation work.
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `mssql` | SQL Server-focused prompt and schema context | T-SQL canonicalization before guard and preview | T-SQL fail-closed guard profile | bounded canonical SQL before preview | timeout and cancellation required | initial read-only SQL Server connector | positive and deny corpus required | active baseline |
 | `postgresql` | PostgreSQL-focused prompt and schema context | PostgreSQL canonicalization before guard and preview | PostgreSQL fail-closed guard profile | bounded canonical SQL before preview | timeout and cancellation required | business PostgreSQL connector separate from app PostgreSQL | positive and deny corpus required | active baseline |
-| `mysql` | MySQL family profile | profile-specific canonicalization | MySQL family guard profile | to be defined by profile approval | to be defined by profile approval | future connector profile | future onboarding corpus required | planned |
+| `mysql` | MySQL family profile, backend-selected from source registry only | MySQL-aware single-statement canonicalization with backtick identifier quoting by default | MySQL family fail-closed guard profile | one policy-bounded `LIMIT`; `OFFSET` only with explicit bounded `LIMIT` | connect timeout, statement timeout, and cancellation probe required | planned read-only backend connector profile with secret indirection | positive, deny, row-bounding, timeout, cancellation, and release-gate reconstruction corpus required before activation | planned metadata only |
 | `mariadb` | MariaDB delta or sibling profile to MySQL | profile-specific canonicalization | MariaDB guard profile | to be defined by profile approval | to be defined by profile approval | future connector profile | future onboarding corpus required | planned after MySQL |
 | `aurora-postgresql` | inherits PostgreSQL generation posture with flavor overrides | PostgreSQL family canonicalization plus flavor notes | PostgreSQL family guard profile with flavor notes | follows PostgreSQL family unless overridden | follows PostgreSQL family unless overridden | Aurora flavor connector profile | PostgreSQL suite plus flavor regressions | planned flavor |
 | `aurora-mysql` | inherits MySQL family generation posture with flavor overrides | MySQL family canonicalization plus flavor notes | MySQL family guard profile with flavor notes | follows MySQL family unless overridden | follows MySQL family unless overridden | Aurora flavor connector profile | MySQL suite plus flavor regressions | planned flavor |
@@ -25,3 +25,8 @@ It is a planning and review aid for connector, guard, and evaluation work.
 - A family or flavor does not become implementation-ready just because it appears in this matrix.
 - Every new family or flavor still requires approval of connector, guard, governance, and evaluation work.
 - The matrix complements the target source registry. It does not replace per-source registry records.
+- MySQL remains planned until a registry-owned `mysql` source profile, connector
+  profile, dialect profile, guard profile, audit contract, and release-gate
+  corpus are approved together.
+- MySQL execution must not be inferred from adapter hints, client-supplied
+  metadata, driver names, connection strings, hostnames, or generated SQL text.

--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -95,3 +95,40 @@ If business PostgreSQL support is added, it must appear as an explicit business 
 - separate policy and dataset contract
 
 This prevents the application system of record from becoming a default execution target inadvertently.
+
+## Planned MySQL Source Profile
+
+MySQL onboarding must use the same registry boundary as the active MSSQL and
+business PostgreSQL baselines. A MySQL source is not executable until the
+registry contains an approved backend-owned source profile and the active
+runtime code has an approved connector, dialect, guard, audit, and evaluation
+profile for that source family.
+
+Minimum MySQL profile fields:
+
+- `source_id`
+- `source_family=mysql`
+- `source_flavor`, for example `mysql-8` or `aurora-mysql`
+- `dataset_contract_version`
+- `schema_snapshot_version`
+- `execution_policy_version`
+- `connector_profile_version`
+- `dialect_profile_version`
+- `activation_posture`
+- `connection_reference`
+
+The `connection_reference` must be a secret indirection such as
+`safequery/business/mysql/<source_id>/reader`. It must not contain raw
+credentials, placeholder credentials treated as valid, or client-supplied
+connection material. MySQL connection identity must include the backend-resolved
+host, port, database, username, and TLS posture so audit reconstruction can
+prove the execution target without exposing the secret value.
+
+The planned MySQL source profile must remain distinct from application
+PostgreSQL. MySQL connector profiles must not reuse application PostgreSQL
+credentials, service identities, endpoints, or migration settings.
+
+MySQL capability flags are advisory until activation. Runtime allow decisions
+must come from the authoritative registry record plus the approved connector and
+guard profiles, not from adapter hints, request metadata, source labels,
+connection string shape, or generated SQL.


### PR DESCRIPTION
## Summary
- add planned MySQL source-family profile metadata without enabling execution
- document MySQL connector, dialect, guard, audit, and release-gate requirements in ADR/matrix/registry docs
- add focused tests proving MySQL stays distinct from active MSSQL/PostgreSQL runtime paths

## Verification
- cd backend && python3 -m pytest tests/test_source_family_profiles.py tests/test_execution_connector_selection.py tests/test_source_registry_models.py
- cd backend && python3 -m pytest tests/test_sql_guard_mssql_profile.py tests/test_sql_guard_postgresql_profile.py tests/test_execution_runtime_controls.py
- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_release_gate.py
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- cd backend && python3 -m compileall -q app/services/source_family_profiles.py tests/test_source_family_profiles.py
- cd backend && python3 -m pytest

Refs #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added planned MySQL source support with backend-owned, read-only connector and dialect profiles, execution disabled by default, explicit permitted flavors, rollout status, and strict allow/deny semantics plus audit/reconstruction requirements.

* **Documentation**
  * Added ADR and design docs detailing MySQL onboarding, security constraints, guard/profile rules, updated capability matrix, and registry-driven activation rules.

* **Tests**
  * Added tests validating the planned MySQL profile, normalization, guard behaviors, audit/reconstruction fields, exclusion from active families and runtime defaults, and selection denial for unsupported bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->