### PR TITLE
Connect governance bindings to preview entitlements

### DIFF
--- a/backend/app/features/auth/bridge.py
+++ b/backend/app/features/auth/bridge.py
@@ -14,6 +14,7 @@ from typing_extensions import Annotated, Self
 
 from app.features.audit.event_model import NonEmptyTrimmedString
 from app.features.auth.context import AuthenticatedSubject
+from app.features.auth.governance_bindings import normalize_governance_binding
 
 
 BindingType = Literal["group", "role", "entitlement"]
@@ -53,7 +54,10 @@ class EnterpriseGovernanceBindingInput(BaseModel):
 
     @property
     def normalized_binding(self) -> str:
-        return f"{self.binding_type}:{self.value}"
+        normalized = normalize_governance_binding(f"{self.binding_type}:{self.value}")
+        if normalized is None:
+            raise ValueError("Governance binding is malformed.")
+        return normalized
 
 
 class EnterpriseAuthBridgeInput(BaseModel):

--- a/backend/app/features/auth/context.py
+++ b/backend/app/features/auth/context.py
@@ -4,12 +4,7 @@ from dataclasses import dataclass, field
 
 from fastapi import HTTPException, Request
 
-
-def _normalize_binding(binding: str) -> str | None:
-    normalized = binding.strip()
-    if not normalized:
-        return None
-    return normalized
+from app.features.auth.governance_bindings import normalize_governance_binding
 
 
 @dataclass(frozen=True)
@@ -30,7 +25,7 @@ class AuthenticatedSubject:
         normalized_bindings = {
             normalized
             for binding in self.governance_bindings
-            if (normalized := _normalize_binding(binding)) is not None
+            if (normalized := normalize_governance_binding(binding)) is not None
         }
         return frozenset(normalized_bindings)
 

--- a/backend/app/features/auth/governance_bindings.py
+++ b/backend/app/features/auth/governance_bindings.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+
+VALID_GOVERNANCE_BINDING_TYPES = frozenset({"group", "role", "entitlement"})
+
+
+def normalize_governance_binding(binding: str | None) -> str | None:
+    if binding is None:
+        return None
+
+    trimmed = binding.strip()
+    if not trimmed or ":" not in trimmed:
+        return None
+
+    binding_type, value = trimmed.split(":", 1)
+    binding_type = binding_type.strip()
+    value = value.strip()
+    if (
+        binding_type not in VALID_GOVERNANCE_BINDING_TYPES
+        or not value
+        or ":" in value
+    ):
+        return None
+
+    return f"{binding_type}:{value}"

--- a/backend/app/services/source_entitlements.py
+++ b/backend/app/services/source_entitlements.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.db.models.dataset_contract import DatasetContract
 from app.db.models.source_registry import RegisteredSource
 from app.features.auth.context import AuthenticatedSubject
+from app.features.auth.governance_bindings import normalize_governance_binding
 from app.services.source_registry import (
     SourceRegistryPostureError,
     ensure_source_is_executable,
@@ -13,21 +14,14 @@ class SourceEntitlementError(PermissionError):
     """Raised when a subject is not entitled to use a selected registered source."""
 
 
-def _normalized_binding(binding: str | None) -> str | None:
-    if binding is None:
-        return None
-    normalized = binding.strip()
-    if not normalized:
-        return None
-    return normalized
-
-
 def _contract_execution_entitlement_bindings(contract: DatasetContract) -> frozenset[str]:
     # Execution entitlement is currently limited to source operators.
     # Review and exception bindings remain available for future role-aware policies
     # but must not implicitly grant execution eligibility.
     bindings = {
-        normalized for binding in (contract.owner_binding,) if (normalized := _normalized_binding(binding))
+        normalized
+        for binding in (contract.owner_binding,)
+        if (normalized := normalize_governance_binding(binding)) is not None
     }
     return frozenset(bindings)
 

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -17,6 +17,7 @@ from app.db.models.dataset_contract import DatasetContract
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.db.session import require_preview_submission_session
+from app.features.auth.bridge import normalize_enterprise_auth_bridge_input
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 from app.features.auth.session import create_test_application_session
 
@@ -76,6 +77,38 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             headers=app_session.headers,
             cookies=app_session.cookies,
             json=payload,
+        )
+
+    def _override_subject_from_enterprise_bridge(
+        self,
+        *,
+        subject_id: str = "user:alice@example.com",
+        binding_type: str = "group",
+        binding_value: str = "finance-analysts",
+    ) -> None:
+        bridge_context = normalize_enterprise_auth_bridge_input(
+            {
+                "bridge_source": "saml-oidc-bridge",
+                "subject": {
+                    "subject_id": subject_id,
+                    "idp_subject": "00u-enterprise-subject",
+                    "issuer": "https://idp.example.test",
+                },
+                "session": {
+                    "session_id": "enterprise-session",
+                    "issuer": "https://idp.example.test",
+                },
+                "governance_bindings": [
+                    {
+                        "binding_type": binding_type,
+                        "value": binding_value,
+                        "source_claim": "groups",
+                    },
+                ],
+            }
+        )
+        self.app.dependency_overrides[require_authenticated_subject] = (
+            lambda: bridge_context.authenticated_subject
         )
 
     def _seed_authoritative_source_governance(
@@ -360,6 +393,94 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         self.assertEqual(audit["events"][2]["candidate_owner_subject"], "user:alice")
         self.assertEqual(audit["events"][3]["candidate_owner_subject"], "user:alice")
         self.assertEqual(audit["events"][3]["candidate_state"], "preview_ready")
+
+    def test_preview_submission_accepts_enterprise_bridge_normalized_binding(self) -> None:
+        self._override_subject_from_enterprise_bridge()
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+            owner_binding="group:finance-analysts",
+        )
+
+        response = self._post_preview(
+            {
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        response_body = response.json()
+        self.assertEqual(response_body["candidate"]["source_id"], "sap-approved-spend")
+        self.assertEqual(
+            response_body["audit"]["events"][0]["user_subject"],
+            "user:alice@example.com",
+        )
+
+    def test_preview_submission_rejects_enterprise_bridge_unrelated_binding(self) -> None:
+        self._override_subject_from_enterprise_bridge(binding_value="people-ops")
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+            owner_binding="group:finance-analysts",
+        )
+
+        response = self._post_preview(
+            {
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
+            },
+        )
+        self.assertNotIn("candidate", response.text)
+
+    def test_client_supplied_governance_metadata_cannot_grant_preview_entitlement(
+        self,
+    ) -> None:
+        self.app.dependency_overrides[
+            require_authenticated_subject
+        ] = lambda: AuthenticatedSubject(
+            subject_id="user:alice", governance_bindings=frozenset({"group:people-ops"})
+        )
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+            owner_binding="group:finance-analysts",
+        )
+
+        app_session = create_test_application_session(self._authenticated_subject())
+        response = self.client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+                "governance_bindings": ["group:finance-analysts"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                }
+            },
+        )
+        self.assertNotIn("candidate", response.text)
 
     def test_operator_workflow_snapshot_exposes_live_source_options_without_secrets(self) -> None:
         self._seed_authoritative_source_governance(

--- a/backend/tests/test_source_entitlements.py
+++ b/backend/tests/test_source_entitlements.py
@@ -93,6 +93,23 @@ class SourceEntitlementTestCase(unittest.TestCase):
         ):
             ensure_subject_is_entitled_for_source(subject, source, contract)
 
+    def test_malformed_matching_binding_is_denied(self) -> None:
+        source = _registered_source(source_id="sap-approved-spend")
+        contract = _dataset_contract(
+            registered_source_id=source.id,
+            owner_binding="finance-analysts",
+        )
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"finance-analysts"}),
+        )
+
+        with self.assertRaisesRegex(
+            SourceEntitlementError,
+            "has no execution-eligible source-scoped governance bindings",
+        ):
+            ensure_subject_is_entitled_for_source(subject, source, contract)
+
     def test_subject_matching_only_security_review_binding_is_denied(self) -> None:
         source = _registered_source(source_id="sap-approved-spend")
         contract = _dataset_contract(


### PR DESCRIPTION
## Summary
- add auth-owned governance binding normalization for group, role, and entitlement bindings
- route authenticated subjects, enterprise bridge binding output, and dataset-contract entitlement matching through the shared normalizer
- cover bridge-backed preview success, unrelated binding denial, malformed binding denial, and client metadata rejection

## Tests
- python3 -m pytest tests/test_source_entitlements.py tests/test_request_source_selection.py tests/test_dev_auth_preview_api.py tests/test_enterprise_auth_bridge_contract.py tests/test_demo_source_seed.py -q
- python3 -m pytest -q

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for governance bindings to prevent malformed entries from being accepted silently.

* **Refactor**
  * Centralized governance binding normalization logic across multiple backend systems for consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for governance binding validation and entitlement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->