### PR TITLE
Add dev demo entitlement binding fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@ The seed is safe to rerun against a local development database. It creates the
 `demo-business-postgres` source registry record, matching dataset contract, two
 minimal allow-listed demo datasets, and an approved schema snapshot pointer. The
 seed references `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` for the business source
-and does not make application PostgreSQL a business target.
+and does not make application PostgreSQL a business target. The dataset contract
+owner binding is the dev/local-only fixture
+`group:safequery-demo-local-operators`, intended for later development auth
+middleware to attach to `user:demo-local-operator`; it is not a production trust
+source and does not bypass the source-scoped entitlement check.
 
 5. Confirm the UI is reachable:
 

--- a/backend/app/services/demo_source_seed.py
+++ b/backend/app/services/demo_source_seed.py
@@ -23,6 +23,8 @@ DEMO_DATASET_CONTRACT_UUID = UUID("33333333-3333-4333-8333-333333333333")
 DEMO_APPROVED_VENDORS_DATASET_UUID = UUID("44444444-4444-4444-8444-444444444444")
 DEMO_QUARTERLY_SPEND_DATASET_UUID = UUID("55555555-5555-4555-8555-555555555555")
 DEMO_REVIEWED_AT = datetime(2026, 1, 1, tzinfo=timezone.utc)
+DEMO_DEV_SUBJECT_ID = "user:demo-local-operator"
+DEMO_DEV_GOVERNANCE_BINDING = "group:safequery-demo-local-operators"
 
 
 @dataclass(frozen=True)
@@ -124,6 +126,9 @@ def _upsert_demo_dataset_contract(
     source: RegisteredSource,
     snapshot: SchemaSnapshot,
 ) -> DatasetContract:
+    # Dev/local fixture only. Later dev auth middleware may grant this exact
+    # binding to DEMO_DEV_SUBJECT_ID; production auth must supply trusted
+    # source-scoped bindings from its own identity boundary.
     contract = session.scalar(
         select(DatasetContract).where(DatasetContract.id == DEMO_DATASET_CONTRACT_UUID)
     )
@@ -134,7 +139,7 @@ def _upsert_demo_dataset_contract(
             schema_snapshot_id=snapshot.id,
             contract_version=1,
             display_name="Demo business PostgreSQL contract",
-            owner_binding="group:finance-analysts",
+            owner_binding=DEMO_DEV_GOVERNANCE_BINDING,
             security_review_binding="group:security-reviewers",
             exception_policy_binding=None,
         )
@@ -144,7 +149,7 @@ def _upsert_demo_dataset_contract(
     contract.schema_snapshot_id = snapshot.id
     contract.contract_version = 1
     contract.display_name = "Demo business PostgreSQL contract"
-    contract.owner_binding = "group:finance-analysts"
+    contract.owner_binding = DEMO_DEV_GOVERNANCE_BINDING
     contract.security_review_binding = "group:security-reviewers"
     contract.exception_policy_binding = None
     session.flush()

--- a/backend/tests/test_demo_source_seed.py
+++ b/backend/tests/test_demo_source_seed.py
@@ -11,9 +11,18 @@ from app.db.models.dataset_contract import DatasetContract, DatasetContractDatas
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
-from app.services.demo_source_seed import DEMO_SOURCE_ID, seed_demo_source_governance
+from app.services.demo_source_seed import (
+    DEMO_DEV_GOVERNANCE_BINDING,
+    DEMO_DEV_SUBJECT_ID,
+    DEMO_SOURCE_ID,
+    seed_demo_source_governance,
+)
 from app.services.operator_workflow import get_operator_workflow_snapshot
-from app.services.request_preview import PreviewSubmissionRequest, submit_preview_request
+from app.services.request_preview import (
+    PreviewSubmissionContractError,
+    PreviewSubmissionRequest,
+    submit_preview_request,
+)
 
 
 @contextmanager
@@ -48,8 +57,8 @@ def test_demo_source_seed_creates_preview_governance_records() -> None:
                 source_id=DEMO_SOURCE_ID,
             ),
             AuthenticatedSubject(
-                subject_id="user:alice",
-                governance_bindings=frozenset({"group:finance-analysts"}),
+                subject_id=DEMO_DEV_SUBJECT_ID,
+                governance_bindings=frozenset({DEMO_DEV_GOVERNANCE_BINDING}),
             ),
             session,
         )
@@ -63,12 +72,37 @@ def test_demo_source_seed_creates_preview_governance_records() -> None:
     assert source.connection_reference == "env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"
     assert contract is not None
     assert contract.contract_version == 1
-    assert contract.owner_binding == "group:finance-analysts"
+    assert contract.owner_binding == DEMO_DEV_GOVERNANCE_BINDING
     assert snapshot is not None
     assert snapshot.review_status == SchemaSnapshotReviewStatus.APPROVED
     assert response.candidate.source_id == DEMO_SOURCE_ID
     assert response.candidate.dataset_contract_version == 1
     assert response.candidate.schema_snapshot_version == 1
+
+
+def test_demo_source_seed_denies_unrelated_demo_subject() -> None:
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+
+        try:
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by quarterly spend",
+                    source_id=DEMO_SOURCE_ID,
+                ),
+                AuthenticatedSubject(
+                    subject_id="user:unrelated-dev",
+                    governance_bindings=frozenset({"group:unrelated-devs"}),
+                ),
+                session,
+            )
+        except PreviewSubmissionContractError as exc:
+            assert str(exc) == (
+                "Authenticated subject 'user:unrelated-dev' is not entitled to use "
+                "registered source 'demo-business-postgres'."
+            )
+        else:
+            raise AssertionError("demo source unexpectedly accepted an unrelated subject")
 
 
 def test_demo_source_seed_is_idempotent_and_visible_to_operator_workflow() -> None:


### PR DESCRIPTION
## Summary
- add explicit dev/local demo subject and governance binding constants
- bind the demo dataset contract owner to the dev/local binding
- tighten seed tests to prove the demo subject is entitled and an unrelated subject is denied
- document the fixture as local-only and unsuitable for production trust

## Verification
- cd backend && python3 -m pytest tests/test_demo_source_seed.py tests/test_source_entitlements.py tests/test_preview_source_governance_resolution.py
- cd backend && python3 -m pytest

Closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified dataset contract governance configuration and owner binding specifications for local development environments.

* **Tests**
  * Expanded access control testing to verify that unauthorized subjects are properly denied access to dataset submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->