### PR TITLE
Define enterprise auth bridge contract

### DIFF
--- a/backend/app/features/auth/__init__.py
+++ b/backend/app/features/auth/__init__.py
@@ -1,1 +1,15 @@
-"""Reserved package for authentication and session enforcement."""
+"""Authentication and session enforcement contracts."""
+
+from app.features.auth.bridge import (
+    EnterpriseAuthBridgeAuditMetadata,
+    EnterpriseAuthBridgeContext,
+    EnterpriseAuthBridgeInput,
+    normalize_enterprise_auth_bridge_input,
+)
+
+__all__ = [
+    "EnterpriseAuthBridgeAuditMetadata",
+    "EnterpriseAuthBridgeContext",
+    "EnterpriseAuthBridgeInput",
+    "normalize_enterprise_auth_bridge_input",
+]

--- a/backend/app/features/auth/bridge.py
+++ b/backend/app/features/auth/bridge.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import Literal, Mapping, Optional
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
+from typing_extensions import Annotated, Self
+
+from app.features.audit.event_model import NonEmptyTrimmedString
+from app.features.auth.context import AuthenticatedSubject
+
+
+BindingType = Literal["group", "role", "entitlement"]
+
+
+class EnterpriseBridgeSubject(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subject_id: NonEmptyTrimmedString
+    idp_subject: Optional[NonEmptyTrimmedString] = None
+    issuer: NonEmptyTrimmedString
+
+
+class EnterpriseBridgeSession(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: NonEmptyTrimmedString
+    issuer: NonEmptyTrimmedString
+
+
+class EnterpriseGovernanceBindingInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    binding_type: BindingType
+    value: NonEmptyTrimmedString
+    source_claim: NonEmptyTrimmedString
+
+    @field_validator("value")
+    @classmethod
+    def reject_prequalified_binding_values(cls, value: str) -> str:
+        if ":" in value:
+            raise ValueError(
+                "Governance binding value must be unqualified; "
+                "binding_type supplies the namespace."
+            )
+        return value
+
+    @property
+    def normalized_binding(self) -> str:
+        return f"{self.binding_type}:{self.value}"
+
+
+class EnterpriseAuthBridgeInput(BaseModel):
+    """Production-facing contract for a trusted enterprise identity bridge.
+
+    The external bridge proves identity and supplies normalized governance hints.
+    SafeQuery still owns session establishment and source entitlement decisions.
+    Tokens, credentials, and IdP secrets are accepted only as redaction posture
+    inputs and are excluded from all serialized contract and audit metadata.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    bridge_source: NonEmptyTrimmedString
+    subject: EnterpriseBridgeSubject
+    session: EnterpriseBridgeSession
+    governance_bindings: Annotated[
+        list[EnterpriseGovernanceBindingInput],
+        Field(min_length=1),
+    ]
+    raw_token: Optional[SecretStr] = Field(default=None, exclude=True)
+    client_secret: Optional[SecretStr] = Field(default=None, exclude=True)
+
+    @model_validator(mode="after")
+    def reject_duplicate_normalized_bindings(self) -> Self:
+        seen: set[str] = set()
+        for binding in self.governance_bindings:
+            normalized = binding.normalized_binding
+            if normalized in seen:
+                raise ValueError(f"Duplicate governance binding: {normalized}")
+            seen.add(normalized)
+        return self
+
+
+class SubjectProvenanceAuditMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    issuer: NonEmptyTrimmedString
+    idp_subject_present: bool
+
+
+class BindingProvenanceAuditMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    binding: NonEmptyTrimmedString
+    binding_type: BindingType
+    source_claim: NonEmptyTrimmedString
+    bridge_source: NonEmptyTrimmedString
+
+
+class EnterpriseAuthBridgeAuditMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bridge_source: NonEmptyTrimmedString
+    subject_id: NonEmptyTrimmedString
+    session_id: NonEmptyTrimmedString
+    subject_provenance: SubjectProvenanceAuditMetadata
+    binding_provenance: list[BindingProvenanceAuditMetadata]
+
+
+class EnterpriseAuthBridgeContext(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    authenticated_subject: AuthenticatedSubject
+    session: EnterpriseBridgeSession
+    audit_metadata: EnterpriseAuthBridgeAuditMetadata
+
+
+def normalize_enterprise_auth_bridge_input(
+    bridge_input: Mapping[str, object] | EnterpriseAuthBridgeInput,
+) -> EnterpriseAuthBridgeContext:
+    normalized_input = (
+        bridge_input
+        if isinstance(bridge_input, EnterpriseAuthBridgeInput)
+        else EnterpriseAuthBridgeInput.model_validate(bridge_input)
+    )
+    bindings = [
+        binding.normalized_binding
+        for binding in normalized_input.governance_bindings
+    ]
+
+    return EnterpriseAuthBridgeContext(
+        authenticated_subject=AuthenticatedSubject(
+            subject_id=normalized_input.subject.subject_id,
+            governance_bindings=frozenset(bindings),
+        ),
+        session=normalized_input.session,
+        audit_metadata=EnterpriseAuthBridgeAuditMetadata(
+            bridge_source=normalized_input.bridge_source,
+            subject_id=normalized_input.subject.subject_id,
+            session_id=normalized_input.session.session_id,
+            subject_provenance=SubjectProvenanceAuditMetadata(
+                issuer=normalized_input.subject.issuer,
+                idp_subject_present=normalized_input.subject.idp_subject is not None,
+            ),
+            binding_provenance=[
+                BindingProvenanceAuditMetadata(
+                    binding=binding.normalized_binding,
+                    binding_type=binding.binding_type,
+                    source_claim=binding.source_claim,
+                    bridge_source=normalized_input.bridge_source,
+                )
+                for binding in normalized_input.governance_bindings
+            ],
+        ),
+    )

--- a/backend/tests/test_enterprise_auth_bridge_contract.py
+++ b/backend/tests/test_enterprise_auth_bridge_contract.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from app.features.auth.bridge import normalize_enterprise_auth_bridge_input
+
+
+def _valid_bridge_payload() -> dict[str, object]:
+    return {
+        "bridge_source": "saml-oidc-bridge",
+        "subject": {
+            "subject_id": " user:alice@example.com ",
+            "idp_subject": "00u-enterprise-alice",
+            "issuer": "https://idp.example.test",
+        },
+        "session": {
+            "session_id": " session-123 ",
+            "issuer": "https://idp.example.test",
+        },
+        "governance_bindings": [
+            {
+                "binding_type": "group",
+                "value": " finance-analysts ",
+                "source_claim": "groups",
+            },
+            {
+                "binding_type": "role",
+                "value": " sql-reviewer ",
+                "source_claim": "roles",
+            },
+        ],
+        "raw_token": "<bridge-token-redacted>",
+        "client_secret": "<client-secret-redacted>",
+    }
+
+
+class EnterpriseAuthBridgeContractTestCase(unittest.TestCase):
+    def test_valid_bridge_input_normalizes_subject_session_and_bindings(self) -> None:
+        context = normalize_enterprise_auth_bridge_input(_valid_bridge_payload())
+
+        self.assertEqual(
+            context.authenticated_subject.normalized_subject_id(),
+            "user:alice@example.com",
+        )
+        self.assertEqual(context.session.session_id, "session-123")
+        self.assertEqual(
+            context.authenticated_subject.normalized_governance_bindings(),
+            frozenset({"group:finance-analysts", "role:sql-reviewer"}),
+        )
+        self.assertEqual(
+            context.audit_metadata.model_dump(),
+            {
+                "bridge_source": "saml-oidc-bridge",
+                "subject_id": "user:alice@example.com",
+                "session_id": "session-123",
+                "subject_provenance": {
+                    "issuer": "https://idp.example.test",
+                    "idp_subject_present": True,
+                },
+                "binding_provenance": [
+                    {
+                        "binding": "group:finance-analysts",
+                        "binding_type": "group",
+                        "source_claim": "groups",
+                        "bridge_source": "saml-oidc-bridge",
+                    },
+                    {
+                        "binding": "role:sql-reviewer",
+                        "binding_type": "role",
+                        "source_claim": "roles",
+                        "bridge_source": "saml-oidc-bridge",
+                    },
+                ],
+            },
+        )
+
+    def test_missing_subject_fails_closed(self) -> None:
+        payload = _valid_bridge_payload()
+        payload.pop("subject")
+
+        with self.assertRaisesRegex(ValidationError, "subject"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_missing_governance_bindings_fail_closed(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = []
+
+        with self.assertRaisesRegex(ValidationError, "governance_bindings"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_duplicate_normalized_bindings_fail_closed(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+            },
+            {
+                "binding_type": "group",
+                "value": " finance-analysts ",
+                "source_claim": "groups",
+            },
+        ]
+
+        with self.assertRaisesRegex(ValidationError, "Duplicate governance binding"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_unsupported_claim_shapes_fail_closed(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = "group:finance-analysts"
+
+        with self.assertRaisesRegex(ValidationError, "governance_bindings"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_raw_tokens_and_secrets_are_not_exposed_in_serialized_context(self) -> None:
+        serialized = normalize_enterprise_auth_bridge_input(
+            _valid_bridge_payload()
+        ).model_dump()
+
+        self.assertNotIn("raw_token", str(serialized))
+        self.assertNotIn("client_secret", str(serialized))
+        self.assertNotIn("<bridge-token-redacted>", str(serialized))
+        self.assertNotIn("<client-secret-redacted>", str(serialized))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add enterprise auth bridge contract models for normalized subject, session, governance bindings, and audit-safe provenance
- Reject missing subject, missing bindings, unsupported claim shapes, duplicate normalized bindings, and prequalified binding values fail closed
- Keep raw token/client secret fields excluded from serialized contract output and document that SafeQuery remains the authorization boundary

## Verification
- python3 -m pytest tests/test_enterprise_auth_bridge_contract.py tests/test_source_entitlements.py tests/test_dev_auth_preview_api.py tests/test_audit_event_model.py -q
- python3 -m pytest tests/test_check_repository_hygiene.py -q
- python3 -m pytest tests -q

Refs #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enterprise authentication bridge integration to support trusted enterprise subject and session data with governance bindings.
  * Enhanced authentication validation with audit metadata tracking for enterprise authentication sources and per-binding provenance.
  * Added validation for enterprise authentication inputs with duplicate binding detection and sensitive field exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->