### PR TITLE
Persist preview lifecycle audit events

### DIFF
--- a/backend/alembic/versions/0007_preview_audit_event_persistence.py
+++ b/backend/alembic/versions/0007_preview_audit_event_persistence.py
@@ -1,0 +1,68 @@
+"""Persist preview lifecycle audit events."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007_preview_audit_event_persistence"
+down_revision: str | None = "0006_preview_persistence"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "preview_audit_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("event_id", sa.Uuid(), nullable=False),
+        sa.Column("lifecycle_order", sa.Integer(), nullable=False),
+        sa.Column("preview_request_id", sa.Uuid(), nullable=False),
+        sa.Column("preview_candidate_id", sa.Uuid(), nullable=True),
+        sa.Column("request_id", sa.String(length=255), nullable=False),
+        sa.Column("candidate_id", sa.String(length=255), nullable=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("correlation_id", sa.String(length=255), nullable=False),
+        sa.Column("causation_event_id", sa.Uuid(), nullable=True),
+        sa.Column("authenticated_subject_id", sa.String(length=255), nullable=False),
+        sa.Column("session_id", sa.String(length=255), nullable=False),
+        sa.Column("auth_source", sa.String(length=255), nullable=True),
+        sa.Column("governance_bindings", sa.Text(), nullable=True),
+        sa.Column("entitlement_decision", sa.String(length=32), nullable=True),
+        sa.Column("entitlement_source_bindings", sa.Text(), nullable=True),
+        sa.Column("application_version", sa.String(length=255), nullable=True),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("source_family", sa.String(length=64), nullable=False),
+        sa.Column("source_flavor", sa.String(length=64), nullable=True),
+        sa.Column("dataset_contract_version", sa.Integer(), nullable=True),
+        sa.Column("schema_snapshot_version", sa.Integer(), nullable=True),
+        sa.Column("primary_deny_code", sa.String(length=255), nullable=True),
+        sa.Column("denial_cause", sa.String(length=255), nullable=True),
+        sa.Column("candidate_state", sa.String(length=64), nullable=True),
+        sa.Column("audit_payload", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["preview_request_id"],
+            ["preview_requests.id"],
+            name=op.f("fk_preview_audit_events_preview_request_id_preview_requests"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["preview_candidate_id"],
+            ["preview_candidates.id"],
+            name=op.f("fk_preview_audit_events_preview_candidate_id_preview_candidates"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_preview_audit_events")),
+        sa.UniqueConstraint("event_id", name=op.f("uq_preview_audit_events_event_id")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("preview_audit_events")

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,5 +1,5 @@
 from app.db.models.dataset_contract import DatasetContract, DatasetContractDataset
-from app.db.models.preview import PreviewCandidate, PreviewRequest
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
 from app.db.models.retrieval_corpus import RetrievalCorpusAsset
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
@@ -7,6 +7,7 @@ from app.db.models.source_registry import RegisteredSource
 __all__ = [
     "DatasetContract",
     "DatasetContractDataset",
+    "PreviewAuditEvent",
     "PreviewCandidate",
     "PreviewRequest",
     "RegisteredSource",

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     ForeignKey,
     ForeignKeyConstraint,
     Integer,
+    JSON,
     String,
     Text,
     UniqueConstraint,
@@ -120,4 +121,70 @@ class PreviewCandidate(Base):
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),
+    )
+
+
+class PreviewAuditEvent(Base):
+    __tablename__ = "preview_audit_events"
+    __table_args__ = (UniqueConstraint("event_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    event_id: Mapped[uuid.UUID] = mapped_column(SqlAlchemyUuid, nullable=False)
+    lifecycle_order: Mapped[int] = mapped_column(Integer, nullable=False)
+    preview_request_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("preview_requests.id"),
+        nullable=False,
+    )
+    preview_candidate_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        ForeignKey("preview_candidates.id"),
+        nullable=True,
+    )
+    request_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    candidate_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    correlation_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    causation_event_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        SqlAlchemyUuid,
+        nullable=True,
+    )
+    authenticated_subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    session_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    auth_source: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    governance_bindings: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    entitlement_decision: Mapped[Optional[str]] = mapped_column(
+        String(32),
+        nullable=True,
+    )
+    entitlement_source_bindings: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+    )
+    application_version: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    source_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_family: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    dataset_contract_version: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+    schema_snapshot_version: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+    primary_deny_code: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    denial_cause: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    candidate_state: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    audit_payload: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
     )

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -10,7 +10,7 @@ from typing_extensions import Annotated
 from uuid import UUID, uuid4
 
 from app.db.models.dataset_contract import DatasetContract
-from app.db.models.preview import PreviewCandidate, PreviewRequest
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
 from app.features.audit.event_model import SourceAwareAuditEvent
@@ -251,8 +251,94 @@ def _build_preview_entitlement_denial_audit_event(
     ]
 
 
+def _build_preview_unavailable_audit_event(
+    *,
+    resolved_source: RegisteredSource,
+    dataset_contract: DatasetContract,
+    schema_snapshot: SchemaSnapshot,
+    audit_context: PreviewAuditContext | None,
+    primary_deny_code: str,
+    denial_cause: str,
+) -> list[SourceAwareAuditEvent]:
+    if audit_context is None:
+        return []
+
+    return [
+        SourceAwareAuditEvent(
+            event_id=uuid4(),
+            event_type="generation_failed",
+            occurred_at=audit_context.occurred_at,
+            request_id=audit_context.request_id,
+            correlation_id=audit_context.correlation_id,
+            user_subject=audit_context.user_subject,
+            session_id=audit_context.session_id,
+            auth_source=audit_context.auth_source,
+            governance_bindings=audit_context.governance_bindings or None,
+            entitlement_decision=audit_context.entitlement_decision,
+            entitlement_source_bindings=(
+                audit_context.entitlement_source_bindings or None
+            ),
+            application_version=audit_context.application_version,
+            source_id=resolved_source.source_id,
+            source_family=resolved_source.source_family,
+            source_flavor=resolved_source.source_flavor,
+            dataset_contract_version=dataset_contract.contract_version,
+            schema_snapshot_version=schema_snapshot.snapshot_version,
+            primary_deny_code=primary_deny_code,
+            denial_cause=denial_cause,
+        )
+    ]
+
+
 def _joined_governance_bindings(bindings: list[str]) -> str | None:
     return ",".join(sorted(bindings)) if bindings else None
+
+
+def _persist_preview_audit_events(
+    session: Session,
+    *,
+    preview_request: PreviewRequest,
+    preview_candidate: PreviewCandidate | None,
+    audit_events: list[SourceAwareAuditEvent],
+) -> None:
+    for lifecycle_order, event in enumerate(audit_events, start=1):
+        payload = event.model_dump(mode="json", exclude_none=True)
+        session.add(
+            PreviewAuditEvent(
+                event_id=event.event_id,
+                lifecycle_order=lifecycle_order,
+                preview_request_id=preview_request.id,
+                preview_candidate_id=(
+                    preview_candidate.id if preview_candidate is not None else None
+                ),
+                request_id=event.request_id,
+                candidate_id=event.query_candidate_id,
+                event_type=event.event_type,
+                occurred_at=event.occurred_at,
+                correlation_id=event.correlation_id,
+                causation_event_id=event.causation_event_id,
+                authenticated_subject_id=event.user_subject,
+                session_id=event.session_id,
+                auth_source=event.auth_source,
+                governance_bindings=_joined_governance_bindings(
+                    list(event.governance_bindings or [])
+                ),
+                entitlement_decision=event.entitlement_decision,
+                entitlement_source_bindings=_joined_governance_bindings(
+                    list(event.entitlement_source_bindings or [])
+                ),
+                application_version=event.application_version,
+                source_id=event.source_id,
+                source_family=event.source_family,
+                source_flavor=event.source_flavor,
+                dataset_contract_version=event.dataset_contract_version,
+                schema_snapshot_version=event.schema_snapshot_version,
+                primary_deny_code=event.primary_deny_code,
+                denial_cause=event.denial_cause,
+                candidate_state=event.candidate_state,
+                audit_payload=payload,
+            )
+        )
 
 
 def _raise_preview_persistence_contract_error(
@@ -272,6 +358,7 @@ def _persist_preview_submission_records(
     schema_snapshot: SchemaSnapshot,
     authenticated_subject: AuthenticatedSubject,
     audit_context: PreviewAuditContext | None,
+    audit_events: list[SourceAwareAuditEvent],
 ) -> None:
     request_id = (
         audit_context.request_id
@@ -382,6 +469,13 @@ def _persist_preview_submission_records(
             preview_candidate.candidate_sql = None
             preview_candidate.guard_status = PREVIEW_PENDING_GUARD_STATUS
             preview_candidate.candidate_state = "preview_ready"
+            session.flush()
+            _persist_preview_audit_events(
+                session,
+                preview_request=preview_request,
+                preview_candidate=preview_candidate,
+                audit_events=audit_events,
+            )
             session.commit()
             return
         except IntegrityError as exc:
@@ -391,6 +485,75 @@ def _persist_preview_submission_records(
             raise PreviewSubmissionContractError(
                 "Preview submission could not be persisted consistently."
             ) from exc
+
+
+def _persist_preview_denial_records(
+    session: Session,
+    *,
+    payload: PreviewSubmissionRequest,
+    resolved_source: RegisteredSource,
+    dataset_contract: DatasetContract,
+    schema_snapshot: SchemaSnapshot,
+    authenticated_subject: AuthenticatedSubject,
+    audit_context: PreviewAuditContext | None,
+    audit_events: list[SourceAwareAuditEvent],
+    request_state: str = "preview_denied",
+) -> None:
+    request_id = (
+        audit_context.request_id
+        if audit_context is not None and audit_context.request_id.strip()
+        else str(uuid4())
+    )
+    subject_id = authenticated_subject.normalized_subject_id()
+    governance_bindings = _joined_governance_bindings(
+        sorted(authenticated_subject.normalized_governance_bindings())
+    )
+
+    try:
+        preview_request = session.execute(
+            select(PreviewRequest).where(PreviewRequest.request_id == request_id)
+        ).scalar_one_or_none()
+        if preview_request is None:
+            preview_request = PreviewRequest(request_id=request_id)
+            session.add(preview_request)
+        elif preview_request.registered_source_id != resolved_source.id:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Preview request cannot be rebound to a different source.",
+            )
+
+        preview_request.registered_source_id = resolved_source.id
+        preview_request.source_id = resolved_source.source_id
+        preview_request.source_family = resolved_source.source_family
+        preview_request.source_flavor = resolved_source.source_flavor
+        preview_request.dataset_contract_id = dataset_contract.id
+        preview_request.dataset_contract_version = dataset_contract.contract_version
+        preview_request.schema_snapshot_id = schema_snapshot.id
+        preview_request.schema_snapshot_version = schema_snapshot.snapshot_version
+        preview_request.authenticated_subject_id = subject_id
+        preview_request.auth_source = (
+            audit_context.auth_source if audit_context is not None else None
+        )
+        preview_request.session_id = (
+            audit_context.session_id if audit_context is not None else None
+        )
+        preview_request.governance_bindings = governance_bindings
+        preview_request.entitlement_decision = "deny"
+        preview_request.request_text = payload.question
+        preview_request.request_state = request_state
+        session.flush()
+        _persist_preview_audit_events(
+            session,
+            preview_request=preview_request,
+            preview_candidate=None,
+            audit_events=audit_events,
+        )
+        session.commit()
+    except IntegrityError as exc:
+        session.rollback()
+        raise PreviewSubmissionContractError(
+            "Preview denial could not be persisted consistently."
+        ) from exc
 
 
 def submit_preview_request(
@@ -412,6 +575,43 @@ def submit_preview_request(
         )
     except SourceEntitlementError as exc:
         if isinstance(exc.__cause__, (SourceRegistryPostureError, ValueError)):
+            _enrich_preview_audit_context(
+                audit_context,
+                authenticated_subject=authenticated_subject,
+                dataset_contract=dataset_contract,
+                entitlement_decision="deny",
+            )
+            audit_events = _build_preview_unavailable_audit_event(
+                resolved_source=source,
+                dataset_contract=dataset_contract,
+                schema_snapshot=schema_snapshot,
+                audit_context=audit_context,
+                primary_deny_code=(
+                    "DENY_SOURCE_GOVERNANCE_INVALID"
+                    if isinstance(exc.__cause__, ValueError)
+                    else "DENY_SOURCE_UNAVAILABLE"
+                ),
+                denial_cause=(
+                    "source_governance_invalid"
+                    if isinstance(exc.__cause__, ValueError)
+                    else "source_unavailable"
+                ),
+            )
+            _persist_preview_denial_records(
+                session,
+                payload=payload,
+                resolved_source=source,
+                dataset_contract=dataset_contract,
+                schema_snapshot=schema_snapshot,
+                authenticated_subject=authenticated_subject,
+                audit_context=audit_context,
+                audit_events=audit_events,
+                request_state=(
+                    "preview_malformed"
+                    if isinstance(exc.__cause__, ValueError)
+                    else "preview_unavailable"
+                ),
+            )
             raise PreviewSubmissionContractError(str(exc)) from exc
         _enrich_preview_audit_context(
             audit_context,
@@ -419,14 +619,25 @@ def submit_preview_request(
             dataset_contract=dataset_contract,
             entitlement_decision="deny",
         )
+        audit_events = _build_preview_entitlement_denial_audit_event(
+            resolved_source=source,
+            dataset_contract=dataset_contract,
+            schema_snapshot=schema_snapshot,
+            audit_context=audit_context,
+        )
+        _persist_preview_denial_records(
+            session,
+            payload=payload,
+            resolved_source=source,
+            dataset_contract=dataset_contract,
+            schema_snapshot=schema_snapshot,
+            authenticated_subject=authenticated_subject,
+            audit_context=audit_context,
+            audit_events=audit_events,
+        )
         raise PreviewSubmissionEntitlementError(
             str(exc),
-            audit_events=_build_preview_entitlement_denial_audit_event(
-                resolved_source=source,
-                dataset_contract=dataset_contract,
-                schema_snapshot=schema_snapshot,
-                audit_context=audit_context,
-            ),
+            audit_events=audit_events,
         ) from exc
 
     _enrich_preview_audit_context(
@@ -454,6 +665,7 @@ def submit_preview_request(
         schema_snapshot=schema_snapshot,
         authenticated_subject=authenticated_subject,
         audit_context=audit_context,
+        audit_events=audit.events,
     )
 
     return PreviewSubmissionResponse(

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -31,7 +31,7 @@ def _session_scope() -> Iterator[Session]:
         session.execute(
             text(
                 "INSERT INTO alembic_version (version_num) "
-                "VALUES ('0006_preview_persistence')"
+                "VALUES ('0007_preview_audit_event_persistence')"
             )
         )
         session.commit()
@@ -125,7 +125,7 @@ def test_first_run_doctor_fails_closed_when_migration_metadata_is_unreadable(
     ]
     assert sections["migrations"]["detail"] == {
         "error": "RuntimeError",
-        "applied_revisions": ["0006_preview_persistence"],
+        "applied_revisions": ["0007_preview_audit_event_persistence"],
     }
     assert "source_registry" in sections
 

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -13,7 +13,7 @@ from sqlalchemy.pool import StaticPool
 from app.core.config import get_settings
 from app.db.base import Base
 from app.db.models.dataset_contract import DatasetContract
-from app.db.models.preview import PreviewCandidate, PreviewRequest
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.db.session import require_preview_submission_session
@@ -27,14 +27,18 @@ from app.services.request_preview import (
 )
 
 
-def _seed_authoritative_source_governance(session: Session) -> None:
+def _seed_authoritative_source_governance(
+    session: Session,
+    *,
+    source_posture: SourceActivationPosture = SourceActivationPosture.ACTIVE,
+) -> None:
     source = RegisteredSource(
         id=uuid4(),
         source_id="sap-approved-spend",
         display_label="SAP spend cube / approved_vendor_spend",
         source_family="postgresql",
         source_flavor="warehouse",
-        activation_posture=SourceActivationPosture.ACTIVE,
+        activation_posture=source_posture,
         connector_profile_id=None,
         dialect_profile_id=None,
         dataset_contract_id=None,
@@ -127,6 +131,13 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
 
         persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_events = (
+            session.execute(
+                select(PreviewAuditEvent).order_by(PreviewAuditEvent.lifecycle_order)
+            )
+            .scalars()
+            .all()
+        )
 
         assert persisted_request.request_id == request_id
         assert persisted_request.request_text == (
@@ -154,6 +165,30 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         assert persisted_candidate.registered_source_id == persisted_request.registered_source_id
         assert persisted_candidate.dataset_contract_id == persisted_request.dataset_contract_id
         assert persisted_candidate.schema_snapshot_id == persisted_request.schema_snapshot_id
+
+        assert [event.event_type for event in persisted_events] == [
+            "query_submitted",
+            "generation_requested",
+            "generation_completed",
+            "guard_evaluated",
+        ]
+        assert all(
+            event.preview_request_id == persisted_request.id for event in persisted_events
+        )
+        assert all(
+            event.preview_candidate_id == persisted_candidate.id
+            for event in persisted_events
+        )
+        assert all(event.request_id == request_id for event in persisted_events)
+        assert persisted_events[-1].candidate_id == response_candidate_id
+        assert persisted_events[-1].candidate_state == "preview_ready"
+        assert persisted_events[-1].audit_payload["event_type"] == "guard_evaluated"
+        assert persisted_events[-1].audit_payload["query_candidate_id"] == (
+            response_candidate_id
+        )
+        serialized_events = str([event.audit_payload for event in persisted_events])
+        assert app_session.csrf_token not in serialized_events
+        assert app_session.cookie_value not in serialized_events
     finally:
         session.close()
         engine.dispose()
@@ -221,6 +256,163 @@ def test_preview_submission_updates_existing_request_and_candidate_records() -> 
     assert persisted_candidates[0].candidate_id == "preview-candidate-231"
     assert persisted_candidates[0].request_id == "preview-request-231"
     assert persisted_candidates[0].source_id == "sap-approved-spend"
+
+
+def test_http_preview_entitlement_denial_persists_audit_event_without_secrets() -> None:
+    previous_env = {
+        name: os.environ.get(name)
+        for name in (
+            "SAFEQUERY_APP_POSTGRES_URL",
+            "SAFEQUERY_SESSION_SIGNING_KEY",
+        )
+    }
+    os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
+        "postgresql://safequery:safequery@db:5432/safequery"
+    )
+    os.environ["SAFEQUERY_SESSION_SIGNING_KEY"] = "x" * 32
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:unentitled-analysts"}),
+    )
+
+    main_module = importlib.import_module("app.main")
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 403
+        request_id = response.headers["X-Request-ID"]
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
+        persisted_events = session.execute(select(PreviewAuditEvent)).scalars().all()
+        persisted_candidates = session.execute(select(PreviewCandidate)).scalars().all()
+
+        assert persisted_candidates == []
+        assert persisted_request.request_id == request_id
+        assert persisted_request.request_state == "preview_denied"
+        assert persisted_request.entitlement_decision == "deny"
+        assert persisted_request.request_text == (
+            "Show approved vendors by quarterly spend"
+        )
+        assert len(persisted_events) == 1
+        assert persisted_events[0].preview_request_id == persisted_request.id
+        assert persisted_events[0].preview_candidate_id is None
+        assert persisted_events[0].event_type == "generation_failed"
+        assert persisted_events[0].primary_deny_code == "DENY_SOURCE_ENTITLEMENT"
+        assert persisted_events[0].audit_payload["denial_cause"] == (
+            "entitlement_denied"
+        )
+        serialized_events = str([event.audit_payload for event in persisted_events])
+        assert app_session.csrf_token not in serialized_events
+        assert app_session.cookie_value not in serialized_events
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        for name, value in previous_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        get_settings.cache_clear()
+
+
+def test_http_preview_unavailable_source_persists_audit_event() -> None:
+    previous_env = {
+        name: os.environ.get(name)
+        for name in (
+            "SAFEQUERY_APP_POSTGRES_URL",
+            "SAFEQUERY_SESSION_SIGNING_KEY",
+        )
+    }
+    os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
+        "postgresql://safequery:safequery@db:5432/safequery"
+    )
+    os.environ["SAFEQUERY_SESSION_SIGNING_KEY"] = "x" * 32
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    main_module = importlib.import_module("app.main")
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(
+            session,
+            source_posture=SourceActivationPosture.PAUSED,
+        )
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 422
+        request_id = response.headers["X-Request-ID"]
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
+        persisted_event = session.execute(select(PreviewAuditEvent)).scalar_one()
+
+        assert persisted_request.request_id == request_id
+        assert persisted_request.request_state == "preview_unavailable"
+        assert persisted_request.entitlement_decision == "deny"
+        assert persisted_event.preview_request_id == persisted_request.id
+        assert persisted_event.preview_candidate_id is None
+        assert persisted_event.event_type == "generation_failed"
+        assert persisted_event.primary_deny_code == "DENY_SOURCE_UNAVAILABLE"
+        assert persisted_event.denial_cause == "source_unavailable"
+        assert persisted_event.audit_payload["source_id"] == "sap-approved-spend"
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        for name, value in previous_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        get_settings.cache_clear()
 
 
 def test_preview_submission_rejects_candidate_rebind_by_request_source_key() -> None:


### PR DESCRIPTION
## Summary
- add PostgreSQL persistence for preview lifecycle audit events
- link persisted audit rows to preview request and candidate records for allow paths
- persist request-linked audit rows for entitlement denial and source-unavailable preview failures without raw cookie or CSRF material

## Tests
- cd backend && python3 -m pytest -q

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced audit event tracking for preview workflows, providing visibility into the complete lifecycle of preview requests from submission through processing and resolution
  * Denial scenarios are now captured with comprehensive audit details, including context and cause information for improved transparency and troubleshooting
  * Preview submission events are persisted for compliance and audit trail purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->