### PR TITLE
[K-4] Add first-run readiness doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,19 +157,29 @@ owner binding is the dev/local-only fixture
 middleware to attach to `user:demo-local-operator`; it is not a production trust
 source and does not bypass the source-scoped entitlement check.
 
-5. Confirm the UI is reachable:
+5. Run the first-run doctor:
+
+```bash
+docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend python -m app.cli.first_run_doctor
+```
+
+The doctor returns machine-readable JSON and fails closed when migrations,
+demo source registry records, linked dataset contracts, approved schema
+snapshots, or dev/local entitlement seed data are missing.
+
+6. Confirm the UI is reachable:
 
 ```bash
 curl -I http://localhost:3000
 ```
 
-6. Confirm the API health endpoint is reachable and healthy:
+7. Confirm the API health endpoint is reachable and healthy:
 
 ```bash
 curl http://localhost:8000/health
 ```
 
-7. Stop the stack when finished:
+8. Stop the stack when finished:
 
 ```bash
 docker-compose --env-file .env -f infra/docker-compose.yml down

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,5 +1,6 @@
 [alembic]
 script_location = alembic
+path_separator = os
 prepend_sys_path = .
 sqlalchemy.url =
 

--- a/backend/app/cli/first_run_doctor.py
+++ b/backend/app/cli/first_run_doctor.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.db.session import get_engine
+from app.services.first_run_doctor import run_first_run_doctor
+
+
+def main() -> None:
+    settings = get_settings()
+    with Session(get_engine(str(settings.app_postgres_url))) as session:
+        result = run_first_run_doctor(session)
+
+    print(json.dumps(result.model_dump(mode="json"), sort_keys=True))
+    if result.status == "fail":
+        raise SystemExit(1)
+    if result.status == "degraded":
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,7 @@ from app.features.auth.context import (
     require_authenticated_subject,
 )
 from app.services.health import check_database_health
+from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
 from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionContractError,
@@ -163,6 +164,12 @@ def create_app() -> FastAPI:
                 "database": database,
             },
         )
+
+    @app.get("/doctor/first-run", response_model=FirstRunDoctorResult)
+    def read_first_run_doctor(
+        session: Session = Depends(require_preview_submission_session),
+    ) -> FirstRunDoctorResult:
+        return run_first_run_doctor(session)
 
     @app.post("/requests/preview", response_model=PreviewSubmissionResponse)
     def create_request_preview(

--- a/backend/app/services/first_run_doctor.py
+++ b/backend/app/services/first_run_doctor.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Literal
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.services.demo_source_seed import (
+    DEMO_DEV_GOVERNANCE_BINDING,
+    DEMO_DEV_SUBJECT_ID,
+)
+from app.services.source_entitlements import (
+    SourceEntitlementError,
+    ensure_subject_is_entitled_for_source,
+)
+
+DoctorStatus = Literal["pass", "fail", "degraded"]
+
+
+class FirstRunDoctorCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    status: DoctorStatus
+    message: str
+    detail: dict[str, object] = Field(default_factory=dict)
+
+
+class FirstRunDoctorResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: DoctorStatus
+    checks: list[FirstRunDoctorCheck]
+
+
+def _backend_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _alembic_heads() -> set[str]:
+    config = Config(str(_backend_root() / "alembic.ini"))
+    config.set_main_option("script_location", str(_backend_root() / "alembic"))
+    return set(ScriptDirectory.from_config(config).get_heads())
+
+
+def _aggregate_status(checks: list[FirstRunDoctorCheck]) -> DoctorStatus:
+    if any(check.status == "fail" for check in checks):
+        return "fail"
+    if any(check.status == "degraded" for check in checks):
+        return "degraded"
+    return "pass"
+
+
+def _check_database(
+    session: Session,
+    database_probe: Callable[[], None] | None,
+) -> FirstRunDoctorCheck:
+    try:
+        if database_probe is None:
+            session.execute(text("SELECT 1")).scalar_one()
+        else:
+            database_probe()
+    except Exception as exc:
+        return FirstRunDoctorCheck(
+            name="database",
+            status="fail",
+            message=(
+                "Application database is not reachable. Start the local stack and "
+                "verify SAFEQUERY_APP_POSTGRES_URL before product evaluation."
+            ),
+            detail={"error": exc.__class__.__name__},
+        )
+
+    return FirstRunDoctorCheck(
+        name="database",
+        status="pass",
+        message="Application database connectivity is ready.",
+    )
+
+
+def _check_migrations(session: Session) -> FirstRunDoctorCheck:
+    try:
+        applied_revisions = {
+            str(row[0])
+            for row in session.execute(text("SELECT version_num FROM alembic_version"))
+        }
+    except SQLAlchemyError as exc:
+        return FirstRunDoctorCheck(
+            name="migrations",
+            status="fail",
+            message=(
+                "Alembic migration state is missing. Run `alembic upgrade head` "
+                "before opening the product evaluation flow."
+            ),
+            detail={"error": exc.__class__.__name__},
+        )
+
+    expected_heads = _alembic_heads()
+    if not applied_revisions:
+        return FirstRunDoctorCheck(
+            name="migrations",
+            status="fail",
+            message=(
+                "Alembic migration state is empty. Run `alembic upgrade head` "
+                "before opening the product evaluation flow."
+            ),
+            detail={"expected_heads": sorted(expected_heads), "applied_revisions": []},
+        )
+    if applied_revisions != expected_heads:
+        return FirstRunDoctorCheck(
+            name="migrations",
+            status="fail",
+            message=(
+                "Application database is not at the current Alembic head. Run "
+                "`alembic upgrade head`, then rerun the first-run doctor."
+            ),
+            detail={
+                "expected_heads": sorted(expected_heads),
+                "applied_revisions": sorted(applied_revisions),
+            },
+        )
+
+    return FirstRunDoctorCheck(
+        name="migrations",
+        status="pass",
+        message="Alembic migration posture is current.",
+        detail={"heads": sorted(expected_heads)},
+    )
+
+
+def _active_demo_sources(session: Session) -> list[RegisteredSource]:
+    return list(
+        session.scalars(
+            select(RegisteredSource)
+            .where(RegisteredSource.activation_posture == SourceActivationPosture.ACTIVE)
+            .where(RegisteredSource.source_flavor == "demo")
+            .order_by(RegisteredSource.source_id)
+        )
+    )
+
+
+def _check_source_registry(
+    active_demo_sources: list[RegisteredSource],
+) -> FirstRunDoctorCheck:
+    if not active_demo_sources:
+        return FirstRunDoctorCheck(
+            name="source_registry",
+            status="fail",
+            message=(
+                "No active demo source is registered. Run "
+                "`python -m app.cli.seed_demo_source` after migrations complete."
+            ),
+        )
+
+    return FirstRunDoctorCheck(
+        name="source_registry",
+        status="pass",
+        message="Active demo source registry record is present.",
+        detail={"source_ids": [source.source_id for source in active_demo_sources]},
+    )
+
+
+def _load_linked_contract(
+    session: Session,
+    source: RegisteredSource | None,
+) -> DatasetContract | None:
+    if source is None or source.dataset_contract_id is None:
+        return None
+    return session.get(DatasetContract, source.dataset_contract_id)
+
+
+def _load_linked_snapshot(
+    session: Session,
+    source: RegisteredSource | None,
+) -> SchemaSnapshot | None:
+    if source is None or source.schema_snapshot_id is None:
+        return None
+    return session.get(SchemaSnapshot, source.schema_snapshot_id)
+
+
+def _check_dataset_contract(
+    session: Session,
+    source: RegisteredSource | None,
+    contract: DatasetContract | None,
+    snapshot: SchemaSnapshot | None,
+) -> FirstRunDoctorCheck:
+    if source is None or contract is None:
+        return FirstRunDoctorCheck(
+            name="dataset_contract",
+            status="fail",
+            message=(
+                "Active demo source has no linked dataset contract. Rerun "
+                "`python -m app.cli.seed_demo_source` and verify the seed completed."
+            ),
+        )
+    if contract.registered_source_id != source.id:
+        return FirstRunDoctorCheck(
+            name="dataset_contract",
+            status="fail",
+            message="Linked dataset contract does not belong to the active demo source.",
+        )
+    if snapshot is not None and contract.schema_snapshot_id != snapshot.id:
+        return FirstRunDoctorCheck(
+            name="dataset_contract",
+            status="fail",
+            message="Linked dataset contract does not point at the source schema snapshot.",
+        )
+
+    dataset_count = session.scalar(
+        select(func.count()).select_from(DatasetContractDataset).where(
+            DatasetContractDataset.dataset_contract_id == contract.id
+        )
+    )
+    if not dataset_count:
+        return FirstRunDoctorCheck(
+            name="dataset_contract",
+            status="fail",
+            message=(
+                "Linked dataset contract has no allowed datasets. Rerun "
+                "`python -m app.cli.seed_demo_source` before product evaluation."
+            ),
+        )
+
+    return FirstRunDoctorCheck(
+        name="dataset_contract",
+        status="pass",
+        message="Linked dataset contract and allowed datasets are present.",
+        detail={
+            "contract_version": contract.contract_version,
+            "dataset_count": int(dataset_count),
+        },
+    )
+
+
+def _check_schema_snapshot(
+    source: RegisteredSource | None,
+    snapshot: SchemaSnapshot | None,
+) -> FirstRunDoctorCheck:
+    if source is None or snapshot is None:
+        return FirstRunDoctorCheck(
+            name="schema_snapshot",
+            status="fail",
+            message=(
+                "Active demo source has no linked schema snapshot. Rerun "
+                "`python -m app.cli.seed_demo_source` and verify migrations are current."
+            ),
+        )
+    if snapshot.registered_source_id != source.id:
+        return FirstRunDoctorCheck(
+            name="schema_snapshot",
+            status="fail",
+            message="Linked schema snapshot does not belong to the active demo source.",
+        )
+    if snapshot.review_status is not SchemaSnapshotReviewStatus.APPROVED:
+        return FirstRunDoctorCheck(
+            name="schema_snapshot",
+            status="fail",
+            message="Linked schema snapshot is not approved for first-run evaluation.",
+            detail={"review_status": snapshot.review_status.value},
+        )
+
+    return FirstRunDoctorCheck(
+        name="schema_snapshot",
+        status="pass",
+        message="Approved schema snapshot is linked to the active demo source.",
+        detail={"snapshot_version": snapshot.snapshot_version},
+    )
+
+
+def _check_entitlement_seed(
+    source: RegisteredSource | None,
+    contract: DatasetContract | None,
+) -> FirstRunDoctorCheck:
+    subject = AuthenticatedSubject(
+        subject_id=DEMO_DEV_SUBJECT_ID,
+        governance_bindings=frozenset({DEMO_DEV_GOVERNANCE_BINDING}),
+    )
+    if source is None or contract is None:
+        return FirstRunDoctorCheck(
+            name="entitlement_seed",
+            status="fail",
+            message=(
+                "The dev/local entitlement seed cannot be evaluated until the "
+                "demo source and dataset contract are present."
+            ),
+        )
+    try:
+        ensure_subject_is_entitled_for_source(subject, source, contract)
+    except SourceEntitlementError as exc:
+        return FirstRunDoctorCheck(
+            name="entitlement_seed",
+            status="fail",
+            message=(
+                "The dev/local entitlement seed is missing or incoherent. Rerun "
+                "`python -m app.cli.seed_demo_source` before product evaluation."
+            ),
+            detail={"error": str(exc)},
+        )
+
+    return FirstRunDoctorCheck(
+        name="entitlement_seed",
+        status="pass",
+        message="Dev/local entitlement seed is coherent for the demo operator.",
+        detail={"subject_id": DEMO_DEV_SUBJECT_ID},
+    )
+
+
+def _check_backend_expectation(backend_base_url: str) -> FirstRunDoctorCheck:
+    normalized = backend_base_url.rstrip("/")
+    return FirstRunDoctorCheck(
+        name="backend",
+        status="pass",
+        message="Backend readiness endpoint is expected to be reachable after startup.",
+        detail={"health_url": f"{normalized}/health"},
+    )
+
+
+def _check_frontend_expectation(
+    frontend_base_url: str,
+    backend_base_url: str,
+) -> FirstRunDoctorCheck:
+    return FirstRunDoctorCheck(
+        name="frontend",
+        status="pass",
+        message="Frontend is expected to call the configured backend base URL after startup.",
+        detail={
+            "frontend_url": frontend_base_url.rstrip("/"),
+            "backend_base_url": backend_base_url.rstrip("/"),
+        },
+    )
+
+
+def run_first_run_doctor(
+    session: Session,
+    *,
+    database_probe: Callable[[], None] | None = None,
+    backend_base_url: str | None = None,
+    frontend_base_url: str | None = None,
+) -> FirstRunDoctorResult:
+    resolved_backend_base_url = backend_base_url or os.getenv(
+        "NEXT_PUBLIC_API_BASE_URL", "http://localhost:8000"
+    )
+    resolved_frontend_base_url = frontend_base_url or os.getenv(
+        "SAFEQUERY_FRONTEND_BASE_URL", "http://localhost:3000"
+    )
+
+    checks = [
+        _check_database(session, database_probe),
+        _check_migrations(session),
+    ]
+
+    active_sources = _active_demo_sources(session)
+    primary_source = active_sources[0] if active_sources else None
+    contract = _load_linked_contract(session, primary_source)
+    snapshot = _load_linked_snapshot(session, primary_source)
+
+    checks.extend(
+        [
+            _check_source_registry(active_sources),
+            _check_dataset_contract(session, primary_source, contract, snapshot),
+            _check_schema_snapshot(primary_source, snapshot),
+            _check_entitlement_seed(primary_source, contract),
+            _check_backend_expectation(resolved_backend_base_url),
+            _check_frontend_expectation(
+                resolved_frontend_base_url,
+                resolved_backend_base_url,
+            ),
+        ]
+    )
+
+    return FirstRunDoctorResult(status=_aggregate_status(checks), checks=checks)

--- a/backend/app/services/first_run_doctor.py
+++ b/backend/app/services/first_run_doctor.py
@@ -106,7 +106,22 @@ def _check_migrations(session: Session) -> FirstRunDoctorCheck:
             detail={"error": exc.__class__.__name__},
         )
 
-    expected_heads = _alembic_heads()
+    try:
+        expected_heads = _alembic_heads()
+    except Exception as exc:
+        return FirstRunDoctorCheck(
+            name="migrations",
+            status="fail",
+            message=(
+                "Unable to read Alembic migration metadata. Verify "
+                "`backend/alembic.ini` and migration scripts are available, "
+                "then rerun the first-run doctor."
+            ),
+            detail={
+                "error": exc.__class__.__name__,
+                "applied_revisions": sorted(applied_revisions),
+            },
+        )
     if not applied_revisions:
         return FirstRunDoctorCheck(
             name="migrations",

--- a/backend/app/services/first_run_doctor.py
+++ b/backend/app/services/first_run_doctor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -24,6 +25,8 @@ from app.services.source_entitlements import (
     SourceEntitlementError,
     ensure_subject_is_entitled_for_source,
 )
+
+logger = logging.getLogger(__name__)
 
 DoctorStatus = Literal["pass", "fail", "degraded"]
 
@@ -331,6 +334,48 @@ def _check_entitlement_seed(
     )
 
 
+def _source_governance_unavailable_checks(
+    exc: SQLAlchemyError,
+) -> list[FirstRunDoctorCheck]:
+    error_detail = {"error": exc.__class__.__name__}
+    return [
+        FirstRunDoctorCheck(
+            name="source_registry",
+            status="fail",
+            message=(
+                "Unable to read demo source readiness data from the database. "
+                "Run `alembic upgrade head`, then rerun "
+                "`python -m app.cli.seed_demo_source`."
+            ),
+            detail=error_detail,
+        ),
+        FirstRunDoctorCheck(
+            name="dataset_contract",
+            status="fail",
+            message=(
+                "Dataset contract readiness could not be evaluated because "
+                "source readiness data is unavailable."
+            ),
+        ),
+        FirstRunDoctorCheck(
+            name="schema_snapshot",
+            status="fail",
+            message=(
+                "Schema snapshot readiness could not be evaluated because "
+                "source readiness data is unavailable."
+            ),
+        ),
+        FirstRunDoctorCheck(
+            name="entitlement_seed",
+            status="fail",
+            message=(
+                "Entitlement seed readiness could not be evaluated because "
+                "source readiness data is unavailable."
+            ),
+        ),
+    ]
+
+
 def _check_backend_expectation(backend_base_url: str) -> FirstRunDoctorCheck:
     normalized = backend_base_url.rstrip("/")
     return FirstRunDoctorCheck(
@@ -375,17 +420,26 @@ def run_first_run_doctor(
         _check_migrations(session),
     ]
 
-    active_sources = _active_demo_sources(session)
-    primary_source = active_sources[0] if active_sources else None
-    contract = _load_linked_contract(session, primary_source)
-    snapshot = _load_linked_snapshot(session, primary_source)
+    try:
+        active_sources = _active_demo_sources(session)
+        primary_source = active_sources[0] if active_sources else None
+        contract = _load_linked_contract(session, primary_source)
+        snapshot = _load_linked_snapshot(session, primary_source)
+
+        checks.extend(
+            [
+                _check_source_registry(active_sources),
+                _check_dataset_contract(session, primary_source, contract, snapshot),
+                _check_schema_snapshot(primary_source, snapshot),
+                _check_entitlement_seed(primary_source, contract),
+            ]
+        )
+    except SQLAlchemyError as exc:
+        logger.exception("First-run doctor could not read source governance data.")
+        checks.extend(_source_governance_unavailable_checks(exc))
 
     checks.extend(
         [
-            _check_source_registry(active_sources),
-            _check_dataset_contract(session, primary_source, contract, snapshot),
-            _check_schema_snapshot(primary_source, snapshot),
-            _check_entitlement_seed(primary_source, contract),
             _check_backend_expectation(resolved_backend_base_url),
             _check_frontend_expectation(
                 resolved_frontend_base_url,

--- a/backend/app/services/first_run_doctor.py
+++ b/backend/app/services/first_run_doctor.py
@@ -214,6 +214,7 @@ def _check_dataset_contract(
     snapshot: SchemaSnapshot | None,
 ) -> FirstRunDoctorCheck:
     if source is None or contract is None:
+        detail = {"source_id": source.source_id} if source is not None else {}
         return FirstRunDoctorCheck(
             name="dataset_contract",
             status="fail",
@@ -221,18 +222,21 @@ def _check_dataset_contract(
                 "Active demo source has no linked dataset contract. Rerun "
                 "`python -m app.cli.seed_demo_source` and verify the seed completed."
             ),
+            detail=detail,
         )
     if contract.registered_source_id != source.id:
         return FirstRunDoctorCheck(
             name="dataset_contract",
             status="fail",
             message="Linked dataset contract does not belong to the active demo source.",
+            detail={"source_id": source.source_id},
         )
     if snapshot is not None and contract.schema_snapshot_id != snapshot.id:
         return FirstRunDoctorCheck(
             name="dataset_contract",
             status="fail",
             message="Linked dataset contract does not point at the source schema snapshot.",
+            detail={"source_id": source.source_id},
         )
 
     dataset_count = session.scalar(
@@ -248,6 +252,7 @@ def _check_dataset_contract(
                 "Linked dataset contract has no allowed datasets. Rerun "
                 "`python -m app.cli.seed_demo_source` before product evaluation."
             ),
+            detail={"source_id": source.source_id},
         )
 
     return FirstRunDoctorCheck(
@@ -255,6 +260,7 @@ def _check_dataset_contract(
         status="pass",
         message="Linked dataset contract and allowed datasets are present.",
         detail={
+            "source_id": source.source_id,
             "contract_version": contract.contract_version,
             "dataset_count": int(dataset_count),
         },
@@ -266,6 +272,7 @@ def _check_schema_snapshot(
     snapshot: SchemaSnapshot | None,
 ) -> FirstRunDoctorCheck:
     if source is None or snapshot is None:
+        detail = {"source_id": source.source_id} if source is not None else {}
         return FirstRunDoctorCheck(
             name="schema_snapshot",
             status="fail",
@@ -273,26 +280,34 @@ def _check_schema_snapshot(
                 "Active demo source has no linked schema snapshot. Rerun "
                 "`python -m app.cli.seed_demo_source` and verify migrations are current."
             ),
+            detail=detail,
         )
     if snapshot.registered_source_id != source.id:
         return FirstRunDoctorCheck(
             name="schema_snapshot",
             status="fail",
             message="Linked schema snapshot does not belong to the active demo source.",
+            detail={"source_id": source.source_id},
         )
     if snapshot.review_status is not SchemaSnapshotReviewStatus.APPROVED:
         return FirstRunDoctorCheck(
             name="schema_snapshot",
             status="fail",
             message="Linked schema snapshot is not approved for first-run evaluation.",
-            detail={"review_status": snapshot.review_status.value},
+            detail={
+                "source_id": source.source_id,
+                "review_status": snapshot.review_status.value,
+            },
         )
 
     return FirstRunDoctorCheck(
         name="schema_snapshot",
         status="pass",
         message="Approved schema snapshot is linked to the active demo source.",
-        detail={"snapshot_version": snapshot.snapshot_version},
+        detail={
+            "source_id": source.source_id,
+            "snapshot_version": snapshot.snapshot_version,
+        },
     )
 
 
@@ -305,6 +320,7 @@ def _check_entitlement_seed(
         governance_bindings=frozenset({DEMO_DEV_GOVERNANCE_BINDING}),
     )
     if source is None or contract is None:
+        detail = {"source_id": source.source_id} if source is not None else {}
         return FirstRunDoctorCheck(
             name="entitlement_seed",
             status="fail",
@@ -312,6 +328,7 @@ def _check_entitlement_seed(
                 "The dev/local entitlement seed cannot be evaluated until the "
                 "demo source and dataset contract are present."
             ),
+            detail=detail,
         )
     try:
         ensure_subject_is_entitled_for_source(subject, source, contract)
@@ -323,15 +340,49 @@ def _check_entitlement_seed(
                 "The dev/local entitlement seed is missing or incoherent. Rerun "
                 "`python -m app.cli.seed_demo_source` before product evaluation."
             ),
-            detail={"error": str(exc)},
+            detail={"source_id": source.source_id, "error": str(exc)},
         )
 
     return FirstRunDoctorCheck(
         name="entitlement_seed",
         status="pass",
         message="Dev/local entitlement seed is coherent for the demo operator.",
-        detail={"subject_id": DEMO_DEV_SUBJECT_ID},
+        detail={"source_id": source.source_id, "subject_id": DEMO_DEV_SUBJECT_ID},
     )
+
+
+def _source_governance_checks_for_source(
+    session: Session,
+    source: RegisteredSource,
+) -> list[FirstRunDoctorCheck]:
+    contract = _load_linked_contract(session, source)
+    snapshot = _load_linked_snapshot(session, source)
+    return [
+        _check_dataset_contract(session, source, contract, snapshot),
+        _check_schema_snapshot(source, snapshot),
+        _check_entitlement_seed(source, contract),
+    ]
+
+
+def _source_governance_checks(
+    session: Session,
+    active_sources: list[RegisteredSource],
+) -> list[FirstRunDoctorCheck]:
+    selected_checks: list[FirstRunDoctorCheck] | None = None
+    for source in active_sources:
+        candidate_checks = _source_governance_checks_for_source(session, source)
+        if all(check.status == "pass" for check in candidate_checks):
+            return candidate_checks
+        if selected_checks is None:
+            selected_checks = candidate_checks
+
+    if selected_checks is not None:
+        return selected_checks
+    return [
+        _check_dataset_contract(session, None, None, None),
+        _check_schema_snapshot(None, None),
+        _check_entitlement_seed(None, None),
+    ]
 
 
 def _source_governance_unavailable_checks(
@@ -422,18 +473,8 @@ def run_first_run_doctor(
 
     try:
         active_sources = _active_demo_sources(session)
-        primary_source = active_sources[0] if active_sources else None
-        contract = _load_linked_contract(session, primary_source)
-        snapshot = _load_linked_snapshot(session, primary_source)
-
-        checks.extend(
-            [
-                _check_source_registry(active_sources),
-                _check_dataset_contract(session, primary_source, contract, snapshot),
-                _check_schema_snapshot(primary_source, snapshot),
-                _check_entitlement_seed(primary_source, contract),
-            ]
-        )
+        checks.append(_check_source_registry(active_sources))
+        checks.extend(_source_governance_checks(session, active_sources))
     except SQLAlchemyError as exc:
         logger.exception("First-run doctor could not read source governance data.")
         checks.extend(_source_governance_unavailable_checks(exc))

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Iterator
+from uuid import UUID
 
 import pytest
 from sqlalchemy import text
@@ -10,7 +11,7 @@ from sqlalchemy.orm import Session
 import app.services.first_run_doctor as first_run_doctor_service
 from app.db.base import Base
 from app.db.models.dataset_contract import DatasetContract
-from app.db.models.source_registry import RegisteredSource
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.services.demo_source_seed import DEMO_SOURCE_UUID, seed_demo_source_governance
 from app.services.first_run_doctor import run_first_run_doctor
 
@@ -117,6 +118,42 @@ def test_first_run_doctor_passes_after_demo_seed() -> None:
     assert sections["entitlement_seed"]["status"] == "pass"
     assert sections["backend"]["status"] == "pass"
     assert sections["frontend"]["status"] == "pass"
+
+
+def test_first_run_doctor_passes_when_any_active_demo_source_is_ready() -> None:
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+        broken_source = RegisteredSource(
+            id=UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+            source_id="aaa-broken-demo",
+            display_label="Broken demo source",
+            source_family="postgresql",
+            source_flavor="demo",
+            activation_posture=SourceActivationPosture.ACTIVE,
+            connector_profile_id=None,
+            dialect_profile_id=None,
+            dataset_contract_id=None,
+            schema_snapshot_id=None,
+            execution_policy_id=None,
+            connection_reference="env:SAFEQUERY_BROKEN_DEMO_URL",
+        )
+        session.add(broken_source)
+        session.commit()
+
+        result = run_first_run_doctor(session, database_probe=lambda: None)
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "pass"
+    assert sections["source_registry"]["detail"]["source_ids"] == [
+        "aaa-broken-demo",
+        "demo-business-postgres",
+    ]
+    assert sections["dataset_contract"]["status"] == "pass"
+    assert sections["dataset_contract"]["detail"]["source_id"] == (
+        "demo-business-postgres"
+    )
+    assert sections["schema_snapshot"]["status"] == "pass"
+    assert sections["entitlement_seed"]["status"] == "pass"
 
 
 def test_first_run_doctor_fails_closed_when_source_seed_is_missing() -> None:

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -131,6 +131,24 @@ def test_first_run_doctor_fails_closed_when_source_seed_is_missing() -> None:
     ]
 
 
+def test_first_run_doctor_fails_closed_when_source_governance_tables_are_missing() -> None:
+    with _session_scope() as session:
+        session.execute(text("DROP TABLE registered_sources"))
+        session.commit()
+
+        result = run_first_run_doctor(session, database_probe=lambda: None)
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "fail"
+    assert sections["source_registry"]["status"] == "fail"
+    assert sections["source_registry"]["detail"] == {"error": "OperationalError"}
+    assert sections["dataset_contract"]["status"] == "fail"
+    assert sections["schema_snapshot"]["status"] == "fail"
+    assert sections["entitlement_seed"]["status"] == "fail"
+    assert sections["backend"]["status"] == "pass"
+    assert sections["frontend"]["status"] == "pass"
+
+
 def test_first_run_doctor_fails_closed_when_contract_or_snapshot_link_is_missing() -> None:
     with _session_scope() as session:
         seed_demo_source_governance(session)

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.source_registry import RegisteredSource
+from app.services.demo_source_seed import DEMO_SOURCE_UUID, seed_demo_source_governance
+from app.services.first_run_doctor import run_first_run_doctor
+
+
+@contextmanager
+def _session_scope() -> Iterator[Session]:
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(255))"))
+        session.execute(
+            text(
+                "INSERT INTO alembic_version (version_num) "
+                "VALUES ('0005_retrieval_corpus_scaffold')"
+            )
+        )
+        session.commit()
+        yield session
+
+
+def _doctor_sections(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    checks = payload["checks"]
+    assert isinstance(checks, list)
+    return {
+        str(check["name"]): check
+        for check in checks
+        if isinstance(check, dict) and "name" in check
+    }
+
+
+def test_first_run_doctor_fails_closed_when_migration_state_is_missing() -> None:
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        result = run_first_run_doctor(session, database_probe=lambda: None)
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "fail"
+    assert sections["migrations"]["status"] == "fail"
+    assert "Alembic migration state is missing" in sections["migrations"]["message"]
+
+
+def test_first_run_doctor_passes_after_demo_seed() -> None:
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+
+        result = run_first_run_doctor(
+            session,
+            database_probe=lambda: None,
+            backend_base_url="http://localhost:8000",
+            frontend_base_url="http://localhost:3000",
+        )
+
+    payload = result.model_dump(mode="json")
+    sections = _doctor_sections(payload)
+    assert payload["status"] == "pass"
+    assert sections["database"]["status"] == "pass"
+    assert sections["migrations"]["status"] == "pass"
+    assert sections["source_registry"]["status"] == "pass"
+    assert sections["dataset_contract"]["status"] == "pass"
+    assert sections["schema_snapshot"]["status"] == "pass"
+    assert sections["entitlement_seed"]["status"] == "pass"
+    assert sections["backend"]["status"] == "pass"
+    assert sections["frontend"]["status"] == "pass"
+
+
+def test_first_run_doctor_fails_closed_when_source_seed_is_missing() -> None:
+    with _session_scope() as session:
+        result = run_first_run_doctor(session, database_probe=lambda: None)
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "fail"
+    assert sections["source_registry"]["status"] == "fail"
+    assert "Run `python -m app.cli.seed_demo_source`" in sections["source_registry"][
+        "message"
+    ]
+
+
+def test_first_run_doctor_fails_closed_when_contract_or_snapshot_link_is_missing() -> None:
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+        source = session.get(RegisteredSource, DEMO_SOURCE_UUID)
+        assert source is not None
+        source.dataset_contract_id = None
+        source.schema_snapshot_id = None
+        session.commit()
+
+        result = run_first_run_doctor(session, database_probe=lambda: None)
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "fail"
+    assert sections["dataset_contract"]["status"] == "fail"
+    assert sections["schema_snapshot"]["status"] == "fail"
+
+
+def test_first_run_doctor_fails_closed_when_entitlement_seed_is_missing() -> None:
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+        source = session.get(RegisteredSource, DEMO_SOURCE_UUID)
+        assert source is not None
+        contract = session.get(DatasetContract, source.dataset_contract_id)
+        assert contract is not None
+        contract.owner_binding = None
+        session.commit()
+
+        result = run_first_run_doctor(session, database_probe=lambda: None)
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "fail"
+    assert sections["entitlement_seed"]["status"] == "fail"
+    assert "dev/local entitlement seed" in sections["entitlement_seed"]["message"]

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from contextlib import contextmanager
 from typing import Iterator
 
+import pytest
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+import app.services.first_run_doctor as first_run_doctor_service
 from app.db.base import Base
 from app.db.models.dataset_contract import DatasetContract
 from app.db.models.source_registry import RegisteredSource
@@ -63,6 +65,34 @@ def test_first_run_doctor_fails_closed_when_migration_state_is_missing() -> None
     assert result.status == "fail"
     assert sections["migrations"]["status"] == "fail"
     assert "Alembic migration state is missing" in sections["migrations"]["message"]
+
+
+def test_first_run_doctor_fails_closed_when_migration_metadata_is_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_head_lookup_error() -> set[str]:
+        raise RuntimeError("missing scripts")
+
+    monkeypatch.setattr(
+        first_run_doctor_service,
+        "_alembic_heads",
+        raise_head_lookup_error,
+    )
+
+    with _session_scope() as session:
+        result = run_first_run_doctor(session, database_probe=lambda: None)
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "fail"
+    assert sections["migrations"]["status"] == "fail"
+    assert "Unable to read Alembic migration metadata" in sections["migrations"][
+        "message"
+    ]
+    assert sections["migrations"]["detail"] == {
+        "error": "RuntimeError",
+        "applied_revisions": ["0005_retrieval_corpus_scaffold"],
+    }
+    assert "source_registry" in sections
 
 
 def test_first_run_doctor_passes_after_demo_seed() -> None:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -207,7 +207,25 @@ The backend `/health` endpoint is the baseline health check for the app and the
 database connection.
 
 For product evaluation, backend health is necessary but not sufficient. Also
-confirm that the frontend can render the operator workflow shell and that source
+run the first-run doctor after migrations and demo seed data are applied:
+
+```bash
+docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend python -m app.cli.first_run_doctor
+```
+
+The doctor emits JSON with pass/fail/degraded checks for application database
+connectivity, Alembic posture, active demo source registry records, linked
+dataset contracts, approved schema snapshots, dev/local entitlement seed data,
+and backend/frontend URL expectations. Missing registry data, contract links,
+schema snapshots, entitlements, or migrations are failures, not empty UI states.
+
+The same payload is available from the running backend:
+
+```bash
+curl http://localhost:8000/doctor/first-run
+```
+
+Confirm that the frontend can render the operator workflow shell and that source
 registry data is available to the shell. Missing registry data should block
 preview submission rather than letting the UI guess an executable source.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -206,10 +206,11 @@ curl http://localhost:8000/health
 The backend `/health` endpoint is the baseline health check for the app and the
 database connection.
 
-For product evaluation, backend health is necessary but not sufficient. Also
-run the first-run doctor after migrations and demo seed data are applied:
+For product evaluation, backend health is necessary but not sufficient. After
+migrations, seed demo governance data and then run the first-run doctor:
 
 ```bash
+docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend python -m app.cli.seed_demo_source
 docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend python -m app.cli.first_run_doctor
 ```
 


### PR DESCRIPTION
## Summary
- add a backend-owned first-run doctor service with machine-readable pass/fail/degraded checks
- expose the doctor through `python -m app.cli.first_run_doctor` and `/doctor/first-run`
- document the first-run doctor in README and local development setup

## Verification
- `cd backend && python3 -m pytest tests/test_first_run_doctor.py`
- `cd backend && python3 -m pytest tests/test_first_run_doctor.py tests/test_demo_source_seed.py tests/test_source_entitlements.py tests/test_source_foundation_smoke.py`
- `cd backend && python3 -m pytest`
- `bash tests/smoke/test-local-startup-docs.sh`
- `bash tests/smoke/test-doc-entrypoints-current-set.sh`
- `python3 -m pytest tests/test_check_repository_hygiene.py`
- `git diff --check`

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a first-run "doctor" that verifies system readiness (DB connectivity, migrations, demo source registry, dataset contracts, approved schema snapshots, and local entitlements) and emits machine-readable pass/fail/degraded results; accessible via a CLI command and a new API endpoint.

* **Documentation**
  * Updated README and local development guide to add demo-data seeding and doctor checks, and to include the doctor step in the startup/verification flow.

* **Tests**
  * Added tests covering failure and success scenarios for the first-run doctor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->