### PR TITLE
Retain HTTP entitlement-denial audit evidence

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from http import HTTPStatus
 from typing import Any
@@ -21,26 +23,37 @@ _SAFE_API_ERROR_CODES = frozenset(
 )
 
 
-def api_error(status_code: int, code: str, message: str) -> HTTPException:
+def api_error(
+    status_code: int,
+    code: str,
+    message: str,
+    *,
+    audit_events: list[dict[str, Any]] | None = None,
+) -> HTTPException:
     if code not in _SAFE_API_ERROR_CODES:
         raise ValueError("Unsupported API error code.")
 
+    detail: dict[str, Any] = {
+        "code": code,
+        "message": message,
+    }
+    if audit_events is not None:
+        detail["audit"] = {"events": audit_events}
+
     return HTTPException(
         status_code=status_code,
-        detail={
-            "code": code,
-            "message": message,
-        },
+        detail=detail,
     )
 
 
-def _error_body(code: str, message: str) -> dict[str, dict[str, str]]:
-    return {
+def _error_body(code: str, message: str) -> dict[str, Any]:
+    body: dict[str, Any] = {
         "error": {
             "code": code,
             "message": message,
         }
     }
+    return body
 
 
 def _request_log_context(request: Request) -> dict[str, str]:
@@ -95,6 +108,31 @@ def _safe_http_exception_error(
     return _http_error_code(exc.status_code), _http_error_message(exc.status_code)
 
 
+def _safe_http_exception_audit(
+    exc: StarletteHTTPException,
+    *,
+    code: str,
+) -> dict[str, list[dict[str, Any]]] | None:
+    if exc.status_code != 403 or code != "entitlement_denied":
+        return None
+
+    detail: Any = exc.detail
+    if not isinstance(detail, dict):
+        return None
+
+    audit = detail.get("audit")
+    if not isinstance(audit, dict):
+        return None
+
+    events = audit.get("events")
+    if not isinstance(events, list):
+        return None
+    if not all(isinstance(event, dict) for event in events):
+        return None
+
+    return {"events": events}
+
+
 async def handle_http_exception(
     request: Request, exc: StarletteHTTPException
 ) -> JSONResponse:
@@ -114,9 +152,14 @@ async def handle_http_exception(
         },
     )
 
+    content = _error_body(code, message)
+    audit = _safe_http_exception_audit(exc, code=code)
+    if audit is not None:
+        content["audit"] = audit
+
     return JSONResponse(
         status_code=status_code,
-        content=_error_body(code, message),
+        content=content,
         headers={"X-Request-ID": getattr(request.state, "request_id", "unknown")},
     )
 

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -22,6 +22,30 @@ _SAFE_API_ERROR_CODES = frozenset(
     }
 )
 
+_SAFE_ENTITLEMENT_DENIAL_AUDIT_FIELDS = frozenset(
+    {
+        "event_id",
+        "event_type",
+        "occurred_at",
+        "request_id",
+        "correlation_id",
+        "user_subject",
+        "session_id",
+        "auth_source",
+        "governance_bindings",
+        "entitlement_decision",
+        "entitlement_source_bindings",
+        "application_version",
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "primary_deny_code",
+        "denial_cause",
+    }
+)
+
 
 def api_error(
     status_code: int,
@@ -130,7 +154,17 @@ def _safe_http_exception_audit(
     if not all(isinstance(event, dict) for event in events):
         return None
 
-    return {"events": events}
+    return {
+        "events": [
+            {
+                key: value
+                for key, value in event.items()
+                if isinstance(key, str)
+                and key in _SAFE_ENTITLEMENT_DENIAL_AUDIT_FIELDS
+            }
+            for event in events
+        ]
+    }
 
 
 async def handle_http_exception(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,44 @@ from app.services.operator_workflow import (
 configure_logging()
 
 
+_ENTITLEMENT_DENIAL_AUDIT_FIELDS = frozenset(
+    {
+        "event_id",
+        "event_type",
+        "occurred_at",
+        "request_id",
+        "correlation_id",
+        "user_subject",
+        "session_id",
+        "auth_source",
+        "governance_bindings",
+        "entitlement_decision",
+        "entitlement_source_bindings",
+        "application_version",
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "primary_deny_code",
+        "denial_cause",
+    }
+)
+
+
+def _serialize_entitlement_denial_audit_events(
+    exc: PreviewSubmissionEntitlementError,
+) -> list[dict[str, object]]:
+    return [
+        event.model_dump(
+            mode="json",
+            include=_ENTITLEMENT_DENIAL_AUDIT_FIELDS,
+            exclude_none=True,
+        )
+        for event in exc.audit_events
+    ]
+
+
 def create_app() -> FastAPI:
     logger = get_logger()
     try:
@@ -224,6 +262,7 @@ def create_app() -> FastAPI:
                 403,
                 "entitlement_denied",
                 "The signed-in operator is not entitled to use that source.",
+                audit_events=_serialize_entitlement_denial_audit_events(exc),
             ) from exc
         except PreviewSubmissionContractError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/backend/tests/test_api_errors.py
+++ b/backend/tests/test_api_errors.py
@@ -75,8 +75,8 @@ class ApiErrorHandlingTestCase(unittest.TestCase):
         self.assertNotIn(test_token, response.text)
 
     def test_entitlement_denial_audit_events_are_allowlisted(self) -> None:
-        raw_token = "raw-token-should-not-render"
-        raw_cookie = "session-cookie-should-not-render"
+        raw_token = "raw-token-should-not-render"  # noqa: S105 - test sentinel
+        raw_cookie = "session-cookie-should-not-render"  # noqa: S105 - test sentinel
 
         @self.app.get("/_test/entitlement-denied-audit")
         def raise_entitlement_denial_with_raw_audit() -> None:

--- a/backend/tests/test_api_errors.py
+++ b/backend/tests/test_api_errors.py
@@ -74,6 +74,93 @@ class ApiErrorHandlingTestCase(unittest.TestCase):
         )
         self.assertNotIn(test_token, response.text)
 
+    def test_entitlement_denial_audit_events_are_allowlisted(self) -> None:
+        raw_token = "raw-token-should-not-render"
+        raw_cookie = "session-cookie-should-not-render"
+
+        @self.app.get("/_test/entitlement-denied-audit")
+        def raise_entitlement_denial_with_raw_audit() -> None:
+            from fastapi import HTTPException
+
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "code": "entitlement_denied",
+                    "message": "Source entitlement denied.",
+                    "audit": {
+                        "events": [
+                            {
+                                "event_id": "event-123",
+                                "event_type": "generation_failed",
+                                "occurred_at": "2026-04-25T12:00:00Z",
+                                "request_id": "request-123",
+                                "correlation_id": "correlation-123",
+                                "user_subject": "subject-123",
+                                "session_id": "session-audit-123",
+                                "auth_source": "enterprise_bridge",
+                                "governance_bindings": ["finance"],
+                                "entitlement_decision": "deny",
+                                "entitlement_source_bindings": ["finance"],
+                                "application_version": "safequery-api/0.1.0",
+                                "source_id": "finance_postgres",
+                                "source_family": "postgresql",
+                                "source_flavor": "aurora",
+                                "dataset_contract_version": 3,
+                                "schema_snapshot_version": 7,
+                                "primary_deny_code": "DENY_SOURCE_ENTITLEMENT",
+                                "denial_cause": "entitlement_denied",
+                                "raw_token": raw_token,
+                                "cookie": raw_cookie,
+                                "csrf_token": "csrf-token-should-not-render",
+                            }
+                        ]
+                    },
+                },
+            )
+
+        response = self.client.get("/_test/entitlement-denied-audit")
+
+        self.assertEqual(response.status_code, 403)
+        body = response.json()
+        self.assertEqual(
+            body["error"],
+            {
+                "code": "entitlement_denied",
+                "message": "Source entitlement denied.",
+            },
+        )
+        self.assertEqual(
+            body["audit"],
+            {
+                "events": [
+                    {
+                        "event_id": "event-123",
+                        "event_type": "generation_failed",
+                        "occurred_at": "2026-04-25T12:00:00Z",
+                        "request_id": "request-123",
+                        "correlation_id": "correlation-123",
+                        "user_subject": "subject-123",
+                        "session_id": "session-audit-123",
+                        "auth_source": "enterprise_bridge",
+                        "governance_bindings": ["finance"],
+                        "entitlement_decision": "deny",
+                        "entitlement_source_bindings": ["finance"],
+                        "application_version": "safequery-api/0.1.0",
+                        "source_id": "finance_postgres",
+                        "source_family": "postgresql",
+                        "source_flavor": "aurora",
+                        "dataset_contract_version": 3,
+                        "schema_snapshot_version": 7,
+                        "primary_deny_code": "DENY_SOURCE_ENTITLEMENT",
+                        "denial_cause": "entitlement_denied",
+                    }
+                ]
+            },
+        )
+        self.assertNotIn(raw_token, response.text)
+        self.assertNotIn(raw_cookie, response.text)
+        self.assertNotIn("csrf-token-should-not-render", response.text)
+
     def test_unhandled_errors_and_logs_do_not_leak_secrets(self) -> None:
         test_token = "test-token-1234"
         stream = StringIO()

--- a/backend/tests/test_dev_auth_preview_api.py
+++ b/backend/tests/test_dev_auth_preview_api.py
@@ -338,13 +338,15 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
-            response.json(),
+            response.json()["error"],
             {
-                "error": {
-                    "code": "entitlement_denied",
-                    "message": "The signed-in operator is not entitled to use that source.",
-                }
+                "code": "entitlement_denied",
+                "message": "The signed-in operator is not entitled to use that source.",
             },
+        )
+        self.assertEqual(
+            response.json()["audit"]["events"][0]["primary_deny_code"],
+            "DENY_SOURCE_ENTITLEMENT",
         )
 
     def test_production_default_dev_auth_blocks_preview_http_request(self) -> None:

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -433,15 +433,38 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 403)
+        response_body = response.json()
         self.assertEqual(
-            response.json(),
+            response_body["error"],
             {
-                "error": {
-                    "code": "entitlement_denied",
-                    "message": "The signed-in operator is not entitled to use that source.",
-                }
+                "code": "entitlement_denied",
+                "message": "The signed-in operator is not entitled to use that source.",
             },
         )
+        self.assertEqual(len(response_body["audit"]["events"]), 1)
+        denial_event = response_body["audit"]["events"][0]
+        self.assertEqual(denial_event["event_type"], "generation_failed")
+        self.assertEqual(denial_event["request_id"], response.headers["X-Request-ID"])
+        self.assertTrue(denial_event["correlation_id"])
+        self.assertEqual(denial_event["user_subject"], "user:alice@example.com")
+        self.assertTrue(denial_event["session_id"])
+        self.assertEqual(denial_event["auth_source"], "test-helper")
+        self.assertEqual(denial_event["governance_bindings"], ["group:people-ops"])
+        self.assertEqual(denial_event["entitlement_decision"], "deny")
+        self.assertEqual(
+            denial_event["entitlement_source_bindings"],
+            ["group:finance-analysts"],
+        )
+        self.assertEqual(denial_event["source_id"], "sap-approved-spend")
+        self.assertEqual(denial_event["source_family"], "postgresql")
+        self.assertEqual(denial_event["source_flavor"], "warehouse")
+        self.assertEqual(denial_event["dataset_contract_version"], 1)
+        self.assertEqual(denial_event["schema_snapshot_version"], 1)
+        self.assertEqual(denial_event["primary_deny_code"], "DENY_SOURCE_ENTITLEMENT")
+        self.assertEqual(denial_event["denial_cause"], "entitlement_denied")
+        self.assertNotIn("csrf", response.text.lower())
+        self.assertNotIn("token", response.text.lower())
+        self.assertNotIn("cookie", response.text.lower())
         self.assertNotIn("candidate", response.text)
 
     def test_client_supplied_governance_metadata_cannot_grant_preview_entitlement(
@@ -543,13 +566,15 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
-            response.json(),
+            response.json()["error"],
             {
-                "error": {
-                    "code": "entitlement_denied",
-                    "message": "The signed-in operator is not entitled to use that source.",
-                }
+                "code": "entitlement_denied",
+                "message": "The signed-in operator is not entitled to use that source.",
             },
+        )
+        self.assertEqual(
+            response.json()["audit"]["events"][0]["primary_deny_code"],
+            "DENY_SOURCE_ENTITLEMENT",
         )
 
     def test_preview_submission_rejects_subject_matching_only_exception_policy_binding(self) -> None:
@@ -573,13 +598,15 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
-            response.json(),
+            response.json()["error"],
             {
-                "error": {
-                    "code": "entitlement_denied",
-                    "message": "The signed-in operator is not entitled to use that source.",
-                }
+                "code": "entitlement_denied",
+                "message": "The signed-in operator is not entitled to use that source.",
             },
+        )
+        self.assertEqual(
+            response.json()["audit"]["events"][0]["primary_deny_code"],
+            "DENY_SOURCE_ENTITLEMENT",
         )
 
 


### PR DESCRIPTION
## Summary
- retain audit-safe preview entitlement-denial events on the HTTP 403 response
- whitelist the denial event fields exposed through the shared API error handler
- add HTTP-level coverage for source, subject, governance-binding, entitlement decision, source binding, and deny-code evidence

## Verification
- cd backend && python3 -m pytest tests/test_request_source_selection.py tests/test_dev_auth_preview_api.py tests/test_preview_source_governance_resolution.py tests/test_source_entitlements.py tests/test_audit_event_model.py tests/test_api_errors.py -q
- cd backend && python3 -m pytest -q

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entitlement-denial error responses (403) now include a validated audit object showing allowlisted event details for clearer denial context, while omitting sensitive fields (tokens, cookies, CSRF).

* **Tests**
  * Added and updated tests to assert audit events are included for entitlement denials, verify only allowlisted fields appear, and ensure sensitive data is not present in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->