### PR TITLE
Fix demo source execution readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ The seed is safe to rerun against a local development database. It creates the
 `demo-business-postgres` source registry record, matching dataset contract, two
 minimal allow-listed demo datasets, and an approved schema snapshot pointer. The
 seed references `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` for the business source
-and does not make application PostgreSQL a business target. The dataset contract
-owner binding is the dev/local-only fixture
+and binds the source to the backend-owned PostgreSQL `warehouse` execution
+profile; it does not make application PostgreSQL a business target. The dataset
+contract owner binding is the dev/local-only fixture
 `group:safequery-demo-local-operators`, intended for later development auth
 middleware to attach to `user:demo-local-operator`; it is not a production trust
 source and does not bypass the source-scoped entitlement check.
@@ -165,7 +166,8 @@ docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend pyth
 
 The doctor returns machine-readable JSON and fails closed when migrations,
 demo source registry records, linked dataset contracts, approved schema
-snapshots, or dev/local entitlement seed data are missing.
+snapshots, dev/local entitlement seed data, or the backend-owned execution
+connector binding are missing.
 
 6. Confirm the live operator workflow contract exposes an active source selector
    option:

--- a/backend/README.md
+++ b/backend/README.md
@@ -61,8 +61,9 @@ docker-compose -f infra/docker-compose.yml run --rm backend python -m app.cli.se
 The seed is idempotent. It creates only backend-owned source registry, dataset
 contract, allow-listed datasets, and approved schema snapshot records for
 `demo-business-postgres`; the connection reference points at
-`SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` and preserves the application
-PostgreSQL role boundary.
+`SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`, the source uses the backend-owned
+PostgreSQL `warehouse` execution profile, and the application PostgreSQL role
+boundary is preserved.
 
 For host-side Alembic commands, point `SAFEQUERY_APP_POSTGRES_URL` at a
 database that is explicitly reachable from your shell before running Alembic:

--- a/backend/app/services/demo_source_seed.py
+++ b/backend/app/services/demo_source_seed.py
@@ -71,7 +71,7 @@ def _upsert_demo_source(session: Session) -> tuple[RegisteredSource, bool]:
             source_id=DEMO_SOURCE_ID,
             display_label="Demo business PostgreSQL",
             source_family="postgresql",
-            source_flavor="demo",
+            source_flavor="warehouse",
             activation_posture=SourceActivationPosture.ACTIVE,
             connector_profile_id=None,
             dialect_profile_id=None,
@@ -84,7 +84,7 @@ def _upsert_demo_source(session: Session) -> tuple[RegisteredSource, bool]:
 
     source.display_label = "Demo business PostgreSQL"
     source.source_family = "postgresql"
-    source.source_flavor = "demo"
+    source.source_flavor = "warehouse"
     source.activation_posture = SourceActivationPosture.ACTIVE
     source.connector_profile_id = None
     source.dialect_profile_id = None

--- a/backend/app/services/first_run_doctor.py
+++ b/backend/app/services/first_run_doctor.py
@@ -17,9 +17,15 @@ from app.db.models.dataset_contract import DatasetContract, DatasetContractDatas
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
+from app.features.execution import (
+    ExecutionConnectorSelectionError,
+    select_execution_connector,
+)
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 from app.services.demo_source_seed import (
     DEMO_DEV_GOVERNANCE_BINDING,
     DEMO_DEV_SUBJECT_ID,
+    DEMO_SOURCE_ID,
 )
 from app.services.source_entitlements import (
     SourceEntitlementError,
@@ -162,7 +168,7 @@ def _active_demo_sources(session: Session) -> list[RegisteredSource]:
         session.scalars(
             select(RegisteredSource)
             .where(RegisteredSource.activation_posture == SourceActivationPosture.ACTIVE)
-            .where(RegisteredSource.source_flavor == "demo")
+            .where(RegisteredSource.source_id == DEMO_SOURCE_ID)
             .order_by(RegisteredSource.source_id)
         )
     )
@@ -351,6 +357,63 @@ def _check_entitlement_seed(
     )
 
 
+def _check_execution_connector(
+    source: RegisteredSource | None,
+    contract: DatasetContract | None,
+    snapshot: SchemaSnapshot | None,
+) -> FirstRunDoctorCheck:
+    if source is None or contract is None or snapshot is None:
+        detail = {"source_id": source.source_id} if source is not None else {}
+        return FirstRunDoctorCheck(
+            name="execution_connector",
+            status="fail",
+            message=(
+                "Demo source execution connector readiness cannot be evaluated until "
+                "the source, dataset contract, and schema snapshot are present."
+            ),
+            detail=detail,
+        )
+
+    try:
+        selection = select_execution_connector(
+            candidate_source=SourceBoundCandidateMetadata(
+                source_id=source.source_id,
+                source_family=source.source_family,
+                source_flavor=source.source_flavor,
+                dataset_contract_version=contract.contract_version,
+                schema_snapshot_version=snapshot.snapshot_version,
+            )
+        )
+    except ExecutionConnectorSelectionError as exc:
+        return FirstRunDoctorCheck(
+            name="execution_connector",
+            status="fail",
+            message=(
+                "Active demo source is not execution-ready because no backend-owned "
+                "execution connector matches its source binding."
+            ),
+            detail={
+                "source_id": source.source_id,
+                "source_family": source.source_family,
+                "source_flavor": source.source_flavor,
+                "deny_code": exc.deny_code,
+            },
+        )
+
+    return FirstRunDoctorCheck(
+        name="execution_connector",
+        status="pass",
+        message="Backend-owned execution connector is ready for the active demo source.",
+        detail={
+            "source_id": selection.source_id,
+            "source_family": selection.source_family,
+            "source_flavor": selection.source_flavor,
+            "connector_id": selection.connector_id,
+            "ownership": selection.ownership,
+        },
+    )
+
+
 def _source_governance_checks_for_source(
     session: Session,
     source: RegisteredSource,
@@ -361,6 +424,7 @@ def _source_governance_checks_for_source(
         _check_dataset_contract(session, source, contract, snapshot),
         _check_schema_snapshot(source, snapshot),
         _check_entitlement_seed(source, contract),
+        _check_execution_connector(source, contract, snapshot),
     ]
 
 
@@ -382,6 +446,7 @@ def _source_governance_checks(
         _check_dataset_contract(session, None, None, None),
         _check_schema_snapshot(None, None),
         _check_entitlement_seed(None, None),
+        _check_execution_connector(None, None, None),
     ]
 
 
@@ -421,6 +486,14 @@ def _source_governance_unavailable_checks(
             status="fail",
             message=(
                 "Entitlement seed readiness could not be evaluated because "
+                "source readiness data is unavailable."
+            ),
+        ),
+        FirstRunDoctorCheck(
+            name="execution_connector",
+            status="fail",
+            message=(
+                "Execution connector readiness could not be evaluated because "
                 "source readiness data is unavailable."
             ),
         ),

--- a/backend/tests/test_demo_source_seed.py
+++ b/backend/tests/test_demo_source_seed.py
@@ -11,6 +11,8 @@ from app.db.models.dataset_contract import DatasetContract, DatasetContractDatas
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
+from app.features.execution import select_execution_connector
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 from app.services.demo_source_seed import (
     DEMO_DEV_GOVERNANCE_BINDING,
     DEMO_DEV_SUBJECT_ID,
@@ -68,7 +70,7 @@ def test_demo_source_seed_creates_preview_governance_records() -> None:
     assert source.display_label == "Demo business PostgreSQL"
     assert source.activation_posture == SourceActivationPosture.ACTIVE
     assert source.source_family == "postgresql"
-    assert source.source_flavor == "demo"
+    assert source.source_flavor == "warehouse"
     assert source.connection_reference == "env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"
     assert contract is not None
     assert contract.contract_version == 1
@@ -78,6 +80,36 @@ def test_demo_source_seed_creates_preview_governance_records() -> None:
     assert response.candidate.source_id == DEMO_SOURCE_ID
     assert response.candidate.dataset_contract_version == 1
     assert response.candidate.schema_snapshot_version == 1
+
+
+def test_demo_source_seed_preview_candidate_selects_execution_connector() -> None:
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id=DEMO_SOURCE_ID,
+            ),
+            AuthenticatedSubject(
+                subject_id=DEMO_DEV_SUBJECT_ID,
+                governance_bindings=frozenset({DEMO_DEV_GOVERNANCE_BINDING}),
+            ),
+            session,
+        )
+
+    selection = select_execution_connector(
+        candidate_source=SourceBoundCandidateMetadata(
+            source_id=response.candidate.source_id,
+            source_family=response.candidate.source_family,
+            source_flavor=response.candidate.source_flavor,
+            dataset_contract_version=response.candidate.dataset_contract_version,
+            schema_snapshot_version=response.candidate.schema_snapshot_version,
+        )
+    )
+
+    assert selection.connector_id == "postgresql_readonly"
+    assert selection.ownership == "backend"
 
 
 def test_demo_source_seed_denies_unrelated_demo_subject() -> None:
@@ -125,4 +157,4 @@ def test_demo_source_seed_is_idempotent_and_visible_to_operator_workflow() -> No
     assert [source.source_id for source in workflow.sources] == [DEMO_SOURCE_ID]
     assert workflow.sources[0].activation_posture == "active"
     assert workflow.sources[0].source_family == "postgresql"
-    assert workflow.sources[0].source_flavor == "demo"
+    assert workflow.sources[0].source_flavor == "warehouse"

--- a/backend/tests/test_execution_connector_selection.py
+++ b/backend/tests/test_execution_connector_selection.py
@@ -92,3 +92,23 @@ def test_select_execution_connector_rejects_unsupported_source_flavor_without_fa
         )
 
     assert exc_info.value.deny_code == DENY_UNSUPPORTED_SOURCE_BINDING
+
+
+def test_select_execution_connector_rejects_preview_only_demo_flavor_without_fallback() -> None:
+    from app.features.execution.connector_selection import (
+        ExecutionConnectorSelectionError,
+        select_execution_connector,
+    )
+
+    with pytest.raises(
+        ExecutionConnectorSelectionError,
+        match="candidate-bound source family 'postgresql' and flavor 'demo'",
+    ) as exc_info:
+        select_execution_connector(
+            candidate_source=_candidate_source(
+                source_id="demo-business-postgres",
+                source_flavor="demo",
+            )
+        )
+
+    assert exc_info.value.deny_code == DENY_UNSUPPORTED_SOURCE_BINDING

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Iterator
-from uuid import UUID
 
 import pytest
 from sqlalchemy import text
@@ -11,7 +10,7 @@ from sqlalchemy.orm import Session
 import app.services.first_run_doctor as first_run_doctor_service
 from app.db.base import Base
 from app.db.models.dataset_contract import DatasetContract
-from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.db.models.source_registry import RegisteredSource
 from app.services.demo_source_seed import DEMO_SOURCE_UUID, seed_demo_source_governance
 from app.services.first_run_doctor import run_first_run_doctor
 
@@ -116,44 +115,41 @@ def test_first_run_doctor_passes_after_demo_seed() -> None:
     assert sections["dataset_contract"]["status"] == "pass"
     assert sections["schema_snapshot"]["status"] == "pass"
     assert sections["entitlement_seed"]["status"] == "pass"
+    assert sections["execution_connector"]["status"] == "pass"
+    assert sections["execution_connector"]["detail"] == {
+        "source_id": "demo-business-postgres",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "connector_id": "postgresql_readonly",
+        "ownership": "backend",
+    }
     assert sections["backend"]["status"] == "pass"
     assert sections["frontend"]["status"] == "pass"
 
 
-def test_first_run_doctor_passes_when_any_active_demo_source_is_ready() -> None:
+def test_first_run_doctor_fails_closed_when_demo_source_connector_binding_drifts() -> None:
     with _session_scope() as session:
         seed_demo_source_governance(session)
-        broken_source = RegisteredSource(
-            id=UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
-            source_id="aaa-broken-demo",
-            display_label="Broken demo source",
-            source_family="postgresql",
-            source_flavor="demo",
-            activation_posture=SourceActivationPosture.ACTIVE,
-            connector_profile_id=None,
-            dialect_profile_id=None,
-            dataset_contract_id=None,
-            schema_snapshot_id=None,
-            execution_policy_id=None,
-            connection_reference="env:SAFEQUERY_BROKEN_DEMO_URL",
-        )
-        session.add(broken_source)
+        source = session.get(RegisteredSource, DEMO_SOURCE_UUID)
+        assert source is not None
+        source.source_flavor = "demo"
         session.commit()
 
         result = run_first_run_doctor(session, database_probe=lambda: None)
 
     sections = _doctor_sections(result.model_dump(mode="json"))
-    assert result.status == "pass"
-    assert sections["source_registry"]["detail"]["source_ids"] == [
-        "aaa-broken-demo",
-        "demo-business-postgres",
-    ]
+    assert result.status == "fail"
+    assert sections["source_registry"]["status"] == "pass"
     assert sections["dataset_contract"]["status"] == "pass"
-    assert sections["dataset_contract"]["detail"]["source_id"] == (
-        "demo-business-postgres"
-    )
     assert sections["schema_snapshot"]["status"] == "pass"
     assert sections["entitlement_seed"]["status"] == "pass"
+    assert sections["execution_connector"]["status"] == "fail"
+    assert sections["execution_connector"]["detail"] == {
+        "source_id": "demo-business-postgres",
+        "source_family": "postgresql",
+        "source_flavor": "demo",
+        "deny_code": "DENY_UNSUPPORTED_SOURCE_BINDING",
+    }
 
 
 def test_first_run_doctor_fails_closed_when_source_seed_is_missing() -> None:
@@ -182,6 +178,7 @@ def test_first_run_doctor_fails_closed_when_source_governance_tables_are_missing
     assert sections["dataset_contract"]["status"] == "fail"
     assert sections["schema_snapshot"]["status"] == "fail"
     assert sections["entitlement_seed"]["status"] == "fail"
+    assert sections["execution_connector"]["status"] == "fail"
     assert sections["backend"]["status"] == "pass"
     assert sections["frontend"]["status"] == "pass"
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -217,8 +217,10 @@ docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend pyth
 The doctor emits JSON with pass/fail/degraded checks for application database
 connectivity, Alembic posture, active demo source registry records, linked
 dataset contracts, approved schema snapshots, dev/local entitlement seed data,
-and backend/frontend URL expectations. Missing registry data, contract links,
-schema snapshots, entitlements, or migrations are failures, not empty UI states.
+the backend-owned execution connector binding, and backend/frontend URL
+expectations. Missing registry data, contract links, schema snapshots,
+entitlements, execution connector readiness, or migrations are failures, not
+empty UI states.
 
 The same payload is available from the running backend:
 

--- a/docs/pilot-safety-verification-checklist.md
+++ b/docs/pilot-safety-verification-checklist.md
@@ -161,12 +161,13 @@ complete:
   `alembic current` succeed for the application-owned control plane.
 - K-3 seed evidence: `python -m app.cli.seed_demo_source` creates the demo
   business PostgreSQL source, dataset contract, approved schema snapshot, and
-  dev/local entitlement binding without treating application PostgreSQL as a
-  business target.
+  dev/local entitlement binding with the backend-owned PostgreSQL `warehouse`
+  execution profile, without treating application PostgreSQL as a business
+  target.
 - K-4 doctor evidence: `python -m app.cli.first_run_doctor` reports pass/fail
   status for migrations, active demo source registry records, dataset contract
-  linkage, schema snapshot approval, entitlement readiness, backend health, and
-  frontend health.
+  linkage, schema snapshot approval, entitlement readiness, execution connector
+  readiness, backend health, and frontend health.
 - K-5 workflow evidence:
   `tests/smoke/test-compose-operator-workflow-source-selector.sh` or the live
   `/operator/workflow` payload shows a non-empty active source selector sourced


### PR DESCRIPTION
## Summary
- bind the seeded demo business PostgreSQL source to the existing backend-owned PostgreSQL warehouse execution profile
- add first-run doctor execution connector readiness so unsupported source binding drift fails closed
- document the active/execution-ready demo source meaning in first-run operator docs

## Verification
- cd backend && python3 -m pytest tests/test_demo_source_seed.py tests/test_first_run_doctor.py tests/test_execution_connector_selection.py
- cd backend && python3 -m pytest tests/test_request_source_selection.py::RequestSourceSelectionTestCase::test_operator_workflow_snapshot_exposes_live_source_options_without_secrets
- bash tests/smoke/test-local-startup-docs.sh
- bash tests/smoke/test-pilot-safety-checklist.sh

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * First-run health diagnostics now include execution connector readiness verification for the demo business PostgreSQL source.

* **Documentation**
  * Updated documentation to reflect demo PostgreSQL source binding to a backend-owned warehouse execution profile.
  * Updated first-run diagnostics requirements in local development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->