### PR TITLE
Define Oracle source family planning requirements

### DIFF
--- a/backend/app/services/source_family_profiles.py
+++ b/backend/app/services/source_family_profiles.py
@@ -337,6 +337,141 @@ MARIADB_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
 )
 
 
+ORACLE_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
+    source_family="oracle",
+    rollout_status="planned",
+    execution_enabled_by_default=False,
+    backend_selected=True,
+    adapter_inference_allowed=False,
+    profile_classification="family_baseline",
+    shared_profile_basis=None,
+    profile_deltas=(
+        "oracle connector identity and wallet references must be backend-owned",
+        "Oracle identifier case and quoted-name behavior must be explicit",
+        "ROWNUM, FETCH FIRST, and analytic pagination behavior must be reviewed",
+        "database links, packages, PL/SQL blocks, and session mutation must deny closed",
+        "release-gate corpus must remain separate until Oracle activation approval",
+    ),
+    permitted_source_flavors=("oracle-19c", "oracle-23ai"),
+    required_profile_contract_fields=(
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+        "activation_posture",
+        "connection_reference",
+    ),
+    required_version_fields=(
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+    ),
+    connector=ConnectorProfileRequirements(
+        profile_id="oracle.readonly.long-range.v1",
+        owner="backend",
+        read_only_posture="required",
+        secret_reference_pattern="safequery/business/oracle/<source_id>/reader",  # noqa: S106 - reference template, not a credential
+        connection_identity_fields=(
+            "connect_descriptor",
+            "service_name",
+            "username",
+            "wallet_reference",
+            "tls_mode",
+        ),
+        required_controls=(
+            "connect_timeout_seconds",
+            "statement_timeout_seconds",
+            "cancellation_probe",
+        ),
+        application_postgres_separation=(
+            "oracle business source credentials and endpoints must be distinct from "
+            "the application PostgreSQL system of record"
+        ),
+    ),
+    dialect=DialectProfileRequirements(
+        profile_id="oracle.family.long-range.v1",
+        canonicalization_requirements=(
+            "single_statement_select_shape",
+            "oracle_identifier_normalization",
+            "quoted_identifier_case_preservation",
+            "literal_preservation_before_guard",
+            "schema_qualified_identifier_normalization",
+            "database_link_reference_rejection",
+        ),
+        identifier_quoting=(
+            "Oracle double-quoted identifiers only when required; preserve case-sensitive "
+            "quoted names and reject ambiguous unquoted identifier assumptions"
+        ),
+        row_bounding_strategy=(
+            "approve one canonical FETCH FIRST or ROWNUM-bounded shape before guard, "
+            "preview, and execution"
+        ),
+        limit_behavior=(
+            "canonical SQL must have one effective policy-bounded row limit; Oracle "
+            "pagination rewrites must not change guard, preview, and execute SQL"
+        ),
+        read_only_statement_allowlist=("SELECT", "WITH_SELECT"),
+        fail_closed_denies=(
+            "multi_statement",
+            "write_operation",
+            "procedure_execution",
+            "dynamic_sql",
+            "external_data_access",
+            "system_catalog_access",
+            "database_link_access",
+            "session_or_package_state_mutation",
+            "unbounded_or_unsafe_fetch",
+            "unsupported_sql_syntax",
+        ),
+    ),
+    audit_and_evaluation=AuditAndEvaluationRequirements(
+        reconstruction_fields=(
+            "source_id",
+            "source_family",
+            "source_flavor",
+            "dataset_contract_version",
+            "schema_snapshot_version",
+            "execution_policy_version",
+            "connector_profile_version",
+            "dialect_profile_version",
+            "guard_version",
+            "primary_deny_code",
+        ),
+        preview_events=("query_submitted", "generation_completed"),
+        guard_events=("guard_evaluated",),
+        execution_events=("execution_requested", "execution_started", "execution_completed"),
+        denial_events=("execution_denied", "candidate_invalidated"),
+        release_gate_fields=(
+            "scenario_id",
+            "source.source_id",
+            "source.source_family",
+            "source.source_flavor",
+            "source.dialect_profile",
+            "source.dialect_profile_version",
+            "source.connector_profile_version",
+            "source.dataset_contract_version",
+            "source.schema_snapshot_version",
+            "source.execution_policy_version",
+            "expected.primary_code",
+        ),
+        evaluation_corpus_requirements=(
+            "positive_readonly_selects",
+            "guard_deny_corpus",
+            "oracle_identifier_and_quoting_regressions",
+            "oracle_row_bounding_regressions",
+            "connector_timeout_and_cancellation",
+            "release_gate_reconstruction",
+        ),
+    ),
+)
+
+
 AURORA_POSTGRESQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
     source_family="postgresql",
     source_flavor="aurora-postgresql",
@@ -573,7 +708,11 @@ AURORA_MYSQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
 
 PLANNED_SOURCE_FAMILY_PROFILE_REQUIREMENTS: tuple[
     SourceFamilyProfileRequirements, ...
-] = (MYSQL_FAMILY_PROFILE_REQUIREMENTS, MARIADB_FAMILY_PROFILE_REQUIREMENTS)
+] = (
+    MYSQL_FAMILY_PROFILE_REQUIREMENTS,
+    MARIADB_FAMILY_PROFILE_REQUIREMENTS,
+    ORACLE_FAMILY_PROFILE_REQUIREMENTS,
+)
 
 PLANNED_SOURCE_FLAVOR_PROFILE_REQUIREMENTS: tuple[
     SourceFlavorProfileRequirements, ...

--- a/backend/tests/test_source_family_profiles.py
+++ b/backend/tests/test_source_family_profiles.py
@@ -16,6 +16,7 @@ from app.services.source_family_profiles import (
     AURORA_POSTGRESQL_FLAVOR_PROFILE_REQUIREMENTS,
     MARIADB_FAMILY_PROFILE_REQUIREMENTS,
     MYSQL_FAMILY_PROFILE_REQUIREMENTS,
+    ORACLE_FAMILY_PROFILE_REQUIREMENTS,
     get_planned_source_flavor_profile_requirements,
     get_planned_source_family_profile_requirements,
 )
@@ -68,6 +69,33 @@ def test_mariadb_profile_is_planned_mysql_delta_and_backend_selected() -> None:
     assert requirements.shared_profile_basis == "mysql.family.planned.v1"
     assert "mariadb-mode canonicalization must be explicit" in requirements.profile_deltas
     assert "sql_mode and version-specific parser drift" in requirements.profile_deltas
+
+
+def test_oracle_family_requirements_are_long_range_planned_and_backend_selected() -> None:
+    requirements = get_planned_source_family_profile_requirements(" Oracle ")
+
+    assert requirements == ORACLE_FAMILY_PROFILE_REQUIREMENTS
+    assert requirements.source_family == "oracle"
+    assert requirements.rollout_status == "planned"
+    assert requirements.execution_enabled_by_default is False
+    assert requirements.backend_selected is True
+    assert requirements.adapter_inference_allowed is False
+    assert requirements.permitted_source_flavors == ("oracle-19c", "oracle-23ai")
+    assert set(requirements.required_profile_contract_fields) == {
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "dialect_profile_version",
+        "activation_posture",
+        "connection_reference",
+    }
+    assert set(requirements.required_version_fields).issubset(
+        requirements.required_profile_contract_fields
+    )
 
 
 def test_aurora_flavors_are_backend_selected_family_flavors() -> None:
@@ -288,6 +316,68 @@ def test_mariadb_delta_requirements_cover_shared_and_specific_boundaries() -> No
     }.issubset(set(requirements.audit_and_evaluation.evaluation_corpus_requirements))
 
 
+def test_oracle_requirements_cover_connector_dialect_guard_and_audit() -> None:
+    requirements = ORACLE_FAMILY_PROFILE_REQUIREMENTS
+
+    assert requirements.connector.model_dump() == {
+        "profile_id": "oracle.readonly.long-range.v1",
+        "owner": "backend",
+        "read_only_posture": "required",
+        "secret_reference_pattern": "safequery/business/oracle/<source_id>/reader",
+        "connection_identity_fields": (
+            "connect_descriptor",
+            "service_name",
+            "username",
+            "wallet_reference",
+            "tls_mode",
+        ),
+        "required_controls": (
+            "connect_timeout_seconds",
+            "statement_timeout_seconds",
+            "cancellation_probe",
+        ),
+        "application_postgres_separation": (
+            "oracle business source credentials and endpoints must be distinct from "
+            "the application PostgreSQL system of record"
+        ),
+    }
+    assert requirements.dialect.profile_id == "oracle.family.long-range.v1"
+    assert "oracle_identifier_normalization" in (
+        requirements.dialect.canonicalization_requirements
+    )
+    assert "quoted_identifier_case_preservation" in (
+        requirements.dialect.canonicalization_requirements
+    )
+    assert requirements.dialect.read_only_statement_allowlist == ("SELECT", "WITH_SELECT")
+    assert {
+        "multi_statement",
+        "write_operation",
+        "procedure_execution",
+        "dynamic_sql",
+        "external_data_access",
+        "system_catalog_access",
+        "database_link_access",
+        "session_or_package_state_mutation",
+        "unbounded_or_unsafe_fetch",
+        "unsupported_sql_syntax",
+    }.issubset(set(requirements.dialect.fail_closed_denies))
+    assert {
+        "source_family",
+        "source_flavor",
+        "connector_profile_version",
+        "dialect_profile_version",
+        "guard_version",
+        "primary_deny_code",
+    }.issubset(set(requirements.audit_and_evaluation.reconstruction_fields))
+    assert {
+        "guard_deny_corpus",
+        "oracle_identifier_and_quoting_regressions",
+        "oracle_row_bounding_regressions",
+        "connector_timeout_and_cancellation",
+        "release_gate_reconstruction",
+    }.issubset(set(requirements.audit_and_evaluation.evaluation_corpus_requirements))
+
+
 def test_planned_mysql_profile_does_not_enable_active_execution_paths() -> None:
     assert ACTIVE_SOURCE_FAMILIES == ("mssql", "postgresql")
     assert "mysql" not in DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY
@@ -324,6 +414,28 @@ def test_planned_mariadb_profile_does_not_enable_active_execution_paths() -> Non
                 source_id="future-mariadb-source",
                 source_family="mariadb",
                 source_flavor="mariadb-approved",
+                dataset_contract_version=1,
+                schema_snapshot_version=1,
+            )
+        )
+
+    assert exc_info.value.deny_code == DENY_UNSUPPORTED_SOURCE_BINDING
+
+
+def test_long_range_oracle_profile_does_not_enable_active_execution_paths() -> None:
+    assert ACTIVE_SOURCE_FAMILIES == ("mssql", "postgresql")
+    assert "oracle" not in DEFAULT_TIMEOUT_SECONDS_BY_SOURCE_FAMILY
+    assert "oracle" not in DEFAULT_MAX_ROWS_BY_SOURCE_FAMILY
+
+    with pytest.raises(
+        ExecutionConnectorSelectionError,
+        match="No backend-owned execution connector is registered",
+    ) as exc_info:
+        select_execution_connector(
+            candidate_source=SourceBoundCandidateMetadata(
+                source_id="future-oracle-source",
+                source_family="oracle",
+                source_flavor="oracle-19c",
                 dataset_contract_version=1,
                 schema_snapshot_version=1,
             )

--- a/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
+++ b/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
@@ -201,6 +201,62 @@ behaves under the MySQL family controls. Because MySQL is still planned
 metadata only, Aurora MySQL must not activate execution until the underlying
 MySQL family connector, guard, audit, and evaluation profiles are approved.
 
+### Long-Range Oracle Family Requirements
+
+Oracle is approved as long-range planned source-family metadata only. Listing
+the family does not activate execution, connector selection, runtime defaults,
+guard behavior, local startup services, release-gate coverage, or adapter
+support.
+
+An Oracle source profile must be registered by the backend with explicit values
+for:
+
+- `source_id`
+- `source_family=oracle`
+- `source_flavor`, such as `oracle-19c` or `oracle-23ai`
+- `dataset_contract_version`
+- `schema_snapshot_version`
+- `execution_policy_version`
+- `connector_profile_version`
+- `dialect_profile_version`
+- `activation_posture`
+- `connection_reference`
+
+The adapter, client, analyst artifacts, MLflow traces, driver name, connection
+descriptor, hostname, source label, request hint, or generated SQL text must not
+infer Oracle eligibility. Connector and dialect profile selection remains
+backend-owned and source-registry governed.
+
+The long-range Oracle connector profile must require:
+
+- read-only database identity and privileges
+- backend-owned secret indirection such as `safequery/business/oracle/<source_id>/reader`
+- explicit connection identity fields for connect descriptor, service name,
+  username, wallet reference, and TLS posture
+- connect timeout, statement timeout, and cancellation probe support
+- separation from application PostgreSQL credentials, service identity, and endpoint
+
+The long-range Oracle dialect and guard profile must require:
+
+- single-statement canonical SQL before preview, guard, and execution
+- Oracle-aware keyword, schema, and identifier normalization
+- preservation of double-quoted identifier case where quoting is required
+- explicit selection of one canonical policy-bounded row limit shape, such as
+  approved `FETCH FIRST` or `ROWNUM` handling, before guard evaluation
+- a read-only statement allowlist for `SELECT` and `WITH`-leading SELECT queries
+- fail-closed denies for writes, multi-statement SQL, PL/SQL blocks, procedure
+  execution, dynamic SQL, external data access, system catalog access, database
+  links, session or package state mutation, unsafe row bounds, and unsupported syntax
+
+Audit, operator-history, candidate lifecycle, entitlement, and release-gate
+reconstruction for Oracle must preserve the source and profile fields needed to
+prove which backend-selected profile was used: `source_id`, `source_family`,
+`source_flavor`, dataset contract version, schema snapshot version, execution
+policy version, connector profile version, dialect profile version, guard
+version, and primary deny code. Oracle activation requires a distinct positive,
+deny, identifier and quoting, row-bounding, timeout, cancellation, and
+release-gate reconstruction corpus before any active connector work begins.
+
 ## Consequences
 
 Positive outcomes:

--- a/docs/design/dialect-capability-matrix.md
+++ b/docs/design/dialect-capability-matrix.md
@@ -18,7 +18,7 @@ It is a planning and review aid for connector, guard, and evaluation work.
 | `mariadb` | planned MySQL-delta profile, backend-selected from source registry only | MySQL-family baseline plus explicit MariaDB mode and version drift canonicalization | separate MariaDB delta fail-closed guard profile; no silent MySQL guard reuse | one policy-bounded `LIMIT`; `OFFSET` only with explicit bounded `LIMIT` after MariaDB delta review | connect timeout, statement timeout, and cancellation probe required | planned read-only MariaDB backend connector profile with secret indirection | MySQL-overlap scenarios plus MariaDB delta deny, row-bounding, timeout, cancellation, and release-gate reconstruction corpus required before activation | planned metadata only |
 | `aurora-postgresql` | inherits PostgreSQL generation posture; registry keeps `source_family=postgresql` and `source_flavor=aurora-postgresql` | inherits PostgreSQL canonicalization and identifier rules | inherits PostgreSQL fail-closed guard and deny corpus | inherits PostgreSQL bounded canonical SQL behavior | connect timeout, statement timeout, and cancellation probe must be reverified for Aurora PostgreSQL | planned Aurora PostgreSQL read-only connector profile with cluster endpoint, engine version, TLS posture, and secret indirection | PostgreSQL suite plus Aurora PostgreSQL flavor, timeout, cancellation, and release-gate reconstruction regressions | planned flavor |
 | `aurora-mysql` | inherits planned MySQL generation posture; registry keeps `source_family=mysql` and `source_flavor=aurora-mysql` | inherits MySQL canonicalization and identifier rules | inherits planned MySQL fail-closed guard and deny corpus | inherits one policy-bounded `LIMIT`; `OFFSET` only with explicit bounded `LIMIT` | connect timeout, statement timeout, and cancellation probe must be reverified for Aurora MySQL | planned Aurora MySQL read-only connector profile with cluster endpoint, engine version, TLS posture, and secret indirection | MySQL suite plus Aurora MySQL flavor, timeout, cancellation, and release-gate reconstruction regressions before activation | planned flavor |
-| `oracle` | Oracle-focused generation profile | Oracle-specific canonicalization | Oracle fail-closed guard profile | to be defined by profile approval | to be defined by profile approval | future connector profile | future onboarding corpus required | long-range planned |
+| `oracle` | Oracle family profile, backend-selected from source registry only | Oracle-aware single-statement canonicalization with explicit quoted identifier case handling | Oracle family fail-closed guard profile with PL/SQL, database link, package, and session mutation denies | one approved policy-bounded `FETCH FIRST` or `ROWNUM` shape before guard, preview, and execution | connect timeout, statement timeout, and cancellation probe required before activation | long-range read-only Oracle backend connector profile with secret indirection, connect descriptor, service name, wallet reference, and TLS posture | positive, deny, identifier and quoting, row-bounding, timeout, cancellation, and release-gate reconstruction corpus required before activation | long-range planned metadata only |
 
 ## Usage Notes
 
@@ -39,3 +39,11 @@ It is a planning and review aid for connector, guard, and evaluation work.
   `source_flavor=aurora-postgresql`, or `source_family=mysql` plus
   `source_flavor=aurora-mysql`; they must not become top-level families or
   client-supplied adapter hints.
+- Oracle is long-range planned metadata only. Oracle support must remain
+  inactive until backend-owned source registry records, connector profile,
+  dialect profile, guard deny corpus, audit and operator-history mapping,
+  entitlement checks, candidate lifecycle revalidation, and release-gate
+  reconstruction are approved together.
+- Oracle execution must not be inferred from adapter hints, client-supplied
+  metadata, analyst artifacts, MLflow traces, driver names, connection
+  descriptors, hostnames, labels, or generated SQL text.

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -79,6 +79,9 @@ After the two-source core path is stable:
 1. onboard `mysql`
 2. evaluate `mariadb` as a sibling or delta profile
 3. add Aurora as source flavors on top of PostgreSQL or MySQL families
-4. onboard `oracle` last
+4. define `oracle` as long-range planned metadata only, then onboard it last
+   after Oracle-specific connector, dialect, guard, audit, entitlement,
+   candidate lifecycle, operator-history, and release-gate reconstruction
+   requirements are approved together
 
 Each later family must be added through source-registry onboarding plus connector, guard, and evaluation profile work rather than through a trusted-control-plane redesign.


### PR DESCRIPTION
## Summary
- define Oracle as long-range planned source-family metadata in the backend profile fixtures
- document Oracle connector, dialect, guard, audit, entitlement, lifecycle, and release-gate onboarding requirements
- prove Oracle remains inactive and distinct from active source families

## Verification
- `python3 -m pytest tests/test_source_family_profiles.py`
- `python3 -m pytest tests/test_release_gate.py tests/test_evaluation_harness.py -q`
- `python3 -m compileall app/services/source_family_profiles.py`
- `bash tests/smoke/test-doc-entrypoints-current-set.sh`
- `bash tests/smoke/test-pilot-safety-checklist.sh`
- `bash tests/smoke/test-design-contract.sh`
- `git diff --check`

Closes #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle database support is now registered as a planned data source family with backend-controlled configuration and read-only access requirements.

* **Documentation**
  * Updated architecture and roadmap documentation with Oracle-specific dialect canonicalization, security constraints, and phased implementation requirements.
  * Clarified Oracle's current availability as planned metadata support, with detailed activation requirements for future phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->