### PR TITLE
Preserve preview fail-closed API states

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -19,6 +19,8 @@ _SAFE_API_ERROR_CODES = frozenset(
         "session_invalid",
         "csrf_failed",
         "entitlement_denied",
+        "preview_source_malformed",
+        "preview_source_unavailable",
     }
 )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -265,6 +265,12 @@ def create_app() -> FastAPI:
                 audit_events=_serialize_entitlement_denial_audit_events(exc),
             ) from exc
         except PreviewSubmissionContractError as exc:
+            if exc.public_code is not None and exc.public_message is not None:
+                raise api_error(
+                    422,
+                    exc.public_code,
+                    exc.public_message,
+                ) from exc
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     @app.get("/operator/workflow", response_model=OperatorWorkflowSnapshot)

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -79,6 +79,17 @@ class PreviewSubmissionResponse(BaseModel):
 class PreviewSubmissionContractError(ValueError):
     """Raised when a preview submission does not carry an executable source binding."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        public_code: str | None = None,
+        public_message: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.public_code = public_code
+        self.public_message = public_message
+
 
 class PreviewSubmissionEntitlementError(PreviewSubmissionContractError, PermissionError):
     """Raised when an authenticated subject lacks source execution entitlement."""
@@ -616,7 +627,19 @@ def submit_preview_request(
                     else "preview_unavailable"
                 ),
             )
-            raise PreviewSubmissionContractError(str(exc)) from exc
+            raise PreviewSubmissionContractError(
+                str(exc),
+                public_code=(
+                    "preview_source_malformed"
+                    if isinstance(exc.__cause__, ValueError)
+                    else "preview_source_unavailable"
+                ),
+                public_message=(
+                    "Selected source governance is malformed."
+                    if isinstance(exc.__cause__, ValueError)
+                    else "Selected source is unavailable for preview."
+                ),
+            ) from exc
         _enrich_preview_audit_context(
             audit_context,
             authenticated_subject=authenticated_subject,

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -394,6 +394,12 @@ def test_http_preview_unavailable_source_persists_audit_event() -> None:
         )
 
         assert response.status_code == 422
+        assert response.json() == {
+            "error": {
+                "code": "preview_source_unavailable",
+                "message": "Selected source is unavailable for preview.",
+            }
+        }
         request_id = response.headers["X-Request-ID"]
         persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_event = session.execute(select(PreviewAuditEvent)).scalar_one()

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -245,8 +245,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             response.json(),
             {
                 "error": {
-                    "code": "invalid_request",
-                    "message": "Request validation failed.",
+                    "code": "preview_source_unavailable",
+                    "message": "Selected source is unavailable for preview.",
                 }
             },
         )
@@ -301,8 +301,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             response.json(),
             {
                 "error": {
-                    "code": "invalid_request",
-                    "message": "Request validation failed.",
+                    "code": "preview_source_malformed",
+                    "message": "Selected source governance is malformed.",
                 }
             },
         )

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -576,6 +576,34 @@ describe("HomePage", () => {
           status: 503,
           json: () => Promise.reject(new SyntaxError("Unexpected token < in JSON"))
         }
+      },
+      {
+        expectedCopy: /preview_source_unavailable/i,
+        response: {
+          ok: false,
+          status: 422,
+          json: () =>
+            Promise.resolve({
+              error: {
+                code: "preview_source_unavailable",
+                message: "Selected source is unavailable for preview."
+              }
+            })
+        }
+      },
+      {
+        expectedCopy: /preview_source_malformed/i,
+        response: {
+          ok: false,
+          status: 422,
+          json: () =>
+            Promise.resolve({
+              error: {
+                code: "preview_source_malformed",
+                message: "Selected source governance is malformed."
+              }
+            })
+        }
       }
     ] as const;
 

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -235,6 +235,33 @@ function parseApiErrorEnvelope(value: unknown): ApiErrorEnvelope | null {
   return { code, message };
 }
 
+function previewSubmissionStatusForApiError(
+  error: ApiErrorEnvelope | null
+): PreviewSubmissionStatus {
+  if (error?.code === "preview_source_malformed") {
+    return {
+      code: error.code,
+      message: error.message,
+      status: "malformed"
+    };
+  }
+
+  if (error?.code === "preview_source_unavailable") {
+    return {
+      code: error.code,
+      message: error.message,
+      status: "unavailable"
+    };
+  }
+
+  return {
+    code: error?.code ?? "preview_submission_failed",
+    message:
+      error?.message ?? "Preview submission failed before an authoritative candidate was returned.",
+    status: "failed"
+  };
+}
+
 function parsePreviewSubmissionResult(
   value: unknown,
   expectedSourceId: string
@@ -1084,13 +1111,7 @@ export function QueryWorkflowShell({
 
       if (!response.ok) {
         const error = parseApiErrorEnvelope(payload);
-        setPreviewSubmission({
-          code: error?.code ?? "preview_submission_failed",
-          message:
-            error?.message ??
-            "Preview submission failed before an authoritative candidate was returned.",
-          status: "failed"
-        });
+        setPreviewSubmission(previewSubmissionStatusForApiError(error));
         return;
       }
 


### PR DESCRIPTION
## Summary
- expose safe preview_source_unavailable and preview_source_malformed envelopes for persisted fail-closed preview submissions
- keep generic contract errors sanitized as invalid_request
- map the new frontend API codes to existing unavailable and malformed preview submission states

## Tests
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_request_source_selection.py tests/test_api_errors.py
- cd frontend && npm test

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Preview submission failures now display specific error messages distinguishing between unavailable sources and malformed source configurations, replacing generic validation errors with clearer, actionable guidance for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->