### PR TITLE
Retry first-run doctor in compose smoke

### DIFF
--- a/tests/smoke/test-compose-operator-workflow-source-selector.sh
+++ b/tests/smoke/test-compose-operator-workflow-source-selector.sh
@@ -11,38 +11,23 @@ project_name="${SAFEQUERY_SMOKE_PROJECT_NAME:-safequery-k5-smoke}"
 backend_url="${SAFEQUERY_SMOKE_BACKEND_URL:-http://localhost:8000}"
 frontend_url="${SAFEQUERY_SMOKE_FRONTEND_URL:-http://localhost:3000}"
 keep_stack="${SAFEQUERY_SMOKE_KEEP_STACK:-0}"
-tmp_dir="$(mktemp -d)"
-response_file="$tmp_dir/response.json"
-curl_error_file="$tmp_dir/curl.err"
-frontend_file="$tmp_dir/frontend.html"
-
-if ! command -v docker-compose >/dev/null 2>&1; then
-  echo "compose smoke unavailable: docker-compose was not found on PATH" >&2
-  exit 127
-fi
-
-if [[ ! -f "$compose_file" ]]; then
-  echo "compose smoke setup failed: missing $compose_file" >&2
-  exit 1
-fi
-
-if [[ ! -f "$env_file" ]]; then
-  echo "compose smoke setup failed: missing $env_file; copy .env.example to .env" >&2
-  exit 1
-fi
 
 compose() {
   docker-compose --env-file "$env_file" -p "$project_name" -f "$compose_file" "$@"
 }
 
 cleanup() {
-  rm -rf "$tmp_dir"
+  if [[ -n "${tmp_dir:-}" ]]; then
+    rm -rf "$tmp_dir"
+  fi
   if [[ "$keep_stack" != "1" ]]; then
     compose down -v --remove-orphans >/dev/null
   fi
 }
 
-trap cleanup EXIT
+smoke_sleep() {
+  sleep "$1"
+}
 
 wait_for_http() {
   local label="$1"
@@ -63,48 +48,11 @@ wait_for_http() {
   return 1
 }
 
-echo "compose smoke: resetting disposable compose project"
-compose down -v --remove-orphans >/dev/null
+doctor_status_passes() {
+  local url="$1"
+  local response_path="$2"
 
-echo "compose smoke: starting baseline stack"
-compose up --build -d
-
-echo "compose smoke: applying migrations"
-if ! compose run --rm backend alembic upgrade head; then
-  echo "compose smoke migration failed: alembic upgrade head did not complete" >&2
-  exit 1
-fi
-
-if ! compose run --rm backend alembic current; then
-  echo "compose smoke migration failed: alembic current did not complete" >&2
-  exit 1
-fi
-
-echo "compose smoke: seeding demo source governance"
-if ! compose run --rm backend python -m app.cli.seed_demo_source; then
-  echo "compose smoke seed failed: python -m app.cli.seed_demo_source did not complete" >&2
-  exit 1
-fi
-
-echo "compose smoke: checking backend health"
-wait_for_http "backend health" "$backend_url/health" 30
-python3 - "$backend_url/health" "$response_file" <<'PY'
-import json
-import sys
-
-url = sys.argv[1]
-response_path = sys.argv[2]
-with open(response_path, encoding="utf-8") as response_file:
-    payload = json.load(response_file)
-if payload.get("status") != "ok" or payload.get("database", {}).get("status") != "ok":
-    raise SystemExit(
-        f"compose smoke backend health failed: {url} returned {json.dumps(payload, sort_keys=True)}"
-    )
-PY
-
-echo "compose smoke: checking first-run doctor"
-wait_for_http "first-run doctor" "$backend_url/doctor/first-run" 10
-python3 - "$backend_url/doctor/first-run" "$response_file" <<'PY'
+  python3 - "$url" "$response_path" <<'PY'
 import json
 import sys
 
@@ -127,10 +75,108 @@ if payload.get("status") != "pass":
         f"{url} reported {json.dumps(failing, sort_keys=True)}"
     )
 PY
+}
 
-echo "compose smoke: checking operator workflow source selector"
-wait_for_http "operator workflow" "$backend_url/operator/workflow" 10
-python3 - "$backend_url/operator/workflow" "$response_file" <<'PY'
+wait_for_first_run_doctor() {
+  local url="$1"
+  local attempts="${2:-30}"
+  local latest_error_file="$tmp_dir/doctor.err"
+
+  : >"$latest_error_file"
+  for attempt in $(seq 1 "$attempts"); do
+    if curl --fail --silent --show-error "$url" >"$response_file" 2>"$curl_error_file"; then
+      if doctor_status_passes "$url" "$response_file" 2>"$latest_error_file"; then
+        return 0
+      fi
+    else
+      {
+        echo "compose smoke first-run doctor failed: $url did not become reachable"
+        if [[ -s "$curl_error_file" ]]; then
+          sed 's/^/curl: /' "$curl_error_file"
+        fi
+      } >"$latest_error_file"
+    fi
+
+    if [[ "$attempt" -lt "$attempts" ]]; then
+      smoke_sleep 2
+    fi
+  done
+
+  echo "compose smoke first-run doctor failed: $url did not report status pass after $attempts attempts" >&2
+  if [[ -s "$latest_error_file" ]]; then
+    sed 's/^/doctor: /' "$latest_error_file" >&2
+  fi
+  return 1
+}
+
+run_compose_source_selector_smoke() {
+  tmp_dir="$(mktemp -d)"
+  response_file="$tmp_dir/response.json"
+  curl_error_file="$tmp_dir/curl.err"
+  frontend_file="$tmp_dir/frontend.html"
+
+  if ! command -v docker-compose >/dev/null 2>&1; then
+    echo "compose smoke unavailable: docker-compose was not found on PATH" >&2
+    exit 127
+  fi
+
+  if [[ ! -f "$compose_file" ]]; then
+    echo "compose smoke setup failed: missing $compose_file" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$env_file" ]]; then
+    echo "compose smoke setup failed: missing $env_file; copy .env.example to .env" >&2
+    exit 1
+  fi
+
+  trap cleanup EXIT
+
+  echo "compose smoke: resetting disposable compose project"
+  compose down -v --remove-orphans >/dev/null
+
+  echo "compose smoke: starting baseline stack"
+  compose up --build -d
+
+  echo "compose smoke: applying migrations"
+  if ! compose run --rm backend alembic upgrade head; then
+    echo "compose smoke migration failed: alembic upgrade head did not complete" >&2
+    exit 1
+  fi
+
+  if ! compose run --rm backend alembic current; then
+    echo "compose smoke migration failed: alembic current did not complete" >&2
+    exit 1
+  fi
+
+  echo "compose smoke: seeding demo source governance"
+  if ! compose run --rm backend python -m app.cli.seed_demo_source; then
+    echo "compose smoke seed failed: python -m app.cli.seed_demo_source did not complete" >&2
+    exit 1
+  fi
+
+  echo "compose smoke: checking backend health"
+  wait_for_http "backend health" "$backend_url/health" 30
+  python3 - "$backend_url/health" "$response_file" <<'PY'
+import json
+import sys
+
+url = sys.argv[1]
+response_path = sys.argv[2]
+with open(response_path, encoding="utf-8") as response_file:
+    payload = json.load(response_file)
+if payload.get("status") != "ok" or payload.get("database", {}).get("status") != "ok":
+    raise SystemExit(
+        f"compose smoke backend health failed: {url} returned {json.dumps(payload, sort_keys=True)}"
+    )
+PY
+
+  echo "compose smoke: checking first-run doctor"
+  wait_for_first_run_doctor "$backend_url/doctor/first-run" 30
+
+  echo "compose smoke: checking operator workflow source selector"
+  wait_for_http "operator workflow" "$backend_url/operator/workflow" 10
+  python3 - "$backend_url/operator/workflow" "$response_file" <<'PY'
 import json
 import sys
 
@@ -172,15 +218,20 @@ print(
 )
 PY
 
-echo "compose smoke: checking frontend reachability"
-if ! curl --fail --silent --show-error "$frontend_url" >"$frontend_file"; then
-  echo "compose smoke frontend failed: $frontend_url was not reachable" >&2
-  exit 1
-fi
+  echo "compose smoke: checking frontend reachability"
+  if ! curl --fail --silent --show-error "$frontend_url" >"$frontend_file"; then
+    echo "compose smoke frontend failed: $frontend_url was not reachable" >&2
+    exit 1
+  fi
 
-if ! grep -Fq "__NEXT_DATA__" "$frontend_file"; then
-  echo "compose smoke frontend failed: $frontend_url did not return a Next.js page" >&2
-  exit 1
-fi
+  if ! grep -Fq "__NEXT_DATA__" "$frontend_file"; then
+    echo "compose smoke frontend failed: $frontend_url did not return a Next.js page" >&2
+    exit 1
+  fi
 
-echo "compose smoke: first-run operator workflow source selector passed"
+  echo "compose smoke: first-run operator workflow source selector passed"
+}
+
+if [[ "${SAFEQUERY_SMOKE_SOURCE_ONLY:-0}" != "1" ]]; then
+  run_compose_source_selector_smoke
+fi

--- a/tests/smoke/test-compose-operator-workflow-source-selector.sh
+++ b/tests/smoke/test-compose-operator-workflow-source-selector.sh
@@ -20,8 +20,11 @@ cleanup() {
   if [[ -n "${tmp_dir:-}" ]]; then
     rm -rf "$tmp_dir"
   fi
-  if [[ "$keep_stack" != "1" ]]; then
-    compose down -v --remove-orphans >/dev/null
+  if [[ "$keep_stack" != "1" ]] \
+    && command -v docker-compose >/dev/null 2>&1 \
+    && [[ -f "$compose_file" ]] \
+    && [[ -f "$env_file" ]]; then
+    compose down -v --remove-orphans >/dev/null || true
   fi
 }
 
@@ -114,6 +117,7 @@ run_compose_source_selector_smoke() {
   response_file="$tmp_dir/response.json"
   curl_error_file="$tmp_dir/curl.err"
   frontend_file="$tmp_dir/frontend.html"
+  trap cleanup EXIT
 
   if ! command -v docker-compose >/dev/null 2>&1; then
     echo "compose smoke unavailable: docker-compose was not found on PATH" >&2
@@ -129,8 +133,6 @@ run_compose_source_selector_smoke() {
     echo "compose smoke setup failed: missing $env_file; copy .env.example to .env" >&2
     exit 1
   fi
-
-  trap cleanup EXIT
 
   echo "compose smoke: resetting disposable compose project"
   compose down -v --remove-orphans >/dev/null

--- a/tests/smoke/test-compose-source-selector-doctor-retry.sh
+++ b/tests/smoke/test-compose-source-selector-doctor-retry.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+SAFEQUERY_SMOKE_SOURCE_ONLY=1 source tests/smoke/test-compose-operator-workflow-source-selector.sh
+
+tmp_dir="$(mktemp -d)"
+response_file="$tmp_dir/response.json"
+curl_error_file="$tmp_dir/curl.err"
+stderr_file="$tmp_dir/stderr.txt"
+
+cleanup_retry_test() {
+  rm -rf "$tmp_dir"
+}
+
+trap cleanup_retry_test EXIT
+
+smoke_sleep() {
+  :
+}
+
+doctor_attempts=0
+curl() {
+  doctor_attempts=$((doctor_attempts + 1))
+  if [[ "$doctor_attempts" -eq 1 ]]; then
+    printf '%s\n' '{"status":"fail","checks":[{"name":"frontend","status":"fail","message":"Frontend app surface is not reachable yet."}]}'
+    return 0
+  fi
+
+  printf '%s\n' '{"status":"pass","checks":[{"name":"frontend","status":"pass","message":"Frontend app is reachable."}]}'
+}
+
+if ! wait_for_first_run_doctor "http://backend.example/doctor/first-run" 3; then
+  echo "doctor retry test failed: first-run doctor did not recover after a transient failing payload" >&2
+  exit 1
+fi
+
+if [[ "$doctor_attempts" -ne 2 ]]; then
+  echo "doctor retry test failed: expected 2 attempts for transient failure, got $doctor_attempts" >&2
+  exit 1
+fi
+
+doctor_attempts=0
+curl() {
+  doctor_attempts=$((doctor_attempts + 1))
+  printf '%s\n' '{"status":"fail","checks":[{"name":"frontend","status":"fail","message":"Frontend app surface is not reachable yet."},{"name":"migrations","status":"pass","message":"Database migrations are current."}]}'
+}
+
+if wait_for_first_run_doctor "http://backend.example/doctor/first-run" 2 2>"$stderr_file"; then
+  echo "doctor retry test failed: persistent failing payload unexpectedly passed" >&2
+  exit 1
+fi
+
+if [[ "$doctor_attempts" -ne 2 ]]; then
+  echo "doctor retry test failed: expected 2 attempts for persistent failure, got $doctor_attempts" >&2
+  exit 1
+fi
+
+for expected in '"name": "frontend"' '"status": "fail"' "Frontend app surface is not reachable yet."; do
+  if ! grep -Fq "$expected" "$stderr_file"; then
+    echo "doctor retry test failed: persistent failure output missing $expected" >&2
+    exit 1
+  fi
+done
+
+echo "doctor retry test passed"


### PR DESCRIPTION
## Summary
- retry `/doctor/first-run` until it reports `status: pass` in the compose source-selector smoke
- keep persistent doctor failures fail-closed with the last failing check names, statuses, and messages
- add a focused shell smoke test that stubs doctor payloads to prove transient fail then pass, and persistent fail diagnostics

## Verification
- `bash -n tests/smoke/test-compose-operator-workflow-source-selector.sh`
- `bash -n tests/smoke/test-compose-source-selector-doctor-retry.sh`
- `bash tests/smoke/test-compose-source-selector-doctor-retry.sh`
- `bash tests/smoke/test-compose-startup-env-wiring.sh`
- `bash tests/smoke/test-baseline.sh`
- `bash tests/smoke/test-pilot-safety-checklist.sh`
- Full compose smoke not run: local Colima-backed Docker daemon is not running in this workspace session.

Closes #213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved startup health-check retry logic with clearer diagnostic capture for faster detection and troubleshooting of initialization issues.

* **Tests**
  * Added smoke tests covering source-selection workflows and first-run health-check retry behavior, including scenarios with intermittent and persistent frontend failures.
  * Tests verify diagnostic output and retry counts to ensure reliable reporting during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->