### PR TITLE
[M-1] Persist preview request and candidate records

### DIFF
--- a/backend/alembic/versions/0006_preview_persistence.py
+++ b/backend/alembic/versions/0006_preview_persistence.py
@@ -99,9 +99,11 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.ForeignKeyConstraint(
-            ["preview_request_id"],
-            ["preview_requests.id"],
-            name=op.f("fk_preview_candidates_preview_request_id_preview_requests"),
+            ["preview_request_id", "registered_source_id"],
+            ["preview_requests.id", "preview_requests.registered_source_id"],
+            name=op.f(
+                "fk_preview_candidates_preview_request_id_registered_source_id_preview_requests"
+            ),
         ),
         sa.ForeignKeyConstraint(
             ["registered_source_id"],

--- a/backend/alembic/versions/0006_preview_persistence.py
+++ b/backend/alembic/versions/0006_preview_persistence.py
@@ -1,0 +1,136 @@
+"""Add authoritative preview request and candidate records."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006_preview_persistence"
+down_revision: str | None = "0005_retrieval_corpus_scaffold"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "preview_requests",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("request_id", sa.String(length=255), nullable=False),
+        sa.Column("registered_source_id", sa.Uuid(), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("source_family", sa.String(length=64), nullable=False),
+        sa.Column("source_flavor", sa.String(length=64), nullable=True),
+        sa.Column("dataset_contract_id", sa.Uuid(), nullable=False),
+        sa.Column("dataset_contract_version", sa.Integer(), nullable=False),
+        sa.Column("schema_snapshot_id", sa.Uuid(), nullable=False),
+        sa.Column("schema_snapshot_version", sa.Integer(), nullable=False),
+        sa.Column("authenticated_subject_id", sa.String(length=255), nullable=False),
+        sa.Column("auth_source", sa.String(length=255), nullable=True),
+        sa.Column("session_id", sa.String(length=255), nullable=True),
+        sa.Column("governance_bindings", sa.Text(), nullable=True),
+        sa.Column("entitlement_decision", sa.String(length=32), nullable=False),
+        sa.Column("request_text", sa.Text(), nullable=False),
+        sa.Column("request_state", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["registered_source_id"],
+            ["registered_sources.id"],
+            name=op.f("fk_preview_requests_registered_source_id_registered_sources"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["dataset_contract_id"],
+            ["dataset_contracts.id"],
+            name=op.f("fk_preview_requests_dataset_contract_id_dataset_contracts"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["schema_snapshot_id"],
+            ["schema_snapshots.id"],
+            name=op.f("fk_preview_requests_schema_snapshot_id_schema_snapshots"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_preview_requests")),
+        sa.UniqueConstraint("request_id", name=op.f("uq_preview_requests_request_id")),
+        sa.UniqueConstraint(
+            "id",
+            "registered_source_id",
+            name=op.f("uq_preview_requests_id"),
+        ),
+    )
+    op.create_table(
+        "preview_candidates",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("candidate_id", sa.String(length=255), nullable=False),
+        sa.Column("preview_request_id", sa.Uuid(), nullable=False),
+        sa.Column("request_id", sa.String(length=255), nullable=False),
+        sa.Column("registered_source_id", sa.Uuid(), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("source_family", sa.String(length=64), nullable=False),
+        sa.Column("source_flavor", sa.String(length=64), nullable=True),
+        sa.Column("dataset_contract_id", sa.Uuid(), nullable=False),
+        sa.Column("dataset_contract_version", sa.Integer(), nullable=False),
+        sa.Column("schema_snapshot_id", sa.Uuid(), nullable=False),
+        sa.Column("schema_snapshot_version", sa.Integer(), nullable=False),
+        sa.Column("authenticated_subject_id", sa.String(length=255), nullable=False),
+        sa.Column("candidate_sql", sa.Text(), nullable=True),
+        sa.Column("guard_status", sa.String(length=64), nullable=False),
+        sa.Column("candidate_state", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["preview_request_id"],
+            ["preview_requests.id"],
+            name=op.f("fk_preview_candidates_preview_request_id_preview_requests"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["registered_source_id"],
+            ["registered_sources.id"],
+            name=op.f("fk_preview_candidates_registered_source_id_registered_sources"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["dataset_contract_id"],
+            ["dataset_contracts.id"],
+            name=op.f("fk_preview_candidates_dataset_contract_id_dataset_contracts"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["schema_snapshot_id"],
+            ["schema_snapshots.id"],
+            name=op.f("fk_preview_candidates_schema_snapshot_id_schema_snapshots"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_preview_candidates")),
+        sa.UniqueConstraint(
+            "candidate_id",
+            name=op.f("uq_preview_candidates_candidate_id"),
+        ),
+        sa.UniqueConstraint(
+            "request_id",
+            "source_id",
+            name=op.f("uq_preview_candidates_request_id"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("preview_candidates")
+    op.drop_table("preview_requests")

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,4 +1,5 @@
 from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
+from app.db.models.preview import PreviewCandidate, PreviewRequest
 from app.db.models.retrieval_corpus import RetrievalCorpusAsset
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
@@ -6,6 +7,8 @@ from app.db.models.source_registry import RegisteredSource
 __all__ = [
     "DatasetContract",
     "DatasetContractDataset",
+    "PreviewCandidate",
+    "PreviewRequest",
     "RegisteredSource",
     "RetrievalCorpusAsset",
     "SchemaSnapshot",

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -4,7 +4,16 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
 from sqlalchemy import Uuid as SqlAlchemyUuid
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -64,6 +73,10 @@ class PreviewRequest(Base):
 class PreviewCandidate(Base):
     __tablename__ = "preview_candidates"
     __table_args__ = (
+        ForeignKeyConstraint(
+            ("preview_request_id", "registered_source_id"),
+            ("preview_requests.id", "preview_requests.registered_source_id"),
+        ),
         UniqueConstraint("candidate_id"),
         UniqueConstraint("request_id", "source_id"),
     )
@@ -74,10 +87,7 @@ class PreviewCandidate(Base):
         default=uuid.uuid4,
     )
     candidate_id: Mapped[str] = mapped_column(String(255), nullable=False)
-    preview_request_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("preview_requests.id"),
-        nullable=False,
-    )
+    preview_request_id: Mapped[uuid.UUID] = mapped_column(SqlAlchemyUuid, nullable=False)
     request_id: Mapped[str] = mapped_column(String(255), nullable=False)
     registered_source_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("registered_sources.id"),

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy import Uuid as SqlAlchemyUuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class PreviewRequest(Base):
+    __tablename__ = "preview_requests"
+    __table_args__ = (
+        UniqueConstraint("request_id"),
+        UniqueConstraint("id", "registered_source_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    request_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    registered_source_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("registered_sources.id"),
+        nullable=False,
+    )
+    source_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_family: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    dataset_contract_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("dataset_contracts.id"),
+        nullable=False,
+    )
+    dataset_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    schema_snapshot_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("schema_snapshots.id"),
+        nullable=False,
+    )
+    schema_snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    authenticated_subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    auth_source: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    session_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    governance_bindings: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    entitlement_decision: Mapped[str] = mapped_column(String(32), nullable=False)
+    request_text: Mapped[str] = mapped_column(Text, nullable=False)
+    request_state: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class PreviewCandidate(Base):
+    __tablename__ = "preview_candidates"
+    __table_args__ = (
+        UniqueConstraint("candidate_id"),
+        UniqueConstraint("request_id", "source_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    candidate_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    preview_request_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("preview_requests.id"),
+        nullable=False,
+    )
+    request_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    registered_source_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("registered_sources.id"),
+        nullable=False,
+    )
+    source_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_family: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    dataset_contract_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("dataset_contracts.id"),
+        nullable=False,
+    )
+    dataset_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    schema_snapshot_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("schema_snapshots.id"),
+        nullable=False,
+    )
+    schema_snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    authenticated_subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    candidate_sql: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    guard_status: Mapped[str] = mapped_column(String(64), nullable=False)
+    candidate_state: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from typing import Optional
 from typing_extensions import Annotated
@@ -15,6 +16,7 @@ from app.db.models.source_registry import RegisteredSource
 from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.auth.context import AuthenticatedSubject
 from app.features.auth.governance_bindings import normalize_governance_binding
+from app.features.operator_history.payloads import GuardStatus
 from app.services.source_entitlements import (
     SourceEntitlementError,
     ensure_subject_is_entitled_for_source,
@@ -27,6 +29,7 @@ from app.services.source_registry import SourceRegistryPostureError
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+PREVIEW_PENDING_GUARD_STATUS: GuardStatus = "pending"
 
 
 class PreviewSubmissionRequest(BaseModel):
@@ -252,6 +255,14 @@ def _joined_governance_bindings(bindings: list[str]) -> str | None:
     return ",".join(sorted(bindings)) if bindings else None
 
 
+def _raise_preview_persistence_contract_error(
+    session: Session,
+    message: str,
+) -> None:
+    session.rollback()
+    raise PreviewSubmissionContractError(message)
+
+
 def _persist_preview_submission_records(
     session: Session,
     *,
@@ -281,67 +292,105 @@ def _persist_preview_submission_records(
         sorted(authenticated_subject.normalized_governance_bindings())
     )
 
-    preview_request = session.execute(
-        select(PreviewRequest).where(PreviewRequest.request_id == request_id)
-    ).scalar_one_or_none()
-    if preview_request is None:
-        preview_request = PreviewRequest(request_id=request_id)
-        session.add(preview_request)
-    elif preview_request.registered_source_id != resolved_source.id:
-        raise PreviewSubmissionContractError(
-            "Preview request cannot be rebound to a different source."
-        )
+    for attempt in range(2):
+        try:
+            preview_request = session.execute(
+                select(PreviewRequest).where(PreviewRequest.request_id == request_id)
+            ).scalar_one_or_none()
+            if preview_request is None:
+                preview_request = PreviewRequest(request_id=request_id)
+                session.add(preview_request)
+            elif preview_request.registered_source_id != resolved_source.id:
+                _raise_preview_persistence_contract_error(
+                    session,
+                    "Preview request cannot be rebound to a different source.",
+                )
 
-    preview_request.registered_source_id = resolved_source.id
-    preview_request.source_id = resolved_source.source_id
-    preview_request.source_family = resolved_source.source_family
-    preview_request.source_flavor = resolved_source.source_flavor
-    preview_request.dataset_contract_id = dataset_contract.id
-    preview_request.dataset_contract_version = dataset_contract.contract_version
-    preview_request.schema_snapshot_id = schema_snapshot.id
-    preview_request.schema_snapshot_version = schema_snapshot.snapshot_version
-    preview_request.authenticated_subject_id = subject_id
-    preview_request.auth_source = (
-        audit_context.auth_source if audit_context is not None else None
-    )
-    preview_request.session_id = (
-        audit_context.session_id if audit_context is not None else None
-    )
-    preview_request.governance_bindings = governance_bindings
-    preview_request.entitlement_decision = "allow"
-    preview_request.request_text = payload.question
-    preview_request.request_state = "previewed"
-    session.flush()
+            preview_request.registered_source_id = resolved_source.id
+            preview_request.source_id = resolved_source.source_id
+            preview_request.source_family = resolved_source.source_family
+            preview_request.source_flavor = resolved_source.source_flavor
+            preview_request.dataset_contract_id = dataset_contract.id
+            preview_request.dataset_contract_version = dataset_contract.contract_version
+            preview_request.schema_snapshot_id = schema_snapshot.id
+            preview_request.schema_snapshot_version = schema_snapshot.snapshot_version
+            preview_request.authenticated_subject_id = subject_id
+            preview_request.auth_source = (
+                audit_context.auth_source if audit_context is not None else None
+            )
+            preview_request.session_id = (
+                audit_context.session_id if audit_context is not None else None
+            )
+            preview_request.governance_bindings = governance_bindings
+            preview_request.entitlement_decision = "allow"
+            preview_request.request_text = payload.question
+            preview_request.request_state = "previewed"
+            session.flush()
 
-    preview_candidate = session.execute(
-        select(PreviewCandidate).where(PreviewCandidate.candidate_id == candidate_id)
-    ).scalar_one_or_none()
-    if preview_candidate is None:
-        preview_candidate = PreviewCandidate(candidate_id=candidate_id)
-        session.add(preview_candidate)
-    elif (
-        preview_candidate.preview_request_id != preview_request.id
-        or preview_candidate.registered_source_id != resolved_source.id
-    ):
-        raise PreviewSubmissionContractError(
-            "Preview candidate cannot be rebound to a different request or source."
-        )
+            preview_candidate = session.execute(
+                select(PreviewCandidate).where(
+                    PreviewCandidate.request_id == request_id,
+                    PreviewCandidate.source_id == resolved_source.source_id,
+                )
+            ).scalar_one_or_none()
+            if preview_candidate is None:
+                preview_candidate = session.execute(
+                    select(PreviewCandidate).where(
+                        PreviewCandidate.candidate_id == candidate_id
+                    )
+                ).scalar_one_or_none()
+                if preview_candidate is None:
+                    preview_candidate = PreviewCandidate(candidate_id=candidate_id)
+                    session.add(preview_candidate)
+                elif (
+                    preview_candidate.request_id != request_id
+                    or preview_candidate.source_id != resolved_source.source_id
+                ):
+                    _raise_preview_persistence_contract_error(
+                        session,
+                        "Preview candidate cannot be rebound to a different request or source.",
+                    )
+            elif preview_candidate.candidate_id != candidate_id:
+                _raise_preview_persistence_contract_error(
+                    session,
+                    "Preview candidate cannot be rebound to a different candidate.",
+                )
 
-    preview_candidate.preview_request_id = preview_request.id
-    preview_candidate.request_id = request_id
-    preview_candidate.registered_source_id = resolved_source.id
-    preview_candidate.source_id = resolved_source.source_id
-    preview_candidate.source_family = resolved_source.source_family
-    preview_candidate.source_flavor = resolved_source.source_flavor
-    preview_candidate.dataset_contract_id = dataset_contract.id
-    preview_candidate.dataset_contract_version = dataset_contract.contract_version
-    preview_candidate.schema_snapshot_id = schema_snapshot.id
-    preview_candidate.schema_snapshot_version = schema_snapshot.snapshot_version
-    preview_candidate.authenticated_subject_id = subject_id
-    preview_candidate.candidate_sql = None
-    preview_candidate.guard_status = "not_evaluated"
-    preview_candidate.candidate_state = "preview_ready"
-    session.commit()
+            if (
+                preview_candidate.preview_request_id is not None
+                and preview_candidate.preview_request_id != preview_request.id
+            ) or (
+                preview_candidate.registered_source_id is not None
+                and preview_candidate.registered_source_id != resolved_source.id
+            ):
+                _raise_preview_persistence_contract_error(
+                    session,
+                    "Preview candidate cannot be rebound to a different request or source.",
+                )
+
+            preview_candidate.preview_request_id = preview_request.id
+            preview_candidate.request_id = request_id
+            preview_candidate.registered_source_id = resolved_source.id
+            preview_candidate.source_id = resolved_source.source_id
+            preview_candidate.source_family = resolved_source.source_family
+            preview_candidate.source_flavor = resolved_source.source_flavor
+            preview_candidate.dataset_contract_id = dataset_contract.id
+            preview_candidate.dataset_contract_version = dataset_contract.contract_version
+            preview_candidate.schema_snapshot_id = schema_snapshot.id
+            preview_candidate.schema_snapshot_version = schema_snapshot.snapshot_version
+            preview_candidate.authenticated_subject_id = subject_id
+            preview_candidate.candidate_sql = None
+            preview_candidate.guard_status = PREVIEW_PENDING_GUARD_STATUS
+            preview_candidate.candidate_state = "preview_ready"
+            session.commit()
+            return
+        except IntegrityError as exc:
+            session.rollback()
+            if attempt == 0:
+                continue
+            raise PreviewSubmissionContractError(
+                "Preview submission could not be persisted consistently."
+            ) from exc
 
 
 def submit_preview_request(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from typing import Optional
 from typing_extensions import Annotated
 from uuid import UUID, uuid4
 
 from app.db.models.dataset_contract import DatasetContract
+from app.db.models.preview import PreviewCandidate, PreviewRequest
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
 from app.features.audit.event_model import SourceAwareAuditEvent
@@ -246,6 +248,102 @@ def _build_preview_entitlement_denial_audit_event(
     ]
 
 
+def _joined_governance_bindings(bindings: list[str]) -> str | None:
+    return ",".join(sorted(bindings)) if bindings else None
+
+
+def _persist_preview_submission_records(
+    session: Session,
+    *,
+    payload: PreviewSubmissionRequest,
+    resolved_source: RegisteredSource,
+    dataset_contract: DatasetContract,
+    schema_snapshot: SchemaSnapshot,
+    authenticated_subject: AuthenticatedSubject,
+    audit_context: PreviewAuditContext | None,
+) -> None:
+    request_id = (
+        audit_context.request_id
+        if audit_context is not None and audit_context.request_id.strip()
+        else str(uuid4())
+    )
+    candidate_id = (
+        audit_context.query_candidate_id
+        if (
+            audit_context is not None
+            and audit_context.query_candidate_id is not None
+            and audit_context.query_candidate_id.strip()
+        )
+        else str(uuid4())
+    )
+    subject_id = authenticated_subject.normalized_subject_id()
+    governance_bindings = _joined_governance_bindings(
+        sorted(authenticated_subject.normalized_governance_bindings())
+    )
+
+    preview_request = session.execute(
+        select(PreviewRequest).where(PreviewRequest.request_id == request_id)
+    ).scalar_one_or_none()
+    if preview_request is None:
+        preview_request = PreviewRequest(request_id=request_id)
+        session.add(preview_request)
+    elif preview_request.registered_source_id != resolved_source.id:
+        raise PreviewSubmissionContractError(
+            "Preview request cannot be rebound to a different source."
+        )
+
+    preview_request.registered_source_id = resolved_source.id
+    preview_request.source_id = resolved_source.source_id
+    preview_request.source_family = resolved_source.source_family
+    preview_request.source_flavor = resolved_source.source_flavor
+    preview_request.dataset_contract_id = dataset_contract.id
+    preview_request.dataset_contract_version = dataset_contract.contract_version
+    preview_request.schema_snapshot_id = schema_snapshot.id
+    preview_request.schema_snapshot_version = schema_snapshot.snapshot_version
+    preview_request.authenticated_subject_id = subject_id
+    preview_request.auth_source = (
+        audit_context.auth_source if audit_context is not None else None
+    )
+    preview_request.session_id = (
+        audit_context.session_id if audit_context is not None else None
+    )
+    preview_request.governance_bindings = governance_bindings
+    preview_request.entitlement_decision = "allow"
+    preview_request.request_text = payload.question
+    preview_request.request_state = "previewed"
+    session.flush()
+
+    preview_candidate = session.execute(
+        select(PreviewCandidate).where(PreviewCandidate.candidate_id == candidate_id)
+    ).scalar_one_or_none()
+    if preview_candidate is None:
+        preview_candidate = PreviewCandidate(candidate_id=candidate_id)
+        session.add(preview_candidate)
+    elif (
+        preview_candidate.preview_request_id != preview_request.id
+        or preview_candidate.registered_source_id != resolved_source.id
+    ):
+        raise PreviewSubmissionContractError(
+            "Preview candidate cannot be rebound to a different request or source."
+        )
+
+    preview_candidate.preview_request_id = preview_request.id
+    preview_candidate.request_id = request_id
+    preview_candidate.registered_source_id = resolved_source.id
+    preview_candidate.source_id = resolved_source.source_id
+    preview_candidate.source_family = resolved_source.source_family
+    preview_candidate.source_flavor = resolved_source.source_flavor
+    preview_candidate.dataset_contract_id = dataset_contract.id
+    preview_candidate.dataset_contract_version = dataset_contract.contract_version
+    preview_candidate.schema_snapshot_id = schema_snapshot.id
+    preview_candidate.schema_snapshot_version = schema_snapshot.snapshot_version
+    preview_candidate.authenticated_subject_id = subject_id
+    preview_candidate.candidate_sql = None
+    preview_candidate.guard_status = "not_evaluated"
+    preview_candidate.candidate_state = "preview_ready"
+    session.commit()
+
+
 def submit_preview_request(
     payload: PreviewSubmissionRequest,
     authenticated_subject: AuthenticatedSubject,
@@ -298,6 +396,15 @@ def submit_preview_request(
             schema_snapshot=schema_snapshot,
             audit_context=audit_context,
         ),
+    )
+    _persist_preview_submission_records(
+        session,
+        payload=payload,
+        resolved_source=resolved_source,
+        dataset_contract=dataset_contract,
+        schema_snapshot=schema_snapshot,
+        authenticated_subject=authenticated_subject,
+        audit_context=audit_context,
     )
 
     return PreviewSubmissionResponse(

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -31,7 +31,7 @@ def _session_scope() -> Iterator[Session]:
         session.execute(
             text(
                 "INSERT INTO alembic_version (version_num) "
-                "VALUES ('0005_retrieval_corpus_scaffold')"
+                "VALUES ('0006_preview_persistence')"
             )
         )
         session.commit()
@@ -125,7 +125,7 @@ def test_first_run_doctor_fails_closed_when_migration_metadata_is_unreadable(
     ]
     assert sections["migrations"]["detail"] == {
         "error": "RuntimeError",
-        "applied_revisions": ["0005_retrieval_corpus_scaffold"],
+        "applied_revisions": ["0006_preview_persistence"],
     }
     assert "source_registry" in sections
 

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import importlib
+import os
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.core.config import get_settings
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.preview import PreviewCandidate, PreviewRequest
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.db.session import require_preview_submission_session
+from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
+from app.features.auth.session import create_test_application_session
+from app.services.request_preview import (
+    PreviewAuditContext,
+    PreviewSubmissionRequest,
+    submit_preview_request,
+)
+
+
+def _seed_authoritative_source_governance(session: Session) -> None:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id="sap-approved-spend",
+        display_label="SAP spend cube / approved_vendor_spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference="vault:sap-approved-spend",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=1,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=1,
+        display_name="SAP spend cube contract",
+        owner_binding="group:finance-analysts",
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.commit()
+
+
+def test_http_preview_submission_persists_request_and_candidate_records() -> None:
+    previous_env = {
+        name: os.environ.get(name)
+        for name in (
+            "SAFEQUERY_APP_POSTGRES_URL",
+            "SAFEQUERY_SESSION_SIGNING_KEY",
+        )
+    }
+    os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
+        "postgresql://safequery:safequery@db:5432/safequery"
+    )
+    os.environ["SAFEQUERY_SESSION_SIGNING_KEY"] = "x" * 32
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    main_module = importlib.import_module("app.main")
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 200
+        request_id = response.headers["X-Request-ID"]
+        response_candidate_id = response.json()["audit"]["events"][2][
+            "query_candidate_id"
+        ]
+
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
+        persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+
+        assert persisted_request.request_id == request_id
+        assert persisted_request.request_text == (
+            "Show approved vendors by quarterly spend"
+        )
+        assert persisted_request.source_id == "sap-approved-spend"
+        assert persisted_request.request_state == "previewed"
+        assert persisted_request.authenticated_subject_id == "user:alice"
+        assert persisted_request.auth_source == "test-helper"
+        assert persisted_request.governance_bindings == "group:finance-analysts"
+        assert persisted_request.dataset_contract_version == 1
+        assert persisted_request.schema_snapshot_version == 1
+
+        assert persisted_candidate.candidate_id == response_candidate_id
+        assert persisted_candidate.request_id == request_id
+        assert persisted_candidate.source_id == "sap-approved-spend"
+        assert persisted_candidate.source_family == "postgresql"
+        assert persisted_candidate.source_flavor == "warehouse"
+        assert persisted_candidate.candidate_state == "preview_ready"
+        assert persisted_candidate.guard_status == "not_evaluated"
+        assert persisted_candidate.candidate_sql is None
+        assert persisted_candidate.authenticated_subject_id == "user:alice"
+        assert persisted_candidate.dataset_contract_version == 1
+        assert persisted_candidate.schema_snapshot_version == 1
+        assert persisted_candidate.registered_source_id == persisted_request.registered_source_id
+        assert persisted_candidate.dataset_contract_id == persisted_request.dataset_contract_id
+        assert persisted_candidate.schema_snapshot_id == persisted_request.schema_snapshot_id
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        for name, value in previous_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        get_settings.cache_clear()
+
+
+def test_preview_submission_updates_existing_request_and_candidate_records() -> None:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    with Session(engine) as session:
+        _seed_authoritative_source_governance(session)
+        audit_context = PreviewAuditContext(
+            occurred_at=datetime.now(timezone.utc),
+            request_id="preview-request-231",
+            correlation_id="preview-correlation-231",
+            user_subject="user:alice",
+            session_id="session-231",
+            query_candidate_id="preview-candidate-231",
+            candidate_owner_subject="user:alice",
+            auth_source="test-helper",
+        )
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=audit_context.model_copy(deep=True),
+        )
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by yearly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=audit_context.model_copy(deep=True),
+        )
+
+        persisted_requests = session.execute(select(PreviewRequest)).scalars().all()
+        persisted_candidates = session.execute(select(PreviewCandidate)).scalars().all()
+
+    assert len(persisted_requests) == 1
+    assert len(persisted_candidates) == 1
+    assert persisted_requests[0].request_id == "preview-request-231"
+    assert persisted_requests[0].request_text == "Show approved vendors by yearly spend"
+    assert persisted_requests[0].request_state == "previewed"
+    assert persisted_candidates[0].candidate_id == "preview-candidate-231"
+    assert persisted_candidates[0].request_id == "preview-request-231"
+    assert persisted_candidates[0].source_id == "sap-approved-spend"

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -21,6 +21,7 @@ from app.features.auth.context import AuthenticatedSubject, require_authenticate
 from app.features.auth.session import create_test_application_session
 from app.services.request_preview import (
     PreviewAuditContext,
+    PreviewSubmissionContractError,
     PreviewSubmissionRequest,
     submit_preview_request,
 )
@@ -145,7 +146,7 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         assert persisted_candidate.source_family == "postgresql"
         assert persisted_candidate.source_flavor == "warehouse"
         assert persisted_candidate.candidate_state == "preview_ready"
-        assert persisted_candidate.guard_status == "not_evaluated"
+        assert persisted_candidate.guard_status == "pending"
         assert persisted_candidate.candidate_sql is None
         assert persisted_candidate.authenticated_subject_id == "user:alice"
         assert persisted_candidate.dataset_contract_version == 1
@@ -220,3 +221,82 @@ def test_preview_submission_updates_existing_request_and_candidate_records() -> 
     assert persisted_candidates[0].candidate_id == "preview-candidate-231"
     assert persisted_candidates[0].request_id == "preview-request-231"
     assert persisted_candidates[0].source_id == "sap-approved-spend"
+
+
+def test_preview_submission_rejects_candidate_rebind_by_request_source_key() -> None:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    with Session(engine) as session:
+        _seed_authoritative_source_governance(session)
+        audit_context = PreviewAuditContext(
+            occurred_at=datetime.now(timezone.utc),
+            request_id="preview-request-231",
+            correlation_id="preview-correlation-231",
+            user_subject="user:alice",
+            session_id="session-231",
+            query_candidate_id="preview-candidate-231",
+            candidate_owner_subject="user:alice",
+            auth_source="test-helper",
+        )
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=audit_context.model_copy(deep=True),
+        )
+
+        rebound_context = audit_context.model_copy(
+            update={"query_candidate_id": "preview-candidate-rebound"}
+        )
+        try:
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by yearly spend",
+                    source_id="sap-approved-spend",
+                ),
+                subject,
+                session,
+                audit_context=rebound_context,
+            )
+        except PreviewSubmissionContractError as exc:
+            assert str(exc) == (
+                "Preview candidate cannot be rebound to a different candidate."
+            )
+        else:
+            raise AssertionError("expected candidate rebinding to fail closed")
+
+        persisted_requests = session.execute(select(PreviewRequest)).scalars().all()
+        persisted_candidates = session.execute(select(PreviewCandidate)).scalars().all()
+
+    assert len(persisted_requests) == 1
+    assert len(persisted_candidates) == 1
+    assert persisted_requests[0].request_text == "Show approved vendors by quarterly spend"
+    assert persisted_candidates[0].candidate_id == "preview-candidate-231"
+    assert persisted_candidates[0].guard_status == "pending"
+
+
+def test_preview_candidate_model_uses_composite_request_source_foreign_key() -> None:
+    foreign_keys = {
+        tuple(element.parent.name for element in constraint.elements): tuple(
+            element.target_fullname for element in constraint.elements
+        )
+        for constraint in PreviewCandidate.__table__.foreign_key_constraints
+    }
+
+    assert foreign_keys[("preview_request_id", "registered_source_id")] == (
+        "preview_requests.id",
+        "preview_requests.registered_source_id",
+    )


### PR DESCRIPTION
## Summary
- add authoritative preview request and candidate persistence models plus migration
- persist successful preview submissions with source, subject, governance, lifecycle, and candidate binding state
- add focused create/update persistence tests and refresh first-run doctor migration-head fixtures

Closes #231

## Verification
- cd backend && python3 -m pytest tests/test_request_source_selection.py tests/test_operator_history_payloads.py tests/test_audit_event_model.py tests/test_preview_persistence.py tests/test_source_bound_records.py tests/test_candidate_source_metadata.py tests/test_preview_source_governance_resolution.py -q
- cd backend && SAFEQUERY_APP_POSTGRES_URL=postgresql://safequery:safequery@db:5432/safequery SAFEQUERY_SESSION_SIGNING_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx python3 -m alembic upgrade head --sql > /tmp/safequery-issue-231-alembic.sql
- cd backend && python3 -m pytest -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview requests and query candidates are now persisted with full audit metadata, source/version links, entitlement/guard state, and timestamps.
  * Repeated preview submissions update existing records; attempts to rebind requests/candidates to a different source are rejected.

* **Tests**
  * Added tests validating preview persistence, update semantics, rebinding rejection, and migration version expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->