### PR TITLE
[N-6] Verify adapter credential and execution isolation

### DIFF
--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -123,6 +123,61 @@ class SQLGenerationAdapterConfigurationError(RuntimeError):
         self.code = code
 
 
+_FORBIDDEN_ADAPTER_RESPONSE_KEYS = frozenset(
+    {
+        "business_postgres_url",
+        "business_mssql_connection_string",
+        "connection_reference",
+        "connection_string",
+        "credentials",
+        "database_url",
+        "execute",
+        "execution_authority",
+        "execution_handle",
+        "execution_result",
+        "query_runner",
+        "raw_schema_inventory",
+        "rows",
+        "runtime_controls",
+        "source_credentials",
+    }
+)
+
+
+def _find_forbidden_adapter_response_key(value: object) -> str | None:
+    if isinstance(value, Mapping):
+        for key, nested_value in value.items():
+            normalized_key = str(key).strip().casefold()
+            if normalized_key in _FORBIDDEN_ADAPTER_RESPONSE_KEYS:
+                return str(key)
+            nested_match = _find_forbidden_adapter_response_key(nested_value)
+            if nested_match is not None:
+                return nested_match
+    elif isinstance(value, list):
+        for item in value:
+            nested_match = _find_forbidden_adapter_response_key(item)
+            if nested_match is not None:
+                return nested_match
+
+    return None
+
+
+def _require_adapter_response_has_no_execution_material(
+    decoded: Mapping[str, object],
+    *,
+    provider_label: str,
+) -> None:
+    forbidden_key = _find_forbidden_adapter_response_key(decoded)
+    if forbidden_key is not None:
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_response_forbidden_material",
+            (
+                f"{provider_label} SQL generation runtime returned forbidden "
+                f"adapter boundary material '{forbidden_key}'."
+            ),
+        )
+
+
 class SQLGenerationAdapter(Protocol):
     def generate_sql(
         self,
@@ -235,6 +290,10 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
                 "sql_generation_response_invalid",
                 "Local LLM SQL generation runtime returned an invalid response.",
             )
+        _require_adapter_response_has_no_execution_material(
+            decoded,
+            provider_label="Local LLM",
+        )
 
         candidate_sql = decoded.get("candidate_sql")
         model = decoded.get("model", self.model)
@@ -264,6 +323,11 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
         for _attempt in range(self.retry_count + 1):
             try:
                 response = self._dispatch_vanna_sql(request)
+            except SQLGenerationAdapterConfigurationError as exc:
+                if exc.code == "sql_generation_response_forbidden_material":
+                    raise
+                last_error = exc
+                continue
             except (
                 HTTPError,
                 URLError,
@@ -271,7 +335,6 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
                 OSError,
                 ValidationError,
                 json.JSONDecodeError,
-                SQLGenerationAdapterConfigurationError,
             ) as exc:
                 last_error = exc
                 continue
@@ -351,6 +414,10 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
                 "sql_generation_response_invalid",
                 "Vanna SQL generation runtime returned an invalid response.",
             )
+        _require_adapter_response_has_no_execution_material(
+            decoded,
+            provider_label="Vanna",
+        )
 
         candidate_sql = decoded.get("candidate_sql", decoded.get("sql"))
         model = decoded.get("model", self.model)

--- a/backend/tests/test_adapter_credential_isolation.py
+++ b/backend/tests/test_adapter_credential_isolation.py
@@ -5,8 +5,10 @@ from app.services.generation_context import (
     PreparedGenerationContext,
 )
 from app.services.sql_generation_adapter import (
+    SQLGenerationAdapterConfigurationError,
     SQLGenerationAdapterRequest,
     build_sql_generation_adapter_request,
+    resolve_sql_generation_adapter,
 )
 
 
@@ -71,3 +73,31 @@ def test_build_sql_generation_adapter_request_uses_only_adapter_safe_fields() ->
     assert "connection_reference" not in str(dumped)
     assert "connector_profile_id" not in str(dumped)
     assert "execution_policy_id" not in str(dumped)
+
+
+def test_adapter_configuration_rejects_source_execution_material() -> None:
+    try:
+        resolve_sql_generation_adapter(
+            {
+                "provider": "vanna",
+                "vanna_base_url": "http://vanna:8084",
+                "business_postgres_url": (
+                    "postgresql://safequery_source:<credential>@business:5432/source"
+                ),
+                "connection_reference": "vault:sap-approved-spend",
+                "execution_authority": True,
+            }
+        )
+    except SQLGenerationAdapterConfigurationError as exc:
+        assert exc.code == "sql_generation_settings_invalid"
+        assert {
+            error["loc"][0]
+            for error in exc.__cause__.errors()
+            if error["type"] == "extra_forbidden"
+        } == {
+            "business_postgres_url",
+            "connection_reference",
+            "execution_authority",
+        }
+    else:
+        raise AssertionError("Expected source execution material to fail closed.")

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -541,7 +541,6 @@ def test_vanna_generation_uses_curated_context_and_bounded_request(
                 {
                     "sql": "select vendor_id from approved_vendor_spend limit 50",
                     "model": "warehouse-assistant",
-                    "execution_result": [{"vendor_id": 1}],
                 }
             ).encode("utf-8")
 
@@ -600,6 +599,70 @@ def test_vanna_generation_uses_curated_context_and_bounded_request(
     assert "execution_result" not in json.dumps(response.model_dump())
 
 
+def test_vanna_generation_fails_closed_for_execution_material_response(
+    monkeypatch,
+) -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "vanna",
+            "vanna_base_url": "http://vanna:8084",
+            "retry_count": 0,
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_82_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            datasets=[
+                {
+                    "schema_name": "finance",
+                    "dataset_name": "approved_vendor_spend",
+                    "dataset_kind": "table",
+                },
+            ],
+        ),
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "sql": "select vendor_id from approved_vendor_spend limit 50",
+                    "execution_result": [{"vendor_id": 1}],
+                }
+            ).encode("utf-8")
+
+    monkeypatch.setattr(adapter_module, "urlopen", lambda request, timeout=None: Response())
+
+    try:
+        adapter.generate_sql(request)
+    except SQLGenerationAdapterConfigurationError as exc:
+        assert exc.code == "sql_generation_response_forbidden_material"
+        assert "execution_result" in str(exc)
+    else:
+        raise AssertionError("Expected execution material response to fail closed.")
+
+
 def test_vanna_generation_fails_closed_for_malformed_response(monkeypatch) -> None:
     adapter = resolve_sql_generation_adapter(
         {
@@ -644,7 +707,7 @@ def test_vanna_generation_fails_closed_for_malformed_response(monkeypatch) -> No
             return None
 
         def read(self) -> bytes:
-            return json.dumps({"execution_result": [{"vendor_id": 1}]}).encode("utf-8")
+            return json.dumps({"model": "warehouse-assistant"}).encode("utf-8")
 
     monkeypatch.setattr(adapter_module, "urlopen", lambda request, timeout=None: Response())
 


### PR DESCRIPTION
## Summary
- reject SQL generation adapter responses that include source credentials, connection references, execution authority, rows, or execution-result material
- keep forbidden Vanna response material fail-closed instead of silently projecting it down to candidate SQL
- add focused regressions for adapter config source-execution material and runtime execution-result leakage

## Verification
- cd backend && python3 -m pytest tests/test_adapter_credential_isolation.py tests/test_adapter_single_source_validation.py
- cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_application_postgres_guard.py
- cd backend && python3 -m pytest tests/test_adapter_credential_isolation.py tests/test_sql_generation_adapter_request.py tests/test_adapter_single_source_validation.py
- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_vertical_slice_lifecycle_revalidation.py tests/test_generation_context_preparation.py
- cd backend && python3 -m pytest

Closes #251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented response-safety validation that scans SQL generation responses for sensitive material and raises errors when detected.
  * Added configuration validation to reject unsafe execution credentials.

* **Tests**
  * Added comprehensive test coverage for response validation and configuration security enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->