### PR TITLE
Define future family evaluation checklist

### DIFF
--- a/backend/app/services/source_family_profiles.py
+++ b/backend/app/services/source_family_profiles.py
@@ -42,6 +42,10 @@ class AuditAndEvaluationRequirements(BaseModel):
     denial_events: tuple[str, ...]
     release_gate_fields: tuple[str, ...]
     evaluation_corpus_requirements: tuple[str, ...]
+    activation_required_coverage: tuple[str, ...]
+    deny_corpus_requirements: tuple[str, ...]
+    authoritative_release_gate_artifacts: tuple[str, ...]
+    supplemental_only_artifacts: tuple[str, ...]
 
 
 class SourceFamilyProfileRequirements(BaseModel):
@@ -83,6 +87,41 @@ class SourceFlavorProfileRequirements(BaseModel):
 
 
 ACTIVE_SOURCE_FAMILIES: tuple[str, ...] = ("mssql", "postgresql")
+
+FUTURE_FAMILY_ACTIVATION_REQUIRED_COVERAGE: tuple[str, ...] = (
+    "positive_scenarios",
+    "safety_deny_scenarios",
+    "connector_selection_scenarios",
+    "candidate_lifecycle_scenarios",
+    "runtime_control_scenarios",
+    "audit_artifact_reconstruction",
+    "release_gate_reconstruction",
+    "operator_history_implications",
+)
+
+FUTURE_FAMILY_DENY_CORPUS_REQUIREMENTS: tuple[str, ...] = (
+    "write_attempts",
+    "multi_statement_behavior",
+    "unsafe_functions",
+    "unbounded_reads",
+    "unsupported_syntax",
+    "stale_policy",
+    "entitlement_drift",
+    "lifecycle_replay",
+    "runtime_cancellation",
+    "connector_profile_mismatch",
+)
+
+FUTURE_FAMILY_AUTH_RELEASE_GATE_ARTIFACTS: tuple[str, ...] = (
+    "safequery_evaluation_outcomes",
+    "safequery_source_aware_audit_events",
+)
+
+FUTURE_FAMILY_SUPPLEMENTAL_ONLY_ARTIFACTS: tuple[str, ...] = (
+    "mlflow_exports",
+    "search_or_analyst_outputs",
+    "adapter_traces",
+)
 
 MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
     source_family="mysql",
@@ -199,7 +238,12 @@ MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
             "guard_deny_corpus",
             "connector_timeout_and_cancellation",
             "release_gate_reconstruction",
+            "profile_version_drift_fail_closed",
         ),
+        activation_required_coverage=FUTURE_FAMILY_ACTIVATION_REQUIRED_COVERAGE,
+        deny_corpus_requirements=FUTURE_FAMILY_DENY_CORPUS_REQUIREMENTS,
+        authoritative_release_gate_artifacts=FUTURE_FAMILY_AUTH_RELEASE_GATE_ARTIFACTS,
+        supplemental_only_artifacts=FUTURE_FAMILY_SUPPLEMENTAL_ONLY_ARTIFACTS,
     ),
 )
 
@@ -332,7 +376,12 @@ MARIADB_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
             "mariadb_delta_deny_fixtures",
             "connector_timeout_and_cancellation",
             "release_gate_reconstruction",
+            "profile_version_drift_fail_closed",
         ),
+        activation_required_coverage=FUTURE_FAMILY_ACTIVATION_REQUIRED_COVERAGE,
+        deny_corpus_requirements=FUTURE_FAMILY_DENY_CORPUS_REQUIREMENTS,
+        authoritative_release_gate_artifacts=FUTURE_FAMILY_AUTH_RELEASE_GATE_ARTIFACTS,
+        supplemental_only_artifacts=FUTURE_FAMILY_SUPPLEMENTAL_ONLY_ARTIFACTS,
     ),
 )
 
@@ -467,7 +516,12 @@ ORACLE_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
             "oracle_row_bounding_regressions",
             "connector_timeout_and_cancellation",
             "release_gate_reconstruction",
+            "profile_version_drift_fail_closed",
         ),
+        activation_required_coverage=FUTURE_FAMILY_ACTIVATION_REQUIRED_COVERAGE,
+        deny_corpus_requirements=FUTURE_FAMILY_DENY_CORPUS_REQUIREMENTS,
+        authoritative_release_gate_artifacts=FUTURE_FAMILY_AUTH_RELEASE_GATE_ARTIFACTS,
+        supplemental_only_artifacts=FUTURE_FAMILY_SUPPLEMENTAL_ONLY_ARTIFACTS,
     ),
 )
 
@@ -610,7 +664,12 @@ AURORA_POSTGRESQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
             "aurora_postgresql_flavor_regressions",
             "connector_timeout_and_cancellation",
             "release_gate_reconstruction",
+            "profile_version_drift_fail_closed",
         ),
+        activation_required_coverage=FUTURE_FAMILY_ACTIVATION_REQUIRED_COVERAGE,
+        deny_corpus_requirements=FUTURE_FAMILY_DENY_CORPUS_REQUIREMENTS,
+        authoritative_release_gate_artifacts=FUTURE_FAMILY_AUTH_RELEASE_GATE_ARTIFACTS,
+        supplemental_only_artifacts=FUTURE_FAMILY_SUPPLEMENTAL_ONLY_ARTIFACTS,
     ),
 )
 
@@ -701,7 +760,12 @@ AURORA_MYSQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
             "aurora_mysql_flavor_regressions",
             "connector_timeout_and_cancellation",
             "release_gate_reconstruction",
+            "profile_version_drift_fail_closed",
         ),
+        activation_required_coverage=FUTURE_FAMILY_ACTIVATION_REQUIRED_COVERAGE,
+        deny_corpus_requirements=FUTURE_FAMILY_DENY_CORPUS_REQUIREMENTS,
+        authoritative_release_gate_artifacts=FUTURE_FAMILY_AUTH_RELEASE_GATE_ARTIFACTS,
+        supplemental_only_artifacts=FUTURE_FAMILY_SUPPLEMENTAL_ONLY_ARTIFACTS,
     ),
 )
 

--- a/backend/tests/test_source_family_profiles.py
+++ b/backend/tests/test_source_family_profiles.py
@@ -22,6 +22,69 @@ from app.services.source_family_profiles import (
 )
 
 
+def _future_family_requirements():
+    return (
+        MYSQL_FAMILY_PROFILE_REQUIREMENTS,
+        MARIADB_FAMILY_PROFILE_REQUIREMENTS,
+        ORACLE_FAMILY_PROFILE_REQUIREMENTS,
+        AURORA_POSTGRESQL_FLAVOR_PROFILE_REQUIREMENTS,
+        AURORA_MYSQL_FLAVOR_PROFILE_REQUIREMENTS,
+    )
+
+
+def test_future_family_activation_checklist_requires_authoritative_coverage() -> None:
+    required_activation_coverage = {
+        "positive_scenarios",
+        "safety_deny_scenarios",
+        "connector_selection_scenarios",
+        "candidate_lifecycle_scenarios",
+        "runtime_control_scenarios",
+        "audit_artifact_reconstruction",
+        "release_gate_reconstruction",
+        "operator_history_implications",
+    }
+    required_deny_topics = {
+        "write_attempts",
+        "multi_statement_behavior",
+        "unsafe_functions",
+        "unbounded_reads",
+        "unsupported_syntax",
+        "stale_policy",
+        "entitlement_drift",
+        "lifecycle_replay",
+        "runtime_cancellation",
+        "connector_profile_mismatch",
+    }
+    supplemental_only = {
+        "mlflow_exports",
+        "search_or_analyst_outputs",
+        "adapter_traces",
+    }
+
+    for requirements in _future_family_requirements():
+        audit_and_evaluation = requirements.audit_and_evaluation
+
+        assert required_activation_coverage.issubset(
+            audit_and_evaluation.activation_required_coverage
+        )
+        assert required_deny_topics.issubset(
+            audit_and_evaluation.deny_corpus_requirements
+        )
+        assert "profile_version_drift_fail_closed" in (
+            audit_and_evaluation.evaluation_corpus_requirements
+        )
+        assert supplemental_only.issubset(
+            audit_and_evaluation.supplemental_only_artifacts
+        )
+        assert not supplemental_only.intersection(
+            audit_and_evaluation.authoritative_release_gate_artifacts
+        )
+        assert {
+            "safequery_evaluation_outcomes",
+            "safequery_source_aware_audit_events",
+        }.issubset(audit_and_evaluation.authoritative_release_gate_artifacts)
+
+
 def test_mysql_family_requirements_are_planned_and_backend_selected() -> None:
     requirements = get_planned_source_family_profile_requirements(" MySQL ")
 

--- a/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
+++ b/docs/adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md
@@ -74,6 +74,20 @@ The dialect profile defines:
 
 Future onboarding must happen by adding or approving profiles, not by redesigning the core SafeQuery control plane.
 
+Before any planned family or flavor is activated, its evaluation expansion must
+include positive, safety-deny, connector-selection, lifecycle, runtime-control,
+audit reconstruction, release-gate reconstruction, and operator-history
+coverage. Its deny corpus must cover write attempts, multi-statement behavior,
+unsafe functions, unbounded reads, unsupported syntax, stale policy,
+entitlement drift, lifecycle replay, runtime cancellation, and connector or
+profile mismatch where applicable. Connector and dialect profile version drift
+must compare fail-closed against the planned source-aware identity.
+
+MLflow exports, search or analyst outputs, and adapter traces remain
+supplemental engineering evidence. They do not satisfy authoritative evaluation,
+audit, or release-gate coverage; those gates must be reconstructable from
+SafeQuery-owned evaluation outcomes and source-aware audit events.
+
 ### Planned MySQL Family Requirements
 
 MySQL is approved as planned source-family metadata only. Listing the family does

--- a/docs/design/dialect-capability-matrix.md
+++ b/docs/design/dialect-capability-matrix.md
@@ -25,6 +25,16 @@ It is a planning and review aid for connector, guard, and evaluation work.
 - A family or flavor does not become implementation-ready just because it appears in this matrix.
 - Every new family or flavor still requires approval of connector, guard, governance, and evaluation work.
 - The matrix complements the target source registry. It does not replace per-source registry records.
+- Future activation requires explicit positive, safety-deny,
+  connector-selection, lifecycle, runtime-control, audit reconstruction,
+  release-gate reconstruction, and operator-history coverage before a planned
+  entry can become active.
+- Release-gate evidence must come from SafeQuery-owned evaluation outcomes and
+  source-aware audit events. MLflow exports, search or analyst outputs, and
+  adapter traces are supplemental and cannot satisfy authoritative coverage.
+- Connector and dialect profile version drift must be represented as a
+  fail-closed evaluation comparison case for each family or flavor before
+  activation.
 - MySQL remains planned until a registry-owned `mysql` source profile, connector
   profile, dialect profile, guard profile, audit contract, and release-gate
   corpus are approved together.

--- a/docs/design/evaluation-harness.md
+++ b/docs/design/evaluation-harness.md
@@ -37,6 +37,36 @@ The baseline taxonomy should distinguish at least:
 - schema-drift regression scenarios
 - replay or invalidation scenarios
 
+## Future Family Activation Checklist
+
+Future source families or flavors remain planned until the application-owned
+evaluation assets include source-aware scenarios for:
+
+- positive read-only outcomes
+- safety deny outcomes
+- connector-selection denies
+- candidate lifecycle revalidation
+- runtime timeout, cancellation, and kill-switch behavior
+- source-aware audit artifact reconstruction
+- release-gate reconstruction
+- operator-history implications
+
+Each scenario must carry source identity, source family, source flavor, dataset
+contract version, schema snapshot version, execution policy version, connector
+profile version, dialect profile version, expected outcome, and expected primary
+deny code when the outcome is a rejection.
+
+Dialect, connector, or profile version drift must be represented as an explicit
+evaluation scenario and must fail closed when the observed artifact no longer
+matches the planned profile version.
+
+MLflow exports, search or analyst outputs, and adapter traces are supplemental
+engineering artifacts. They may help explain a run, but they cannot satisfy
+authoritative evaluation coverage, audit coverage, or release-gate
+reconstruction for a future family or flavor. Release gates must remain
+reconstructable from SafeQuery-owned evaluation outcomes and source-aware audit
+events.
+
 ## Gold Answer Representation
 
 Gold answers may be represented through:

--- a/docs/design/sql-guard-deny-corpus.md
+++ b/docs/design/sql-guard-deny-corpus.md
@@ -26,6 +26,8 @@ The baseline corpus must include representative scenarios for:
 - expired-candidate execution attempts
 - candidate replay or stale-policy execution attempts
 - candidate owner mismatch and entitlement-change attempts
+- connector or dialect profile mismatch attempts
+- runtime cancellation, timeout, or kill-switch denials
 
 ## Expected Outcomes
 
@@ -44,3 +46,11 @@ Critical deny corpus scenarios must pass at 100 percent for pilot entry.
 ## Relation to Evaluation Harness
 
 The evaluation harness should treat this corpus as a required safety subset rather than as optional examples.
+
+Future family or flavor activation must expand this corpus before execution is
+enabled. The expansion must cover write attempts, multi-statement behavior,
+unsafe functions, unbounded reads, unsupported syntax, stale policy,
+entitlement drift, lifecycle replay, runtime cancellation, and connector or
+profile mismatch where applicable. Shared family coverage may be inherited only
+when the planned profile explicitly says so; otherwise the family or flavor
+needs its own deny scenarios and expected deny codes.


### PR DESCRIPTION
## Summary
- add explicit future-family activation coverage and deny-corpus requirements to planned family/flavor profiles
- mark SafeQuery evaluation outcomes and source-aware audit events as authoritative release-gate artifacts
- document that MLflow/search/analyst outputs and adapter traces are supplemental only

## Verification
- cd backend && python3 -m pytest tests/test_source_family_profiles.py
- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_release_gate.py
- cd backend && python3 -m pytest
- python3 -m pytest tests/test_check_repository_hygiene.py

Refs #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activation validation requirements for planned source families, mandating comprehensive evaluation coverage, safety-deny testing, audit reconstruction, and fail-closed rules for profile version drift before activation.

* **Documentation**
  * Updated architecture and design documentation with enhanced governance rules for deny corpus coverage, release-gate reconstruction standards, and supplemental vs. authoritative evidence requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->