### PR TITLE
Normalize auth and entitlement failure states

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -1,13 +1,37 @@
 import logging
 from http import HTTPStatus
+from typing import Any
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.logging import get_logger
+
+
+_SAFE_API_ERROR_CODES = frozenset(
+    {
+        "unauthenticated",
+        "session_invalid",
+        "csrf_failed",
+        "entitlement_denied",
+    }
+)
+
+
+def api_error(status_code: int, code: str, message: str) -> HTTPException:
+    if code not in _SAFE_API_ERROR_CODES:
+        raise ValueError("Unsupported API error code.")
+
+    return HTTPException(
+        status_code=status_code,
+        detail={
+            "code": code,
+            "message": message,
+        },
+    )
 
 
 def _error_body(code: str, message: str) -> dict[str, dict[str, str]]:
@@ -52,13 +76,31 @@ def _http_error_message(status_code: int) -> str:
         return "HTTP error."
 
 
+def _safe_http_exception_error(
+    exc: StarletteHTTPException,
+) -> tuple[str, str]:
+    detail: Any = exc.detail
+    if isinstance(detail, dict):
+        code = detail.get("code")
+        message = detail.get("message")
+        if (
+            isinstance(code, str)
+            and code.strip()
+            and code in _SAFE_API_ERROR_CODES
+            and isinstance(message, str)
+            and message.strip()
+        ):
+            return code, message
+
+    return _http_error_code(exc.status_code), _http_error_message(exc.status_code)
+
+
 async def handle_http_exception(
     request: Request, exc: StarletteHTTPException
 ) -> JSONResponse:
     logger = get_logger()
     status_code = exc.status_code
-    code = _http_error_code(status_code)
-    message = _http_error_message(status_code)
+    code, message = _safe_http_exception_error(exc)
 
     logger.warning(
         "request.http_error",

--- a/backend/app/features/auth/context.py
+++ b/backend/app/features/auth/context.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from fastapi import HTTPException, Request
+from fastapi import Request
 
+from app.core.errors import api_error
 from app.features.auth.governance_bindings import normalize_governance_binding
 
 
@@ -15,9 +16,10 @@ class AuthenticatedSubject:
     def normalized_subject_id(self) -> str:
         normalized = self.subject_id.strip()
         if not normalized:
-            raise HTTPException(
-                status_code=403,
-                detail="Authenticated subject context is malformed.",
+            raise api_error(
+                401,
+                "unauthenticated",
+                "Sign in before submitting preview requests.",
             )
         return normalized
 
@@ -33,9 +35,10 @@ class AuthenticatedSubject:
 def require_authenticated_subject(request: Request) -> AuthenticatedSubject:
     subject = getattr(request.state, "authenticated_subject", None)
     if not isinstance(subject, AuthenticatedSubject):
-        raise HTTPException(
-            status_code=403,
-            detail="Authenticated subject context is required.",
+        raise api_error(
+            401,
+            "unauthenticated",
+            "Sign in before submitting preview requests.",
         )
 
     return AuthenticatedSubject(

--- a/backend/app/features/auth/session.py
+++ b/backend/app/features/auth/session.py
@@ -9,10 +9,11 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, Request
 from pydantic import BaseModel, ConfigDict, StringConstraints, ValidationError
 from typing_extensions import Annotated
 
+from app.core.errors import api_error
 from app.core.config import Settings, get_settings
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 
@@ -109,18 +110,20 @@ def _session_signing_key(settings: Settings) -> bytes:
                 or signing_key.lower() in _PLACEHOLDER_SIGNING_KEYS
             )
         ):
-            raise HTTPException(
-                status_code=403,
-                detail="Application session signing key is not trusted.",
+            raise api_error(
+                401,
+                "session_invalid",
+                "Sign in again before submitting preview requests.",
             )
         return signing_key.encode("utf-8")
 
     if settings.dev_auth_enabled and settings.environment in {"development", "test"}:
         return DEV_SESSION_SIGNING_KEY.encode("utf-8")
 
-    raise HTTPException(
-        status_code=403,
-        detail="Application session signing key is required.",
+    raise api_error(
+        401,
+        "session_invalid",
+        "Sign in again before submitting preview requests.",
     )
 
 
@@ -152,15 +155,17 @@ def _decode_signed_payload(token: str, *, signing_key: bytes) -> dict[str, Any]:
 
         payload = json.loads(_b64decode(encoded_payload))
     except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
-        raise HTTPException(
-            status_code=403,
-            detail="Application session context is malformed.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         ) from None
 
     if not isinstance(payload, dict):
-        raise HTTPException(
-            status_code=403,
-            detail="Application session context is malformed.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         )
     return payload
 
@@ -210,10 +215,17 @@ def require_application_session(
     settings = get_settings()
     session_cookie = request.cookies.get(APPLICATION_SESSION_COOKIE)
     csrf_token = request.headers.get(CSRF_HEADER)
-    if not session_cookie or not csrf_token:
-        raise HTTPException(
-            status_code=403,
-            detail="Application session and CSRF context are required.",
+    if not session_cookie:
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
+        )
+    if not csrf_token:
+        raise api_error(
+            403,
+            "csrf_failed",
+            "Refresh the page before submitting preview requests.",
         )
 
     payload = _decode_signed_payload(
@@ -223,49 +235,56 @@ def require_application_session(
     try:
         claims = ApplicationSessionClaims.model_validate(payload)
     except ValidationError:
-        raise HTTPException(
-            status_code=403,
-            detail="Application session context is malformed.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         ) from None
 
     if claims.version != _SESSION_VERSION:
-        raise HTTPException(
-            status_code=403,
-            detail="Application session context is malformed.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         )
 
     now = int(datetime.now(timezone.utc).timestamp())
     if claims.issued_at > now or claims.expires_at <= claims.issued_at:
-        raise HTTPException(
-            status_code=403,
-            detail="Application session context is malformed.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         )
 
     if claims.expires_at <= now:
-        raise HTTPException(
-            status_code=403,
-            detail="Application session context is expired.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         )
 
     subject_id = authenticated_subject.normalized_subject_id()
     governance_bindings = authenticated_subject.normalized_governance_bindings()
     if claims.subject_id != subject_id:
-        raise HTTPException(
-            status_code=403,
-            detail="Application session subject does not match authenticated subject.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         )
 
     session_bindings = frozenset(claims.governance_bindings)
     if session_bindings != governance_bindings:
-        raise HTTPException(
-            status_code=403,
-            detail="Application session governance context does not match.",
+        raise api_error(
+            401,
+            "session_invalid",
+            "Sign in again before submitting preview requests.",
         )
 
     if not hmac.compare_digest(claims.csrf_token_hash, _csrf_token_hash(csrf_token)):
-        raise HTTPException(
-            status_code=403,
-            detail="Application session CSRF context does not match.",
+        raise api_error(
+            403,
+            "csrf_failed",
+            "Refresh the page before submitting preview requests.",
         )
 
     return ApplicationSessionContext(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.errors import (
+    api_error,
     handle_http_exception,
     handle_unexpected_exception,
     handle_validation_exception,
@@ -34,6 +35,7 @@ from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_do
 from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionContractError,
+    PreviewSubmissionEntitlementError,
     PreviewSubmissionRequest,
     PreviewSubmissionResponse,
     submit_preview_request,
@@ -216,6 +218,12 @@ def create_app() -> FastAPI:
                 session,
                 audit_context=audit_context,
             )
+        except PreviewSubmissionEntitlementError as exc:
+            raise api_error(
+                403,
+                "entitlement_denied",
+                "The signed-in operator is not entitled to use that source.",
+            ) from exc
         except PreviewSubmissionContractError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -20,6 +20,7 @@ from app.services.source_governance import (
     SourceGovernanceResolutionError,
     resolve_authoritative_source_governance,
 )
+from app.services.source_registry import SourceRegistryPostureError
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
@@ -67,6 +68,10 @@ class PreviewSubmissionResponse(BaseModel):
 
 class PreviewSubmissionContractError(ValueError):
     """Raised when a preview submission does not carry an executable source binding."""
+
+
+class PreviewSubmissionEntitlementError(PreviewSubmissionContractError, PermissionError):
+    """Raised when an authenticated subject lacks source execution entitlement."""
 
 
 class PreviewAuditContext(BaseModel):
@@ -171,7 +176,9 @@ def submit_preview_request(
             dataset_contract,
         )
     except SourceEntitlementError as exc:
-        raise PreviewSubmissionContractError(str(exc)) from exc
+        if isinstance(exc.__cause__, (SourceRegistryPostureError, ValueError)):
+            raise PreviewSubmissionContractError(str(exc)) from exc
+        raise PreviewSubmissionEntitlementError(str(exc)) from exc
 
     audit = AuditRecord(
         source_id=resolved_source.source_id,

--- a/backend/tests/test_api_errors.py
+++ b/backend/tests/test_api_errors.py
@@ -43,6 +43,37 @@ class ApiErrorHandlingTestCase(unittest.TestCase):
         self.assertEqual(_http_error_message(499), "HTTP error.")
         self.assertEqual(_http_error_message(599), "HTTP error.")
 
+    def test_unknown_http_detail_dict_does_not_become_public_error_message(
+        self,
+    ) -> None:
+        test_token = "idp-token-should-not-render"
+
+        @self.app.get("/_test/detail-dict")
+        def raise_detail_dict_error() -> None:
+            from fastapi import HTTPException
+
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "unexpected_auth_error",
+                    "message": f"Raw identity detail {test_token}",
+                },
+            )
+
+        response = self.client.get("/_test/detail-dict")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "http_error",
+                    "message": "Forbidden",
+                }
+            },
+        )
+        self.assertNotIn(test_token, response.text)
+
     def test_unhandled_errors_and_logs_do_not_leak_secrets(self) -> None:
         test_token = "test-token-1234"
         stream = StringIO()

--- a/backend/tests/test_dev_auth_preview_api.py
+++ b/backend/tests/test_dev_auth_preview_api.py
@@ -165,13 +165,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "session_invalid",
+                    "message": "Sign in again before submitting preview requests.",
                 }
             },
         )
@@ -190,13 +190,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "session_invalid",
+                    "message": "Sign in again before submitting preview requests.",
                 }
             },
         )
@@ -221,8 +221,8 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "csrf_failed",
+                    "message": "Refresh the page before submitting preview requests.",
                 }
             },
         )
@@ -247,13 +247,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "session_invalid",
+                    "message": "Sign in again before submitting preview requests.",
                 }
             },
         )
@@ -277,13 +277,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "session_invalid",
+                    "message": "Sign in again before submitting preview requests.",
                 }
             },
         )
@@ -300,13 +300,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "unauthenticated",
+                    "message": "Sign in before submitting preview requests.",
                 }
             },
         )
@@ -327,13 +327,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "invalid_request",
-                    "message": "Request validation failed.",
+                    "code": "entitlement_denied",
+                    "message": "The signed-in operator is not entitled to use that source.",
                 }
             },
         )
@@ -349,13 +349,13 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "unauthenticated",
+                    "message": "Sign in before submitting preview requests.",
                 }
             },
         )

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -179,13 +179,13 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "http_error",
-                    "message": "Forbidden",
+                    "code": "unauthenticated",
+                    "message": "Sign in before submitting preview requests.",
                 }
             },
         )
@@ -432,13 +432,13 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "invalid_request",
-                    "message": "Request validation failed.",
+                    "code": "entitlement_denied",
+                    "message": "The signed-in operator is not entitled to use that source.",
                 }
             },
         )
@@ -541,13 +541,13 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "invalid_request",
-                    "message": "Request validation failed.",
+                    "code": "entitlement_denied",
+                    "message": "The signed-in operator is not entitled to use that source.",
                 }
             },
         )
@@ -571,13 +571,13 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
             {
                 "error": {
-                    "code": "invalid_request",
-                    "message": "Request validation failed.",
+                    "code": "entitlement_denied",
+                    "message": "The signed-in operator is not entitled to use that source.",
                 }
             },
         )

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -221,6 +221,65 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders normalized auth and entitlement workflow failures without leaking sensitive details", async () => {
+    const secretDetail = "idp-token-should-not-render";
+    const failureCases = [
+      {
+        code: "unauthenticated",
+        message: "Sign in before submitting preview requests.",
+        statusCopy: /sign in before loading the operator workflow/i
+      },
+      {
+        code: "session_invalid",
+        message: "Sign in again before submitting preview requests.",
+        statusCopy: /operator session is no longer valid/i
+      },
+      {
+        code: "csrf_failed",
+        message: "Refresh the page before submitting preview requests.",
+        statusCopy: /request freshness check failed/i
+      },
+      {
+        code: "entitlement_denied",
+        message: "The signed-in operator is not entitled to use that source.",
+        statusCopy: /this source or workflow context/i
+      }
+    ] as const;
+
+    for (const failureCase of failureCases) {
+      cleanup();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((input: RequestInfo | URL) => {
+          const url = input.toString();
+
+          if (url.endsWith("/operator/workflow")) {
+            return Promise.resolve({
+              ok: false,
+              json: () =>
+                Promise.resolve({
+                  error: {
+                    code: failureCase.code,
+                    message: failureCase.message,
+                    raw: secretDetail
+                  }
+                })
+            });
+          }
+
+          return new Promise(() => {});
+        })
+      );
+
+      render(await HomePage({}));
+
+      expect(screen.getByLabelText(/operator history/i)).toHaveTextContent(failureCase.code);
+      expect(screen.getByText(failureCase.statusCopy)).toBeInTheDocument();
+      expect(screen.getByText(failureCase.message)).toBeInTheDocument();
+      expect(screen.queryByText(secretDetail)).not.toBeInTheDocument();
+    }
+  });
+
   it("renders the shell before the health probe completes", async () => {
     const fetchMock = stubWorkflowFetch();
     vi.stubGlobal("fetch", fetchMock);

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -264,6 +264,22 @@ function getWorkflowDataStatusCopy(status: OperatorWorkflowSnapshot["status"]): 
     return "Source registry and history summary loaded from the backend workflow contract.";
   }
 
+  if (status === "unauthenticated") {
+    return "Sign in before loading the operator workflow. No source or history data is trusted yet.";
+  }
+
+  if (status === "session_invalid") {
+    return "The operator session is no longer valid. Sign in again before continuing.";
+  }
+
+  if (status === "csrf_failed") {
+    return "The request freshness check failed. Refresh the page before continuing.";
+  }
+
+  if (status === "entitlement_denied") {
+    return "The signed-in operator is not entitled to this source or workflow context.";
+  }
+
   if (status === "malformed") {
     return "Backend workflow payload was malformed, so the source selector remains blocked.";
   }
@@ -818,6 +834,12 @@ export function QueryWorkflowShell({
               </span>
             </div>
             <p className="section-copy">{getWorkflowDataStatusCopy(operatorWorkflow.status)}</p>
+            {operatorWorkflow.error ? (
+              <div className="state-callout state-callout-danger">
+                <p className="state-callout-title">{operatorWorkflow.error.code}</p>
+                <p>{operatorWorkflow.error.message}</p>
+              </div>
+            ) : null}
             <div className="history-list">
               {operatorWorkflow.history.length > 0 ? (
                 operatorWorkflow.history.map(renderHistoryItem)

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -22,9 +22,20 @@ export type OperatorHistoryItem = {
 };
 
 export type OperatorWorkflowSnapshot = {
+  error?: {
+    code: string;
+    message: string;
+  };
   history: OperatorHistoryItem[];
   sources: SourceOption[];
-  status: "live" | "unavailable" | "malformed";
+  status:
+    | "live"
+    | "unavailable"
+    | "malformed"
+    | "unauthenticated"
+    | "session_invalid"
+    | "csrf_failed"
+    | "entitlement_denied";
 };
 
 type RawObject = Record<string, unknown>;
@@ -110,6 +121,37 @@ function unavailableSnapshot(status: OperatorWorkflowSnapshot["status"]): Operat
   };
 }
 
+function parseApiError(value: unknown): OperatorWorkflowSnapshot["error"] | undefined {
+  if (!isObject(value) || !isObject(value.error)) {
+    return undefined;
+  }
+
+  const code = readOptionalString(value.error.code);
+  const message = readOptionalString(value.error.message);
+  if (!code || !message) {
+    return undefined;
+  }
+
+  return { code, message };
+}
+
+function unavailableSnapshotForApiError(payload: unknown): OperatorWorkflowSnapshot {
+  const error = parseApiError(payload);
+  if (
+    error?.code === "unauthenticated" ||
+    error?.code === "session_invalid" ||
+    error?.code === "csrf_failed" ||
+    error?.code === "entitlement_denied"
+  ) {
+    return {
+      ...unavailableSnapshot(error.code),
+      error
+    };
+  }
+
+  return unavailableSnapshot("unavailable");
+}
+
 function isParsedSourceOption(value: SourceOption | null): value is SourceOption {
   return value !== null;
 }
@@ -127,7 +169,14 @@ export async function getOperatorWorkflowSnapshot(
     });
 
     if (!response.ok) {
-      return unavailableSnapshot("unavailable");
+      let payload: unknown;
+      try {
+        payload = (await response.json()) as unknown;
+      } catch {
+        return unavailableSnapshot("unavailable");
+      }
+
+      return unavailableSnapshotForApiError(payload);
     }
 
     let payload: unknown;


### PR DESCRIPTION
## Summary
- Normalize SafeQuery API error envelopes for unauthenticated, invalid session, CSRF, and entitlement-denied preview failures.
- Preserve existing validation/source-posture failures as invalid request responses.
- Teach the operator workflow shell to render normalized auth and entitlement failures without raw detail leakage.

## Verification
- PYTHONPATH=backend python3 -m pytest backend/tests
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized API error responses with structured error codes and messages
  * Enhanced error handling for authentication, CSRF, and entitlement scenarios
  * Improved error display UI with code and message information

* **Bug Fixes**
  * More specific HTTP status codes for different error scenarios (401 for authentication, 403 for authorization/CSRF, etc.)
  * Refined error message handling to prevent exposure of sensitive details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->