### PR TITLE
[N-5] Normalize adapter output before guard evaluation

### DIFF
--- a/backend/app/features/guard/sql_guard.py
+++ b/backend/app/features/guard/sql_guard.py
@@ -143,6 +143,10 @@ _MSSQL_MULTI_STATEMENT_SEPARATOR = re.compile(
     r";\s*\S|^\s*GO\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+_MSSQL_POSTGRESQL_LIMIT_SYNTAX = re.compile(
+    r"\bLIMIT\s+\d+(?:\s+OFFSET\s+\d+)?\s*;?\s*$",
+    re.IGNORECASE,
+)
 _POSTGRESQL_DENY_RULES: tuple[MSSQLGuardRule, ...] = (
     MSSQLGuardRule(
         code=DENY_WRITE_OPERATION,
@@ -176,6 +180,10 @@ _POSTGRESQL_DENY_RULES: tuple[MSSQLGuardRule, ...] = (
 
 _POSTGRESQL_QUERY_START = re.compile(r"^\s*(SELECT|WITH)\b", re.IGNORECASE)
 _POSTGRESQL_MULTI_STATEMENT_SEPARATOR = re.compile(r";\s*\S", re.IGNORECASE)
+_POSTGRESQL_MSSQL_TOP_SYNTAX = re.compile(
+    r"^\s*SELECT\s+TOP\s+(?:\(\s*)?\d+",
+    re.IGNORECASE,
+)
 _POSTGRESQL_IDENTIFIER = r"(?:\"(?:[^\"]|\"\")+\"|[A-Za-z_][\w$]*)"
 _POSTGRESQL_FROM_CLAUSE = re.compile(
     r"\bFROM\b(?P<body>.*?)(?=\bWHERE\b|\bGROUP\s+BY\b|\bHAVING\b|\bORDER\s+BY\b|"
@@ -353,6 +361,15 @@ def evaluate_mssql_sql_guard(
             detail="Canonical SQL must contain exactly one SELECT statement.",
         )
 
+    if _MSSQL_POSTGRESQL_LIMIT_SYNTAX.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="mssql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code=DENY_UNSUPPORTED_SQL_SYNTAX,
+            detail="PostgreSQL LIMIT syntax is not allowed in the MSSQL guard profile.",
+        )
+
     for rule in _MSSQL_DENY_RULES:
         if re.search(rule.pattern, canonical_sql, re.IGNORECASE):
             return _reject_sql_guard(
@@ -424,6 +441,15 @@ def evaluate_postgresql_sql_guard(
             source=request.source,
             code=DENY_MULTI_STATEMENT,
             detail="Canonical SQL must contain exactly one SELECT statement.",
+        )
+
+    if _POSTGRESQL_MSSQL_TOP_SYNTAX.search(canonical_sql):
+        return _reject_sql_guard(
+            profile="postgresql",
+            canonical_sql=canonical_sql,
+            source=request.source,
+            code=DENY_UNSUPPORTED_SQL_SYNTAX,
+            detail="MSSQL TOP syntax is not allowed in the PostgreSQL guard profile.",
         )
 
     for rule in _POSTGRESQL_DENY_RULES:

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -41,6 +41,7 @@ from app.services.sql_generation_adapter import (
     SQLGenerationAdapterRunMetadata,
     build_sql_generation_adapter_run_metadata,
     build_sql_generation_adapter_request,
+    normalize_adapter_generated_sql,
 )
 
 
@@ -337,7 +338,7 @@ def run_mssql_core_vertical_slice(
         adapter_response=adapter_response,
         adapter_run_id=candidate_audit_context.correlation_id,
     )
-    canonical_sql = adapter_response.candidate_sql
+    canonical_sql = normalize_adapter_generated_sql(adapter_response.candidate_sql)
     generated = GeneratedMSSQLCandidate(
         canonical_sql=canonical_sql,
         source=candidate_source,
@@ -380,6 +381,9 @@ def run_mssql_core_vertical_slice(
             candidate_sql=canonical_sql,
             adapter_metadata=adapter_metadata,
             audit_events=audit_events,
+            request_state="blocked",
+            candidate_state="blocked",
+            guard_status="blocked",
         )
         raise MSSQLVerticalSliceDenied(
             deny_code=primary_deny_code,
@@ -438,6 +442,9 @@ def run_mssql_core_vertical_slice(
         candidate_sql=canonical_sql,
         adapter_metadata=adapter_metadata,
         audit_events=audit_events,
+        request_state="previewed",
+        candidate_state="preview_ready",
+        guard_status="allow",
     )
 
     selection = select_execution_connector(candidate_source=candidate_source)

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -41,6 +41,7 @@ from app.services.sql_generation_adapter import (
     SQLGenerationAdapterRunMetadata,
     build_sql_generation_adapter_run_metadata,
     build_sql_generation_adapter_request,
+    normalize_adapter_generated_sql,
 )
 
 
@@ -356,7 +357,7 @@ def run_postgresql_core_vertical_slice(
         adapter_response=adapter_response,
         adapter_run_id=candidate_audit_context.correlation_id,
     )
-    canonical_sql = adapter_response.candidate_sql
+    canonical_sql = normalize_adapter_generated_sql(adapter_response.candidate_sql)
     generated = GeneratedPostgreSQLCandidate(
         canonical_sql=canonical_sql,
         source=candidate_source,
@@ -399,6 +400,9 @@ def run_postgresql_core_vertical_slice(
             candidate_sql=canonical_sql,
             adapter_metadata=adapter_metadata,
             audit_events=audit_events,
+            request_state="blocked",
+            candidate_state="blocked",
+            guard_status="blocked",
         )
         raise PostgreSQLVerticalSliceDenied(
             deny_code=primary_deny_code,
@@ -457,6 +461,9 @@ def run_postgresql_core_vertical_slice(
         candidate_sql=canonical_sql,
         adapter_metadata=adapter_metadata,
         audit_events=audit_events,
+        request_state="previewed",
+        candidate_state="preview_ready",
+        guard_status="allow",
     )
 
     selection = select_execution_connector(candidate_source=candidate_source)

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -523,6 +523,9 @@ def persist_generated_candidate_audit_context(
     candidate_sql: str,
     adapter_metadata: SQLGenerationAdapterRunMetadata,
     audit_events: list[SourceAwareAuditEvent],
+    request_state: str | None = None,
+    candidate_state: str | None = None,
+    guard_status: GuardStatus | None = None,
 ) -> None:
     try:
         preview_request = session.execute(
@@ -545,6 +548,8 @@ def persist_generated_candidate_audit_context(
                 "Generated candidate metadata cannot be rebound to a different request.",
             )
 
+        if request_state is not None:
+            preview_request.request_state = request_state
         preview_candidate.candidate_sql = candidate_sql
         preview_candidate.adapter_provider = adapter_metadata.adapter_provider
         preview_candidate.adapter_model = adapter_metadata.adapter_model
@@ -552,6 +557,10 @@ def persist_generated_candidate_audit_context(
         preview_candidate.adapter_run_id = adapter_metadata.adapter_run_id
         preview_candidate.prompt_version = adapter_metadata.prompt_version
         preview_candidate.prompt_fingerprint = adapter_metadata.prompt_fingerprint
+        if candidate_state is not None:
+            preview_candidate.candidate_state = candidate_state
+        if guard_status is not None:
+            preview_candidate.guard_status = guard_status
         _persist_preview_audit_events(
             session,
             preview_request=preview_request,

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -482,3 +482,15 @@ def build_sql_generation_adapter_run_metadata(
             f"sha256:{hashlib.sha256(prompt_projection.encode('utf-8')).hexdigest()}"
         ),
     )
+
+
+def normalize_adapter_generated_sql(candidate_sql: str) -> NonEmptyTrimmedString:
+    normalized = candidate_sql.strip()
+    if normalized.endswith(";"):
+        normalized = normalized[:-1].strip()
+    if not normalized:
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_response_invalid",
+            "SQL generation adapter returned empty SQL after normalization.",
+        )
+    return normalized

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -17,7 +17,7 @@ from app.db.models.dataset_contract import (
     DatasetContractDatasetKind,
 )
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
-from app.db.models.preview import PreviewAuditEvent, PreviewCandidate
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
 from app.features.evaluation import (
@@ -52,6 +52,7 @@ from app.features.guard.deny_taxonomy import (
     DENY_RUNTIME_RATE_LIMIT,
     DENY_SOURCE_BINDING_MISMATCH,
     DENY_UNSUPPORTED_SOURCE_BINDING,
+    DENY_UNSUPPORTED_SQL_SYNTAX,
 )
 from app.features.guard.sql_guard import evaluate_postgresql_sql_guard
 from app.services.candidate_lifecycle import (
@@ -935,6 +936,74 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
             "execution_policy_version": scenario.source.execution_policy_version,
             "connector_profile_version": scenario.source.connector_profile_version,
         }.items() <= dumped.items()
+
+
+def test_postgresql_core_vertical_slice_blocks_mssql_adapter_output_before_preview_ready() -> None:
+    from app.services.postgresql_vertical_slice import (
+        PostgreSQLVerticalSliceDenied,
+        run_postgresql_core_vertical_slice,
+    )
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-positive-approved-vendor-spend-top-vendors"
+    ]
+    incompatible_sql = "SELECT TOP 10 vendor_name FROM finance.approved_vendor_spend"
+
+    class IncompatibleAdapter:
+        def generate_sql(self, request):
+            return _adapter_response(incompatible_sql)
+
+    def fake_query_runner(**_: object) -> list[dict[str, object]]:
+        raise AssertionError("PostgreSQL execution must not run for incompatible SQL")
+
+    with _session_scope() as session:
+        _seed_postgresql_source(session, scenario=scenario)
+
+        with pytest.raises(PostgreSQLVerticalSliceDenied) as exc_info:
+            run_postgresql_core_vertical_slice(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=IncompatibleAdapter(),
+                business_postgres_url=POSTGRESQL_TEST_URL,
+                application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+                query_runner=fake_query_runner,
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-142-incompatible-adapter-output",
+                    correlation_id="correlation-142-incompatible-adapter-output",
+                    user_subject="user:alice",
+                    session_id="session-142-incompatible-adapter-output",
+                    query_candidate_id="candidate-142-incompatible-adapter-output",
+                    candidate_owner_subject="user:alice",
+                    guard_version="postgresql-guard-v1",
+                    application_version="safequery-test",
+                ),
+            )
+
+        persisted_request = session.query(PreviewRequest).one()
+        persisted_candidate = session.query(PreviewCandidate).one()
+        persisted_denial_event = (
+            session.query(PreviewAuditEvent)
+            .filter(PreviewAuditEvent.event_type == "guard_evaluated")
+            .one()
+        )
+
+    assert exc_info.value.deny_code == DENY_UNSUPPORTED_SQL_SYNTAX
+    assert exc_info.value.guard.decision == "reject"
+    assert persisted_request.request_state == "blocked"
+    assert persisted_candidate.candidate_sql == incompatible_sql
+    assert persisted_candidate.candidate_state == "blocked"
+    assert persisted_candidate.guard_status == "blocked"
+    assert persisted_denial_event.primary_deny_code == DENY_UNSUPPORTED_SQL_SYNTAX
+    assert persisted_denial_event.candidate_state == "denied"
 
 
 def test_postgresql_core_vertical_slice_denies_application_postgres_reuse_before_query() -> None:

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -14,6 +14,7 @@ from app.services.sql_generation_adapter import (
     SQLGenerationContextReferences,
     SQLGenerationSourceBinding,
     build_sql_generation_adapter_run_metadata,
+    normalize_adapter_generated_sql,
     resolve_sql_generation_adapter,
 )
 
@@ -201,6 +202,15 @@ def test_sql_generation_adapter_run_metadata_fingerprints_safe_request_projectio
     assert metadata.prompt_fingerprint.startswith("sha256:")
     assert "Show approved vendors" not in metadata.prompt_fingerprint
     assert "sap-approved-spend" not in metadata.prompt_fingerprint
+
+
+def test_normalize_adapter_generated_sql_strips_wrapping_whitespace_and_terminal_semicolon() -> None:
+    assert (
+        normalize_adapter_generated_sql(
+            "\n SELECT vendor_id FROM approved_vendor_spend LIMIT 50; \t"
+        )
+        == "SELECT vendor_id FROM approved_vendor_spend LIMIT 50"
+    )
 
 
 def test_sql_generation_adapter_registry_fails_closed_when_disabled() -> None:

--- a/backend/tests/test_sql_guard_mssql_profile.py
+++ b/backend/tests/test_sql_guard_mssql_profile.py
@@ -128,6 +128,43 @@ def test_mssql_sql_guard_rejects_non_mssql_source_binding_fail_closed() -> None:
     }
 
 
+def test_mssql_sql_guard_rejects_postgresql_limit_syntax_fail_closed() -> None:
+    evaluation = evaluate_mssql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT vendor_name FROM dbo.approved_vendor_spend LIMIT 10"
+            ),
+            "source": {
+                "source_id": "business-mssql-source",
+                "source_family": "mssql",
+                "source_flavor": "sqlserver",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "mssql",
+        "canonical_sql": (
+            "SELECT vendor_name FROM dbo.approved_vendor_spend LIMIT 10"
+        ),
+        "source": {
+            "source_id": "business-mssql-source",
+            "source_family": "mssql",
+            "source_flavor": "sqlserver",
+        },
+        "rejections": [
+            {
+                "code": "DENY_UNSUPPORTED_SQL_SYNTAX",
+                "detail": (
+                    "PostgreSQL LIMIT syntax is not allowed in the MSSQL guard profile."
+                ),
+                "path": "canonical_sql",
+            }
+        ],
+    }
+
+
 def test_mssql_sql_guard_rejects_waitfor_delay_fail_closed() -> None:
     evaluation = evaluate_mssql_sql_guard(
         {

--- a/backend/tests/test_sql_guard_postgresql_profile.py
+++ b/backend/tests/test_sql_guard_postgresql_profile.py
@@ -324,3 +324,40 @@ def test_postgresql_sql_guard_rejects_non_postgresql_source_binding_fail_closed(
             }
         ],
     }
+
+
+def test_postgresql_sql_guard_rejects_mssql_top_syntax_fail_closed() -> None:
+    evaluation = evaluate_postgresql_sql_guard(
+        {
+            "canonical_sql": (
+                "SELECT TOP 10 vendor_name FROM finance.approved_vendor_spend"
+            ),
+            "source": {
+                "source_id": "business-postgres-source",
+                "source_family": "postgresql",
+                "source_flavor": "warehouse",
+            },
+        }
+    )
+
+    assert evaluation.model_dump() == {
+        "decision": "reject",
+        "profile": "postgresql",
+        "canonical_sql": (
+            "SELECT TOP 10 vendor_name FROM finance.approved_vendor_spend"
+        ),
+        "source": {
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        },
+        "rejections": [
+            {
+                "code": "DENY_UNSUPPORTED_SQL_SYNTAX",
+                "detail": (
+                    "MSSQL TOP syntax is not allowed in the PostgreSQL guard profile."
+                ),
+                "path": "canonical_sql",
+            }
+        ],
+    }


### PR DESCRIPTION
## Summary
- normalize adapter-generated SQL before vertical-slice guard evaluation
- reject PostgreSQL LIMIT syntax in the MSSQL guard profile and MSSQL TOP syntax in the PostgreSQL guard profile
- persist guard-rejected generated candidates as blocked instead of preview-ready

## Verification
- cd backend && python3 -m pytest tests/test_sql_guard_common_contract.py tests/test_sql_guard_mssql_profile.py tests/test_sql_guard_postgresql_profile.py
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_request_source_selection.py
- cd backend && python3 -m pytest tests/test_evaluation_harness.py

Closes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to reject incompatible SQL syntax—PostgreSQL `LIMIT` syntax in MSSQL contexts and MSSQL `TOP` syntax in PostgreSQL contexts—with clear error messaging.

* **Improvements**
  * Enhanced SQL normalization for adapter-generated queries.
  * Expanded audit logging to track detailed query lifecycle states (blocked, previewed, etc.) for improved visibility.

* **Tests**
  * Added test coverage for syntax compatibility validation and lifecycle state tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->