### PR TITLE
Add local LLM health and retry policy

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,6 +41,8 @@ class SQLGenerationSettings(BaseModel):
     vanna_model: Optional[str] = None
     vanna_api_key: Optional[SecretStr] = None
     timeout_seconds: int = Field(default=30, ge=1, le=300)
+    retry_count: int = Field(default=1, ge=0, le=3)
+    circuit_breaker_failure_threshold: int = Field(default=3, ge=1, le=10)
 
 
 class SourceRoleTelemetry(BaseModel):
@@ -70,6 +72,12 @@ class Settings(BaseSettings):
     sql_generation_vanna_model: Optional[str] = None
     sql_generation_vanna_api_key: Optional[SecretStr] = None
     sql_generation_timeout_seconds: int = Field(default=30, ge=1, le=300)
+    sql_generation_retry_count: int = Field(default=1, ge=0, le=3)
+    sql_generation_circuit_breaker_failure_threshold: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+    )
     cors_origins: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["http://localhost:3000"]
     )
@@ -91,7 +99,6 @@ class Settings(BaseSettings):
         return value
 
     @field_validator(
-        "business_mssql_source_connection_string",
         "sql_generation_local_llm_model",
         "sql_generation_vanna_model",
         mode="before",
@@ -198,6 +205,10 @@ class Settings(BaseSettings):
             vanna_model=self.sql_generation_vanna_model,
             vanna_api_key=self.sql_generation_vanna_api_key,
             timeout_seconds=self.sql_generation_timeout_seconds,
+            retry_count=self.sql_generation_retry_count,
+            circuit_breaker_failure_threshold=(
+                self.sql_generation_circuit_breaker_failure_threshold
+            ),
         )
 
     def source_posture_telemetry(self) -> SourcePostureTelemetry:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,10 @@ from app.features.auth.session import (
     ApplicationSessionContext,
     require_application_session,
 )
-from app.services.health import check_database_health
+from app.services.health import (
+    check_database_health,
+    check_sql_generation_runtime_health,
+)
 from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
 from app.services.request_preview import (
     PreviewAuditContext,
@@ -202,7 +205,13 @@ def create_app() -> FastAPI:
     @app.get("/health")
     def read_health() -> JSONResponse:
         database = check_database_health(str(settings.app_postgres_url))
-        healthy = database["status"] == "ok"
+        sql_generation = check_sql_generation_runtime_health(settings.sql_generation)
+        sql_generation_status = sql_generation["status"]
+        healthy = database["status"] == "ok" and sql_generation_status in {
+            "ok",
+            "disabled",
+            "unchecked",
+        }
 
         return JSONResponse(
             status_code=200 if healthy else 503,
@@ -210,6 +219,7 @@ def create_app() -> FastAPI:
                 "status": "ok" if healthy else "degraded",
                 "service": "safequery-api",
                 "database": database,
+                "sql_generation": sql_generation,
             },
         )
 

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -1,6 +1,12 @@
 from collections.abc import Mapping
+import json
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import Request, urlopen
 
 import psycopg
+
+from app.core.config import SQLGenerationSettings
 
 
 def check_database_health(database_url: str) -> Mapping[str, str]:
@@ -16,6 +22,91 @@ def check_database_health(database_url: str) -> Mapping[str, str]:
         }
 
     return {
+        "status": "ok",
+        "detail": "ready",
+    }
+
+
+def _safe_endpoint(base_url: str) -> str:
+    parsed = urlsplit(base_url)
+    return urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+def _health_url(base_url: str) -> str:
+    return f"{str(base_url).rstrip('/')}/health"
+
+
+def check_sql_generation_runtime_health(
+    settings: SQLGenerationSettings,
+) -> Mapping[str, object]:
+    base_payload: dict[str, object] = {
+        "status": "disabled",
+        "detail": "provider_disabled",
+        "provider": settings.provider,
+        "timeout_seconds": settings.timeout_seconds,
+        "retry_count": settings.retry_count,
+        "circuit_breaker_failure_threshold": (
+            settings.circuit_breaker_failure_threshold
+        ),
+    }
+
+    if settings.provider == "disabled":
+        return base_payload
+
+    if settings.provider != "local_llm":
+        return {
+            **base_payload,
+            "status": "unchecked",
+            "detail": "provider_health_probe_not_configured",
+        }
+
+    if settings.local_llm_base_url is None:
+        return {
+            **base_payload,
+            "status": "error",
+            "detail": "missing_endpoint",
+        }
+
+    endpoint = _safe_endpoint(str(settings.local_llm_base_url))
+    payload = {
+        **base_payload,
+        "provider": "local_llm",
+        "endpoint": endpoint,
+    }
+    request = Request(
+        _health_url(str(settings.local_llm_base_url)),
+        headers={"Accept": "application/json"},
+        method="GET",
+    )
+
+    try:
+        with urlopen(request, timeout=settings.timeout_seconds) as response:  # noqa: S310
+            raw_body = response.read().decode("utf-8", errors="replace")
+            status = getattr(response, "status", 200)
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        return {
+            **payload,
+            "status": "error",
+            "detail": exc.__class__.__name__,
+        }
+
+    runtime_status = None
+    try:
+        decoded = json.loads(raw_body)
+    except json.JSONDecodeError:
+        decoded = None
+    if isinstance(decoded, dict):
+        runtime_status = decoded.get("status")
+
+    if status >= 400 or runtime_status not in {"ok", "ready"}:
+        return {
+            **payload,
+            "status": "error",
+            "detail": "unhealthy_response",
+        }
+
+    return {
+        **payload,
         "status": "ok",
         "detail": "ready",
     }

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -147,7 +147,14 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
         for _attempt in range(self.retry_count + 1):
             try:
                 response = self._dispatch_local_llm_sql(request)
-            except (HTTPError, URLError, TimeoutError, OSError, ValidationError) as exc:
+            except (
+                HTTPError,
+                URLError,
+                TimeoutError,
+                OSError,
+                ValidationError,
+                json.JSONDecodeError,
+            ) as exc:
                 last_error = exc
                 continue
 

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import json
 from typing import Optional, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 from pydantic import (
     BaseModel,
     ConfigDict,
+    PrivateAttr,
     SecretStr,
     StringConstraints,
     ValidationError,
@@ -113,14 +117,97 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
     model: Optional[NonEmptyTrimmedString] = None
     api_key: Optional[SecretStr] = None
     timeout_seconds: int
+    retry_count: int
+    circuit_breaker_failure_threshold: int
+    _consecutive_failures: int = PrivateAttr(default=0)
 
     def generate_sql(
         self,
         request: SQLGenerationAdapterRequest,
     ) -> SQLGenerationAdapterResponse:
+        if self.provider == "local_llm":
+            return self._generate_local_llm_sql(request)
+
         raise SQLGenerationAdapterConfigurationError(
             "sql_generation_provider_not_implemented",
             f"Provider '{self.provider}' is configured but dispatch is not implemented.",
+        )
+
+    def _generate_local_llm_sql(
+        self,
+        request: SQLGenerationAdapterRequest,
+    ) -> SQLGenerationAdapterResponse:
+        if self._consecutive_failures >= self.circuit_breaker_failure_threshold:
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_runtime_circuit_open",
+                "Local LLM SQL generation runtime is unhealthy; circuit breaker is open.",
+            )
+
+        last_error: BaseException | None = None
+        for _attempt in range(self.retry_count + 1):
+            try:
+                response = self._dispatch_local_llm_sql(request)
+            except (HTTPError, URLError, TimeoutError, OSError, ValidationError) as exc:
+                last_error = exc
+                continue
+
+            self._consecutive_failures = 0
+            return response
+
+        self._consecutive_failures += 1
+        detail = (
+            last_error.__class__.__name__
+            if last_error is not None
+            else "UnknownAdapterFailure"
+        )
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_runtime_unhealthy",
+            f"Local LLM SQL generation runtime is unavailable ({detail}).",
+        )
+
+    def _dispatch_local_llm_sql(
+        self,
+        request: SQLGenerationAdapterRequest,
+    ) -> SQLGenerationAdapterResponse:
+        payload = {
+            "request": request.model_dump(mode="json"),
+        }
+        if self.model is not None:
+            payload["model"] = self.model
+
+        http_request = Request(
+            f"{self.base_url.rstrip('/')}/generate-sql",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urlopen(http_request, timeout=self.timeout_seconds) as response:  # noqa: S310
+            status = getattr(response, "status", 200)
+            raw_body = response.read().decode("utf-8", errors="replace")
+
+        if status >= 400:
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_runtime_unhealthy",
+                "Local LLM SQL generation runtime returned an unhealthy response.",
+            )
+
+        decoded = json.loads(raw_body)
+        if not isinstance(decoded, dict):
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_response_invalid",
+                "Local LLM SQL generation runtime returned an invalid response.",
+            )
+
+        candidate_sql = decoded.get("candidate_sql")
+        model = decoded.get("model", self.model)
+        return SQLGenerationAdapterResponse(
+            candidate_sql=candidate_sql,
+            provider="local_llm",
+            adapter_version=self.adapter_version,
+            model=model,
         )
 
 
@@ -161,6 +248,10 @@ def resolve_sql_generation_adapter(
             base_url=str(generation_settings.local_llm_base_url),
             model=generation_settings.local_llm_model,
             timeout_seconds=generation_settings.timeout_seconds,
+            retry_count=generation_settings.retry_count,
+            circuit_breaker_failure_threshold=(
+                generation_settings.circuit_breaker_failure_threshold
+            ),
         )
 
     if generation_settings.provider == "vanna":
@@ -176,6 +267,10 @@ def resolve_sql_generation_adapter(
             model=generation_settings.vanna_model,
             api_key=generation_settings.vanna_api_key,
             timeout_seconds=generation_settings.timeout_seconds,
+            retry_count=generation_settings.retry_count,
+            circuit_breaker_failure_threshold=(
+                generation_settings.circuit_breaker_failure_threshold
+            ),
         )
 
     raise SQLGenerationAdapterConfigurationError(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -100,6 +100,9 @@ class SettingsTestCase(unittest.TestCase):
             sql_generation_provider="local_llm",
             sql_generation_local_llm_base_url="http://local-llm:8080",
             sql_generation_local_llm_model="safequery-local-sql",
+            sql_generation_timeout_seconds=17,
+            sql_generation_retry_count=2,
+            sql_generation_circuit_breaker_failure_threshold=4,
             business_postgres_source_url=(
                 "postgresql://source_reader:read-only@pg-source:5432/business"
             ),
@@ -116,9 +119,32 @@ class SettingsTestCase(unittest.TestCase):
             settings.sql_generation.local_llm_model,
             "safequery-local-sql",
         )
+        self.assertEqual(settings.sql_generation.timeout_seconds, 17)
+        self.assertEqual(settings.sql_generation.retry_count, 2)
+        self.assertEqual(settings.sql_generation.circuit_breaker_failure_threshold, 4)
         dumped = settings.sql_generation.model_dump(mode="json", exclude_none=True)
         self.assertNotIn("business_postgres_source_url", dumped)
         self.assertNotIn("business_mssql_source_connection_string", dumped)
+
+    def test_sql_generation_retry_policy_settings_are_bounded(self) -> None:
+        for field, value in (
+            ("sql_generation_timeout_seconds", 0),
+            ("sql_generation_timeout_seconds", 301),
+            ("sql_generation_retry_count", -1),
+            ("sql_generation_retry_count", 4),
+            ("sql_generation_circuit_breaker_failure_threshold", 0),
+            ("sql_generation_circuit_breaker_failure_threshold", 11),
+        ):
+            with self.subTest(field=field, value=value):
+                with self.assertRaises(ValidationError):
+                    Settings(
+                        app_postgres_url=(
+                            "postgresql://safequery:safequery@db:5432/safequery"
+                        ),
+                        _env_file=None,
+                        _env_prefix="SAFEQUERY_",
+                        **{field: value},
+                    )
 
     def test_sql_generation_provider_fails_closed_when_selected_without_endpoint(
         self,

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -304,6 +304,70 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
     assert "credentials" not in json.dumps(calls[0][2])
 
 
+def test_local_llm_generation_retries_malformed_json_response(monkeypatch) -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "local_llm",
+            "local_llm_base_url": "http://local-llm:8080",
+            "retry_count": 1,
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_80_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+        ),
+    )
+    calls = 0
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            if calls == 1:
+                return b'{"candidate_sql":'
+            return json.dumps(
+                {
+                    "candidate_sql": (
+                        "select vendor_id from approved_vendor_spend limit 50"
+                    ),
+                    "model": "safequery-local-sql",
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(http_request, timeout=None):
+        nonlocal calls
+        calls += 1
+        return Response()
+
+    monkeypatch.setattr(adapter_module, "urlopen", fake_urlopen)
+
+    response = adapter.generate_sql(request)
+
+    assert calls == 2
+    assert response.candidate_sql == (
+        "select vendor_id from approved_vendor_spend limit 50"
+    )
+
+
 def test_local_llm_generation_circuit_breaker_fails_closed(monkeypatch) -> None:
     adapter = resolve_sql_generation_adapter(
         {

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -1,5 +1,12 @@
+import json
+from urllib.error import URLError
+
 from pydantic import ValidationError
 
+import app.services.health as health_module
+import app.services.sql_generation_adapter as adapter_module
+from app.core.config import SQLGenerationSettings
+from app.services.health import check_sql_generation_runtime_health
 from app.services.sql_generation_adapter import (
     SQLGenerationAdapterConfigurationError,
     SQLGenerationAdapterRequest,
@@ -181,6 +188,8 @@ def test_sql_generation_adapter_registry_selects_configured_providers() -> None:
         "base_url": "http://local-llm:8080/",
         "model": "safequery-local-sql",
         "timeout_seconds": 30,
+        "retry_count": 1,
+        "circuit_breaker_failure_threshold": 3,
     }
     assert vanna_adapter.model_dump(exclude_none=True) == {
         "provider": "vanna",
@@ -188,6 +197,8 @@ def test_sql_generation_adapter_registry_selects_configured_providers() -> None:
         "base_url": "http://vanna:8084/",
         "model": "warehouse-assistant",
         "timeout_seconds": 30,
+        "retry_count": 1,
+        "circuit_breaker_failure_threshold": 3,
     }
 
 
@@ -219,15 +230,139 @@ def test_sql_generation_adapter_registry_wraps_mapping_validation_errors() -> No
         raise AssertionError("Expected invalid adapter settings to fail closed.")
 
 
-def test_configured_sql_generation_adapter_fails_closed_before_dispatch() -> None:
+def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
     adapter = resolve_sql_generation_adapter(
         {
             "provider": "local_llm",
             "local_llm_base_url": "http://local-llm:8080",
+            "retry_count": 1,
+            "timeout_seconds": 7,
         }
     )
     request = SQLGenerationAdapterRequest(
         request_id="req_80_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+        ),
+    )
+    calls: list[tuple[str, float | None, dict[str, object]]] = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "candidate_sql": (
+                        "select vendor_id from approved_vendor_spend limit 50"
+                    ),
+                    "model": "safequery-local-sql",
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(http_request, timeout=None):
+        body = json.loads(http_request.data.decode("utf-8"))
+        calls.append((http_request.full_url, timeout, body))
+        if len(calls) == 1:
+            raise URLError("slow local runtime")
+        return Response()
+
+    monkeypatch.setattr(adapter_module, "urlopen", fake_urlopen)
+
+    response = adapter.generate_sql(request)
+
+    assert response.model_dump(exclude_none=True) == {
+        "candidate_sql": "select vendor_id from approved_vendor_spend limit 50",
+        "provider": "local_llm",
+        "adapter_version": "local_llm.v1",
+        "model": "safequery-local-sql",
+    }
+    assert [call[0] for call in calls] == [
+        "http://local-llm:8080/generate-sql",
+        "http://local-llm:8080/generate-sql",
+    ]
+    assert [call[1] for call in calls] == [7, 7]
+    assert calls[0][2]["request"]["question"] == "Show approved vendors"
+    assert "credentials" not in json.dumps(calls[0][2])
+
+
+def test_local_llm_generation_circuit_breaker_fails_closed(monkeypatch) -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "local_llm",
+            "local_llm_base_url": "http://local-llm:8080",
+            "retry_count": 0,
+            "circuit_breaker_failure_threshold": 1,
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_81_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+        ),
+    )
+    calls = 0
+
+    def fake_urlopen(http_request, timeout=None):
+        nonlocal calls
+        calls += 1
+        raise TimeoutError("local runtime timed out")
+
+    monkeypatch.setattr(adapter_module, "urlopen", fake_urlopen)
+
+    for expected_code in (
+        "sql_generation_runtime_unhealthy",
+        "sql_generation_runtime_circuit_open",
+    ):
+        try:
+            adapter.generate_sql(request)
+        except SQLGenerationAdapterConfigurationError as exc:
+            assert exc.code == expected_code
+        else:
+            raise AssertionError("Expected unhealthy runtime to fail closed.")
+
+    assert calls == 1
+
+
+def test_vanna_adapter_still_fails_closed_before_dispatch() -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "vanna",
+            "vanna_base_url": "http://vanna:8084",
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_82_preview",
         question="Show approved vendors",
         source=SQLGenerationSourceBinding(
             source_id="sap-approved-spend",
@@ -252,3 +387,80 @@ def test_configured_sql_generation_adapter_fails_closed_before_dispatch() -> Non
         assert "dispatch is not implemented" in str(exc)
     else:
         raise AssertionError("Expected configured adapter dispatch to fail closed.")
+
+
+def test_local_llm_runtime_health_payload_is_safe_and_bounded(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return b'{"status":"ok","prompt":"raw prompt must not pass through"}'
+
+    def fake_urlopen(http_request, timeout=None):
+        seen["url"] = http_request.full_url
+        seen["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr(health_module, "urlopen", fake_urlopen)
+
+    result = check_sql_generation_runtime_health(
+        SQLGenerationSettings(
+            provider="local_llm",
+            local_llm_base_url="http://local-llm:8080",
+            local_llm_model="safequery-local-sql",
+            timeout_seconds=9,
+            retry_count=2,
+            circuit_breaker_failure_threshold=4,
+        )
+    )
+
+    assert result == {
+        "status": "ok",
+        "detail": "ready",
+        "provider": "local_llm",
+        "endpoint": "http://local-llm:8080",
+        "timeout_seconds": 9,
+        "retry_count": 2,
+        "circuit_breaker_failure_threshold": 4,
+    }
+    assert seen == {"url": "http://local-llm:8080/health", "timeout": 9}
+    assert "prompt" not in json.dumps(result)
+
+
+def test_local_llm_runtime_health_fails_closed_without_leaking_endpoint_body(
+    monkeypatch,
+) -> None:
+    class Response:
+        status = 503
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return b'{"status":"error","token":"secret-runtime-token"}'
+
+    monkeypatch.setattr(health_module, "urlopen", lambda request, timeout=None: Response())
+
+    result = check_sql_generation_runtime_health(
+        SQLGenerationSettings(
+            provider="local_llm",
+            local_llm_base_url="http://local-llm:8080",
+            timeout_seconds=9,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert result["detail"] == "unhealthy_response"
+    assert result["provider"] == "local_llm"
+    assert "secret-runtime-token" not in json.dumps(result)


### PR DESCRIPTION
## Summary
- add bounded local SQL generation timeout, retry, and circuit breaker settings
- expose safe SQL generation runtime readiness through the backend health payload
- implement local LLM adapter dispatch with retry and fail-closed circuit behavior

## Verification
- cd backend && python3 -m pytest tests/test_first_run_doctor.py tests/test_config.py tests/test_sql_generation_adapter_request.py
- cd backend && python3 -m pytest

Closes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health endpoint now includes SQL generation runtime status and details.
  * SQL generation supports local runtime with configurable retry and circuit-breaker controls.

* **Bug Fixes / Behavior**
  * Improved health computation to require both DB and SQL-generation healthy states.
  * Validation tightened for SQL generation resilience fields.

* **Tests**
  * Expanded tests covering retries, circuit-breaker behavior, and health-check safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->