### PR TITLE
[N-1] Add SQL generation adapter provider boundary

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,7 +2,9 @@ from functools import lru_cache
 from typing import Annotated, Literal, Optional
 
 from pydantic import (
+    AnyHttpUrl,
     BaseModel,
+    ConfigDict,
     Field,
     PostgresDsn,
     SecretStr,
@@ -26,6 +28,21 @@ class BusinessMssqlSourceSettings(BaseModel):
     connection_string: str
 
 
+SQLGenerationProvider = Literal["disabled", "local_llm", "vanna"]
+
+
+class SQLGenerationSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: SQLGenerationProvider = "disabled"
+    local_llm_base_url: Optional[AnyHttpUrl] = None
+    local_llm_model: Optional[str] = None
+    vanna_base_url: Optional[AnyHttpUrl] = None
+    vanna_model: Optional[str] = None
+    vanna_api_key: Optional[SecretStr] = None
+    timeout_seconds: int = Field(default=30, ge=1, le=300)
+
+
 class SourceRoleTelemetry(BaseModel):
     application_postgres_persistence: Literal["configured"] = "configured"
     business_postgres_source_generation: Literal["configured", "unconfigured"]
@@ -46,6 +63,13 @@ class Settings(BaseSettings):
     session_signing_key: Optional[SecretStr] = None
     business_postgres_source_url: Optional[PostgresDsn] = None
     business_mssql_source_connection_string: Optional[str] = None
+    sql_generation_provider: SQLGenerationProvider = "disabled"
+    sql_generation_local_llm_base_url: Optional[AnyHttpUrl] = None
+    sql_generation_local_llm_model: Optional[str] = None
+    sql_generation_vanna_base_url: Optional[AnyHttpUrl] = None
+    sql_generation_vanna_model: Optional[str] = None
+    sql_generation_vanna_api_key: Optional[SecretStr] = None
+    sql_generation_timeout_seconds: int = Field(default=30, ge=1, le=300)
     cors_origins: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["http://localhost:3000"]
     )
@@ -66,8 +90,40 @@ class Settings(BaseSettings):
 
         return value
 
+    @field_validator(
+        "business_mssql_source_connection_string",
+        "sql_generation_local_llm_model",
+        "sql_generation_vanna_model",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_optional_text(cls, value: object) -> object:
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+
+        return value
+
+    @field_validator("sql_generation_vanna_api_key")
+    @classmethod
+    def _reject_placeholder_vanna_api_key(
+        cls,
+        value: Optional[SecretStr],
+    ) -> Optional[SecretStr]:
+        if value is None:
+            return value
+
+        normalized = value.get_secret_value().strip().lower()
+        if normalized in {"change-me", "changeme", "todo", "placeholder", "example"}:
+            raise ValueError(
+                "SAFEQUERY_SQL_GENERATION_VANNA_API_KEY must come from a trusted "
+                "credential source, not a placeholder value."
+            )
+
+        return value
+
     @model_validator(mode="after")
-    def _validate_distinct_postgres_roles(self) -> "Settings":
+    def _validate_distinct_postgres_roles_and_generation_provider(self) -> "Settings":
         if self.dev_auth_enabled and self.environment not in {"development", "test"}:
             raise ValueError(
                 "SAFEQUERY_DEV_AUTH_ENABLED is only allowed when "
@@ -79,6 +135,24 @@ class Settings(BaseSettings):
             raise ValueError(
                 "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must not reuse "
                 "SAFEQUERY_APP_POSTGRES_URL."
+            )
+
+        if (
+            self.sql_generation_provider == "local_llm"
+            and self.sql_generation_local_llm_base_url is None
+        ):
+            raise ValueError(
+                "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL must be configured "
+                "when SAFEQUERY_SQL_GENERATION_PROVIDER=local_llm."
+            )
+
+        if (
+            self.sql_generation_provider == "vanna"
+            and self.sql_generation_vanna_base_url is None
+        ):
+            raise ValueError(
+                "SAFEQUERY_SQL_GENERATION_VANNA_BASE_URL must be configured "
+                "when SAFEQUERY_SQL_GENERATION_PROVIDER=vanna."
             )
 
         return self
@@ -112,6 +186,18 @@ class Settings(BaseSettings):
 
         return BusinessMssqlSourceSettings(
             connection_string=normalized_connection_string
+        )
+
+    @property
+    def sql_generation(self) -> SQLGenerationSettings:
+        return SQLGenerationSettings(
+            provider=self.sql_generation_provider,
+            local_llm_base_url=self.sql_generation_local_llm_base_url,
+            local_llm_model=self.sql_generation_local_llm_model,
+            vanna_base_url=self.sql_generation_vanna_base_url,
+            vanna_model=self.sql_generation_vanna_model,
+            vanna_api_key=self.sql_generation_vanna_api_key,
+            timeout_seconds=self.sql_generation_timeout_seconds,
         )
 
     def source_posture_telemetry(self) -> SourcePostureTelemetry:

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -300,7 +300,8 @@ def run_mssql_core_vertical_slice(
         event_type="generation_requested",
     )
 
-    canonical_sql = sql_generation_adapter.generate_sql(adapter_request)
+    adapter_response = sql_generation_adapter.generate_sql(adapter_request)
+    canonical_sql = adapter_response.candidate_sql
     generated = GeneratedMSSQLCandidate(
         canonical_sql=canonical_sql,
         source=candidate_source,

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -319,7 +319,8 @@ def run_postgresql_core_vertical_slice(
         event_type="generation_requested",
     )
 
-    canonical_sql = sql_generation_adapter.generate_sql(adapter_request)
+    adapter_response = sql_generation_adapter.generate_sql(adapter_request)
+    canonical_sql = adapter_response.candidate_sql
     generated = GeneratedPostgreSQLCandidate(
         canonical_sql=canonical_sql,
         source=candidate_source,

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -6,6 +6,7 @@ from typing import Optional, Protocol
 from pydantic import (
     BaseModel,
     ConfigDict,
+    SecretStr,
     StringConstraints,
     ValidationError,
     model_validator,
@@ -110,6 +111,7 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
     adapter_version: NonEmptyTrimmedString
     base_url: NonEmptyTrimmedString
     model: Optional[NonEmptyTrimmedString] = None
+    api_key: Optional[SecretStr] = None
     timeout_seconds: int
 
     def generate_sql(
@@ -172,6 +174,7 @@ def resolve_sql_generation_adapter(
             adapter_version="vanna.v1",
             base_url=str(generation_settings.vanna_base_url),
             model=generation_settings.vanna_model,
+            api_key=generation_settings.vanna_api_key,
             timeout_seconds=generation_settings.timeout_seconds,
         )
 

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Optional, Protocol
 
 from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
 from typing_extensions import Annotated
 
+from app.core.config import SQLGenerationProvider, SQLGenerationSettings
 from app.services.generation_context import PreparedGenerationContext
 
 
@@ -63,9 +65,107 @@ class SQLGenerationAdapterRequest(BaseModel):
         return self
 
 
+class SQLGenerationAdapterResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_sql: NonEmptyTrimmedString
+    provider: SQLGenerationProvider
+    adapter_version: NonEmptyTrimmedString
+    model: Optional[NonEmptyTrimmedString] = None
+
+
+class SQLGenerationAdapterError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: NonEmptyTrimmedString
+    message: NonEmptyTrimmedString
+    provider: Optional[SQLGenerationProvider] = None
+    retryable: bool = False
+
+
+class SQLGenerationAdapterConfigurationError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
 class SQLGenerationAdapter(Protocol):
-    def generate_sql(self, request: SQLGenerationAdapterRequest) -> str:
+    def generate_sql(
+        self,
+        request: SQLGenerationAdapterRequest,
+    ) -> SQLGenerationAdapterResponse:
         """Generate SQL from the adapter-safe request projection."""
+
+
+class ConfiguredSQLGenerationAdapter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: NonEmptyTrimmedString
+    adapter_version: NonEmptyTrimmedString
+    base_url: NonEmptyTrimmedString
+    model: Optional[NonEmptyTrimmedString] = None
+    timeout_seconds: int
+
+    def generate_sql(
+        self,
+        request: SQLGenerationAdapterRequest,
+    ) -> SQLGenerationAdapterResponse:
+        raise NotImplementedError(
+            "Concrete SQL generation provider dispatch is not implemented yet."
+        )
+
+
+def _settings_from_mapping(settings: Mapping[str, object]) -> SQLGenerationSettings:
+    return SQLGenerationSettings.model_validate(settings)
+
+
+def resolve_sql_generation_adapter(
+    settings: SQLGenerationSettings | Mapping[str, object],
+) -> SQLGenerationAdapter:
+    generation_settings = (
+        _settings_from_mapping(settings)
+        if isinstance(settings, Mapping)
+        else settings
+    )
+
+    if generation_settings.provider == "disabled":
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_disabled",
+            "SQL generation is disabled; no adapter can be used for candidate generation.",
+        )
+
+    if generation_settings.provider == "local_llm":
+        if generation_settings.local_llm_base_url is None:
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_local_llm_misconfigured",
+                "Local LLM SQL generation requires a configured base URL.",
+            )
+        return ConfiguredSQLGenerationAdapter(
+            provider="local_llm",
+            adapter_version="local_llm.v1",
+            base_url=str(generation_settings.local_llm_base_url),
+            model=generation_settings.local_llm_model,
+            timeout_seconds=generation_settings.timeout_seconds,
+        )
+
+    if generation_settings.provider == "vanna":
+        if generation_settings.vanna_base_url is None:
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_vanna_misconfigured",
+                "Vanna SQL generation requires a configured base URL.",
+            )
+        return ConfiguredSQLGenerationAdapter(
+            provider="vanna",
+            adapter_version="vanna.v1",
+            base_url=str(generation_settings.vanna_base_url),
+            model=generation_settings.vanna_model,
+            timeout_seconds=generation_settings.timeout_seconds,
+        )
+
+    raise SQLGenerationAdapterConfigurationError(
+        "sql_generation_provider_unknown",
+        "SQL generation provider selection is not recognized.",
+    )
 
 
 def build_sql_generation_adapter_request(

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Optional, Protocol
 
-from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    StringConstraints,
+    ValidationError,
+    model_validator,
+)
 from typing_extensions import Annotated
 
 from app.core.config import SQLGenerationProvider, SQLGenerationSettings
@@ -110,13 +116,20 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
         self,
         request: SQLGenerationAdapterRequest,
     ) -> SQLGenerationAdapterResponse:
-        raise NotImplementedError(
-            "Concrete SQL generation provider dispatch is not implemented yet."
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_provider_not_implemented",
+            f"Provider '{self.provider}' is configured but dispatch is not implemented.",
         )
 
 
 def _settings_from_mapping(settings: Mapping[str, object]) -> SQLGenerationSettings:
-    return SQLGenerationSettings.model_validate(settings)
+    try:
+        return SQLGenerationSettings.model_validate(settings)
+    except ValidationError as exc:
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_settings_invalid",
+            "SQL generation adapter settings are invalid.",
+        ) from exc
 
 
 def resolve_sql_generation_adapter(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -80,6 +80,8 @@ class SettingsTestCase(unittest.TestCase):
             _env_prefix="SAFEQUERY_",
         )
 
+        self.assertEqual(settings.sql_generation.provider, "disabled")
+
         with self.assertRaisesRegex(
             RuntimeError, "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"
         ):
@@ -89,6 +91,60 @@ class SettingsTestCase(unittest.TestCase):
             RuntimeError, "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING"
         ):
             settings.require_business_mssql_source()
+
+    def test_sql_generation_provider_settings_select_local_llm_without_source_credentials(
+        self,
+    ) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            sql_generation_provider="local_llm",
+            sql_generation_local_llm_base_url="http://local-llm:8080",
+            sql_generation_local_llm_model="safequery-local-sql",
+            business_postgres_source_url=(
+                "postgresql://source_reader:read-only@pg-source:5432/business"
+            ),
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        self.assertEqual(settings.sql_generation.provider, "local_llm")
+        self.assertEqual(
+            str(settings.sql_generation.local_llm_base_url),
+            "http://local-llm:8080/",
+        )
+        self.assertEqual(
+            settings.sql_generation.local_llm_model,
+            "safequery-local-sql",
+        )
+        dumped = settings.sql_generation.model_dump(mode="json", exclude_none=True)
+        self.assertNotIn("business_postgres_source_url", dumped)
+        self.assertNotIn("business_mssql_source_connection_string", dumped)
+
+    def test_sql_generation_provider_fails_closed_when_selected_without_endpoint(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL must be configured",
+        ):
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                sql_generation_provider="local_llm",
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
+
+    def test_sql_generation_vanna_provider_requires_endpoint(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_SQL_GENERATION_VANNA_BASE_URL must be configured",
+        ):
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                sql_generation_provider="vanna",
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
 
     def test_business_postgres_source_must_not_reuse_app_postgres_url(self) -> None:
         with self.assertRaisesRegex(

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -59,6 +59,7 @@ from app.services.candidate_lifecycle import (
     SourceBoundCandidateMetadata,
     revalidate_candidate_lifecycle,
 )
+from app.services.sql_generation_adapter import SQLGenerationAdapterResponse
 
 
 MSSQL_TEST_CONNECTION_STRING = (
@@ -77,6 +78,15 @@ POSTGRESQL_TEST_URL = (
 APPLICATION_POSTGRESQL_TEST_URL = (
     "postgresql://placeholder_user:placeholder_password@app-postgres:5432/safequery"
 )
+
+
+def _adapter_response(canonical_sql: str) -> SQLGenerationAdapterResponse:
+    return SQLGenerationAdapterResponse(
+        candidate_sql=canonical_sql,
+        provider="local_llm",
+        adapter_version="test.local_llm.v1",
+        model="safequery-test-sql",
+    )
 
 
 def _mssql_scenarios_by_id() -> dict[str, MSSQLEvaluationScenario]:
@@ -404,7 +414,7 @@ def test_mssql_core_vertical_slice_submits_generates_guards_executes_and_audits(
     class RecordingAdapter:
         def generate_sql(self, request):
             captured["adapter_request"] = request
-            return scenario.expected.canonical_sql
+            return _adapter_response(scenario.expected.canonical_sql)
 
     def fake_query_runner(
         *,
@@ -551,7 +561,7 @@ def test_mssql_core_vertical_slice_denies_guard_rejection_before_execution() -> 
 
     class DeniedAdapter:
         def generate_sql(self, request):
-            return scenario.canonical_sql
+            return _adapter_response(scenario.canonical_sql)
 
     def fake_query_runner(**_: object) -> list[dict[str, object]]:
         raise AssertionError("MSSQL execution must not run after a guard rejection")
@@ -613,7 +623,7 @@ def test_mssql_core_vertical_slice_applies_runtime_kill_switch_before_execution(
 
     class RecordingAdapter:
         def generate_sql(self, request):
-            return scenario.expected.canonical_sql
+            return _adapter_response(scenario.expected.canonical_sql)
 
     def fake_query_runner(**_: object) -> list[dict[str, object]]:
         raise AssertionError("MSSQL execution must not run after runtime denial")
@@ -675,7 +685,7 @@ def test_mssql_core_vertical_slice_cancellation_probe_blocks_before_execution() 
 
     class RecordingAdapter:
         def generate_sql(self, request):
-            return scenario.expected.canonical_sql
+            return _adapter_response(scenario.expected.canonical_sql)
 
     def fake_query_runner(**_: object) -> list[dict[str, object]]:
         raise AssertionError("MSSQL execution must not run after cancellation")
@@ -795,7 +805,7 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
     class RecordingAdapter:
         def generate_sql(self, request):
             captured["adapter_request"] = request
-            return scenario.expected.canonical_sql
+            return _adapter_response(scenario.expected.canonical_sql)
 
     def fake_query_runner(
         *,
@@ -892,7 +902,7 @@ def test_postgresql_core_vertical_slice_denies_application_postgres_reuse_before
 
     class RecordingAdapter:
         def generate_sql(self, request):
-            return scenario.expected.canonical_sql
+            return _adapter_response(scenario.expected.canonical_sql)
 
     def fake_query_runner(**_: object) -> list[dict[str, object]]:
         raise AssertionError("PostgreSQL execution must not run for application reuse")
@@ -959,7 +969,7 @@ def test_postgresql_core_vertical_slice_applies_runtime_rate_limit_before_execut
 
     class RecordingAdapter:
         def generate_sql(self, request):
-            return scenario.expected.canonical_sql
+            return _adapter_response(scenario.expected.canonical_sql)
 
     def fake_query_runner(**_: object) -> list[dict[str, object]]:
         raise AssertionError("PostgreSQL execution must not run after runtime denial")
@@ -1024,7 +1034,7 @@ def test_postgresql_core_vertical_slice_cancellation_probe_blocks_before_executi
 
     class RecordingAdapter:
         def generate_sql(self, request):
-            return scenario.expected.canonical_sql
+            return _adapter_response(scenario.expected.canonical_sql)
 
     def fake_query_runner(**_: object) -> list[dict[str, object]]:
         raise AssertionError("PostgreSQL execution must not run after cancellation")

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -1,9 +1,12 @@
 from pydantic import ValidationError
 
 from app.services.sql_generation_adapter import (
+    SQLGenerationAdapterConfigurationError,
     SQLGenerationAdapterRequest,
+    SQLGenerationAdapterResponse,
     SQLGenerationContextReferences,
     SQLGenerationSourceBinding,
+    resolve_sql_generation_adapter,
 )
 
 
@@ -110,4 +113,79 @@ def test_sql_generation_adapter_request_rejects_credentials_and_unbounded_contex
         ("credentials", "extra_forbidden"),
         ("execution_authority", "extra_forbidden"),
         ("raw_schema_inventory", "extra_forbidden"),
+    }
+
+
+def test_sql_generation_adapter_response_shape_is_typed_and_credential_free() -> None:
+    response = SQLGenerationAdapterResponse(
+        candidate_sql="select vendor_id, total_spend from approved_vendor_spend limit 50",
+        provider="local_llm",
+        adapter_version="local_llm.v1",
+        model="safequery-local-sql",
+    )
+
+    assert response.model_dump(exclude_none=True) == {
+        "candidate_sql": (
+            "select vendor_id, total_spend from approved_vendor_spend limit 50"
+        ),
+        "provider": "local_llm",
+        "adapter_version": "local_llm.v1",
+        "model": "safequery-local-sql",
+    }
+
+    try:
+        SQLGenerationAdapterResponse.model_validate(
+            {
+                "candidate_sql": "select 1",
+                "provider": "local_llm",
+                "adapter_version": "local_llm.v1",
+                "source_credentials": {"password": "not-allowed"},
+            }
+        )
+    except ValidationError as exc:
+        assert exc.errors()[0]["loc"] == ("source_credentials",)
+        assert exc.errors()[0]["type"] == "extra_forbidden"
+    else:
+        raise AssertionError("Expected response validation to reject credentials.")
+
+
+def test_sql_generation_adapter_registry_fails_closed_when_disabled() -> None:
+    try:
+        resolve_sql_generation_adapter({"provider": "disabled"})
+    except SQLGenerationAdapterConfigurationError as exc:
+        assert exc.code == "sql_generation_disabled"
+        assert "disabled" in str(exc)
+    else:
+        raise AssertionError("Expected disabled SQL generation to fail closed.")
+
+
+def test_sql_generation_adapter_registry_selects_configured_providers() -> None:
+    local_adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "local_llm",
+            "local_llm_base_url": "http://local-llm:8080",
+            "local_llm_model": "safequery-local-sql",
+        }
+    )
+    vanna_adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "vanna",
+            "vanna_base_url": "http://vanna:8084",
+            "vanna_model": "warehouse-assistant",
+        }
+    )
+
+    assert local_adapter.model_dump(exclude_none=True) == {
+        "provider": "local_llm",
+        "adapter_version": "local_llm.v1",
+        "base_url": "http://local-llm:8080/",
+        "model": "safequery-local-sql",
+        "timeout_seconds": 30,
+    }
+    assert vanna_adapter.model_dump(exclude_none=True) == {
+        "provider": "vanna",
+        "adapter_version": "vanna.v1",
+        "base_url": "http://vanna:8084/",
+        "model": "warehouse-assistant",
+        "timeout_seconds": 30,
     }

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -191,6 +191,24 @@ def test_sql_generation_adapter_registry_selects_configured_providers() -> None:
     }
 
 
+def test_sql_generation_adapter_registry_preserves_masked_vanna_api_key() -> None:
+    vanna_adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "vanna",
+            "vanna_base_url": "http://vanna:8084",
+            "vanna_model": "warehouse-assistant",
+            "vanna_api_key": "trusted-vanna-token",
+        }
+    )
+
+    assert vanna_adapter.api_key is not None
+    assert vanna_adapter.api_key.get_secret_value() == "trusted-vanna-token"
+    assert (
+        vanna_adapter.model_dump(mode="json", exclude_none=True)["api_key"]
+        == "**********"
+    )
+
+
 def test_sql_generation_adapter_registry_wraps_mapping_validation_errors() -> None:
     try:
         resolve_sql_generation_adapter({"provider": "not-a-provider"})

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -189,3 +189,48 @@ def test_sql_generation_adapter_registry_selects_configured_providers() -> None:
         "model": "warehouse-assistant",
         "timeout_seconds": 30,
     }
+
+
+def test_sql_generation_adapter_registry_wraps_mapping_validation_errors() -> None:
+    try:
+        resolve_sql_generation_adapter({"provider": "not-a-provider"})
+    except SQLGenerationAdapterConfigurationError as exc:
+        assert exc.code == "sql_generation_settings_invalid"
+        assert isinstance(exc.__cause__, ValidationError)
+    else:
+        raise AssertionError("Expected invalid adapter settings to fail closed.")
+
+
+def test_configured_sql_generation_adapter_fails_closed_before_dispatch() -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "local_llm",
+            "local_llm_base_url": "http://local-llm:8080",
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_80_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+        ),
+    )
+
+    try:
+        adapter.generate_sql(request)
+    except SQLGenerationAdapterConfigurationError as exc:
+        assert exc.code == "sql_generation_provider_not_implemented"
+        assert "dispatch is not implemented" in str(exc)
+    else:
+        raise AssertionError("Expected configured adapter dispatch to fail closed.")

--- a/backend/tests/test_vertical_slice_lifecycle_revalidation.py
+++ b/backend/tests/test_vertical_slice_lifecycle_revalidation.py
@@ -38,6 +38,7 @@ from app.services.postgresql_vertical_slice import (
     run_postgresql_core_vertical_slice,
 )
 from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+from app.services.sql_generation_adapter import SQLGenerationAdapterResponse
 
 
 MSSQL_TEST_CONNECTION_STRING = (
@@ -55,6 +56,15 @@ POSTGRESQL_TEST_URL = (
 APPLICATION_POSTGRESQL_TEST_URL = (
     "postgresql://placeholder_user:placeholder_password@app-postgres:5432/safequery"
 )
+
+
+def _adapter_response(canonical_sql: str) -> SQLGenerationAdapterResponse:
+    return SQLGenerationAdapterResponse(
+        candidate_sql=canonical_sql,
+        provider="local_llm",
+        adapter_version="test.local_llm.v1",
+        model="safequery-test-sql",
+    )
 
 
 @contextmanager
@@ -180,12 +190,16 @@ def _audit_context(*, prefix: str) -> PreviewAuditContext:
 
 class _MSSQLAdapter:
     def generate_sql(self, request):
-        return "SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend"
+        return _adapter_response(
+            "SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend"
+        )
 
 
 class _PostgreSQLAdapter:
     def generate_sql(self, request):
-        return "SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10"
+        return _adapter_response(
+            "SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10"
+        )
 
 
 def _unexpected_query_runner(**_: object) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary
- add typed SQL generation settings for disabled, local_llm, and vanna provider selection
- add adapter response/error shapes and a fail-closed provider factory
- keep generation adapter settings separate from source execution credentials

## Verification
- cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py tests/test_config.py tests/test_request_source_selection.py
- cd backend && python3 -m pytest tests/test_first_run_doctor.py tests/test_release_gate.py

Closes #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable SQL generation with provider selection: disabled, local LLM, or Vanna.
  * Adapter results now return structured responses including SQL plus provider/model/metadata.

* **Bug Fixes**
  * Normalizes optional text inputs (trims empty/whitespace → unset) and rejects placeholder API keys.
  * Enforces required base URLs for selected providers and fail‑closed behavior on misconfiguration.

* **Tests**
  * Updated tests and harnesses to validate structured adapter responses and provider configuration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->