### PR TITLE
[M-6] Replace placeholder SQL preview with candidate payload

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -32,6 +32,8 @@ class OperatorWorkflowHistoryItem(BaseModel):
     source_label: str = Field(serialization_alias="sourceLabel")
     lifecycle_state: str = Field(serialization_alias="lifecycleState")
     occurred_at: datetime = Field(serialization_alias="occurredAt")
+    candidate_sql: Optional[str] = Field(default=None, serialization_alias="candidateSql")
+    request_id: Optional[str] = Field(default=None, serialization_alias="requestId")
     guard_status: Optional[str] = Field(default=None, serialization_alias="guardStatus")
     run_state: Optional[str] = Field(default=None, serialization_alias="runState")
 
@@ -146,6 +148,8 @@ def _build_operator_history(
                     candidate_events.get(candidate.candidate_id),
                     candidate.updated_at or candidate.created_at,
                 ),
+                candidate_sql=candidate.candidate_sql,
+                request_id=candidate.request_id,
                 guard_status=candidate.guard_status,
             )
         )

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -41,11 +41,15 @@ class PreviewSubmissionRequest(BaseModel):
 
 class RequestRecord(BaseModel):
     question: str
+    request_id: str
     source_id: str
     state: str
 
 
 class CandidateRecord(BaseModel):
+    candidate_id: str
+    candidate_sql: Optional[str]
+    guard_status: GuardStatus
     source_id: str
     source_family: str
     source_flavor: Optional[str]
@@ -359,7 +363,7 @@ def _persist_preview_submission_records(
     authenticated_subject: AuthenticatedSubject,
     audit_context: PreviewAuditContext | None,
     audit_events: list[SourceAwareAuditEvent],
-) -> None:
+) -> tuple[str, str]:
     request_id = (
         audit_context.request_id
         if audit_context is not None and audit_context.request_id.strip()
@@ -477,7 +481,7 @@ def _persist_preview_submission_records(
                 audit_events=audit_events,
             )
             session.commit()
-            return
+            return request_id, candidate_id
         except IntegrityError as exc:
             session.rollback()
             if attempt == 0:
@@ -657,7 +661,7 @@ def submit_preview_request(
             audit_context=audit_context,
         ),
     )
-    _persist_preview_submission_records(
+    request_id, candidate_id = _persist_preview_submission_records(
         session,
         payload=payload,
         resolved_source=resolved_source,
@@ -671,10 +675,14 @@ def submit_preview_request(
     return PreviewSubmissionResponse(
         request=RequestRecord(
             question=payload.question,
+            request_id=request_id,
             source_id=resolved_source.source_id,
             state="submitted",
         ),
         candidate=CandidateRecord(
+            candidate_id=candidate_id,
+            candidate_sql=None,
+            guard_status=PREVIEW_PENDING_GUARD_STATUS,
             source_id=resolved_source.source_id,
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,

--- a/backend/tests/test_candidate_source_metadata.py
+++ b/backend/tests/test_candidate_source_metadata.py
@@ -90,11 +90,15 @@ def test_preview_candidate_carries_authoritative_source_metadata() -> None:
             session,
         )
 
-    assert response.model_dump()["candidate"] == {
+    candidate = response.model_dump()["candidate"]
+    assert {
         "source_id": "sap-approved-spend",
         "source_family": "postgresql",
         "source_flavor": "warehouse",
         "dataset_contract_version": 3,
         "schema_snapshot_version": 7,
         "state": "preview_ready",
-    }
+        "candidate_sql": None,
+        "guard_status": "pending",
+    }.items() <= candidate.items()
+    assert candidate["candidate_id"]

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -223,6 +223,7 @@ def test_operator_workflow_history_is_built_from_preview_request_and_candidate_r
             "sourceLabel": "SAP spend cube / approved_vendor_spend",
             "lifecycleState": "preview_ready",
             "occurredAt": "2026-01-02T03:04:05Z",
+            "requestId": "preview-request-234",
             "guardStatus": "pending",
         },
         {

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -124,10 +124,14 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         )
 
         assert response.status_code == 200
+        response_payload = response.json()
         request_id = response.headers["X-Request-ID"]
-        response_candidate_id = response.json()["audit"]["events"][2][
-            "query_candidate_id"
-        ]
+        response_candidate_id = response_payload["audit"]["events"][2]["query_candidate_id"]
+
+        assert response_payload["request"]["request_id"] == request_id
+        assert response_payload["candidate"]["candidate_id"] == response_candidate_id
+        assert response_payload["candidate"]["guard_status"] == "pending"
+        assert response_payload["candidate"]["candidate_sql"] is None
 
         persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -322,16 +322,16 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         response_body = response.json()
-        self.assertEqual(
-            response_body["request"],
+        self.assertLessEqual(
             {
                 "question": "Show approved vendors by quarterly spend",
                 "source_id": "sap-approved-spend",
                 "state": "submitted",
-            },
+            }.items(),
+            response_body["request"].items(),
         )
-        self.assertEqual(
-            response_body["candidate"],
+        self.assertTrue(response_body["request"]["request_id"])
+        self.assertLessEqual(
             {
                 "source_id": "sap-approved-spend",
                 "source_family": "postgresql",
@@ -339,8 +339,12 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                 "dataset_contract_version": 1,
                 "schema_snapshot_version": 1,
                 "state": "preview_ready",
-            },
+                "candidate_sql": None,
+                "guard_status": "pending",
+            }.items(),
+            response_body["candidate"].items(),
         )
+        self.assertTrue(response_body["candidate"]["candidate_id"])
         self.assertEqual(
             response_body["evaluation"],
             {

--- a/backend/tests/test_source_bound_records.py
+++ b/backend/tests/test_source_bound_records.py
@@ -90,20 +90,32 @@ def test_preview_submission_binds_all_records_to_authoritative_source_id() -> No
             session,
         )
 
-    assert response.model_dump() == {
+    payload = response.model_dump()
+    assert {
+        "question": "Show approved vendors by quarterly spend",
+        "source_id": "sap-approved-spend",
+        "state": "submitted",
+    }.items() <= payload["request"].items()
+    assert payload["request"]["request_id"]
+    assert {
+        "source_id": "sap-approved-spend",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "dataset_contract_version": 1,
+        "schema_snapshot_version": 1,
+        "state": "preview_ready",
+        "candidate_sql": None,
+        "guard_status": "pending",
+    }.items() <= payload["candidate"].items()
+    assert payload["candidate"]["candidate_id"]
+    assert payload == {
         "request": {
             "question": "Show approved vendors by quarterly spend",
+            "request_id": payload["request"]["request_id"],
             "source_id": "sap-approved-spend",
             "state": "submitted",
         },
-        "candidate": {
-            "source_id": "sap-approved-spend",
-            "source_family": "postgresql",
-            "source_flavor": "warehouse",
-            "dataset_contract_version": 1,
-            "schema_snapshot_version": 1,
-            "state": "preview_ready",
-        },
+        "candidate": payload["candidate"],
         "audit": {
             "source_id": "sap-approved-spend",
             "state": "recorded",

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -317,6 +317,70 @@ describe("HomePage", () => {
     expect(screen.queryByText(/placeholder sql generated from the question review surface/i)).not.toBeInTheDocument();
   });
 
+  it("anchors reopened candidate previews to the URL history record", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select 'wrong candidate' as preview;",
+                    guardStatus: "blocked",
+                    itemType: "candidate",
+                    label: "Earlier blocked candidate",
+                    lifecycleState: "blocked",
+                    occurredAt: "2026-04-21T14:20:00Z",
+                    recordId: "candidate-wrong",
+                    requestId: "request-wrong",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Selected candidate",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-selected",
+                    requestId: "request-selected",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-selected",
+          question: "Selected candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    expect(screen.getByText("select vendor_name from approved_vendor_spend;")).toBeInTheDocument();
+    expect(screen.getByText("request-selected")).toBeInTheDocument();
+    expect(screen.getByText("candidate-selected")).toBeInTheDocument();
+    expect(screen.queryByText("select 'wrong candidate' as preview;")).not.toBeInTheDocument();
+  });
+
   it("submits the selected source and question to the preview API", async () => {
     const csrfToken = document.createElement("meta");
     csrfToken.name = "safequery-csrf-token";

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -312,7 +312,9 @@ describe("HomePage", () => {
 
     expect(screen.getByRole("heading", { name: /sql preview state/i })).toBeInTheDocument();
     expect(screen.getByDisplayValue("Show approved vendors by quarterly spend")).toBeInTheDocument();
-    expect(screen.getAllByText(/sql preview placeholder/i)).not.toHaveLength(0);
+    expect(screen.getByText(/authoritative sql preview/i)).toBeInTheDocument();
+    expect(screen.getByText(/no authoritative candidate selected/i)).toBeInTheDocument();
+    expect(screen.queryByText(/placeholder sql generated from the question review surface/i)).not.toBeInTheDocument();
   });
 
   it("submits the selected source and question to the preview API", async () => {
@@ -342,7 +344,10 @@ describe("HomePage", () => {
                 state: "recorded"
               },
               candidate: {
+                candidate_id: "candidate-accepted-123",
+                candidate_sql: null,
                 dataset_contract_version: 1,
+                guard_status: "pending",
                 schema_snapshot_version: 1,
                 source_family: "postgresql",
                 source_flavor: "warehouse",
@@ -355,6 +360,7 @@ describe("HomePage", () => {
               },
               request: {
                 question: "Show approved vendors by quarterly spend",
+                request_id: "request-accepted-123",
                 source_id: "sap-approved-spend",
                 state: "submitted"
               }
@@ -394,6 +400,9 @@ describe("HomePage", () => {
       );
     });
     expect(screen.getByText(/preview request accepted/i)).toBeInTheDocument();
+    expect(screen.getByText("candidate-accepted-123")).toBeInTheDocument();
+    expect(screen.getByText(/canonical sql has not been generated for this candidate/i)).toBeInTheDocument();
+    expect(screen.queryByText(/placeholder sql generated from the question review surface/i)).not.toBeInTheDocument();
   });
 
   it("maps authoritative preview API states without presenting them as successful SQL previews", async () => {
@@ -433,7 +442,10 @@ describe("HomePage", () => {
                   state: "recorded"
                 },
                 candidate: {
+                  candidate_id: `candidate-${stateCase.candidateState}`,
+                  candidate_sql: null,
                   dataset_contract_version: 1,
+                  guard_status: stateCase.candidateState === "denied" ? "blocked" : "pending",
                   schema_snapshot_version: 1,
                   source_family: "postgresql",
                   source_flavor: "warehouse",
@@ -446,6 +458,7 @@ describe("HomePage", () => {
                 },
                 request: {
                   question: "Show approved vendors by quarterly spend",
+                  request_id: `request-${stateCase.requestState}`,
                   source_id: "sap-approved-spend",
                   state: stateCase.requestState
                 }
@@ -660,8 +673,8 @@ describe("HomePage", () => {
         state: "review_denied",
         heading: /review denied state/i,
         status: /review denied before execution/i,
-        lifecycle: /candidate state/i,
-        identity: /candidate-sq-204/i
+        lifecycle: /lifecycle state/i,
+        identity: /^Draft only$/i
       },
       {
         state: "completed",
@@ -708,9 +721,9 @@ describe("HomePage", () => {
       expect(screen.getByRole("heading", { name: terminalState.heading })).toBeInTheDocument();
       expect(screen.getByText(terminalState.status)).toBeInTheDocument();
       expect(screen.getByText(/source identity/i)).toBeInTheDocument();
-      expect(screen.getByText(/request identity/i)).toBeInTheDocument();
+      expect(screen.getByText(/request (identity|posture)/i)).toBeInTheDocument();
       expect(screen.getByText(terminalState.lifecycle)).toBeInTheDocument();
-      expect(screen.getByText(terminalState.identity)).toBeInTheDocument();
+      expect(screen.getAllByText(terminalState.identity).length).toBeGreaterThan(0);
     }
   });
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -22,6 +22,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const config = getAppConfig();
   const question = readParam(params.question)?.trim() || "List the top 10 approved vendors by quarterly spend.";
   const sourceId = readParam(params.source_id)?.trim();
+  const historyRecordId = readParam(params.history_record_id)?.trim();
   const state = resolveWorkflowState(readParam(params.state));
   const operatorWorkflow = await getOperatorWorkflowSnapshot(config.apiInternalBaseUrl);
 
@@ -31,6 +32,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
       health={DEFAULT_HEALTH_SNAPSHOT}
       operatorWorkflow={operatorWorkflow}
       question={question}
+      historyRecordId={historyRecordId}
       sourceId={sourceId}
       state={state}
     />

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -50,6 +50,7 @@ type StateDefinition = {
 type WorkflowContext = {
   candidateIdentity?: string;
   candidateState?: string;
+  guardStatus?: string;
   lifecycleTimestamp?: string;
   requestIdentity?: string;
   runIdentity?: string;
@@ -99,9 +100,23 @@ type PreviewSubmissionStatus =
     };
 
 type PreviewSubmissionResult = {
+  candidateId: string;
+  candidateSql: string | null;
   candidateState: string;
+  guardStatus: string;
+  requestId: string;
   requestState: string;
   sourceId: string;
+};
+
+type AuthoritativeCandidatePreview = {
+  candidateId: string;
+  candidateSql: string | null;
+  candidateState: string;
+  guardStatus: string;
+  requestId?: string;
+  sourceId: string;
+  sourceLabel?: string;
 };
 
 type ApiErrorEnvelope = {
@@ -131,7 +146,7 @@ const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
     label: "Failed"
   },
   preview: {
-    description: "The operator request has been staged for governed review with generated SQL still in placeholder mode.",
+    description: "The operator request has been staged for governed candidate review.",
     label: "SQL preview"
   },
   query: {
@@ -228,13 +243,24 @@ function parsePreviewSubmissionResult(
   }
 
   const requestSourceId = readRequiredString(value.request.source_id);
+  const requestId = readRequiredString(value.request.request_id);
   const candidateSourceId = readRequiredString(value.candidate.source_id);
+  const candidateId = readRequiredString(value.candidate.candidate_id);
+  const candidateSql =
+    typeof value.candidate.candidate_sql === "string" &&
+    value.candidate.candidate_sql.trim().length > 0
+      ? value.candidate.candidate_sql
+      : null;
+  const guardStatus = readRequiredString(value.candidate.guard_status);
   const requestState = readRequiredString(value.request.state);
   const candidateState = readRequiredString(value.candidate.state);
 
   if (
+    !requestId ||
     requestSourceId !== expectedSourceId ||
+    !candidateId ||
     candidateSourceId !== expectedSourceId ||
+    !guardStatus ||
     !requestState ||
     !candidateState
   ) {
@@ -242,7 +268,11 @@ function parsePreviewSubmissionResult(
   }
 
   return {
+    candidateId,
+    candidateSql,
     candidateState,
+    guardStatus,
+    requestId,
     requestState,
     sourceId: expectedSourceId
   };
@@ -445,31 +475,82 @@ function buildStateHref(
   return `/?${params.toString()}`;
 }
 
-function getSqlPreview(question: string): string {
-  return [
-    "-- placeholder SQL generated from the question review surface",
-    "SELECT vendor_name, SUM(quarterly_spend) AS quarterly_spend",
-    "FROM approved_vendor_spend",
-    `WHERE review_prompt = '${question.replace(/'/g, "''")}'`,
-    "GROUP BY vendor_name",
-    "ORDER BY quarterly_spend DESC",
-    "LIMIT 10;"
-  ].join("\n");
+function findAuthoritativeCandidatePreview(
+  history: OperatorHistoryItem[],
+  sourceId?: string,
+  historyRecordId?: string
+): AuthoritativeCandidatePreview | null {
+  const candidates = history.filter(
+    (item) =>
+      item.itemType === "candidate" &&
+      (!sourceId || item.sourceId === sourceId) &&
+      (!historyRecordId || item.recordId === historyRecordId)
+  );
+  const candidate = candidates[0];
+  if (!candidate) {
+    return null;
+  }
+
+  return {
+    candidateId: candidate.recordId,
+    candidateSql: candidate.candidateSql ?? null,
+    candidateState: candidate.lifecycleState,
+    guardStatus: candidate.guardStatus ?? "pending",
+    requestId: candidate.requestId ?? undefined,
+    sourceId: candidate.sourceId,
+    sourceLabel: candidate.sourceLabel
+  };
+}
+
+function renderCandidateSqlPreview(preview: AuthoritativeCandidatePreview | null) {
+  if (!preview) {
+    return (
+      <div className="placeholder-block">
+        <p className="placeholder-title">No authoritative candidate selected</p>
+        <p>
+          Submit the question for preview or reopen a candidate history row before SQL preview can
+          be shown.
+        </p>
+      </div>
+    );
+  }
+
+  if (!preview.candidateSql) {
+    return (
+      <div className="placeholder-block">
+        <p className="placeholder-title">Canonical SQL pending</p>
+        <p>Canonical SQL has not been generated for this candidate.</p>
+      </div>
+    );
+  }
+
+  return (
+    <pre className="sql-preview">
+      <code>{preview.candidateSql}</code>
+    </pre>
+  );
 }
 
 function getWorkflowContext(
   state: CanonicalWorkflowState,
-  source?: SourceOption
+  source?: SourceOption,
+  candidatePreview?: AuthoritativeCandidatePreview | null
 ): WorkflowContext {
-  const sourceIdentity = source?.displayLabel ?? "No source selected yet";
-  const requestIdentity = "req-sq-204";
+  const sourceIdentity =
+    candidatePreview?.sourceLabel ?? source?.displayLabel ?? "No source selected yet";
+
+  if (candidatePreview && (state === "preview" || state === "review_denied")) {
+    return {
+      candidateIdentity: candidatePreview.candidateId,
+      candidateState: candidatePreview.candidateState,
+      guardStatus: candidatePreview.guardStatus,
+      requestIdentity: candidatePreview.requestId,
+      sourceIdentity
+    };
+  }
 
   if (state === "preview" || state === "review_denied") {
     return {
-      candidateIdentity: "candidate-sq-204",
-      candidateState: state === "review_denied" ? "guard_denied" : "preview_ready",
-      lifecycleTimestamp: state === "review_denied" ? "2026-04-21 14:24 JST" : "2026-04-21 14:18 JST",
-      requestIdentity,
       sourceIdentity
     };
   }
@@ -481,8 +562,6 @@ function getWorkflowContext(
   }
 
   return {
-    candidateIdentity: "candidate-sq-204",
-    candidateState: "approved_previewed",
     lifecycleTimestamp:
       state === "completed"
         ? "2026-04-21 14:32 JST"
@@ -493,7 +572,6 @@ function getWorkflowContext(
             : state === "failed"
               ? "2026-04-21 14:35 JST"
               : "2026-04-21 14:33 JST",
-    requestIdentity,
     runIdentity: "run-sq-204",
     runState:
       state === "completed"
@@ -578,7 +656,7 @@ function getGuardCopy(state: CanonicalWorkflowState): string {
     return "Cancellation is distinct from denial and failure. The shell preserves run lineage and lifecycle context so the operator can see that execution started but did not finish.";
   }
 
-  return "The first shell stops at review boundaries. No real auth, SQL generation, or execution path is trusted in this issue.";
+  return "The shell stops at review boundaries unless an authoritative candidate record supplies guard posture and SQL preview data.";
 }
 
 function getResultTitle(state: CanonicalWorkflowState): string {
@@ -903,6 +981,8 @@ export function QueryWorkflowShell({
   const [previewSubmission, setPreviewSubmission] = useState<PreviewSubmissionStatus>({
     status: "idle"
   });
+  const [submittedCandidatePreview, setSubmittedCandidatePreview] =
+    useState<AuthoritativeCandidatePreview | null>(null);
   const [submittedQuestion, setSubmittedQuestion] = useState(question);
   const [submittedSourceId, setSubmittedSourceId] = useState(sourceId);
   const [submittedState, setSubmittedState] = useState(requestedState);
@@ -912,6 +992,7 @@ export function QueryWorkflowShell({
     setSubmittedSourceId(sourceId);
     setSubmittedState(requestedState);
     setPreviewSubmission({ status: "idle" });
+    setSubmittedCandidatePreview(null);
   }, [question, requestedState, sourceId]);
 
   const sourceBinding = resolveSourceBinding(
@@ -920,11 +1001,19 @@ export function QueryWorkflowShell({
     submittedSourceId
   );
   const normalizedState = sourceBinding.state;
-  const sqlPreview = getSqlPreview(submittedQuestion);
   const activeState = workflowStates[normalizedState];
   const queryLocked = normalizedState === "signin" || previewSubmission.status === "submitting";
   const guardTone = getGuardTone(normalizedState);
-  const workflowContext = getWorkflowContext(normalizedState, sourceBinding.source);
+  const historyCandidatePreview = findAuthoritativeCandidatePreview(
+    operatorWorkflow.history,
+    submittedSourceId
+  );
+  const candidatePreview = submittedCandidatePreview ?? historyCandidatePreview;
+  const workflowContext = getWorkflowContext(
+    normalizedState,
+    sourceBinding.source,
+    candidatePreview
+  );
   const sourceSelectVisible = normalizedState === "query";
   const boundSourceId = sourceBinding.source?.sourceId;
 
@@ -1016,6 +1105,15 @@ export function QueryWorkflowShell({
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
         setSubmittedState("review_denied");
+        setSubmittedCandidatePreview({
+          candidateId: result.candidateId,
+          candidateSql: result.candidateSql,
+          candidateState: result.candidateState,
+          guardStatus: result.guardStatus,
+          requestId: result.requestId,
+          sourceId: result.sourceId,
+          sourceLabel: selectedSource.displayLabel
+        });
         setPreviewSubmission({
           candidateState: result.candidateState,
           requestState: result.requestState,
@@ -1028,6 +1126,15 @@ export function QueryWorkflowShell({
       if (isPendingPreviewState(result) && !isReadyPreviewState(result)) {
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
+        setSubmittedCandidatePreview({
+          candidateId: result.candidateId,
+          candidateSql: result.candidateSql,
+          candidateState: result.candidateState,
+          guardStatus: result.guardStatus,
+          requestId: result.requestId,
+          sourceId: result.sourceId,
+          sourceLabel: selectedSource.displayLabel
+        });
         setPreviewSubmission({
           candidateState: result.candidateState,
           requestState: result.requestState,
@@ -1049,6 +1156,15 @@ export function QueryWorkflowShell({
       setSubmittedQuestion(submittedQuestionText);
       setSubmittedSourceId(result.sourceId);
       setSubmittedState("preview");
+      setSubmittedCandidatePreview({
+        candidateId: result.candidateId,
+        candidateSql: result.candidateSql,
+        candidateState: result.candidateState,
+        guardStatus: result.guardStatus,
+        requestId: result.requestId,
+        sourceId: result.sourceId,
+        sourceLabel: selectedSource.displayLabel
+      });
       setPreviewSubmission({
         candidateState: result.candidateState,
         requestState: result.requestState,
@@ -1295,13 +1411,11 @@ export function QueryWorkflowShell({
             <div className="section-header">
               <div>
                 <p className="eyebrow">Generated SQL</p>
-                <h2 className="panel-title">SQL preview placeholder</h2>
+                <h2 className="panel-title">Authoritative SQL preview</h2>
               </div>
               <span className="surface-badge surface-badge-code">Preview</span>
             </div>
-            <pre className="sql-preview">
-              <code>{sqlPreview}</code>
-            </pre>
+            {renderCandidateSqlPreview(candidatePreview)}
           </section>
 
           <section className="surface surface-secondary">
@@ -1335,6 +1449,12 @@ export function QueryWorkflowShell({
                 </span>
                 <strong>{workflowContext.candidateState ?? "drafting"}</strong>
               </div>
+              {workflowContext.guardStatus ? (
+                <div className="guard-item">
+                  <span className="meta-label">Guard status</span>
+                  <strong>{workflowContext.guardStatus}</strong>
+                </div>
+              ) : null}
               {workflowContext.runIdentity ? (
                 <>
                   <div className="guard-item">
@@ -1371,8 +1491,8 @@ export function QueryWorkflowShell({
                 <strong>Placeholder only</strong>
               </div>
               <div className="guard-item">
-                <span className="meta-label">Approval record</span>
-                <strong>Not yet wired</strong>
+                <span className="meta-label">Candidate guard</span>
+                <strong>{candidatePreview?.guardStatus ?? "No candidate record"}</strong>
               </div>
               <div className="guard-item">
                 <span className="meta-label">Execution path</span>

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -36,6 +36,7 @@ type CanonicalWorkflowState =
 type QueryWorkflowShellProps = {
   apiUrl: string;
   health: HealthSnapshot;
+  historyRecordId?: string;
   operatorWorkflow: OperatorWorkflowSnapshot;
   question: string;
   sourceId?: string;
@@ -972,6 +973,7 @@ function renderStatePanel(
 export function QueryWorkflowShell({
   apiUrl,
   health,
+  historyRecordId,
   operatorWorkflow,
   question,
   sourceId,
@@ -1006,7 +1008,8 @@ export function QueryWorkflowShell({
   const guardTone = getGuardTone(normalizedState);
   const historyCandidatePreview = findAuthoritativeCandidatePreview(
     operatorWorkflow.history,
-    submittedSourceId
+    submittedSourceId,
+    historyRecordId
   );
   const candidatePreview = submittedCandidatePreview ?? historyCandidatePreview;
   const workflowContext = getWorkflowContext(

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -10,12 +10,14 @@ export type SourceOption = {
 };
 
 export type OperatorHistoryItem = {
+  candidateSql?: string | null;
   guardStatus?: string | null;
   itemType: "request" | "candidate" | "run";
   label: string;
   lifecycleState: string;
   occurredAt: string;
   recordId: string;
+  requestId?: string | null;
   runState?: string | null;
   sourceId: string;
   sourceLabel: string;
@@ -101,12 +103,14 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   }
 
   return {
+    candidateSql: readOptionalString(value.candidateSql) ?? null,
     guardStatus: readOptionalString(value.guardStatus) ?? null,
     itemType,
     label,
     lifecycleState,
     occurredAt,
     recordId,
+    requestId: readOptionalString(value.requestId) ?? null,
     runState: readOptionalString(value.runState) ?? null,
     sourceId,
     sourceLabel


### PR DESCRIPTION
## Summary
- expose request/candidate identifiers, candidate SQL, and guard status in the preview response
- carry candidate SQL and request linkage through operator workflow history
- replace synthetic frontend SQL preview with authoritative candidate preview rendering and explicit pending/no-candidate states

## Verification
- frontend: npm test -- --run
- backend: python3 -m pytest

Closes #236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview submissions now include generated request and candidate identifiers for improved tracking and reference.
  * SQL preview displays authoritative candidate SQL when available (nullable otherwise), replacing placeholder content.
  * Guard status is now tracked and displayed for each preview candidate.
  * Operator workflow history now surfaces request identifiers and links to the authoritative candidate preview for improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->