### PR TITLE
[N-4] Persist generated candidate adapter metadata

### DIFF
--- a/backend/alembic/versions/0008_generated_candidate_adapter_metadata.py
+++ b/backend/alembic/versions/0008_generated_candidate_adapter_metadata.py
@@ -1,0 +1,37 @@
+"""Persist generated candidate adapter metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008_generated_candidate_adapter_metadata"
+down_revision: str | None = "0007_preview_audit_event_persistence"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_METADATA_COLUMNS: tuple[tuple[str, sa.String], ...] = (
+    ("adapter_provider", sa.String(length=64)),
+    ("adapter_model", sa.String(length=255)),
+    ("adapter_version", sa.String(length=255)),
+    ("adapter_run_id", sa.String(length=255)),
+    ("prompt_version", sa.String(length=255)),
+    ("prompt_fingerprint", sa.String(length=255)),
+)
+
+
+def upgrade() -> None:
+    for name, column_type in _METADATA_COLUMNS:
+        op.add_column("preview_candidates", sa.Column(name, column_type, nullable=True))
+    for name, column_type in _METADATA_COLUMNS:
+        op.add_column("preview_audit_events", sa.Column(name, column_type, nullable=True))
+
+
+def downgrade() -> None:
+    for name, _column_type in reversed(_METADATA_COLUMNS):
+        op.drop_column("preview_audit_events", name)
+    for name, _column_type in reversed(_METADATA_COLUMNS):
+        op.drop_column("preview_candidates", name)

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -109,6 +109,12 @@ class PreviewCandidate(Base):
     schema_snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
     authenticated_subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
     candidate_sql: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    adapter_provider: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    adapter_model: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    adapter_version: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    adapter_run_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    prompt_version: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    prompt_fingerprint: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     guard_status: Mapped[str] = mapped_column(String(64), nullable=False)
     candidate_state: Mapped[str] = mapped_column(String(64), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -167,6 +173,12 @@ class PreviewAuditEvent(Base):
         Text,
         nullable=True,
     )
+    adapter_provider: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    adapter_model: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    adapter_version: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    adapter_run_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    prompt_version: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    prompt_fingerprint: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     application_version: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     source_id: Mapped[str] = mapped_column(String(255), nullable=False)
     source_family: Mapped[str] = mapped_column(String(64), nullable=False)

--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -114,7 +114,12 @@ class SourceAwareAuditEvent(BaseModel):
     governance_bindings: Optional[list[NonEmptyTrimmedString]] = None
     entitlement_decision: Optional[Literal["allow", "deny"]] = None
     entitlement_source_bindings: Optional[list[NonEmptyTrimmedString]] = None
+    adapter_provider: Optional[NonEmptyTrimmedString] = None
     adapter_version: Optional[NonEmptyTrimmedString] = None
+    adapter_model: Optional[NonEmptyTrimmedString] = None
+    adapter_run_id: Optional[NonEmptyTrimmedString] = None
+    prompt_version: Optional[NonEmptyTrimmedString] = None
+    prompt_fingerprint: Optional[NonEmptyTrimmedString] = None
     guard_version: Optional[NonEmptyTrimmedString] = None
     application_version: Optional[NonEmptyTrimmedString] = None
     retrieval_corpus_version: Optional[NonEmptyTrimmedString] = None

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -32,11 +32,14 @@ from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionRequest,
     PreviewSubmissionResponse,
+    persist_generated_candidate_audit_context,
     submit_preview_request,
 )
 from app.services.sql_generation_adapter import (
     SQLGenerationAdapter,
     SQLGenerationAdapterRequest,
+    SQLGenerationAdapterRunMetadata,
+    build_sql_generation_adapter_run_metadata,
     build_sql_generation_adapter_request,
 )
 
@@ -64,6 +67,7 @@ class GeneratedMSSQLCandidate(BaseModel):
 
     canonical_sql: str
     source: SourceBoundCandidateMetadata
+    adapter_metadata: SQLGenerationAdapterRunMetadata
 
 
 class MSSQLCoreVerticalSliceResult(BaseModel):
@@ -117,6 +121,7 @@ def _audit_base(
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
+    adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
 ) -> SourceAwareAuditEvent:
     return SourceAwareAuditEvent(
         event_id=uuid4(),
@@ -156,6 +161,24 @@ def _audit_base(
         guard_version=(
             audit_context.guard_version if event_type == "guard_evaluated" else None
         ),
+        adapter_provider=(
+            adapter_metadata.adapter_provider if adapter_metadata is not None else None
+        ),
+        adapter_model=(
+            adapter_metadata.adapter_model if adapter_metadata is not None else None
+        ),
+        adapter_version=(
+            adapter_metadata.adapter_version if adapter_metadata is not None else None
+        ),
+        adapter_run_id=(
+            adapter_metadata.adapter_run_id if adapter_metadata is not None else None
+        ),
+        prompt_version=(
+            adapter_metadata.prompt_version if adapter_metadata is not None else None
+        ),
+        prompt_fingerprint=(
+            adapter_metadata.prompt_fingerprint if adapter_metadata is not None else None
+        ),
         application_version=audit_context.application_version,
         source_id=candidate_source.source_id,
         source_family=cast(SourceFamily, candidate_source.source_family),
@@ -183,6 +206,7 @@ def _append_audit_event(
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
+    adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
 ) -> None:
     events.append(
         _audit_base(
@@ -194,6 +218,7 @@ def _append_audit_event(
             candidate_state=candidate_state,
             execution_row_count=execution_row_count,
             result_truncated=result_truncated,
+            adapter_metadata=adapter_metadata,
         )
     )
 
@@ -276,17 +301,23 @@ def run_mssql_core_vertical_slice(
     candidate_source = _source_metadata_from_preview(preview)
     if candidate_source.source_family != "mssql":
         raise ValueError("The MSSQL core vertical slice requires an MSSQL source.")
+    candidate_audit_context = audit_context.model_copy(
+        update={
+            "request_id": preview.request.request_id,
+            "query_candidate_id": preview.candidate.candidate_id,
+        }
+    )
 
     audit_events: list[SourceAwareAuditEvent] = []
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="query_submitted",
     )
 
     prepared_context = prepare_generation_context(
-        request_id=audit_context.request_id,
+        request_id=candidate_audit_context.request_id,
         question=payload.question,
         source_id=candidate_source.source_id,
         authenticated_subject=authenticated_subject,
@@ -295,23 +326,30 @@ def run_mssql_core_vertical_slice(
     adapter_request = build_sql_generation_adapter_request(prepared_context)
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="generation_requested",
     )
 
     adapter_response = sql_generation_adapter.generate_sql(adapter_request)
+    adapter_metadata = build_sql_generation_adapter_run_metadata(
+        adapter_request=adapter_request,
+        adapter_response=adapter_response,
+        adapter_run_id=candidate_audit_context.correlation_id,
+    )
     canonical_sql = adapter_response.candidate_sql
     generated = GeneratedMSSQLCandidate(
         canonical_sql=canonical_sql,
         source=candidate_source,
+        adapter_metadata=adapter_metadata,
     )
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="generation_completed",
         candidate_state="generated",
+        adapter_metadata=adapter_metadata,
     )
 
     guard = evaluate_mssql_sql_guard(
@@ -328,11 +366,20 @@ def run_mssql_core_vertical_slice(
         primary_deny_code = guard.rejections[0].code if guard.rejections else "guard_rejected"
         _append_audit_event(
             audit_events,
-            audit_context=audit_context,
+            audit_context=candidate_audit_context,
             candidate_source=candidate_source,
             event_type="guard_evaluated",
             primary_deny_code=primary_deny_code,
             candidate_state="denied",
+            adapter_metadata=adapter_metadata,
+        )
+        persist_generated_candidate_audit_context(
+            session,
+            request_id=preview.request.request_id,
+            candidate_id=preview.candidate.candidate_id,
+            candidate_sql=canonical_sql,
+            adapter_metadata=adapter_metadata,
+            audit_events=audit_events,
         )
         raise MSSQLVerticalSliceDenied(
             deny_code=primary_deny_code,
@@ -343,16 +390,25 @@ def run_mssql_core_vertical_slice(
 
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="guard_evaluated",
         candidate_state="preview_ready",
+        adapter_metadata=adapter_metadata,
+    )
+    persist_generated_candidate_audit_context(
+        session,
+        request_id=preview.request.request_id,
+        candidate_id=preview.candidate.candidate_id,
+        candidate_sql=canonical_sql,
+        adapter_metadata=adapter_metadata,
+        audit_events=audit_events,
     )
 
     lifecycle_record = candidate_lifecycle or _build_default_candidate_lifecycle(
         candidate_source=candidate_source,
         authenticated_subject=authenticated_subject,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
     )
     try:
         revalidate_candidate_lifecycle(
@@ -362,7 +418,7 @@ def run_mssql_core_vertical_slice(
             as_of=audit_context.occurred_at,
             selected_source_id=candidate_source.source_id,
             audit_context=_build_candidate_lifecycle_audit_context(
-                audit_context=audit_context,
+                audit_context=candidate_audit_context,
                 lifecycle_record=lifecycle_record,
             ),
         )
@@ -388,7 +444,7 @@ def run_mssql_core_vertical_slice(
         cancellation_probe=cancellation_probe,
         runtime_safety_state=runtime_safety_state,
         audit_context=_build_execution_audit_context(
-            audit_context=audit_context,
+            audit_context=candidate_audit_context,
             previous_event_id=audit_events[-1].event_id,
         ),
     )

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -396,15 +396,6 @@ def run_mssql_core_vertical_slice(
         candidate_state="preview_ready",
         adapter_metadata=adapter_metadata,
     )
-    persist_generated_candidate_audit_context(
-        session,
-        request_id=preview.request.request_id,
-        candidate_id=preview.candidate.candidate_id,
-        candidate_sql=canonical_sql,
-        adapter_metadata=adapter_metadata,
-        audit_events=audit_events,
-    )
-
     lifecycle_record = candidate_lifecycle or _build_default_candidate_lifecycle(
         candidate_source=candidate_source,
         authenticated_subject=authenticated_subject,
@@ -425,12 +416,29 @@ def run_mssql_core_vertical_slice(
     except CandidateLifecycleRevalidationError as exc:
         if exc.audit_event is not None:
             audit_events.append(exc.audit_event)
+        persist_generated_candidate_audit_context(
+            session,
+            request_id=preview.request.request_id,
+            candidate_id=preview.candidate.candidate_id,
+            candidate_sql=canonical_sql,
+            adapter_metadata=adapter_metadata,
+            audit_events=audit_events,
+        )
         raise MSSQLVerticalSliceDenied(
             deny_code=exc.deny_code,
             message=str(exc),
             guard=guard,
             audit_events=audit_events,
         ) from exc
+
+    persist_generated_candidate_audit_context(
+        session,
+        request_id=preview.request.request_id,
+        candidate_id=preview.candidate.candidate_id,
+        candidate_sql=canonical_sql,
+        adapter_metadata=adapter_metadata,
+        audit_events=audit_events,
+    )
 
     selection = select_execution_connector(candidate_source=candidate_source)
     execution = execute_candidate_sql(

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -415,15 +415,6 @@ def run_postgresql_core_vertical_slice(
         candidate_state="preview_ready",
         adapter_metadata=adapter_metadata,
     )
-    persist_generated_candidate_audit_context(
-        session,
-        request_id=preview.request.request_id,
-        candidate_id=preview.candidate.candidate_id,
-        candidate_sql=canonical_sql,
-        adapter_metadata=adapter_metadata,
-        audit_events=audit_events,
-    )
-
     lifecycle_record = candidate_lifecycle or _build_default_candidate_lifecycle(
         candidate_source=candidate_source,
         authenticated_subject=authenticated_subject,
@@ -444,12 +435,29 @@ def run_postgresql_core_vertical_slice(
     except CandidateLifecycleRevalidationError as exc:
         if exc.audit_event is not None:
             audit_events.append(exc.audit_event)
+        persist_generated_candidate_audit_context(
+            session,
+            request_id=preview.request.request_id,
+            candidate_id=preview.candidate.candidate_id,
+            candidate_sql=canonical_sql,
+            adapter_metadata=adapter_metadata,
+            audit_events=audit_events,
+        )
         raise PostgreSQLVerticalSliceDenied(
             deny_code=exc.deny_code,
             message=str(exc),
             guard=guard,
             audit_events=audit_events,
         ) from exc
+
+    persist_generated_candidate_audit_context(
+        session,
+        request_id=preview.request.request_id,
+        candidate_id=preview.candidate.candidate_id,
+        candidate_sql=canonical_sql,
+        adapter_metadata=adapter_metadata,
+        audit_events=audit_events,
+    )
 
     selection = select_execution_connector(candidate_source=candidate_source)
     execution = execute_candidate_sql(

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -32,11 +32,14 @@ from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionRequest,
     PreviewSubmissionResponse,
+    persist_generated_candidate_audit_context,
     submit_preview_request,
 )
 from app.services.sql_generation_adapter import (
     SQLGenerationAdapter,
     SQLGenerationAdapterRequest,
+    SQLGenerationAdapterRunMetadata,
+    build_sql_generation_adapter_run_metadata,
     build_sql_generation_adapter_request,
 )
 
@@ -77,6 +80,7 @@ class GeneratedPostgreSQLCandidate(BaseModel):
 
     canonical_sql: str
     source: SourceBoundCandidateMetadata
+    adapter_metadata: SQLGenerationAdapterRunMetadata
 
 
 class PostgreSQLCoreVerticalSliceResult(BaseModel):
@@ -130,6 +134,7 @@ def _audit_base(
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
+    adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
 ) -> SourceAwareAuditEvent:
     return SourceAwareAuditEvent(
         event_id=uuid4(),
@@ -169,6 +174,24 @@ def _audit_base(
         guard_version=(
             audit_context.guard_version if event_type == "guard_evaluated" else None
         ),
+        adapter_provider=(
+            adapter_metadata.adapter_provider if adapter_metadata is not None else None
+        ),
+        adapter_model=(
+            adapter_metadata.adapter_model if adapter_metadata is not None else None
+        ),
+        adapter_version=(
+            adapter_metadata.adapter_version if adapter_metadata is not None else None
+        ),
+        adapter_run_id=(
+            adapter_metadata.adapter_run_id if adapter_metadata is not None else None
+        ),
+        prompt_version=(
+            adapter_metadata.prompt_version if adapter_metadata is not None else None
+        ),
+        prompt_fingerprint=(
+            adapter_metadata.prompt_fingerprint if adapter_metadata is not None else None
+        ),
         application_version=audit_context.application_version,
         source_id=candidate_source.source_id,
         source_family=cast(SourceFamily, candidate_source.source_family),
@@ -196,6 +219,7 @@ def _append_audit_event(
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
+    adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
 ) -> None:
     events.append(
         _audit_base(
@@ -207,6 +231,7 @@ def _append_audit_event(
             candidate_state=candidate_state,
             execution_row_count=execution_row_count,
             result_truncated=result_truncated,
+            adapter_metadata=adapter_metadata,
         )
     )
 
@@ -295,17 +320,23 @@ def run_postgresql_core_vertical_slice(
         raise ValueError(
             "The PostgreSQL core vertical slice requires a PostgreSQL source."
         )
+    candidate_audit_context = audit_context.model_copy(
+        update={
+            "request_id": preview.request.request_id,
+            "query_candidate_id": preview.candidate.candidate_id,
+        }
+    )
 
     audit_events: list[SourceAwareAuditEvent] = []
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="query_submitted",
     )
 
     prepared_context = prepare_generation_context(
-        request_id=audit_context.request_id,
+        request_id=candidate_audit_context.request_id,
         question=payload.question,
         source_id=candidate_source.source_id,
         authenticated_subject=authenticated_subject,
@@ -314,23 +345,30 @@ def run_postgresql_core_vertical_slice(
     adapter_request = build_sql_generation_adapter_request(prepared_context)
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="generation_requested",
     )
 
     adapter_response = sql_generation_adapter.generate_sql(adapter_request)
+    adapter_metadata = build_sql_generation_adapter_run_metadata(
+        adapter_request=adapter_request,
+        adapter_response=adapter_response,
+        adapter_run_id=candidate_audit_context.correlation_id,
+    )
     canonical_sql = adapter_response.candidate_sql
     generated = GeneratedPostgreSQLCandidate(
         canonical_sql=canonical_sql,
         source=candidate_source,
+        adapter_metadata=adapter_metadata,
     )
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="generation_completed",
         candidate_state="generated",
+        adapter_metadata=adapter_metadata,
     )
 
     guard = evaluate_postgresql_sql_guard(
@@ -347,11 +385,20 @@ def run_postgresql_core_vertical_slice(
         primary_deny_code = guard.rejections[0].code if guard.rejections else "guard_rejected"
         _append_audit_event(
             audit_events,
-            audit_context=audit_context,
+            audit_context=candidate_audit_context,
             candidate_source=candidate_source,
             event_type="guard_evaluated",
             primary_deny_code=primary_deny_code,
             candidate_state="denied",
+            adapter_metadata=adapter_metadata,
+        )
+        persist_generated_candidate_audit_context(
+            session,
+            request_id=preview.request.request_id,
+            candidate_id=preview.candidate.candidate_id,
+            candidate_sql=canonical_sql,
+            adapter_metadata=adapter_metadata,
+            audit_events=audit_events,
         )
         raise PostgreSQLVerticalSliceDenied(
             deny_code=primary_deny_code,
@@ -362,16 +409,25 @@ def run_postgresql_core_vertical_slice(
 
     _append_audit_event(
         audit_events,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="guard_evaluated",
         candidate_state="preview_ready",
+        adapter_metadata=adapter_metadata,
+    )
+    persist_generated_candidate_audit_context(
+        session,
+        request_id=preview.request.request_id,
+        candidate_id=preview.candidate.candidate_id,
+        candidate_sql=canonical_sql,
+        adapter_metadata=adapter_metadata,
+        audit_events=audit_events,
     )
 
     lifecycle_record = candidate_lifecycle or _build_default_candidate_lifecycle(
         candidate_source=candidate_source,
         authenticated_subject=authenticated_subject,
-        audit_context=audit_context,
+        audit_context=candidate_audit_context,
     )
     try:
         revalidate_candidate_lifecycle(
@@ -381,7 +437,7 @@ def run_postgresql_core_vertical_slice(
             as_of=audit_context.occurred_at,
             selected_source_id=candidate_source.source_id,
             audit_context=_build_candidate_lifecycle_audit_context(
-                audit_context=audit_context,
+                audit_context=candidate_audit_context,
                 lifecycle_record=lifecycle_record,
             ),
         )
@@ -408,7 +464,7 @@ def run_postgresql_core_vertical_slice(
         cancellation_probe=cancellation_probe,
         runtime_safety_state=runtime_safety_state,
         audit_context=_build_execution_audit_context(
-            audit_context=audit_context,
+            audit_context=candidate_audit_context,
             previous_event_id=audit_events[-1].event_id,
         ),
     )

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -26,6 +26,7 @@ from app.services.source_governance import (
     resolve_authoritative_source_governance,
 )
 from app.services.source_registry import SourceRegistryPostureError
+from app.services.sql_generation_adapter import SQLGenerationAdapterRunMetadata
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
@@ -342,6 +343,12 @@ def _persist_preview_audit_events(
                 entitlement_source_bindings=_joined_governance_bindings(
                     list(event.entitlement_source_bindings or [])
                 ),
+                adapter_provider=event.adapter_provider,
+                adapter_model=event.adapter_model,
+                adapter_version=event.adapter_version,
+                adapter_run_id=event.adapter_run_id,
+                prompt_version=event.prompt_version,
+                prompt_fingerprint=event.prompt_fingerprint,
                 application_version=event.application_version,
                 source_id=event.source_id,
                 source_family=event.source_family,
@@ -482,6 +489,12 @@ def _persist_preview_submission_records(
             preview_candidate.schema_snapshot_version = schema_snapshot.snapshot_version
             preview_candidate.authenticated_subject_id = subject_id
             preview_candidate.candidate_sql = None
+            preview_candidate.adapter_provider = None
+            preview_candidate.adapter_model = None
+            preview_candidate.adapter_version = None
+            preview_candidate.adapter_run_id = None
+            preview_candidate.prompt_version = None
+            preview_candidate.prompt_fingerprint = None
             preview_candidate.guard_status = PREVIEW_PENDING_GUARD_STATUS
             preview_candidate.candidate_state = "preview_ready"
             session.flush()
@@ -500,6 +513,57 @@ def _persist_preview_submission_records(
             raise PreviewSubmissionContractError(
                 "Preview submission could not be persisted consistently."
             ) from exc
+
+
+def persist_generated_candidate_audit_context(
+    session: Session,
+    *,
+    request_id: str,
+    candidate_id: str,
+    candidate_sql: str,
+    adapter_metadata: SQLGenerationAdapterRunMetadata,
+    audit_events: list[SourceAwareAuditEvent],
+) -> None:
+    try:
+        preview_request = session.execute(
+            select(PreviewRequest).where(PreviewRequest.request_id == request_id)
+        ).scalar_one_or_none()
+        preview_candidate = session.execute(
+            select(PreviewCandidate).where(
+                PreviewCandidate.request_id == request_id,
+                PreviewCandidate.candidate_id == candidate_id,
+            )
+        ).scalar_one_or_none()
+        if preview_request is None or preview_candidate is None:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Generated candidate metadata cannot be persisted without a bound preview record.",
+            )
+        if preview_candidate.preview_request_id != preview_request.id:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Generated candidate metadata cannot be rebound to a different request.",
+            )
+
+        preview_candidate.candidate_sql = candidate_sql
+        preview_candidate.adapter_provider = adapter_metadata.adapter_provider
+        preview_candidate.adapter_model = adapter_metadata.adapter_model
+        preview_candidate.adapter_version = adapter_metadata.adapter_version
+        preview_candidate.adapter_run_id = adapter_metadata.adapter_run_id
+        preview_candidate.prompt_version = adapter_metadata.prompt_version
+        preview_candidate.prompt_fingerprint = adapter_metadata.prompt_fingerprint
+        _persist_preview_audit_events(
+            session,
+            preview_request=preview_request,
+            preview_candidate=preview_candidate,
+            audit_events=audit_events,
+        )
+        session.commit()
+    except IntegrityError as exc:
+        session.rollback()
+        raise PreviewSubmissionContractError(
+            "Generated candidate metadata could not be persisted consistently."
+        ) from exc
 
 
 def _persist_preview_denial_records(

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import hashlib
 import json
 from typing import Literal, Optional, Protocol
 from urllib.error import HTTPError, URLError
@@ -94,6 +95,17 @@ class SQLGenerationAdapterResponse(BaseModel):
     provider: SQLGenerationProvider
     adapter_version: NonEmptyTrimmedString
     model: Optional[NonEmptyTrimmedString] = None
+
+
+class SQLGenerationAdapterRunMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adapter_provider: SQLGenerationProvider
+    adapter_version: NonEmptyTrimmedString
+    adapter_model: Optional[NonEmptyTrimmedString] = None
+    adapter_run_id: NonEmptyTrimmedString
+    prompt_version: NonEmptyTrimmedString = "sql_generation_adapter_request.v1"
+    prompt_fingerprint: NonEmptyTrimmedString
 
 
 class SQLGenerationAdapterError(BaseModel):
@@ -446,5 +458,27 @@ def build_sql_generation_adapter_request(
                 )
                 for dataset in prepared_context.datasets
             ],
+        ),
+    )
+
+
+def build_sql_generation_adapter_run_metadata(
+    *,
+    adapter_request: SQLGenerationAdapterRequest,
+    adapter_response: SQLGenerationAdapterResponse,
+    adapter_run_id: str,
+) -> SQLGenerationAdapterRunMetadata:
+    prompt_projection = json.dumps(
+        adapter_request.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return SQLGenerationAdapterRunMetadata(
+        adapter_provider=adapter_response.provider,
+        adapter_version=adapter_response.adapter_version,
+        adapter_model=adapter_response.model,
+        adapter_run_id=adapter_run_id,
+        prompt_fingerprint=(
+            f"sha256:{hashlib.sha256(prompt_projection.encode('utf-8')).hexdigest()}"
         ),
     )

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -17,6 +17,7 @@ from app.db.models.dataset_contract import (
     DatasetContractDatasetKind,
 )
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
 from app.features.evaluation import (
@@ -453,6 +454,12 @@ def test_mssql_core_vertical_slice_submits_generates_guards_executes_and_audits(
                 application_version="safequery-test",
             ),
         )
+        persisted_candidate = session.query(PreviewCandidate).one()
+        persisted_generation_event = (
+            session.query(PreviewAuditEvent)
+            .filter(PreviewAuditEvent.event_type == "generation_completed")
+            .one()
+        )
 
     adapter_request = captured["adapter_request"]
     adapter_payload = adapter_request.model_dump()
@@ -468,6 +475,22 @@ def test_mssql_core_vertical_slice_submits_generates_guards_executes_and_audits(
 
     assert result.preview.candidate.source_id == scenario.source.source_id
     assert result.generated.canonical_sql == scenario.expected.canonical_sql
+    assert persisted_candidate.candidate_sql == scenario.expected.canonical_sql
+    assert persisted_candidate.adapter_provider == "local_llm"
+    assert persisted_candidate.adapter_model == "safequery-test-sql"
+    assert persisted_candidate.adapter_version == "test.local_llm.v1"
+    assert persisted_candidate.adapter_run_id == "correlation-141"
+    assert persisted_candidate.prompt_version == "sql_generation_adapter_request.v1"
+    assert persisted_candidate.prompt_fingerprint is not None
+    assert scenario.prompt not in persisted_candidate.prompt_fingerprint
+    assert {
+        "adapter_provider": "local_llm",
+        "adapter_model": "safequery-test-sql",
+        "adapter_version": "test.local_llm.v1",
+        "adapter_run_id": "correlation-141",
+        "prompt_version": "sql_generation_adapter_request.v1",
+        "prompt_fingerprint": persisted_candidate.prompt_fingerprint,
+    }.items() <= persisted_generation_event.audit_payload.items()
     assert result.guard.decision == "allow"
     assert result.execution.rows == [
         {"vendor_name": "Northwind", "approved_amount": 4200}
@@ -845,6 +868,12 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
                 application_version="safequery-test",
             ),
         )
+        persisted_candidate = session.query(PreviewCandidate).one()
+        persisted_generation_event = (
+            session.query(PreviewAuditEvent)
+            .filter(PreviewAuditEvent.event_type == "generation_completed")
+            .one()
+        )
 
     adapter_request = captured["adapter_request"]
     adapter_payload = adapter_request.model_dump()
@@ -860,6 +889,22 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
 
     assert result.preview.candidate.source_id == scenario.source.source_id
     assert result.generated.canonical_sql == scenario.expected.canonical_sql
+    assert persisted_candidate.candidate_sql == scenario.expected.canonical_sql
+    assert persisted_candidate.adapter_provider == "local_llm"
+    assert persisted_candidate.adapter_model == "safequery-test-sql"
+    assert persisted_candidate.adapter_version == "test.local_llm.v1"
+    assert persisted_candidate.adapter_run_id == "correlation-142"
+    assert persisted_candidate.prompt_version == "sql_generation_adapter_request.v1"
+    assert persisted_candidate.prompt_fingerprint is not None
+    assert scenario.prompt not in persisted_candidate.prompt_fingerprint
+    assert {
+        "adapter_provider": "local_llm",
+        "adapter_model": "safequery-test-sql",
+        "adapter_version": "test.local_llm.v1",
+        "adapter_run_id": "correlation-142",
+        "prompt_version": "sql_generation_adapter_request.v1",
+        "prompt_fingerprint": persisted_candidate.prompt_fingerprint,
+    }.items() <= persisted_generation_event.audit_payload.items()
     assert result.guard.decision == "allow"
     assert result.execution.rows == [
         {"vendor_name": "Northwind", "approved_amount": 4200}

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -31,7 +31,7 @@ def _session_scope() -> Iterator[Session]:
         session.execute(
             text(
                 "INSERT INTO alembic_version (version_num) "
-                "VALUES ('0007_preview_audit_event_persistence')"
+                "VALUES ('0008_generated_candidate_adapter_metadata')"
             )
         )
         session.commit()
@@ -125,7 +125,7 @@ def test_first_run_doctor_fails_closed_when_migration_metadata_is_unreadable(
     ]
     assert sections["migrations"]["detail"] == {
         "error": "RuntimeError",
-        "applied_revisions": ["0007_preview_audit_event_persistence"],
+        "applied_revisions": ["0008_generated_candidate_adapter_metadata"],
     }
     assert "source_registry" in sections
 

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -13,6 +13,7 @@ from app.services.sql_generation_adapter import (
     SQLGenerationAdapterResponse,
     SQLGenerationContextReferences,
     SQLGenerationSourceBinding,
+    build_sql_generation_adapter_run_metadata,
     resolve_sql_generation_adapter,
 )
 
@@ -155,6 +156,51 @@ def test_sql_generation_adapter_response_shape_is_typed_and_credential_free() ->
         assert exc.errors()[0]["type"] == "extra_forbidden"
     else:
         raise AssertionError("Expected response validation to reject credentials.")
+
+
+def test_sql_generation_adapter_run_metadata_fingerprints_safe_request_projection() -> None:
+    request = SQLGenerationAdapterRequest(
+        request_id="req_79_preview",
+        question="Show approved vendors by quarterly spend",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+        ),
+    )
+    response = SQLGenerationAdapterResponse(
+        candidate_sql="select vendor_id from approved_vendor_spend limit 50",
+        provider="local_llm",
+        adapter_version="local_llm.v1",
+        model="safequery-local-sql",
+    )
+
+    metadata = build_sql_generation_adapter_run_metadata(
+        adapter_request=request,
+        adapter_response=response,
+        adapter_run_id="correlation-79",
+    )
+
+    assert metadata.model_dump(exclude_none=True) == {
+        "adapter_provider": "local_llm",
+        "adapter_version": "local_llm.v1",
+        "adapter_model": "safequery-local-sql",
+        "adapter_run_id": "correlation-79",
+        "prompt_version": "sql_generation_adapter_request.v1",
+        "prompt_fingerprint": metadata.prompt_fingerprint,
+    }
+    assert metadata.prompt_fingerprint.startswith("sha256:")
+    assert "Show approved vendors" not in metadata.prompt_fingerprint
+    assert "sap-approved-spend" not in metadata.prompt_fingerprint
 
 
 def test_sql_generation_adapter_registry_fails_closed_when_disabled() -> None:

--- a/backend/tests/test_vertical_slice_lifecycle_revalidation.py
+++ b/backend/tests/test_vertical_slice_lifecycle_revalidation.py
@@ -16,6 +16,7 @@ from app.db.models.dataset_contract import (
     DatasetContractDataset,
     DatasetContractDatasetKind,
 )
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
@@ -206,6 +207,57 @@ def _unexpected_query_runner(**_: object) -> list[dict[str, object]]:
     raise AssertionError("execution must not run after lifecycle revalidation denies")
 
 
+def _assert_persisted_lifecycle_denial(
+    session: Session,
+    *,
+    request_id: str,
+    candidate_id: str,
+    correlation_id: str,
+    canonical_sql: str,
+    deny_code: str,
+    event_type: str,
+    candidate_state: str,
+) -> None:
+    persisted_candidate = (
+        session.query(PreviewCandidate)
+        .filter(
+            PreviewCandidate.request_id == request_id,
+            PreviewCandidate.candidate_id == candidate_id,
+        )
+        .one()
+    )
+    assert persisted_candidate.candidate_sql == canonical_sql
+    assert persisted_candidate.adapter_provider == "local_llm"
+    assert persisted_candidate.adapter_model == "safequery-test-sql"
+    assert persisted_candidate.adapter_version == "test.local_llm.v1"
+    assert persisted_candidate.adapter_run_id == correlation_id
+    assert persisted_candidate.prompt_fingerprint is not None
+
+    persisted_generation_event = (
+        session.query(PreviewAuditEvent)
+        .filter(
+            PreviewAuditEvent.request_id == request_id,
+            PreviewAuditEvent.candidate_id == candidate_id,
+            PreviewAuditEvent.event_type == "generation_completed",
+        )
+        .one()
+    )
+    assert persisted_generation_event.adapter_run_id == correlation_id
+
+    persisted_denial_event = (
+        session.query(PreviewAuditEvent)
+        .filter(
+            PreviewAuditEvent.request_id == request_id,
+            PreviewAuditEvent.candidate_id == candidate_id,
+            PreviewAuditEvent.primary_deny_code == deny_code,
+        )
+        .one()
+    )
+    assert persisted_denial_event.event_type == event_type
+    assert persisted_denial_event.candidate_state == candidate_state
+    assert persisted_denial_event.audit_payload["primary_deny_code"] == deny_code
+
+
 def test_mssql_vertical_slice_denies_expired_candidate_before_execution() -> None:
     with _session_scope() as session:
         _seed_source(
@@ -244,6 +296,16 @@ def test_mssql_vertical_slice_denies_expired_candidate_before_execution() -> Non
                     - timedelta(seconds=1),
                 ),
             )
+        _assert_persisted_lifecycle_denial(
+            session,
+            request_id=exc_info.value.audit_events[-1].request_id,
+            candidate_id=exc_info.value.audit_events[-1].query_candidate_id,
+            correlation_id="correlation-mssql-expired",
+            canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+            deny_code=DENY_APPROVAL_EXPIRED,
+            event_type="execution_denied",
+            candidate_state="denied",
+        )
 
     denial = exc_info.value.audit_events[-1].model_dump(exclude_none=True)
     assert exc_info.value.deny_code == DENY_APPROVAL_EXPIRED
@@ -351,6 +413,16 @@ def test_postgresql_vertical_slice_denies_invalidated_candidate_before_execution
                     invalidated_at=datetime.now(timezone.utc) - timedelta(seconds=1),
                 ),
             )
+        _assert_persisted_lifecycle_denial(
+            session,
+            request_id=exc_info.value.audit_events[-1].request_id,
+            candidate_id=exc_info.value.audit_events[-1].query_candidate_id,
+            correlation_id="correlation-postgres-invalidated",
+            canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
+            deny_code=DENY_CANDIDATE_INVALIDATED,
+            event_type="candidate_invalidated",
+            candidate_state="invalidated",
+        )
 
     denial = exc_info.value.audit_events[-1].model_dump(exclude_none=True)
     assert exc_info.value.deny_code == DENY_CANDIDATE_INVALIDATED


### PR DESCRIPTION
## Summary
- persist adapter provider, model, version, run correlation, prompt version, and safe prompt fingerprint on generated preview candidates
- include the same reconstruction metadata on durable preview lifecycle audit events
- add Alembic revision 0008 and focused regression coverage for MSSQL/PostgreSQL generation paths

## Verification
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_operator_workflow_history.py tests/test_audit_event_model.py tests/test_release_gate.py
- cd backend && python3 -m pytest tests/test_sql_generation_adapter_request.py tests/test_evaluation_harness.py::test_mssql_core_vertical_slice_submits_generates_guards_executes_and_audits tests/test_evaluation_harness.py::test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_audits tests/test_first_run_doctor.py
- cd backend && python3 -m pytest

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview candidates and audit events now store SQL-generation adapter metadata (provider, model, version, run ID) and prompt metadata (version, deterministic fingerprint) for better traceability.

* **Persistence / DB**
  * Migration added to persist the new adapter and prompt fields to preview candidate and audit records.

* **Tests**
  * Added/updated tests to validate persisted adapter/prompt metadata and fingerprinting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->