### PR TITLE
[codex] Add demo source governance seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,19 +141,31 @@ docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend alem
 docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend alembic current
 ```
 
-4. Confirm the UI is reachable:
+4. Seed the local demo source governance records:
+
+```bash
+docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend python -m app.cli.seed_demo_source
+```
+
+The seed is safe to rerun against a local development database. It creates the
+`demo-business-postgres` source registry record, matching dataset contract, two
+minimal allow-listed demo datasets, and an approved schema snapshot pointer. The
+seed references `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` for the business source
+and does not make application PostgreSQL a business target.
+
+5. Confirm the UI is reachable:
 
 ```bash
 curl -I http://localhost:3000
 ```
 
-5. Confirm the API health endpoint is reachable and healthy:
+6. Confirm the API health endpoint is reachable and healthy:
 
 ```bash
 curl http://localhost:8000/health
 ```
 
-6. Stop the stack when finished:
+7. Stop the stack when finished:
 
 ```bash
 docker-compose --env-file .env -f infra/docker-compose.yml down

--- a/backend/README.md
+++ b/backend/README.md
@@ -59,7 +59,7 @@ docker-compose -f infra/docker-compose.yml run --rm backend python -m app.cli.se
 ```
 
 The seed is idempotent. It creates only backend-owned source registry, dataset
-contract, allow-listed dataset, and approved schema snapshot records for
+contract, allow-listed datasets, and approved schema snapshot records for
 `demo-business-postgres`; the connection reference points at
 `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` and preserves the application
 PostgreSQL role boundary.

--- a/backend/README.md
+++ b/backend/README.md
@@ -51,6 +51,19 @@ docker-compose -f infra/docker-compose.yml run --rm backend alembic upgrade head
 docker-compose -f infra/docker-compose.yml run --rm backend alembic current
 ```
 
+After migrations, a local development database can be seeded with one
+non-production demo business source:
+
+```bash
+docker-compose -f infra/docker-compose.yml run --rm backend python -m app.cli.seed_demo_source
+```
+
+The seed is idempotent. It creates only backend-owned source registry, dataset
+contract, allow-listed dataset, and approved schema snapshot records for
+`demo-business-postgres`; the connection reference points at
+`SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` and preserves the application
+PostgreSQL role boundary.
+
 For host-side Alembic commands, point `SAFEQUERY_APP_POSTGRES_URL` at a
 database that is explicitly reachable from your shell before running Alembic:
 

--- a/backend/app/cli/__init__.py
+++ b/backend/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line utilities for local SafeQuery backend operations."""

--- a/backend/app/cli/seed_demo_source.py
+++ b/backend/app/cli/seed_demo_source.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.db.session import get_engine
+from app.services.demo_source_seed import seed_demo_source_governance
+
+
+def main() -> None:
+    settings = get_settings()
+    with Session(get_engine(str(settings.app_postgres_url))) as session:
+        result = seed_demo_source_governance(session)
+
+    print(
+        json.dumps(
+            {
+                "source_id": result.source_id,
+                "created": result.created,
+                "source_record_id": str(result.source_record_id),
+                "dataset_contract_id": str(result.dataset_contract_id),
+                "schema_snapshot_id": str(result.schema_snapshot_id),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/services/demo_source_seed.py
+++ b/backend/app/services/demo_source_seed.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.dataset_contract import (
+    DatasetContract,
+    DatasetContractDataset,
+    DatasetContractDatasetKind,
+)
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+
+
+DEMO_SOURCE_ID = "demo-business-postgres"
+DEMO_SOURCE_UUID = UUID("11111111-1111-4111-8111-111111111111")
+DEMO_SCHEMA_SNAPSHOT_UUID = UUID("22222222-2222-4222-8222-222222222222")
+DEMO_DATASET_CONTRACT_UUID = UUID("33333333-3333-4333-8333-333333333333")
+DEMO_APPROVED_VENDORS_DATASET_UUID = UUID("44444444-4444-4444-8444-444444444444")
+DEMO_QUARTERLY_SPEND_DATASET_UUID = UUID("55555555-5555-4555-8555-555555555555")
+DEMO_REVIEWED_AT = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class DemoSourceSeedResult:
+    source_id: str
+    created: bool
+    source_record_id: UUID
+    dataset_contract_id: UUID
+    schema_snapshot_id: UUID
+
+
+@dataclass(frozen=True)
+class _DemoDatasetSeed:
+    record_id: UUID
+    schema_name: str
+    dataset_name: str
+    dataset_kind: DatasetContractDatasetKind
+
+
+_DEMO_DATASETS = (
+    _DemoDatasetSeed(
+        record_id=DEMO_APPROVED_VENDORS_DATASET_UUID,
+        schema_name="public",
+        dataset_name="approved_vendors",
+        dataset_kind=DatasetContractDatasetKind.TABLE,
+    ),
+    _DemoDatasetSeed(
+        record_id=DEMO_QUARTERLY_SPEND_DATASET_UUID,
+        schema_name="public",
+        dataset_name="quarterly_spend",
+        dataset_kind=DatasetContractDatasetKind.TABLE,
+    ),
+)
+
+
+def _upsert_demo_source(session: Session) -> tuple[RegisteredSource, bool]:
+    source = session.scalar(
+        select(RegisteredSource).where(RegisteredSource.source_id == DEMO_SOURCE_ID)
+    )
+    created = source is None
+    if source is None:
+        source = RegisteredSource(
+            id=DEMO_SOURCE_UUID,
+            source_id=DEMO_SOURCE_ID,
+            display_label="Demo business PostgreSQL",
+            source_family="postgresql",
+            source_flavor="demo",
+            activation_posture=SourceActivationPosture.ACTIVE,
+            connector_profile_id=None,
+            dialect_profile_id=None,
+            dataset_contract_id=None,
+            schema_snapshot_id=None,
+            execution_policy_id=None,
+            connection_reference="env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        )
+        session.add(source)
+
+    source.display_label = "Demo business PostgreSQL"
+    source.source_family = "postgresql"
+    source.source_flavor = "demo"
+    source.activation_posture = SourceActivationPosture.ACTIVE
+    source.connector_profile_id = None
+    source.dialect_profile_id = None
+    source.execution_policy_id = None
+    source.connection_reference = "env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"
+    session.flush()
+    return source, created
+
+
+def _upsert_demo_schema_snapshot(
+    session: Session,
+    *,
+    source: RegisteredSource,
+) -> SchemaSnapshot:
+    snapshot = session.scalar(
+        select(SchemaSnapshot).where(SchemaSnapshot.id == DEMO_SCHEMA_SNAPSHOT_UUID)
+    )
+    if snapshot is None:
+        snapshot = SchemaSnapshot(
+            id=DEMO_SCHEMA_SNAPSHOT_UUID,
+            registered_source_id=source.id,
+            snapshot_version=1,
+            review_status=SchemaSnapshotReviewStatus.APPROVED,
+            reviewed_at=DEMO_REVIEWED_AT,
+        )
+        session.add(snapshot)
+
+    snapshot.registered_source_id = source.id
+    snapshot.snapshot_version = 1
+    snapshot.review_status = SchemaSnapshotReviewStatus.APPROVED
+    snapshot.reviewed_at = DEMO_REVIEWED_AT
+    session.flush()
+    return snapshot
+
+
+def _upsert_demo_dataset_contract(
+    session: Session,
+    *,
+    source: RegisteredSource,
+    snapshot: SchemaSnapshot,
+) -> DatasetContract:
+    contract = session.scalar(
+        select(DatasetContract).where(DatasetContract.id == DEMO_DATASET_CONTRACT_UUID)
+    )
+    if contract is None:
+        contract = DatasetContract(
+            id=DEMO_DATASET_CONTRACT_UUID,
+            registered_source_id=source.id,
+            schema_snapshot_id=snapshot.id,
+            contract_version=1,
+            display_name="Demo business PostgreSQL contract",
+            owner_binding="group:finance-analysts",
+            security_review_binding="group:security-reviewers",
+            exception_policy_binding=None,
+        )
+        session.add(contract)
+
+    contract.registered_source_id = source.id
+    contract.schema_snapshot_id = snapshot.id
+    contract.contract_version = 1
+    contract.display_name = "Demo business PostgreSQL contract"
+    contract.owner_binding = "group:finance-analysts"
+    contract.security_review_binding = "group:security-reviewers"
+    contract.exception_policy_binding = None
+    session.flush()
+    return contract
+
+
+def _upsert_demo_dataset(
+    session: Session,
+    *,
+    contract: DatasetContract,
+    dataset_seed: _DemoDatasetSeed,
+) -> DatasetContractDataset:
+    dataset = session.scalar(
+        select(DatasetContractDataset).where(
+            DatasetContractDataset.id == dataset_seed.record_id
+        )
+    )
+    if dataset is None:
+        dataset = DatasetContractDataset(
+            id=dataset_seed.record_id,
+            dataset_contract_id=contract.id,
+            schema_name=dataset_seed.schema_name,
+            dataset_name=dataset_seed.dataset_name,
+            dataset_kind=dataset_seed.dataset_kind,
+        )
+        session.add(dataset)
+
+    dataset.dataset_contract_id = contract.id
+    dataset.schema_name = dataset_seed.schema_name
+    dataset.dataset_name = dataset_seed.dataset_name
+    dataset.dataset_kind = dataset_seed.dataset_kind
+    session.flush()
+    return dataset
+
+
+def seed_demo_source_governance(session: Session) -> DemoSourceSeedResult:
+    try:
+        source, created = _upsert_demo_source(session)
+        snapshot = _upsert_demo_schema_snapshot(session, source=source)
+        contract = _upsert_demo_dataset_contract(
+            session,
+            source=source,
+            snapshot=snapshot,
+        )
+        for dataset_seed in _DEMO_DATASETS:
+            _upsert_demo_dataset(
+                session,
+                contract=contract,
+                dataset_seed=dataset_seed,
+            )
+
+        source.dataset_contract_id = contract.id
+        source.schema_snapshot_id = snapshot.id
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+
+    return DemoSourceSeedResult(
+        source_id=source.source_id,
+        created=created,
+        source_record_id=source.id,
+        dataset_contract_id=contract.id,
+        schema_snapshot_id=snapshot.id,
+    )

--- a/backend/tests/test_demo_source_seed.py
+++ b/backend/tests/test_demo_source_seed.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.services.demo_source_seed import DEMO_SOURCE_ID, seed_demo_source_governance
+from app.services.operator_workflow import get_operator_workflow_snapshot
+from app.services.request_preview import PreviewSubmissionRequest, submit_preview_request
+
+
+@contextmanager
+def _session_scope() -> Session:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+def test_demo_source_seed_creates_preview_governance_records() -> None:
+    with _session_scope() as session:
+        result = seed_demo_source_governance(session)
+
+        source = session.scalar(
+            select(RegisteredSource).where(RegisteredSource.source_id == DEMO_SOURCE_ID)
+        )
+        contract = session.scalar(
+            select(DatasetContract).where(DatasetContract.id == source.dataset_contract_id)
+        )
+        snapshot = session.scalar(
+            select(SchemaSnapshot).where(SchemaSnapshot.id == source.schema_snapshot_id)
+        )
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id=DEMO_SOURCE_ID,
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+        )
+
+    assert result.created is True
+    assert source is not None
+    assert source.display_label == "Demo business PostgreSQL"
+    assert source.activation_posture == SourceActivationPosture.ACTIVE
+    assert source.source_family == "postgresql"
+    assert source.source_flavor == "demo"
+    assert source.connection_reference == "env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"
+    assert contract is not None
+    assert contract.contract_version == 1
+    assert contract.owner_binding == "group:finance-analysts"
+    assert snapshot is not None
+    assert snapshot.review_status == SchemaSnapshotReviewStatus.APPROVED
+    assert response.candidate.source_id == DEMO_SOURCE_ID
+    assert response.candidate.dataset_contract_version == 1
+    assert response.candidate.schema_snapshot_version == 1
+
+
+def test_demo_source_seed_is_idempotent_and_visible_to_operator_workflow() -> None:
+    with _session_scope() as session:
+        first = seed_demo_source_governance(session)
+        second = seed_demo_source_governance(session)
+
+        sources = session.scalars(select(RegisteredSource)).all()
+        contracts = session.scalars(select(DatasetContract)).all()
+        snapshots = session.scalars(select(SchemaSnapshot)).all()
+        datasets = session.scalars(select(DatasetContractDataset)).all()
+        workflow = get_operator_workflow_snapshot(session)
+
+    assert first.created is True
+    assert second.created is False
+    assert len(sources) == 1
+    assert len(contracts) == 1
+    assert len(snapshots) == 1
+    assert len(datasets) == 2
+    assert [source.source_id for source in workflow.sources] == [DEMO_SOURCE_ID]
+    assert workflow.sources[0].activation_posture == "active"
+    assert workflow.sources[0].source_family == "postgresql"
+    assert workflow.sources[0].source_flavor == "demo"


### PR DESCRIPTION
## Summary
- Add a deterministic backend seed utility for the local demo business PostgreSQL source.
- Add a `python -m app.cli.seed_demo_source` entrypoint for compose-backed first-run setup.
- Cover successful seed creation, idempotent reruns, preview governance linkage, and operator workflow source listing.
- Document the seed command in the root and backend README files.

## Validation
- `cd backend && python3 -m pytest tests/test_demo_source_seed.py`
- `cd backend && python3 -m pytest tests/test_demo_source_seed.py tests/test_preview_source_governance_resolution.py tests/test_request_source_selection.py`
- `cd backend && python3 -m pytest`
- `python3 scripts/ci/check_repository_hygiene.py`

## Notes
- The seed references `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` and does not activate application PostgreSQL as a business source.
- The seed creates only the PostgreSQL demo source; no future-family source is activated.

Closes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Local development guides updated with a new Step to run a CLI seed for demo source governance and renumbered subsequent steps; notes that seeding is idempotent and confined to demo artifacts.

* **New Features**
  * Added a development utility to populate demo source governance records, datasets, and an approved schema snapshot in the local database.

* **Tests**
  * Integration tests added to verify seeding, idempotency, and resulting governance artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->