### PR TITLE
Refresh README and local development baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,77 @@
-# SafeQuery Baseline
+# SafeQuery Source-Aware Baseline
 
-SafeQuery is a controlled enterprise NL2SQL application. This repository checkpoint establishes the minimum local baseline for:
+SafeQuery is a controlled enterprise NL2SQL application. This repository now
+captures the source-aware core service baseline for the first productized local
+run:
 
-- a Next.js frontend
-- a FastAPI backend
-- a PostgreSQL application database
+- a Next.js operator workflow shell
+- a FastAPI backend control plane
+- an application PostgreSQL system of record
+- Alembic migrations for source registry, dataset, schema snapshot, retrieval,
+  and related control-plane records
+- source-aware preview, audit, evaluation, and operator-workflow contracts
 
-The baseline intentionally stops at placeholder UI and health-oriented API behavior. No auth, SQL generation, SQL guard, or SQL execution logic is implemented yet.
-
-The current Epic A frontend should be treated as a developer state demo, not the intended production information architecture. It exists to make the baseline lifecycle and review states concrete while SafeQuery is still wiring the trusted backend boundary.
-
-For future UI implementation work, the next authoritative UI direction is the UX-1 workflow-first operator shell contract in [docs/design/operator-workflow-information-architecture.md](./docs/design/operator-workflow-information-architecture.md). Contributors should use that document as the source of truth for production-facing shell structure, workflow regions, and operator navigation rather than extending the current top-level demo shell as if it were the final product IA.
+The current baseline is intentionally application-owned. The backend-owned
+source registry controls which business sources can be selected, application
+PostgreSQL remains separate from business-source credentials, and execution must
+stay candidate-only through server-owned candidate identifiers. The browser, SQL
+generation adapter, LLM, analyst surface, search surface, and MLflow exports do
+not receive execution authority.
 
 ## Repository Shape
 
 ```text
-frontend/  Next.js UI placeholder and local stack status surface
-backend/   FastAPI API placeholder and PostgreSQL-backed health checks
+frontend/  Next.js operator workflow shell and product-state surfaces
+backend/   FastAPI control plane, migrations, source registry, and contracts
 infra/     Docker Compose baseline for local startup
-tests/     Focused smoke checks for repository structure
-docs/      Architecture and requirements source material
+tests/     Focused smoke checks for repository and documentation contracts
+docs/      Architecture, requirements, roadmap, and local development guides
 ```
 
-## Local Startup
+## Product evaluation flow
 
-For the full baseline startup workflow, including env setup, compose startup,
+Use this path when you want to inspect the current product baseline as a
+non-developer evaluator:
+
+1. Create `.env` from the checked-in example.
+2. Start the compose stack.
+3. Run migrations.
+4. Open the frontend at `http://localhost:3000`.
+5. Confirm the backend health endpoint at `http://localhost:8000/health`.
+6. Confirm the operator shell can load source registry options from the backend
+   instead of relying on hard-coded source names.
+
+A successful first run should show the workflow-first operator shell, reachable
+backend health, an application PostgreSQL-backed control plane, and source
+registry readiness for reviewed source records. The local baseline can exercise
+source-aware request and preview contracts, but it should not be read as a
+complete production pilot.
+
+Known product-readiness gaps remain for later Epic K/O/P work:
+
+- real authentication and session wiring
+- production SQL generation adapter integration
+- fully persisted candidate and run history
+- final execute-path wiring for approved candidates
+- production deployment, secrets, and release operations
+
+The operator shell direction is defined in
+`docs/design/operator-workflow-information-architecture.md`; extend that
+workflow-first contract rather than reintroducing placeholder-only health UI.
+
+Optional governed search, analyst-style orchestration, and MLflow integrations
+are extension tracks. They can observe or enrich the product when separately
+enabled, but they are not prerequisites for the core SafeQuery control path and
+must not become trusted execution or authorization authorities.
+
+Future MySQL, MariaDB, Aurora, Oracle, Search, Analyst, and MLflow UI activation
+work remains planned metadata or optional extension work unless a later issue
+explicitly activates it. First-run productization must not infer those families
+from docs, service names, driver names, or placeholder configuration.
+
+## Developer setup flow
+
+For the full local startup workflow, including env setup, compose startup,
 migrations, and troubleshooting, use
 [docs/local-development.md](./docs/local-development.md).
 
@@ -63,10 +110,12 @@ Keep the local roles distinct from the start:
   `app-postgres` service for SafeQuery-owned state
 - business PostgreSQL source uses
   `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` and the
-  `business-postgres-source` service for later generation-context work
+  `business-postgres-source` service for source-specific context work
 - business MSSQL source uses
   `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` and the
-  `business-mssql-source` service for later execution-path work
+  `business-mssql-source` service for source-specific connector work
+
+This role split does not make the application database a business target.
 
 2. Start the local stack:
 
@@ -74,38 +123,37 @@ Keep the local roles distinct from the start:
 docker-compose --env-file .env -f infra/docker-compose.yml up --build -d
 ```
 
-If `.env` is missing or a required value is blank, Docker Compose will stop with
-an explicit missing-variable error instead of silently using local defaults.
+If `.env` is missing or a required value is blank, Docker Compose stops with an
+explicit missing-variable error instead of silently using local defaults.
 
-The baseline startup path still uses the same compose entrypoint, but the local
-topology now declares a separate application PostgreSQL service, a separate
-business PostgreSQL source, and a separate business MSSQL source so later
-source-aware work has explicit local anchors. This role split does not make the application database a business target.
-
-3. Confirm the UI is reachable:
-
-```bash
-curl -I http://localhost:3000
-```
-
-4. Confirm the API health endpoint is reachable and healthy:
-
-```bash
-curl http://localhost:8000/health
-```
-
-PostgreSQL stays on the compose network only for this baseline. The app stack
-reaches it internally, which avoids common host-port conflicts during local
-startup.
-
-If your Docker shell is pointed at a stale Colima socket, scope the command to the active profile instead of changing global settings:
+If your Docker shell is pointed at a stale Colima socket, scope the command to
+the active profile instead of changing global settings:
 
 ```bash
 DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock" \
   docker-compose --env-file .env -f infra/docker-compose.yml up --build -d
 ```
 
-5. Stop the stack when finished:
+3. Apply migrations:
+
+```bash
+docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend alembic upgrade head
+docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend alembic current
+```
+
+4. Confirm the UI is reachable:
+
+```bash
+curl -I http://localhost:3000
+```
+
+5. Confirm the API health endpoint is reachable and healthy:
+
+```bash
+curl http://localhost:8000/health
+```
+
+6. Stop the stack when finished:
 
 ```bash
 docker-compose --env-file .env -f infra/docker-compose.yml down
@@ -117,20 +165,33 @@ To remove the PostgreSQL volume as well:
 docker-compose --env-file .env -f infra/docker-compose.yml down -v
 ```
 
-## Extension Seams
+## Trust Boundary
 
-The initial structure leaves explicit room for later feature work:
+SafeQuery's trusted boundary stays in the backend:
 
-- `backend/app/features/auth/` for session and identity enforcement
-- `backend/app/features/guard/` for SQL validation and deny logic
-- `backend/app/features/execution/` for approved query execution handling
-- `backend/app/features/audit/` for lifecycle audit persistence
+- the backend-owned source registry decides which source records are executable
+- application PostgreSQL stores SafeQuery control-plane state only
+- business-source credentials are distinct from application persistence
+- preview and execute surfaces are tied to server-owned source and candidate
+  records
+- candidate-only execution is required; clients must not submit raw SQL for
+  execution
+- no LLM or adapter execution authority is granted by this baseline
 
-The frontend remains a simple shell so later query input, SQL preview, and audit workflows can be added without changing the trusted backend boundary.
+The fail-closed startup guards are intentional:
 
-That simple shell is a developer state demo for the Epic A prototype. It is useful for exercising baseline states and component posture, but it is not the intended production information architecture.
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse SAFEQUERY_APP_POSTGRES_URL`
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be configured before the business MSSQL execution source can be used.`
 
-When UI work moves beyond the current prototype, follow the UX-1 workflow-first operator shell contract in [docs/design/operator-workflow-information-architecture.md](./docs/design/operator-workflow-information-architecture.md) as the next authoritative UI direction.
+The compose topology mirrors those roles explicitly:
+
+- `app-postgres` for application PostgreSQL persistence
+- `business-postgres-source` for the optional local business PostgreSQL source
+- `business-mssql-source` for the optional local business MSSQL source
+
+On startup, the backend logs `source_posture`, `configured_source_count`, and a
+`source_roles` map so local diagnosis can confirm which source role is
+configured or intentionally left unset without inferring from service names.
 
 ## Focused Verification
 
@@ -140,15 +201,13 @@ Repository structure smoke check:
 tests/smoke/test-baseline.sh
 ```
 
-Optional local component checks:
+Documentation entrypoint checks:
 
 ```bash
-cd frontend && cp .env.local.example .env.local && npm install && npm run build
-cd ../backend && cp .env.example .env && python3 -m pip install -e .
+bash tests/smoke/test-local-startup-docs.sh
+bash tests/smoke/test-doc-entrypoints-current-set.sh
+bash tests/smoke/test-epic-a-doc-framing.sh
 ```
-
-Backend settings can also load from `.env` or `../.env`, so running from the
-repo root or from `backend/` uses the same configuration path.
 
 Backend migration scaffold verification:
 
@@ -188,35 +247,14 @@ Local topology smoke verification:
 bash tests/smoke/test-local-topology-roles.sh
 ```
 
-Application persistence and business-source access now use separate reviewed
-names:
+## Epic K Sequence
 
-- `SAFEQUERY_APP_POSTGRES_URL` for the application-owned PostgreSQL system of
-  record
-- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` for a business PostgreSQL source used
-  to curate generation context later
-- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` for the dedicated MSSQL
-  execution source path
+The intended Epic K order starts with this README and local development refresh,
+then moves through first-run seed data, doctor/readiness checks, and the next
+source-aware productization issues. Track that sequence in
+[docs/implementation-roadmap.md](./docs/implementation-roadmap.md) and keep
+issue text path-hygienic by using repo-relative commands and placeholders such
+as `<supervisor-config-path>` instead of workstation-local absolute paths.
 
-Do not reuse the application PostgreSQL credential as a business-source secret.
-
-The fail-closed startup guards are intentional:
-
-- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse SAFEQUERY_APP_POSTGRES_URL`
-- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must be configured before the business MSSQL execution source can be used.`
-
-The compose topology mirrors those roles explicitly:
-
-- `app-postgres` for application PostgreSQL persistence
-- `business-postgres-source` for the optional local business PostgreSQL source
-- `business-mssql-source` for the optional local business MSSQL source
-
-The backend baseline still depends only on `app-postgres`; the source services
-exist to keep the local topology and credentials explicit for later work.
-
-On startup, the backend logs `source_posture`, `configured_source_count`, and a
-`source_roles` map so local diagnosis can confirm which source role is
-configured or intentionally left unset without inferring from service names.
-
-The dedicated local startup guide remains the source of truth for contributor
-setup and troubleshooting.
+The roadmap is directional planning, not an activation switch for later source
+families or optional UI tracks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory contains the current baseline documentation set for SafeQuery, a 
 
 The current Epic A repository shell should be read as a developer state demo, not the production information architecture. It helps contributors inspect baseline UI states and backend posture while the product-facing shell contract is being implemented against the reviewed docs baseline.
 
-The UX-1 workflow-first operator shell contract in `docs/design/operator-workflow-information-architecture.md` and the accompanying visual contract in `../DESIGN.md` are part of the current source-aware and UX-foundation baseline. Do not treat the current top-level prototype shell as the production information architecture.
+The UX-1 workflow-first operator shell contract in `docs/design/operator-workflow-information-architecture.md` and the accompanying visual contract in `../DESIGN.md` are part of the current source-aware and UX-foundation baseline and remain the authoritative UI direction. Do not treat the current top-level prototype shell as the production information architecture.
 
 The docs are organized to make three things clear from the start for current baseline contributors:
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,18 +1,28 @@
 # Local Development Startup
 
 This guide documents the current baseline startup path for local SafeQuery
-development. It is intentionally limited to the foundation stack that exists in
-this repository today:
+development and product evaluation. It separates developer setup commands from
+the product evaluation flow so first-run users can tell the difference between
+building the stack and judging the current SafeQuery baseline.
+
+The repository currently contains the source-aware core service baseline:
 
 - Next.js frontend
 - FastAPI backend
 - application PostgreSQL
-- Alembic migration scaffold
+- Alembic migrations for the application-owned control plane
+- backend-owned source registry readiness
+- source-aware preview, audit, evaluation, and operator-workflow contracts
 
 The local topology also declares dedicated source-role services:
 
 - business PostgreSQL source
 - business MSSQL source
+
+Those source services are local role anchors. They do not make application
+PostgreSQL a business target, and they do not grant execution authority to an
+LLM, SQL generation adapter, browser client, MLflow export, search surface, or
+analyst surface.
 
 Use this document as the source of truth for first local runs. `README.md`
 keeps a shorter entrypoint and links back here.
@@ -25,7 +35,49 @@ SafeQuery currently supports two practical local workflows:
 - host-shell component checks for the frontend or backend in isolation
 
 The compose-backed path is the baseline because it wires the frontend, backend,
-database, and health checks together with the repository's current settings.
+database, source registry records, migrations, and health checks together with
+the repository's current settings.
+
+## Product evaluation flow
+
+Use this flow when you are evaluating the current product baseline rather than
+developing an individual component:
+
+1. Create `.env` from `.env.example`.
+2. Start the compose stack from the repository root.
+3. Apply Alembic migrations through the compose-backed backend service.
+4. Open `http://localhost:3000` and inspect the workflow-first operator shell.
+5. Confirm `http://localhost:8000/health` returns a healthy backend response.
+6. Confirm the operator shell is using backend source registry data, not a
+   source inferred from a service name or local credential name.
+
+A successful first-run baseline should show:
+
+- backend health backed by application PostgreSQL
+- source registry readiness for reviewed local source records
+- source-aware request and preview contracts anchored to backend records
+- explicit source visibility in the operator shell
+- candidate-only execution posture, with no raw-SQL execute authority exposed to
+  the client
+
+Known Missing Product Wiring:
+
+- real authentication and session bridge wiring
+- production SQL generation adapter integration
+- final persisted candidate and run history
+- execute-path wiring for approved candidates
+- deployment, secrets, and production release operations
+
+Optional governed search, analyst-style orchestration, and MLflow integrations
+remain extension tracks. They are not required for first-run Epic K activation
+and must not become execution, authorization, audit, or source-registry
+authorities.
+
+## Developer setup flow
+
+Use the numbered setup sections below when you need to build, migrate, test, or
+troubleshoot the stack locally. The commands are intentionally repo-relative and
+avoid workstation-local absolute paths.
 
 ## Prerequisites
 
@@ -84,6 +136,10 @@ Treat those as three different local roles:
 The hardened local foundation keeps those roles explicit before any source-aware
 core path exists, so operators can inspect the topology without guessing and
 without treating application PostgreSQL as a business target.
+
+The backend-owned source registry remains authoritative for source activation.
+Do not infer an active source from a hostname, credential name, driver string,
+or nearby documentation note.
 
 The checked-in baseline values are already wired to the compose network:
 
@@ -150,6 +206,11 @@ curl http://localhost:8000/health
 The backend `/health` endpoint is the baseline health check for the app and the
 database connection.
 
+For product evaluation, backend health is necessary but not sufficient. Also
+confirm that the frontend can render the operator workflow shell and that source
+registry data is available to the shell. Missing registry data should block
+preview submission rather than letting the UI guess an executable source.
+
 ## 4. Validate the Hardened Foundation
 
 Run the focused smoke checks that prove the local role split and fail-closed
@@ -185,6 +246,11 @@ that summarize the hardened foundation without inferring from service names:
 - `source_posture`
 - `configured_source_count`
 - `source_roles`
+
+These checks preserve the SafeQuery trust boundary: source registry decisions
+are backend-owned, application PostgreSQL stays separate from business sources,
+candidate-only execution remains the only approved execute posture, and there is
+no LLM or adapter execution authority.
 
 ## 5. Run Migrations
 
@@ -233,6 +299,10 @@ python3 -m pip install -e backend
 
 The backend settings loader accepts `.env` and `../.env`, which keeps the repo
 root and `backend/` command paths aligned.
+
+Host-shell component checks are developer setup checks. They do not replace the
+compose-backed product evaluation flow because they do not prove the full
+frontend, backend, migration, and source-registry topology together.
 
 ## 7. Stop the Stack
 
@@ -299,3 +369,18 @@ If that succeeds, re-check the frontend env values in `.env` or
 This is expected if you try to use the compose-only hostname `app-postgres` from a
 host shell. Use the compose-backed migration commands instead, or point
 `SAFEQUERY_APP_POSTGRES_URL` at a host-reachable database endpoint.
+
+## Epic K Sequence
+
+Epic K starts with the refreshed README and this local development guide, then
+continues into first-run seed data, source-registry doctor/readiness checks, and
+the next productization issues. Keep the sequence aligned with
+[docs/implementation-roadmap.md](./implementation-roadmap.md) and use
+repo-relative commands or placeholders such as `<supervisor-config-path>` when
+writing issue text or validation notes.
+
+Future families from Epic J remain planned metadata only unless a later issue
+explicitly activates them through backend-owned source registry, connector,
+guard, entitlement, audit, candidate lifecycle, and release-gate work. MySQL,
+MariaDB, Aurora, Oracle, Search, Analyst, and MLflow UI work must not be treated
+as part of first-run Epic K activation.

--- a/tests/smoke/test-epic-a-doc-framing.sh
+++ b/tests/smoke/test-epic-a-doc-framing.sh
@@ -16,11 +16,11 @@ for path in "$readme_path" "$docs_index_path"; do
 done
 
 readme_required_patterns=(
-  "developer state demo"
-  "not the intended production information architecture"
+  "source-aware core service baseline"
+  "Product evaluation flow"
+  "Known product-readiness gaps"
   "docs/design/operator-workflow-information-architecture.md"
-  "next authoritative UI direction"
-  "UX-1 workflow-first operator shell contract"
+  "docs/implementation-roadmap.md"
 )
 
 docs_index_required_patterns=(

--- a/tests/smoke/test-local-startup-docs.sh
+++ b/tests/smoke/test-local-startup-docs.sh
@@ -61,6 +61,12 @@ for pattern in "${local_doc_hardening_patterns[@]}"; do
 done
 
 readme_hardening_patterns=(
+  "source-aware core service baseline"
+  "backend-owned source registry"
+  "candidate-only execution"
+  "no LLM or adapter execution authority"
+  "Product evaluation flow"
+  "docs/implementation-roadmap.md"
   "application PostgreSQL"
   "business PostgreSQL source"
   "business MSSQL source"
@@ -78,6 +84,39 @@ readme_hardening_patterns=(
 for pattern in "${readme_hardening_patterns[@]}"; do
   if ! grep -Fq "$pattern" "$readme_path"; then
     echo "missing hardened README detail: $pattern" >&2
+    missing=1
+  fi
+done
+
+product_baseline_doc_patterns=(
+  "Developer setup flow"
+  "Product evaluation flow"
+  "source registry readiness"
+  "backend-owned source registry"
+  "candidate-only execution"
+  "no LLM or adapter execution authority"
+  "Known Missing Product Wiring"
+  "Epic K Sequence"
+  "docs/implementation-roadmap.md"
+  "planned metadata only"
+)
+
+for pattern in "${product_baseline_doc_patterns[@]}"; do
+  if ! grep -Fq "$pattern" "$doc_path"; then
+    echo "missing product-baseline local-doc detail: $pattern" >&2
+    missing=1
+  fi
+done
+
+stale_readme_patterns=(
+  "The baseline intentionally stops at placeholder UI and health-oriented API behavior."
+  "frontend/  Next.js UI placeholder and local stack status surface"
+  "backend/   FastAPI API placeholder and PostgreSQL-backed health checks"
+)
+
+for pattern in "${stale_readme_patterns[@]}"; do
+  if grep -Fq "$pattern" "$readme_path"; then
+    echo "README still contains stale placeholder-baseline wording: $pattern" >&2
     missing=1
   fi
 done


### PR DESCRIPTION
## Summary
- refresh the root README around the current source-aware core service baseline
- split local development guidance into product evaluation and developer setup flows
- tighten doc smoke checks so stale placeholder-only README wording fails

## Verification
- bash tests/smoke/test-baseline.sh
- bash tests/smoke/test-local-topology-roles.sh
- bash tests/smoke/test-local-startup-docs.sh && bash tests/smoke/test-doc-entrypoints-current-set.sh && bash tests/smoke/test-epic-a-doc-framing.sh
- python3 scripts/ci/check_repository_hygiene.py
- git diff --check

Refs #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and local development guides with clearer product evaluation procedures and setup instructions.
  * Enhanced documentation on trust boundaries, backend source registry ownership, and security posture.
  * Improved operator workflow guidance and acceptance criteria for initial setup validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->