### PR TITLE
Implement preview session and CSRF posture

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,14 @@
 from functools import lru_cache
 from typing import Annotated, Literal, Optional
 
-from pydantic import BaseModel, Field, PostgresDsn, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PostgresDsn,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
@@ -36,6 +43,7 @@ class Settings(BaseSettings):
     environment: Literal["development", "test", "staging", "production"] = "development"
     app_postgres_url: PostgresDsn
     dev_auth_enabled: bool = False
+    session_signing_key: Optional[SecretStr] = None
     business_postgres_source_url: Optional[PostgresDsn] = None
     business_mssql_source_connection_string: Optional[str] = None
     cors_origins: Annotated[list[str], NoDecode] = Field(

--- a/backend/app/features/auth/session.py
+++ b/backend/app/features/auth/session.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, StringConstraints, ValidationError
+from typing_extensions import Annotated
+
+from app.core.config import Settings, get_settings
+from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
+
+
+APPLICATION_SESSION_COOKIE = "safequery_session"
+CSRF_HEADER = "x-safequery-csrf"
+DEV_SESSION_SIGNING_KEY = "safequery-development-session-boundary-key"
+_PLACEHOLDER_SIGNING_KEYS = {
+    "change-me",
+    "changeme",
+    "dev-secret",
+    "password",
+    "secret",
+    "test",
+    "todo",
+}
+_SESSION_VERSION = 1
+_DEFAULT_TTL = timedelta(hours=8)
+
+NonEmptyTrimmedString = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]
+
+
+class ApplicationSessionClaims(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int
+    session_id: NonEmptyTrimmedString
+    subject_id: NonEmptyTrimmedString
+    governance_bindings: list[NonEmptyTrimmedString]
+    csrf_token_hash: NonEmptyTrimmedString
+    issued_at: int
+    expires_at: int
+    auth_source: NonEmptyTrimmedString
+
+
+@dataclass(frozen=True)
+class ApplicationSessionContext:
+    """Validated application-owned session boundary for state-changing routes.
+
+    Development auth and future production bridge inputs establish identity first.
+    This context then proves that the browser/API request also carries a coherent
+    SafeQuery session and matching CSRF token. Entitlement checks still happen
+    after this boundary against authoritative source governance records.
+    """
+
+    subject_id: str
+    governance_bindings: frozenset[str]
+    auth_source: str
+
+    @property
+    def audit_session_id(self) -> str:
+        return "application-session-redacted"
+
+
+@dataclass(frozen=True)
+class TestApplicationSession:
+    cookie_name: str
+    cookie_value: str
+    csrf_header_name: str
+    csrf_token: str
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        return {self.cookie_name: self.cookie_value}
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {self.csrf_header_name: self.csrf_token}
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}".encode("ascii"))
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _session_signing_key(settings: Settings) -> bytes:
+    if settings.session_signing_key:
+        signing_key = settings.session_signing_key.get_secret_value().strip()
+        if (
+            settings.environment not in {"development", "test"}
+            and (
+                len(signing_key) < 32
+                or signing_key.lower() in _PLACEHOLDER_SIGNING_KEYS
+            )
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Application session signing key is not trusted.",
+            )
+        return signing_key.encode("utf-8")
+
+    if settings.dev_auth_enabled and settings.environment in {"development", "test"}:
+        return DEV_SESSION_SIGNING_KEY.encode("utf-8")
+
+    raise HTTPException(
+        status_code=403,
+        detail="Application session signing key is required.",
+    )
+
+
+def _csrf_token_hash(csrf_token: str) -> str:
+    return hashlib.sha256(csrf_token.encode("utf-8")).hexdigest()
+
+
+def _sign_payload(payload: dict[str, Any], *, signing_key: bytes) -> str:
+    encoded_payload = _b64encode(_canonical_json(payload))
+    signature = hmac.new(
+        signing_key,
+        encoded_payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{encoded_payload}.{_b64encode(signature)}"
+
+
+def _decode_signed_payload(token: str, *, signing_key: bytes) -> dict[str, Any]:
+    try:
+        encoded_payload, encoded_signature = token.split(".", 1)
+        expected_signature = hmac.new(
+            signing_key,
+            encoded_payload.encode("ascii"),
+            hashlib.sha256,
+        ).digest()
+        supplied_signature = _b64decode(encoded_signature)
+        if not hmac.compare_digest(expected_signature, supplied_signature):
+            raise ValueError("signature mismatch")
+
+        payload = json.loads(_b64decode(encoded_payload))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=403,
+            detail="Application session context is malformed.",
+        ) from None
+
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=403,
+            detail="Application session context is malformed.",
+        )
+    return payload
+
+
+def create_test_application_session(
+    authenticated_subject: AuthenticatedSubject,
+    *,
+    settings: Settings | None = None,
+    now: datetime | None = None,
+    ttl: timedelta = _DEFAULT_TTL,
+    auth_source: str = "test-helper",
+    csrf_token: str | None = None,
+) -> TestApplicationSession:
+    settings = settings or get_settings()
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    expires_at = current_time + ttl
+    csrf_token = csrf_token or secrets.token_urlsafe(32)
+    payload = {
+        "version": _SESSION_VERSION,
+        "session_id": secrets.token_urlsafe(32),
+        "subject_id": authenticated_subject.normalized_subject_id(),
+        "governance_bindings": sorted(
+            authenticated_subject.normalized_governance_bindings()
+        ),
+        "csrf_token_hash": _csrf_token_hash(csrf_token),
+        "issued_at": int(current_time.timestamp()),
+        "expires_at": int(expires_at.timestamp()),
+        "auth_source": auth_source,
+    }
+    return TestApplicationSession(
+        cookie_name=APPLICATION_SESSION_COOKIE,
+        cookie_value=_sign_payload(
+            payload,
+            signing_key=_session_signing_key(settings),
+        ),
+        csrf_header_name=CSRF_HEADER,
+        csrf_token=csrf_token,
+    )
+
+
+def require_application_session(
+    request: Request,
+    authenticated_subject: AuthenticatedSubject = Depends(require_authenticated_subject),
+) -> ApplicationSessionContext:
+    settings = get_settings()
+    session_cookie = request.cookies.get(APPLICATION_SESSION_COOKIE)
+    csrf_token = request.headers.get(CSRF_HEADER)
+    if not session_cookie or not csrf_token:
+        raise HTTPException(
+            status_code=403,
+            detail="Application session and CSRF context are required.",
+        )
+
+    payload = _decode_signed_payload(
+        session_cookie,
+        signing_key=_session_signing_key(settings),
+    )
+    try:
+        claims = ApplicationSessionClaims.model_validate(payload)
+    except ValidationError:
+        raise HTTPException(
+            status_code=403,
+            detail="Application session context is malformed.",
+        ) from None
+
+    if claims.version != _SESSION_VERSION:
+        raise HTTPException(
+            status_code=403,
+            detail="Application session context is malformed.",
+        )
+
+    now = int(datetime.now(timezone.utc).timestamp())
+    if claims.issued_at > now or claims.expires_at <= claims.issued_at:
+        raise HTTPException(
+            status_code=403,
+            detail="Application session context is malformed.",
+        )
+
+    if claims.expires_at <= now:
+        raise HTTPException(
+            status_code=403,
+            detail="Application session context is expired.",
+        )
+
+    subject_id = authenticated_subject.normalized_subject_id()
+    governance_bindings = authenticated_subject.normalized_governance_bindings()
+    if claims.subject_id != subject_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Application session subject does not match authenticated subject.",
+        )
+
+    session_bindings = frozenset(claims.governance_bindings)
+    if session_bindings != governance_bindings:
+        raise HTTPException(
+            status_code=403,
+            detail="Application session governance context does not match.",
+        )
+
+    if not hmac.compare_digest(claims.csrf_token_hash, _csrf_token_hash(csrf_token)):
+        raise HTTPException(
+            status_code=403,
+            detail="Application session CSRF context does not match.",
+        )
+
+    return ApplicationSessionContext(
+        subject_id=subject_id,
+        governance_bindings=session_bindings,
+        auth_source=claims.auth_source,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,10 @@ from app.features.auth.context import (
     AuthenticatedSubject,
     require_authenticated_subject,
 )
+from app.features.auth.session import (
+    ApplicationSessionContext,
+    require_application_session,
+)
 from app.services.health import check_database_health
 from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
 from app.services.request_preview import (
@@ -88,7 +92,7 @@ def create_app() -> FastAPI:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_origins_list,
-        allow_credentials=False,
+        allow_credentials=True,
         allow_methods=["GET", "POST"],
         allow_headers=["*"],
     )
@@ -182,6 +186,9 @@ def create_app() -> FastAPI:
         authenticated_subject: AuthenticatedSubject = Depends(
             require_authenticated_subject
         ),
+        application_session: ApplicationSessionContext = Depends(
+            require_application_session
+        ),
         session: Session = Depends(require_preview_submission_session),
     ) -> PreviewSubmissionResponse:
         try:
@@ -198,7 +205,7 @@ def create_app() -> FastAPI:
                 request_id=request_id,
                 correlation_id=str(uuid4()),
                 user_subject=user_subject,
-                session_id=str(uuid4()),
+                session_id=application_session.audit_session_id,
                 query_candidate_id=str(uuid4()),
                 candidate_owner_subject=user_subject,
                 application_version=f"safequery-api/{app.version}",

--- a/backend/tests/test_dev_auth_preview_api.py
+++ b/backend/tests/test_dev_auth_preview_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
@@ -17,7 +17,14 @@ from app.db.models.dataset_contract import DatasetContract
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.db.session import require_preview_submission_session
+from app.features.auth.dev import build_dev_authenticated_subject
+from app.features.auth.context import AuthenticatedSubject
+from app.features.auth.session import (
+    APPLICATION_SESSION_COOKIE,
+    create_test_application_session,
+)
 from app.services.demo_source_seed import (
+    DEMO_DEV_GOVERNANCE_BINDING,
     DEMO_DEV_SUBJECT_ID,
     DEMO_SOURCE_ID,
     seed_demo_source_governance,
@@ -32,6 +39,7 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
                 "SAFEQUERY_APP_POSTGRES_URL",
                 "SAFEQUERY_ENVIRONMENT",
                 "SAFEQUERY_DEV_AUTH_ENABLED",
+                "SAFEQUERY_SESSION_SIGNING_KEY",
             )
         }
         os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
@@ -39,6 +47,7 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
         )
         os.environ.pop("SAFEQUERY_ENVIRONMENT", None)
         os.environ.pop("SAFEQUERY_DEV_AUTH_ENABLED", None)
+        os.environ.pop("SAFEQUERY_SESSION_SIGNING_KEY", None)
         self.engine = create_engine(
             "sqlite+pysqlite:///:memory:",
             connect_args={"check_same_thread": False},
@@ -115,9 +124,12 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
     def test_enabled_development_dev_auth_allows_demo_preview_http_request(self) -> None:
         os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
         os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        app_session = create_test_application_session(build_dev_authenticated_subject())
 
         response = self._client().post(
             "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
             json={
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": DEMO_SOURCE_ID,
@@ -131,6 +143,149 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
         self.assertEqual(
             payload["audit"]["events"][0]["user_subject"],
             DEMO_DEV_SUBJECT_ID,
+        )
+        self.assertEqual(
+            payload["audit"]["events"][0]["session_id"],
+            "application-session-redacted",
+        )
+        self.assertNotIn(app_session.csrf_token, response.text)
+        self.assertNotIn(app_session.cookie_value, response.text)
+
+    def test_enabled_dev_auth_without_session_or_csrf_blocks_preview_http_request(
+        self,
+    ) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+
+        response = self._client().post(
+            "/requests/preview",
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": DEMO_SOURCE_ID,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "http_error",
+                    "message": "Forbidden",
+                }
+            },
+        )
+
+    def test_malformed_application_session_blocks_preview_http_request(self) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+
+        response = self._client().post(
+            "/requests/preview",
+            headers={"x-safequery-csrf": "csrf-token"},
+            cookies={APPLICATION_SESSION_COOKIE: "malformed-session"},
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": DEMO_SOURCE_ID,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "http_error",
+                    "message": "Forbidden",
+                }
+            },
+        )
+
+    def test_mismatched_csrf_blocks_preview_http_request(self) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+
+        response = self._client().post(
+            "/requests/preview",
+            headers={"x-safequery-csrf": "different-csrf-token"},
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": DEMO_SOURCE_ID,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "http_error",
+                    "message": "Forbidden",
+                }
+            },
+        )
+
+    def test_mismatched_session_subject_blocks_preview_http_request(self) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        app_session = create_test_application_session(
+            AuthenticatedSubject(
+                subject_id="user:different-local-operator",
+                governance_bindings=frozenset({DEMO_DEV_GOVERNANCE_BINDING}),
+            )
+        )
+
+        response = self._client().post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": DEMO_SOURCE_ID,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "http_error",
+                    "message": "Forbidden",
+                }
+            },
+        )
+
+    def test_expired_application_session_blocks_preview_http_request(self) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        app_session = create_test_application_session(
+            build_dev_authenticated_subject(),
+            now=datetime.now(timezone.utc) - timedelta(hours=2),
+            ttl=timedelta(minutes=5),
+        )
+
+        response = self._client().post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": DEMO_SOURCE_ID,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "http_error",
+                    "message": "Forbidden",
+                }
+            },
         )
 
     def test_disabled_dev_auth_blocks_preview_http_request(self) -> None:
@@ -159,10 +314,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
     def test_enabled_dev_auth_still_enforces_preview_entitlement(self) -> None:
         os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
         os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        app_session = create_test_application_session(build_dev_authenticated_subject())
         self._seed_restricted_source("restricted-business-postgres")
 
         response = self._client().post(
             "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
             json={
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": "restricted-business-postgres",

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -18,13 +18,22 @@ from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewSt
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
+from app.features.auth.session import create_test_application_session
 
 
 class RequestSourceSelectionTestCase(unittest.TestCase):
     def setUp(self) -> None:
+        self._previous_env = {
+            name: os.environ.get(name)
+            for name in (
+                "SAFEQUERY_APP_POSTGRES_URL",
+                "SAFEQUERY_SESSION_SIGNING_KEY",
+            )
+        }
         os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
             "postgresql://safequery:safequery@db:5432/safequery"
         )
+        os.environ["SAFEQUERY_SESSION_SIGNING_KEY"] = "x" * 32
         get_settings.cache_clear()
         self.engine = create_engine(
             "sqlite+pysqlite:///:memory:",
@@ -48,9 +57,26 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
     def tearDown(self) -> None:
         self.session.close()
         self.engine.dispose()
-        os.environ.pop("SAFEQUERY_APP_POSTGRES_URL", None)
+        for name, value in self._previous_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
         get_settings.cache_clear()
         self.app.dependency_overrides.clear()
+
+    def _authenticated_subject(self) -> AuthenticatedSubject:
+        dependency = self.app.dependency_overrides[require_authenticated_subject]
+        return dependency()
+
+    def _post_preview(self, payload: dict[str, str]) -> object:
+        app_session = create_test_application_session(self._authenticated_subject())
+        return self.client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json=payload,
+        )
 
     def _seed_authoritative_source_governance(
         self,
@@ -132,9 +158,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         )
 
     def test_preview_submission_requires_explicit_source_id(self) -> None:
-        response = self.client.post(
-            "/requests/preview",
-            json={
+        response = self._post_preview(
+            {
                 "question": "Show approved vendors by quarterly spend",
             },
         )
@@ -151,9 +176,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         )
 
     def test_preview_submission_rejects_unknown_source_id(self) -> None:
-        response = self.client.post(
-            "/requests/preview",
-            json={
+        response = self._post_preview(
+            {
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": "unregistered-source",
             },
@@ -176,9 +200,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             source_posture=SourceActivationPosture.PAUSED,
         )
 
-        response = self.client.post(
-            "/requests/preview",
-            json={
+        response = self._post_preview(
+            {
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": "legacy-finance-archive",
             },
@@ -233,9 +256,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             "app.services.request_preview._resolve_authoritative_source_governance",
             return_value=(malformed_source, malformed_contract, malformed_snapshot),
         ):
-            response = self.client.post(
-                "/requests/preview",
-                json={
+            response = self._post_preview(
+                {
                     "question": "Show approved vendors by quarterly spend",
                     "source_id": "broken-source",
                 },
@@ -258,9 +280,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             source_posture=SourceActivationPosture.ACTIVE,
         )
 
-        response = self.client.post(
-            "/requests/preview",
-            json={
+        response = self._post_preview(
+            {
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": "sap-approved-spend",
             },
@@ -392,9 +413,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             security_review_binding="group:security-reviewers",
         )
 
-        response = self.client.post(
-            "/requests/preview",
-            json={
+        response = self._post_preview(
+            {
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": "sap-approved-spend",
             },
@@ -423,9 +443,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             exception_policy_binding="group:exception-approvers",
         )
 
-        response = self.client.post(
-            "/requests/preview",
-            json={
+        response = self._post_preview(
+            {
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": "sap-approved-spend",
             },


### PR DESCRIPTION
## Summary
- add signed application session and CSRF validation for state-changing preview requests
- keep raw session cookie and CSRF material out of preview responses while preserving entitlement checks
- update preview API/source-selection tests to pass through the explicit session boundary

## Verification
- cd backend && python3 -m pytest -q
- cd backend && python3 -m compileall -q app
- python3 scripts/ci/check_repository_hygiene.py

Closes #218