### PR TITLE
Add Vanna-backed SQL generation adapter

### DIFF
--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -190,7 +190,10 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
         request: SQLGenerationAdapterRequest,
     ) -> SQLGenerationAdapterResponse:
         payload = {
-            "request": request.model_dump(mode="json"),
+            "request": request.model_dump(
+                mode="json",
+                exclude={"context": {"datasets"}},
+            ),
         }
         if self.model is not None:
             payload["model"] = self.model

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import json
-from typing import Optional, Protocol
+from typing import Literal, Optional, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     PrivateAttr,
     SecretStr,
     StringConstraints,
@@ -22,6 +23,7 @@ from app.services.generation_context import PreparedGenerationContext
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+DatasetKindLiteral = Literal["view", "table", "materialized_view"]
 
 
 class SQLGenerationSourceBinding(BaseModel):
@@ -32,20 +34,29 @@ class SQLGenerationSourceBinding(BaseModel):
     source_flavor: Optional[NonEmptyTrimmedString] = None
 
 
-class SQLGenerationContextReferences(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    dataset_contract: "SQLGenerationContextReference"
-    schema_snapshot: "SQLGenerationContextReference"
-    glossary: Optional["SQLGenerationContextReference"] = None
-    policy: Optional["SQLGenerationContextReference"] = None
-
-
 class SQLGenerationContextReference(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     context_id: NonEmptyTrimmedString
     source_id: NonEmptyTrimmedString
+
+
+class SQLGenerationCuratedDataset(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_name: NonEmptyTrimmedString
+    dataset_name: NonEmptyTrimmedString
+    dataset_kind: DatasetKindLiteral
+
+
+class SQLGenerationContextReferences(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_contract: SQLGenerationContextReference
+    schema_snapshot: SQLGenerationContextReference
+    glossary: Optional[SQLGenerationContextReference] = None
+    policy: Optional[SQLGenerationContextReference] = None
+    datasets: list[SQLGenerationCuratedDataset] = Field(default_factory=list)
 
 
 class SQLGenerationAdapterRequest(BaseModel):
@@ -127,6 +138,8 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
     ) -> SQLGenerationAdapterResponse:
         if self.provider == "local_llm":
             return self._generate_local_llm_sql(request)
+        if self.provider == "vanna":
+            return self._generate_vanna_sql(request)
 
         raise SQLGenerationAdapterConfigurationError(
             "sql_generation_provider_not_implemented",
@@ -213,6 +226,122 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
         return SQLGenerationAdapterResponse(
             candidate_sql=candidate_sql,
             provider="local_llm",
+            adapter_version=self.adapter_version,
+            model=model,
+        )
+
+    def _generate_vanna_sql(
+        self,
+        request: SQLGenerationAdapterRequest,
+    ) -> SQLGenerationAdapterResponse:
+        if not request.context.datasets:
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_vanna_context_missing",
+                "Vanna SQL generation requires curated source-scoped dataset context.",
+            )
+        if self._consecutive_failures >= self.circuit_breaker_failure_threshold:
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_runtime_circuit_open",
+                "Vanna SQL generation runtime is unhealthy; circuit breaker is open.",
+            )
+
+        last_error: BaseException | None = None
+        for _attempt in range(self.retry_count + 1):
+            try:
+                response = self._dispatch_vanna_sql(request)
+            except (
+                HTTPError,
+                URLError,
+                TimeoutError,
+                OSError,
+                ValidationError,
+                json.JSONDecodeError,
+                SQLGenerationAdapterConfigurationError,
+            ) as exc:
+                last_error = exc
+                continue
+
+            self._consecutive_failures = 0
+            return response
+
+        self._consecutive_failures += 1
+        detail = (
+            last_error.__class__.__name__
+            if last_error is not None
+            else "UnknownAdapterFailure"
+        )
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_runtime_unhealthy",
+            f"Vanna SQL generation runtime is unavailable ({detail}).",
+        )
+
+    def _dispatch_vanna_sql(
+        self,
+        request: SQLGenerationAdapterRequest,
+    ) -> SQLGenerationAdapterResponse:
+        context_payload: dict[str, object] = {
+            "dataset_contract": request.context.dataset_contract.model_dump(
+                mode="json"
+            ),
+            "schema_snapshot": request.context.schema_snapshot.model_dump(
+                mode="json"
+            ),
+            "datasets": [
+                dataset.model_dump(mode="json")
+                for dataset in request.context.datasets
+            ],
+        }
+        payload: dict[str, object] = {
+            "question": request.question,
+            "source": request.source.model_dump(mode="json"),
+            "context": context_payload,
+        }
+        if request.context.glossary is not None:
+            context_payload["glossary"] = request.context.glossary.model_dump(
+                mode="json"
+            )
+        if request.context.policy is not None:
+            context_payload["policy"] = request.context.policy.model_dump(
+                mode="json"
+            )
+        if self.model is not None:
+            payload["model"] = self.model
+
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if self.api_key is not None:
+            headers["Authorization"] = f"Bearer {self.api_key.get_secret_value()}"
+
+        http_request = Request(
+            f"{self.base_url.rstrip('/')}/api/v0/generate_sql",
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        with urlopen(http_request, timeout=self.timeout_seconds) as response:  # noqa: S310
+            status = getattr(response, "status", 200)
+            raw_body = response.read().decode("utf-8", errors="replace")
+
+        if status >= 400:
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_runtime_unhealthy",
+                "Vanna SQL generation runtime returned an unhealthy response.",
+            )
+
+        decoded = json.loads(raw_body)
+        if not isinstance(decoded, dict):
+            raise SQLGenerationAdapterConfigurationError(
+                "sql_generation_response_invalid",
+                "Vanna SQL generation runtime returned an invalid response.",
+            )
+
+        candidate_sql = decoded.get("candidate_sql", decoded.get("sql"))
+        model = decoded.get("model", self.model)
+        return SQLGenerationAdapterResponse(
+            candidate_sql=candidate_sql,
+            provider="vanna",
             adapter_version=self.adapter_version,
             model=model,
         )
@@ -306,5 +435,13 @@ def build_sql_generation_adapter_request(
                 context_id=prepared_context.governance.schema_snapshot_id,
                 source_id=prepared_context.source.source_id,
             ),
+            datasets=[
+                SQLGenerationCuratedDataset(
+                    schema_name=dataset.schema_name,
+                    dataset_name=dataset.dataset_name,
+                    dataset_kind=dataset.dataset_kind,
+                )
+                for dataset in prepared_context.datasets
+            ],
         ),
     )

--- a/backend/tests/test_adapter_credential_isolation.py
+++ b/backend/tests/test_adapter_credential_isolation.py
@@ -26,7 +26,13 @@ def test_build_sql_generation_adapter_request_uses_only_adapter_safe_fields() ->
             dataset_contract_id="contract_finance_v1",
             schema_snapshot_id="snapshot_finance_v3",
         ),
-        datasets=[],
+        datasets=[
+            {
+                "schema_name": "finance",
+                "dataset_name": "approved_vendor_spend",
+                "dataset_kind": "table",
+            },
+        ],
     )
 
     adapter_request = build_sql_generation_adapter_request(prepared_context)
@@ -51,11 +57,17 @@ def test_build_sql_generation_adapter_request_uses_only_adapter_safe_fields() ->
             },
             "glossary": None,
             "policy": None,
+            "datasets": [
+                {
+                    "schema_name": "finance",
+                    "dataset_name": "approved_vendor_spend",
+                    "dataset_kind": "table",
+                },
+            ],
         },
     }
     dumped = adapter_request.model_dump()
     assert "display_label" not in str(dumped)
-    assert "datasets" not in dumped
     assert "connection_reference" not in str(dumped)
     assert "connector_profile_id" not in str(dumped)
     assert "execution_policy_id" not in str(dumped)

--- a/backend/tests/test_adapter_single_source_validation.py
+++ b/backend/tests/test_adapter_single_source_validation.py
@@ -59,6 +59,7 @@ def test_adapter_request_accepts_single_source_context_fragments() -> None:
                 "context_id": "policy_generation_v1",
                 "source_id": "sap-approved-spend",
             },
+            "datasets": [],
         },
     }
 

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -71,6 +71,7 @@ def test_sql_generation_adapter_request_is_source_aware_and_single_source() -> N
                 "context_id": "policy_generation_v1",
                 "source_id": "sap-approved-spend",
             },
+            "datasets": [],
         },
     }
 
@@ -418,7 +419,181 @@ def test_local_llm_generation_circuit_breaker_fails_closed(monkeypatch) -> None:
     assert calls == 1
 
 
-def test_vanna_adapter_still_fails_closed_before_dispatch() -> None:
+def test_vanna_generation_uses_curated_context_and_bounded_request(
+    monkeypatch,
+) -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "vanna",
+            "vanna_base_url": "http://vanna:8084",
+            "vanna_model": "warehouse-assistant",
+            "vanna_api_key": "trusted-vanna-token",
+            "timeout_seconds": 11,
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_82_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            datasets=[
+                {
+                    "schema_name": "finance",
+                    "dataset_name": "approved_vendor_spend",
+                    "dataset_kind": "table",
+                },
+                {
+                    "schema_name": "analytics",
+                    "dataset_name": "vendor_spend_summary",
+                    "dataset_kind": "view",
+                },
+            ],
+        ),
+    )
+    seen: dict[str, object] = {}
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "sql": "select vendor_id from approved_vendor_spend limit 50",
+                    "model": "warehouse-assistant",
+                    "execution_result": [{"vendor_id": 1}],
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(http_request, timeout=None):
+        seen["url"] = http_request.full_url
+        seen["timeout"] = timeout
+        seen["headers"] = dict(http_request.header_items())
+        seen["body"] = json.loads(http_request.data.decode("utf-8"))
+        return Response()
+
+    monkeypatch.setattr(adapter_module, "urlopen", fake_urlopen)
+
+    response = adapter.generate_sql(request)
+
+    assert response.model_dump(exclude_none=True) == {
+        "candidate_sql": "select vendor_id from approved_vendor_spend limit 50",
+        "provider": "vanna",
+        "adapter_version": "vanna.v1",
+        "model": "warehouse-assistant",
+    }
+    assert seen["url"] == "http://vanna:8084/api/v0/generate_sql"
+    assert seen["timeout"] == 11
+    assert seen["headers"]["Authorization"] == "Bearer trusted-vanna-token"
+    assert seen["body"] == {
+        "question": "Show approved vendors",
+        "model": "warehouse-assistant",
+        "source": {
+            "source_id": "sap-approved-spend",
+            "source_family": "postgresql",
+            "source_flavor": None,
+        },
+        "context": {
+            "dataset_contract": {
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            "schema_snapshot": {
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            "datasets": [
+                {
+                    "schema_name": "finance",
+                    "dataset_name": "approved_vendor_spend",
+                    "dataset_kind": "table",
+                },
+                {
+                    "schema_name": "analytics",
+                    "dataset_name": "vendor_spend_summary",
+                    "dataset_kind": "view",
+                },
+            ],
+        },
+    }
+    assert "credentials" not in json.dumps(seen["body"])
+    assert "execution_result" not in json.dumps(response.model_dump())
+
+
+def test_vanna_generation_fails_closed_for_malformed_response(monkeypatch) -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "vanna",
+            "vanna_base_url": "http://vanna:8084",
+            "retry_count": 0,
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_82_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            datasets=[
+                {
+                    "schema_name": "finance",
+                    "dataset_name": "approved_vendor_spend",
+                    "dataset_kind": "table",
+                },
+            ],
+        ),
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps({"execution_result": [{"vendor_id": 1}]}).encode("utf-8")
+
+    monkeypatch.setattr(adapter_module, "urlopen", lambda request, timeout=None: Response())
+
+    try:
+        adapter.generate_sql(request)
+    except SQLGenerationAdapterConfigurationError as exc:
+        assert exc.code == "sql_generation_runtime_unhealthy"
+        assert "Vanna" in str(exc)
+    else:
+        raise AssertionError("Expected malformed Vanna response to fail closed.")
+
+
+def test_vanna_generation_fails_closed_without_curated_datasets(monkeypatch) -> None:
     adapter = resolve_sql_generation_adapter(
         {
             "provider": "vanna",
@@ -444,13 +619,17 @@ def test_vanna_adapter_still_fails_closed_before_dispatch() -> None:
         ),
     )
 
+    def unexpected_urlopen(http_request, timeout=None):
+        raise AssertionError("Vanna dispatch must not run without curated datasets.")
+
+    monkeypatch.setattr(adapter_module, "urlopen", unexpected_urlopen)
+
     try:
         adapter.generate_sql(request)
     except SQLGenerationAdapterConfigurationError as exc:
-        assert exc.code == "sql_generation_provider_not_implemented"
-        assert "dispatch is not implemented" in str(exc)
+        assert exc.code == "sql_generation_vanna_context_missing"
     else:
-        raise AssertionError("Expected configured adapter dispatch to fail closed.")
+        raise AssertionError("Expected missing curated context to fail closed.")
 
 
 def test_local_llm_runtime_health_payload_is_safe_and_bounded(monkeypatch) -> None:

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -256,6 +256,13 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
                 "context_id": "snapshot_finance_v3",
                 "source_id": "sap-approved-spend",
             },
+            datasets=[
+                {
+                    "schema_name": "finance",
+                    "dataset_name": "approved_vendor_spend",
+                    "dataset_kind": "table",
+                },
+            ],
         ),
     )
     calls: list[tuple[str, float | None, dict[str, object]]] = []
@@ -302,6 +309,7 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
     ]
     assert [call[1] for call in calls] == [7, 7]
     assert calls[0][2]["request"]["question"] == "Show approved vendors"
+    assert "datasets" not in calls[0][2]["request"]["context"]
     assert "credentials" not in json.dumps(calls[0][2])
 
 


### PR DESCRIPTION
## Summary
- add curated dataset descriptors to the SQL generation adapter request boundary
- implement Vanna-backed SQL generation dispatch with timeout/retry/circuit-breaker handling
- fail closed for missing curated context and malformed Vanna responses without carrying credentials or execution results

## Tests
- cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py tests/test_generation_context_preparation.py -q
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_request_source_selection.py -q
- cd backend && python3 -m pytest -q

Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new external SQL-generation provider with curated dataset context, optional glossary/policy, and bearer auth support.
  * Built-in circuit-breaker and retry behavior for external provider calls.

* **Bug Fixes**
  * Validates curated-dataset context and fails closed on missing context or malformed provider responses.
  * Ensures local model requests do not include curated dataset payloads.

* **Tests**
  * Updated and added tests covering provider request/response handling and credential isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->