### PR TITLE
[codex] Build operator workflow history from preview records

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -65,28 +65,47 @@ def _request_labels_by_id(requests: list[PreviewRequest]) -> dict[str, str]:
     return {request.request_id: request.request_text for request in requests}
 
 
-def _latest_request_event_times(
+def _audit_event_sort_key(event: PreviewAuditEvent) -> tuple[datetime, int, str]:
+    return (
+        _as_utc_datetime(event.occurred_at),
+        event.lifecycle_order,
+        str(event.event_id),
+    )
+
+
+def _latest_request_events(
     audit_events: list[PreviewAuditEvent],
-) -> dict[str, datetime]:
-    latest: dict[str, datetime] = {}
+) -> dict[str, PreviewAuditEvent]:
+    latest: dict[str, PreviewAuditEvent] = {}
     for event in audit_events:
         current = latest.get(event.request_id)
-        if current is None or event.occurred_at > current:
-            latest[event.request_id] = event.occurred_at
+        if current is None or _audit_event_sort_key(event) > _audit_event_sort_key(
+            current
+        ):
+            latest[event.request_id] = event
     return latest
 
 
-def _latest_candidate_event_times(
+def _latest_candidate_events(
     audit_events: list[PreviewAuditEvent],
-) -> dict[str, datetime]:
-    latest: dict[str, datetime] = {}
+) -> dict[str, PreviewAuditEvent]:
+    latest: dict[str, PreviewAuditEvent] = {}
     for event in audit_events:
         if event.candidate_id is None:
             continue
         current = latest.get(event.candidate_id)
-        if current is None or event.occurred_at > current:
-            latest[event.candidate_id] = event.occurred_at
+        if current is None or _audit_event_sort_key(event) > _audit_event_sort_key(
+            current
+        ):
+            latest[event.candidate_id] = event
     return latest
+
+
+def _history_occurred_at(
+    event: PreviewAuditEvent | None,
+    fallback: datetime,
+) -> datetime:
+    return _as_utc_datetime(event.occurred_at if event is not None else fallback)
 
 
 def _build_operator_history(
@@ -96,12 +115,22 @@ def _build_operator_history(
 ) -> list[OperatorWorkflowHistoryItem]:
     requests = session.execute(select(PreviewRequest)).scalars().all()
     candidates = session.execute(select(PreviewCandidate)).scalars().all()
-    audit_events = session.execute(select(PreviewAuditEvent)).scalars().all()
+    audit_events = (
+        session.execute(
+            select(PreviewAuditEvent).order_by(
+                PreviewAuditEvent.occurred_at,
+                PreviewAuditEvent.lifecycle_order,
+                PreviewAuditEvent.event_id,
+            )
+        )
+        .scalars()
+        .all()
+    )
 
     source_labels = _source_labels_by_id(sources)
     request_labels = _request_labels_by_id(requests)
-    request_event_times = _latest_request_event_times(audit_events)
-    candidate_event_times = _latest_candidate_event_times(audit_events)
+    request_events = _latest_request_events(audit_events)
+    candidate_events = _latest_candidate_events(audit_events)
 
     history: list[OperatorWorkflowHistoryItem] = []
     for candidate in candidates:
@@ -113,11 +142,9 @@ def _build_operator_history(
                 source_id=candidate.source_id,
                 source_label=source_labels.get(candidate.source_id, candidate.source_id),
                 lifecycle_state=candidate.candidate_state,
-                occurred_at=_as_utc_datetime(
-                    candidate_event_times.get(
-                        candidate.candidate_id,
-                        candidate.updated_at or candidate.created_at,
-                    )
+                occurred_at=_history_occurred_at(
+                    candidate_events.get(candidate.candidate_id),
+                    candidate.updated_at or candidate.created_at,
                 ),
                 guard_status=candidate.guard_status,
             )
@@ -132,11 +159,9 @@ def _build_operator_history(
                 source_id=request.source_id,
                 source_label=source_labels.get(request.source_id, request.source_id),
                 lifecycle_state=request.request_state,
-                occurred_at=_as_utc_datetime(
-                    request_event_times.get(
-                        request.request_id,
-                        request.updated_at or request.created_at,
-                    )
+                occurred_at=_history_occurred_at(
+                    request_events.get(request.request_id),
+                    request.updated_at or request.created_at,
                 ),
             )
         )

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
 from app.db.models.source_registry import RegisteredSource
 
 
@@ -50,6 +51,108 @@ def _source_description(source: RegisteredSource) -> str:
     )
 
 
+def _as_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _source_labels_by_id(sources: list[RegisteredSource]) -> dict[str, str]:
+    return {source.source_id: source.display_label for source in sources}
+
+
+def _request_labels_by_id(requests: list[PreviewRequest]) -> dict[str, str]:
+    return {request.request_id: request.request_text for request in requests}
+
+
+def _latest_request_event_times(
+    audit_events: list[PreviewAuditEvent],
+) -> dict[str, datetime]:
+    latest: dict[str, datetime] = {}
+    for event in audit_events:
+        current = latest.get(event.request_id)
+        if current is None or event.occurred_at > current:
+            latest[event.request_id] = event.occurred_at
+    return latest
+
+
+def _latest_candidate_event_times(
+    audit_events: list[PreviewAuditEvent],
+) -> dict[str, datetime]:
+    latest: dict[str, datetime] = {}
+    for event in audit_events:
+        if event.candidate_id is None:
+            continue
+        current = latest.get(event.candidate_id)
+        if current is None or event.occurred_at > current:
+            latest[event.candidate_id] = event.occurred_at
+    return latest
+
+
+def _build_operator_history(
+    session: Session,
+    *,
+    sources: list[RegisteredSource],
+) -> list[OperatorWorkflowHistoryItem]:
+    requests = session.execute(select(PreviewRequest)).scalars().all()
+    candidates = session.execute(select(PreviewCandidate)).scalars().all()
+    audit_events = session.execute(select(PreviewAuditEvent)).scalars().all()
+
+    source_labels = _source_labels_by_id(sources)
+    request_labels = _request_labels_by_id(requests)
+    request_event_times = _latest_request_event_times(audit_events)
+    candidate_event_times = _latest_candidate_event_times(audit_events)
+
+    history: list[OperatorWorkflowHistoryItem] = []
+    for candidate in candidates:
+        history.append(
+            OperatorWorkflowHistoryItem(
+                item_type="candidate",
+                record_id=candidate.candidate_id,
+                label=request_labels.get(candidate.request_id, "SQL preview"),
+                source_id=candidate.source_id,
+                source_label=source_labels.get(candidate.source_id, candidate.source_id),
+                lifecycle_state=candidate.candidate_state,
+                occurred_at=_as_utc_datetime(
+                    candidate_event_times.get(
+                        candidate.candidate_id,
+                        candidate.updated_at or candidate.created_at,
+                    )
+                ),
+                guard_status=candidate.guard_status,
+            )
+        )
+
+    for request in requests:
+        history.append(
+            OperatorWorkflowHistoryItem(
+                item_type="request",
+                record_id=request.request_id,
+                label=request.request_text,
+                source_id=request.source_id,
+                source_label=source_labels.get(request.source_id, request.source_id),
+                lifecycle_state=request.request_state,
+                occurred_at=_as_utc_datetime(
+                    request_event_times.get(
+                        request.request_id,
+                        request.updated_at or request.created_at,
+                    )
+                ),
+            )
+        )
+
+    item_priority = {"candidate": 0, "request": 1, "run": 2}
+    return sorted(
+        history,
+        key=lambda item: (
+            item.occurred_at,
+            -item_priority[item.item_type],
+            item.record_id,
+        ),
+        reverse=True,
+    )
+
+
 def get_operator_workflow_snapshot(session: Session) -> OperatorWorkflowSnapshot:
     sources = (
         session.execute(select(RegisteredSource).order_by(RegisteredSource.source_id))
@@ -69,4 +172,7 @@ def get_operator_workflow_snapshot(session: Session) -> OperatorWorkflowSnapshot
         for source in sources
     ]
 
-    return OperatorWorkflowSnapshot(sources=source_options, history=[])
+    return OperatorWorkflowSnapshot(
+        sources=source_options,
+        history=_build_operator_history(session, sources=sources),
+    )

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import create_engine
@@ -11,10 +11,15 @@ from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
 from app.db.models.dataset_contract import DatasetContract
+from app.db.models.preview import PreviewAuditEvent
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
-from app.services.operator_workflow import get_operator_workflow_snapshot
+from app.services.operator_workflow import (
+    _latest_candidate_events,
+    _latest_request_events,
+    get_operator_workflow_snapshot,
+)
 from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionContractError,
@@ -96,6 +101,90 @@ def _audit_context(*, request_id: str, candidate_id: str | None = None) -> Previ
         query_candidate_id=candidate_id,
         candidate_owner_subject="user:alice" if candidate_id is not None else None,
         auth_source="test-helper",
+    )
+
+
+def _audit_event(
+    *,
+    event_id: UUID,
+    lifecycle_order: int,
+    event_type: str,
+    request_id: str = "preview-request-234",
+    candidate_id: str | None = None,
+) -> PreviewAuditEvent:
+    return PreviewAuditEvent(
+        event_id=event_id,
+        lifecycle_order=lifecycle_order,
+        preview_request_id=uuid4(),
+        preview_candidate_id=uuid4() if candidate_id is not None else None,
+        request_id=request_id,
+        candidate_id=candidate_id,
+        event_type=event_type,
+        occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        correlation_id=f"{request_id}-correlation",
+        authenticated_subject_id="user:alice",
+        session_id=f"{request_id}-session",
+        source_id="sap-approved-spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        audit_payload={"event_type": event_type},
+    )
+
+
+def test_latest_audit_event_selection_uses_lifecycle_order_when_timestamps_tie() -> None:
+    submitted = _audit_event(
+        event_id=UUID("00000000-0000-4000-8000-000000000001"),
+        lifecycle_order=1,
+        event_type="query_submitted",
+    )
+    completed = _audit_event(
+        event_id=UUID("00000000-0000-4000-8000-000000000002"),
+        lifecycle_order=3,
+        event_type="generation_completed",
+        candidate_id="preview-candidate-234",
+    )
+    evaluated = _audit_event(
+        event_id=UUID("00000000-0000-4000-8000-000000000003"),
+        lifecycle_order=4,
+        event_type="guard_evaluated",
+        candidate_id="preview-candidate-234",
+    )
+
+    assert (
+        _latest_request_events([submitted, completed, evaluated])["preview-request-234"]
+        is evaluated
+    )
+    assert (
+        _latest_candidate_events([completed, evaluated])["preview-candidate-234"]
+        is evaluated
+    )
+
+
+def test_latest_audit_event_selection_uses_event_id_when_lifecycle_order_ties() -> None:
+    lower_event_id = _audit_event(
+        event_id=UUID("00000000-0000-4000-8000-000000000001"),
+        lifecycle_order=4,
+        event_type="guard_evaluated",
+        candidate_id="preview-candidate-234",
+    )
+    higher_event_id = _audit_event(
+        event_id=UUID("00000000-0000-4000-8000-000000000002"),
+        lifecycle_order=4,
+        event_type="guard_evaluated_retry",
+        candidate_id="preview-candidate-234",
+    )
+
+    assert (
+        _latest_request_events([lower_event_id, higher_event_id])[
+            "preview-request-234"
+        ]
+        is higher_event_id
+    )
+    assert (
+        _latest_candidate_events([lower_event_id, higher_event_id])[
+            "preview-candidate-234"
+        ]
+        is higher_event_id
     )
 
 

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.services.operator_workflow import get_operator_workflow_snapshot
+from app.services.request_preview import (
+    PreviewAuditContext,
+    PreviewSubmissionContractError,
+    PreviewSubmissionRequest,
+    submit_preview_request,
+)
+
+
+@contextmanager
+def _session_scope() -> Session:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _seed_authoritative_source_governance(
+    session: Session,
+    *,
+    source_posture: SourceActivationPosture = SourceActivationPosture.ACTIVE,
+) -> None:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id="sap-approved-spend",
+        display_label="SAP spend cube / approved_vendor_spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=source_posture,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference="vault:sap-approved-spend",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=1,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=1,
+        display_name="SAP spend cube contract",
+        owner_binding="group:finance-analysts",
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.commit()
+
+
+def _audit_context(*, request_id: str, candidate_id: str | None = None) -> PreviewAuditContext:
+    return PreviewAuditContext(
+        occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        request_id=request_id,
+        correlation_id=f"{request_id}-correlation",
+        user_subject="user:alice",
+        session_id=f"{request_id}-session",
+        query_candidate_id=candidate_id,
+        candidate_owner_subject="user:alice" if candidate_id is not None else None,
+        auth_source="test-helper",
+    )
+
+
+def test_operator_workflow_history_is_built_from_preview_request_and_candidate_records() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-234",
+                candidate_id="preview-candidate-234",
+            ),
+        )
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    history = [
+        item.model_dump(mode="json", by_alias=True, exclude_none=True)
+        for item in snapshot.history
+    ]
+    assert history == [
+        {
+            "itemType": "candidate",
+            "recordId": "preview-candidate-234",
+            "label": "Show approved vendors by quarterly spend",
+            "sourceId": "sap-approved-spend",
+            "sourceLabel": "SAP spend cube / approved_vendor_spend",
+            "lifecycleState": "preview_ready",
+            "occurredAt": "2026-01-02T03:04:05Z",
+            "guardStatus": "pending",
+        },
+        {
+            "itemType": "request",
+            "recordId": "preview-request-234",
+            "label": "Show approved vendors by quarterly spend",
+            "sourceId": "sap-approved-spend",
+            "sourceLabel": "SAP spend cube / approved_vendor_spend",
+            "lifecycleState": "previewed",
+            "occurredAt": "2026-01-02T03:04:05Z",
+        },
+    ]
+
+
+def test_operator_workflow_history_includes_audit_safe_unavailable_preview_denials() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(
+            session,
+            source_posture=SourceActivationPosture.PAUSED,
+        )
+
+        with pytest.raises(PreviewSubmissionContractError):
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by quarterly spend",
+                    source_id="sap-approved-spend",
+                ),
+                AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session,
+                audit_context=_audit_context(request_id="preview-request-denied-234"),
+            )
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    history = [
+        item.model_dump(mode="json", by_alias=True, exclude_none=True)
+        for item in snapshot.history
+    ]
+    assert history == [
+        {
+            "itemType": "request",
+            "recordId": "preview-request-denied-234",
+            "label": "Show approved vendors by quarterly spend",
+            "sourceId": "sap-approved-spend",
+            "sourceLabel": "SAP spend cube / approved_vendor_spend",
+            "lifecycleState": "preview_unavailable",
+            "occurredAt": "2026-01-02T03:04:05Z",
+        }
+    ]
+    serialized_history = str(history).lower()
+    assert "csrf" not in serialized_history
+    assert "cookie" not in serialized_history
+    assert "token" not in serialized_history
+    assert "secret" not in serialized_history


### PR DESCRIPTION
## Summary
- assemble operator workflow history from persisted preview request, candidate, and audit records
- preserve source labels, lifecycle state, guard status, and audit-event ordering in the operator snapshot
- cover accepted preview history and audit-safe unavailable-denial history with focused backend tests

## Root cause
`get_operator_workflow_snapshot` returned live source options but always emitted an empty `history` list, leaving product workflow paths on placeholder-only history despite authoritative preview records existing.

## Verification
- `python3 -m pytest tests/test_operator_workflow_history.py`
- `python3 -m pytest tests/test_operator_workflow_history.py tests/test_operator_history_payloads.py tests/test_preview_persistence.py tests/test_request_source_selection.py tests/test_audit_event_model.py`
- `python3 -m pytest`
- `npm test -- --run`

Closes #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow snapshots now include a computed, chronologically ordered history of requests and candidates with readable source labels and timestamps.
* **Bug Fixes**
  * Resolved cases where workflow history was empty so users now see complete history entries.
* **Security**
  * Serialized history omits sensitive audit fields (tokens, cookies, CSRF, secrets).
* **Tests**
  * Added coverage validating history construction, event selection, and paused-source behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->