### PR TITLE
Connect preview API states to UI

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -526,6 +526,9 @@ describe("HomePage", () => {
       fireEvent.change(screen.getByRole("combobox", { name: /source/i }), {
         target: { value: "sap-approved-spend" }
       });
+      fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+        target: { value: "Show approved vendors by quarterly spend" }
+      });
       fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
 
       expect(await screen.findByRole("alert")).toHaveTextContent(failureCase.expectedCopy);

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -396,6 +396,144 @@ describe("HomePage", () => {
     expect(screen.getByText(/preview request accepted/i)).toBeInTheDocument();
   });
 
+  it("maps authoritative preview API states without presenting them as successful SQL previews", async () => {
+    const stateCases = [
+      {
+        candidateState: "pending_generation",
+        expectedCopy: /preview generation pending/i,
+        requestState: "submitted"
+      },
+      {
+        candidateState: "denied",
+        expectedCopy: /preview denied/i,
+        requestState: "blocked"
+      }
+    ] as const;
+
+    for (const stateCase of stateCases) {
+      cleanup();
+      const fetchMock = vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(workflowPayload())
+          });
+        }
+
+        if (url.endsWith("/requests/preview")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                audit: {
+                  events: [],
+                  source_id: "sap-approved-spend",
+                  state: "recorded"
+                },
+                candidate: {
+                  dataset_contract_version: 1,
+                  schema_snapshot_version: 1,
+                  source_family: "postgresql",
+                  source_flavor: "warehouse",
+                  source_id: "sap-approved-spend",
+                  state: stateCase.candidateState
+                },
+                evaluation: {
+                  source_id: "sap-approved-spend",
+                  state: "pending"
+                },
+                request: {
+                  question: "Show approved vendors by quarterly spend",
+                  source_id: "sap-approved-spend",
+                  state: stateCase.requestState
+                }
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      render(await HomePage({}));
+
+      fireEvent.change(screen.getByRole("combobox", { name: /source/i }), {
+        target: { value: "sap-approved-spend" }
+      });
+      fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+        target: { value: "Show approved vendors by quarterly spend" }
+      });
+      fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+      expect(await screen.findByText(stateCase.expectedCopy)).toBeInTheDocument();
+      expect(screen.queryByText(/preview request accepted/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
+    }
+  });
+
+  it("maps malformed and unavailable preview submission failures distinctly", async () => {
+    const failureCases = [
+      {
+        expectedCopy: /malformed_preview_response/i,
+        response: {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              candidate: {
+                source_id: "wrong-source",
+                state: "preview_ready"
+              },
+              request: {
+                source_id: "sap-approved-spend",
+                state: "submitted"
+              }
+            })
+        }
+      },
+      {
+        expectedCopy: /preview_submission_unavailable/i,
+        response: {
+          ok: true,
+          json: () => Promise.reject(new SyntaxError("Unexpected token < in JSON"))
+        }
+      }
+    ] as const;
+
+    for (const failureCase of failureCases) {
+      cleanup();
+      const fetchMock = vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(workflowPayload())
+          });
+        }
+
+        if (url.endsWith("/requests/preview")) {
+          return Promise.resolve(failureCase.response);
+        }
+
+        return new Promise(() => {});
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      render(await HomePage({}));
+
+      fireEvent.change(screen.getByRole("combobox", { name: /source/i }), {
+        target: { value: "sap-approved-spend" }
+      });
+      fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(failureCase.expectedCopy);
+      expect(screen.queryByText(/preview request accepted/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
+    }
+  });
+
   it("renders preview API auth and entitlement failure envelopes without leaking details", async () => {
     const failureCases = [
       {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -495,7 +495,8 @@ describe("HomePage", () => {
       {
         expectedCopy: /preview_submission_unavailable/i,
         response: {
-          ok: true,
+          ok: false,
+          status: 503,
           json: () => Promise.reject(new SyntaxError("Unexpected token < in JSON"))
         }
       }

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -84,6 +84,17 @@ type PreviewSubmissionStatus =
       candidateState: string;
       requestState: string;
       sourceId: string;
+      status: "denied" | "pending";
+    }
+  | {
+      code: string;
+      message: string;
+      status: "malformed" | "unavailable";
+    }
+  | {
+      candidateState: string;
+      requestState: string;
+      sourceId: string;
       status: "succeeded";
     };
 
@@ -235,6 +246,37 @@ function parsePreviewSubmissionResult(
     requestState,
     sourceId: expectedSourceId
   };
+}
+
+function isPendingPreviewState(result: PreviewSubmissionResult): boolean {
+  const requestState = result.requestState.toLowerCase();
+  const candidateState = result.candidateState.toLowerCase();
+
+  return (
+    requestState === "pending" ||
+    requestState === "submitted" ||
+    candidateState === "pending" ||
+    candidateState === "pending_generation"
+  );
+}
+
+function isDeniedPreviewState(result: PreviewSubmissionResult): boolean {
+  const requestState = result.requestState.toLowerCase();
+  const candidateState = result.candidateState.toLowerCase();
+
+  return (
+    requestState === "blocked" ||
+    requestState === "review_denied" ||
+    requestState === "preview_denied" ||
+    candidateState === "blocked" ||
+    candidateState === "denied" ||
+    candidateState === "invalidated" ||
+    candidateState === "review_denied"
+  );
+}
+
+function isReadyPreviewState(result: PreviewSubmissionResult): boolean {
+  return result.candidateState.toLowerCase() === "preview_ready";
 }
 
 function resolveSourceBinding(
@@ -936,7 +978,17 @@ export function QueryWorkflowShell({
         headers,
         method: "POST"
       });
-      const payload = (await response.json()) as unknown;
+      let payload: unknown;
+      try {
+        payload = (await response.json()) as unknown;
+      } catch {
+        setPreviewSubmission({
+          code: "preview_submission_unavailable",
+          message: "Preview submission unavailable before an authoritative payload was returned.",
+          status: "unavailable"
+        });
+        return;
+      }
 
       if (!response.ok) {
         const error = parseApiErrorEnvelope(payload);
@@ -955,7 +1007,41 @@ export function QueryWorkflowShell({
         setPreviewSubmission({
           code: "malformed_preview_response",
           message: "Preview response did not match the submitted source binding.",
-          status: "failed"
+          status: "malformed"
+        });
+        return;
+      }
+
+      if (isDeniedPreviewState(result)) {
+        setSubmittedQuestion(submittedQuestionText);
+        setSubmittedSourceId(result.sourceId);
+        setSubmittedState("review_denied");
+        setPreviewSubmission({
+          candidateState: result.candidateState,
+          requestState: result.requestState,
+          sourceId: result.sourceId,
+          status: "denied"
+        });
+        return;
+      }
+
+      if (isPendingPreviewState(result) && !isReadyPreviewState(result)) {
+        setSubmittedQuestion(submittedQuestionText);
+        setSubmittedSourceId(result.sourceId);
+        setPreviewSubmission({
+          candidateState: result.candidateState,
+          requestState: result.requestState,
+          sourceId: result.sourceId,
+          status: "pending"
+        });
+        return;
+      }
+
+      if (!isReadyPreviewState(result)) {
+        setPreviewSubmission({
+          code: "malformed_preview_response",
+          message: "Preview response returned an unrecognized authoritative lifecycle state.",
+          status: "malformed"
         });
         return;
       }
@@ -973,7 +1059,7 @@ export function QueryWorkflowShell({
       setPreviewSubmission({
         code: "preview_submission_unavailable",
         message: "Preview submission transport is unavailable.",
-        status: "failed"
+        status: "unavailable"
       });
     }
   }
@@ -1148,7 +1234,38 @@ export function QueryWorkflowShell({
                   </p>
                 </div>
               ) : null}
+              {previewSubmission.status === "pending" ? (
+                <div className="state-callout state-callout-warning" role="status">
+                  <p className="state-callout-title">Preview generation pending</p>
+                  <p>
+                    Request state {previewSubmission.requestState}; candidate state{" "}
+                    {previewSubmission.candidateState}. The shell stays in query review until SQL
+                    preview is ready.
+                  </p>
+                </div>
+              ) : null}
+              {previewSubmission.status === "denied" ? (
+                <div className="state-callout state-callout-danger" role="status">
+                  <p className="state-callout-title">Preview denied</p>
+                  <p>
+                    Request state {previewSubmission.requestState}; candidate state{" "}
+                    {previewSubmission.candidateState}. No successful SQL preview is displayed.
+                  </p>
+                </div>
+              ) : null}
               {previewSubmission.status === "failed" ? (
+                <div className="state-callout state-callout-danger" role="alert">
+                  <p className="state-callout-title">{previewSubmission.code}</p>
+                  <p>{previewSubmission.message}</p>
+                </div>
+              ) : null}
+              {previewSubmission.status === "malformed" ? (
+                <div className="state-callout state-callout-danger" role="alert">
+                  <p className="state-callout-title">{previewSubmission.code}</p>
+                  <p>{previewSubmission.message}</p>
+                </div>
+              ) : null}
+              {previewSubmission.status === "unavailable" ? (
                 <div className="state-callout state-callout-danger" role="alert">
                   <p className="state-callout-title">{previewSubmission.code}</p>
                   <p>{previewSubmission.message}</p>


### PR DESCRIPTION
## Summary
- map authoritative preview submission states so pending and denied responses do not masquerade as successful SQL preview
- render distinct malformed and unavailable preview submission alerts
- add frontend regression coverage for pending, denied, malformed, and unavailable preview mappings

Closes #235

## Verification
- npm test -- app/page.test.tsx
- npm test
- python3 -m pytest tests/test_api_errors.py tests/test_dev_auth_preview_api.py tests/test_request_source_selection.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now shows distinct state-specific messages for preview lifecycle states (pending, denied) with detailed state info.

* **Bug Fixes**
  * Better error classification and messaging for malformed preview payloads and unavailable services.
  * JSON parsing failures are detected and surfaced as explicit unavailable/malformed statuses instead of generic success.

* **Tests**
  * Added preview-focused tests validating UI behavior across success, pending, denied, malformed, and unavailable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->