### PR TITLE
[N-7] Connect supplemental-only MLflow tracing to adapter runs

### DIFF
--- a/backend/app/features/mlflow_export/__init__.py
+++ b/backend/app/features/mlflow_export/__init__.py
@@ -7,6 +7,7 @@ from app.features.mlflow_export.contract import (
     MLflowRedactedSample,
     build_mlflow_export_from_audit_event,
     build_mlflow_export_from_evaluation_scenario,
+    export_adapter_run_trace_from_audit_event,
     prepare_mlflow_export_from_audit_event,
     prepare_mlflow_export_from_evaluation_scenario,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "MLflowRedactedSample",
     "build_mlflow_export_from_audit_event",
     "build_mlflow_export_from_evaluation_scenario",
+    "export_adapter_run_trace_from_audit_event",
     "prepare_mlflow_export_from_audit_event",
     "prepare_mlflow_export_from_evaluation_scenario",
 ]

--- a/backend/app/features/mlflow_export/contract.py
+++ b/backend/app/features/mlflow_export/contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from collections.abc import Mapping
 from typing import Literal, Optional, Protocol
 from uuid import UUID
@@ -58,6 +59,11 @@ _PROHIBITED_SAMPLE_PATTERNS = (
     re.compile(r"\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}\b", re.IGNORECASE),
 )
 
+_RAW_WORKSTATION_PATH_PATTERNS = (
+    re.compile(r"(?<![A-Za-z0-9_.-])/(?:Users|home)/[^/\s]+/"),
+    re.compile(r"(?<![A-Za-z0-9_.-])[A-Za-z]:\\Users\\[^\\\s]+\\"),
+)
+
 
 PROHIBITED_EXPORT_FIELDS = frozenset(
     {
@@ -78,6 +84,8 @@ PROHIBITED_EXPORT_FIELDS = frozenset(
         "execution_approval_state",
         "guard_decision",
         "identity_claims",
+        "connection_reference",
+        "connection_references",
         "release_gate_status",
         "runtime_safety_state",
         "sql_guard_decision",
@@ -184,7 +192,10 @@ class MLflowExportPayload(BaseModel):
     prompt_version: Optional[NonEmptyTrimmedString] = None
     model_version: Optional[NonEmptyTrimmedString] = None
     application_version: Optional[NonEmptyTrimmedString] = None
+    adapter_provider: Optional[NonEmptyTrimmedString] = None
+    adapter_model: Optional[NonEmptyTrimmedString] = None
     adapter_version: Optional[NonEmptyTrimmedString] = None
+    adapter_run_id: Optional[NonEmptyTrimmedString] = None
 
     evaluation_scenario_id: Optional[NonEmptyTrimmedString] = None
     evaluation_kind: Optional[EvaluationScenarioKind] = None
@@ -202,6 +213,12 @@ class MLflowExportPayload(BaseModel):
             raise ValueError(
                 "MLflow export payload includes prohibited field(s): "
                 + ", ".join(prohibited)
+            )
+        raw_path_fields = _raw_workstation_path_fields_in_mapping(value)
+        if raw_path_fields:
+            raise ValueError(
+                "MLflow export payload includes raw workstation-local path field(s): "
+                + ", ".join(raw_path_fields)
             )
         return value
 
@@ -360,7 +377,10 @@ def build_mlflow_export_from_audit_event(
         prompt_version=prompt_version,
         model_version=model_version,
         application_version=audit_event.application_version,
+        adapter_provider=audit_event.adapter_provider,
+        adapter_model=audit_event.adapter_model,
         adapter_version=audit_event.adapter_version,
+        adapter_run_id=audit_event.adapter_run_id,
         redacted_samples=redacted_samples,
     )
 
@@ -423,6 +443,59 @@ def prepare_mlflow_export_from_audit_event(
         safequery_audit_event_id=audit_event.event_id,
         request_id=audit_event.request_id,
     )
+
+
+def export_adapter_run_trace_from_audit_event(
+    audit_event: SourceAwareAuditEvent,
+    *,
+    enabled: bool,
+    export_sink: Callable[[MLflowExportPayload], object] | None = None,
+    retention_days: int = 30,
+    authoritative_audit_retention_days: int = 90,
+    retention_extension_approval_id: Optional[str] = None,
+    access_roles: tuple[AccessRole, ...] = ("engineering", "operations"),
+    redacted_samples: tuple[MLflowRedactedSample, ...] = (),
+    latency_ms: Optional[int] = None,
+    mlflow_run_id: Optional[str] = None,
+    prompt_version: Optional[str] = None,
+    model_version: Optional[str] = None,
+) -> MLflowExportDecision:
+    decision = prepare_mlflow_export_from_audit_event(
+        audit_event,
+        enabled=enabled,
+        retention_days=retention_days,
+        authoritative_audit_retention_days=authoritative_audit_retention_days,
+        retention_extension_approval_id=retention_extension_approval_id,
+        access_roles=access_roles,
+        redacted_samples=redacted_samples,
+        latency_ms=latency_ms,
+        mlflow_run_id=mlflow_run_id,
+        prompt_version=prompt_version or audit_event.prompt_version,
+        model_version=model_version,
+    )
+    if not enabled or decision.payload is None:
+        return decision
+    if export_sink is None:
+        return MLflowExportDecision(
+            payload=decision.payload,
+            suppressed=True,
+            reasons=("export_sink_missing",),
+            safequery_audit_event_id=audit_event.event_id,
+            request_id=audit_event.request_id,
+        )
+
+    try:
+        export_sink(decision.payload)
+    except Exception as exc:
+        return MLflowExportDecision(
+            payload=decision.payload,
+            suppressed=True,
+            reasons=(f"export_sink_failed:{exc.__class__.__name__}",),
+            safequery_audit_event_id=audit_event.event_id,
+            request_id=audit_event.request_id,
+        )
+
+    return decision
 
 
 def build_mlflow_export_from_evaluation_scenario(
@@ -619,3 +692,22 @@ def _prohibited_export_fields_in_mapping(value: object) -> tuple[str, ...]:
 
     collect(value)
     return tuple(sorted(prohibited))
+
+
+def _raw_workstation_path_fields_in_mapping(value: object) -> tuple[str, ...]:
+    fields: set[str] = set()
+
+    def collect(candidate: object, field_name: str | None = None) -> None:
+        if isinstance(candidate, Mapping):
+            for key, nested_value in candidate.items():
+                collect(nested_value, key if isinstance(key, str) else field_name)
+        elif isinstance(candidate, (list, tuple)):
+            for item in candidate:
+                collect(item, field_name)
+        elif isinstance(candidate, str) and any(
+            pattern.search(candidate) for pattern in _RAW_WORKSTATION_PATH_PATTERNS
+        ):
+            fields.add(field_name or "<unknown>")
+
+    collect(value)
+    return tuple(sorted(fields))

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import timedelta
 from typing import cast
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
-from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent, SourceFamily
+from app.features.audit.event_model import (
+    AuditEventType,
+    SourceAwareAuditEvent,
+    SourceFamily,
+)
 from app.features.auth.context import AuthenticatedSubject
 from app.features.execution import execute_candidate_sql, select_execution_connector
 from app.features.execution.runtime import (
@@ -20,6 +25,11 @@ from app.features.execution.runtime import (
     QueryRunner,
 )
 from app.features.guard import SQLGuardEvaluation, evaluate_mssql_sql_guard
+from app.features.mlflow_export import (
+    MLflowExportDecision,
+    MLflowExportPayload,
+    export_adapter_run_trace_from_audit_event,
+)
 from app.services.candidate_lifecycle import (
     CandidateLifecycleAuditContext,
     CandidateLifecycleRecord,
@@ -80,6 +90,9 @@ class MSSQLCoreVerticalSliceResult(BaseModel):
     guard: SQLGuardEvaluation
     execution: ExecutionResult
     audit_events: list[SourceAwareAuditEvent]
+    supplemental_mlflow_exports: list[MLflowExportDecision] = Field(
+        default_factory=list
+    )
 
 
 class MSSQLVerticalSliceDenied(PermissionError):
@@ -288,6 +301,11 @@ def run_mssql_core_vertical_slice(
     runtime_safety_state: ExecutionRuntimeSafetyState | None = None,
     audit_context: PreviewAuditContext,
     candidate_lifecycle: CandidateLifecycleRecord | None = None,
+    mlflow_adapter_run_export_enabled: bool = False,
+    mlflow_adapter_run_export_sink: (
+        Callable[[MLflowExportPayload], object] | None
+    ) = None,
+    mlflow_run_id: str | None = None,
 ) -> MSSQLCoreVerticalSliceResult:
     normalized_business_mssql_connection_string = (
         _normalize_business_mssql_connection_string(business_mssql_connection_string)
@@ -352,6 +370,14 @@ def run_mssql_core_vertical_slice(
         candidate_state="generated",
         adapter_metadata=adapter_metadata,
     )
+    supplemental_mlflow_exports = [
+        export_adapter_run_trace_from_audit_event(
+            audit_events[-1],
+            enabled=mlflow_adapter_run_export_enabled,
+            export_sink=mlflow_adapter_run_export_sink,
+            mlflow_run_id=mlflow_run_id,
+        )
+    ]
 
     guard = evaluate_mssql_sql_guard(
         {
@@ -472,4 +498,5 @@ def run_mssql_core_vertical_slice(
         guard=guard,
         execution=execution,
         audit_events=audit_events,
+        supplemental_mlflow_exports=supplemental_mlflow_exports,
     )

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import timedelta
 from typing import cast
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
-from app.features.audit.event_model import AuditEventType, SourceAwareAuditEvent, SourceFamily
+from app.features.audit.event_model import (
+    AuditEventType,
+    SourceAwareAuditEvent,
+    SourceFamily,
+)
 from app.features.auth.context import AuthenticatedSubject
 from app.features.execution import execute_candidate_sql, select_execution_connector
 from app.features.execution.runtime import (
@@ -20,6 +25,11 @@ from app.features.execution.runtime import (
     QueryRunner,
 )
 from app.features.guard import SQLGuardEvaluation, evaluate_postgresql_sql_guard
+from app.features.mlflow_export import (
+    MLflowExportDecision,
+    MLflowExportPayload,
+    export_adapter_run_trace_from_audit_event,
+)
 from app.services.candidate_lifecycle import (
     CandidateLifecycleAuditContext,
     CandidateLifecycleRecord,
@@ -93,6 +103,9 @@ class PostgreSQLCoreVerticalSliceResult(BaseModel):
     guard: SQLGuardEvaluation
     execution: ExecutionResult
     audit_events: list[SourceAwareAuditEvent]
+    supplemental_mlflow_exports: list[MLflowExportDecision] = Field(
+        default_factory=list
+    )
 
 
 class PostgreSQLVerticalSliceDenied(PermissionError):
@@ -302,6 +315,11 @@ def run_postgresql_core_vertical_slice(
     runtime_safety_state: ExecutionRuntimeSafetyState | None = None,
     audit_context: PreviewAuditContext,
     candidate_lifecycle: CandidateLifecycleRecord | None = None,
+    mlflow_adapter_run_export_enabled: bool = False,
+    mlflow_adapter_run_export_sink: (
+        Callable[[MLflowExportPayload], object] | None
+    ) = None,
+    mlflow_run_id: str | None = None,
 ) -> PostgreSQLCoreVerticalSliceResult:
     normalized_business_postgres_url = _normalize_business_postgres_url(
         business_postgres_url
@@ -371,6 +389,14 @@ def run_postgresql_core_vertical_slice(
         candidate_state="generated",
         adapter_metadata=adapter_metadata,
     )
+    supplemental_mlflow_exports = [
+        export_adapter_run_trace_from_audit_event(
+            audit_events[-1],
+            enabled=mlflow_adapter_run_export_enabled,
+            export_sink=mlflow_adapter_run_export_sink,
+            mlflow_run_id=mlflow_run_id,
+        )
+    ]
 
     guard = evaluate_postgresql_sql_guard(
         {
@@ -492,4 +518,5 @@ def run_postgresql_core_vertical_slice(
         guard=guard,
         execution=execution,
         audit_events=audit_events,
+        supplemental_mlflow_exports=supplemental_mlflow_exports,
     )

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -825,6 +825,7 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
         "postgresql-positive-approved-vendor-spend-top-vendors"
     ]
     captured: dict[str, object] = {}
+    exported_mlflow_traces: list[dict[str, object]] = []
 
     class RecordingAdapter:
         def generate_sql(self, request):
@@ -857,6 +858,13 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
             business_postgres_url=POSTGRESQL_TEST_URL,
             application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
             query_runner=fake_query_runner,
+            mlflow_adapter_run_export_enabled=True,
+            mlflow_adapter_run_export_sink=(
+                lambda payload: exported_mlflow_traces.append(
+                    payload.model_dump(exclude_none=True)
+                )
+            ),
+            mlflow_run_id="mlflow-run-142",
             audit_context=PreviewAuditContext(
                 occurred_at=datetime.now(timezone.utc),
                 request_id="request-142",
@@ -906,6 +914,21 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
         "prompt_version": "sql_generation_adapter_request.v1",
         "prompt_fingerprint": persisted_candidate.prompt_fingerprint,
     }.items() <= persisted_generation_event.audit_payload.items()
+    assert len(exported_mlflow_traces) == 1
+    assert {
+        "mlflow_run_id": "mlflow-run-142",
+        "adapter_provider": "local_llm",
+        "adapter_model": "safequery-test-sql",
+        "adapter_version": "test.local_llm.v1",
+        "adapter_run_id": "correlation-142",
+        "prompt_version": "sql_generation_adapter_request.v1",
+        "source_id": scenario.source.source_id,
+    }.items() <= exported_mlflow_traces[0].items()
+    assert exported_mlflow_traces[0]["authority"] == "engineering_observability"
+    assert exported_mlflow_traces[0]["can_authorize_or_mutate_audit"] is False
+    assert "connection_reference" not in exported_mlflow_traces[0]
+    assert "canonical_sql" not in exported_mlflow_traces[0]
+    assert result.supplemental_mlflow_exports[0].suppressed is False
     assert result.guard.decision == "allow"
     assert result.execution.rows == [
         {"vendor_name": "Northwind", "approved_amount": 4200}
@@ -936,6 +959,88 @@ def test_postgresql_core_vertical_slice_submits_generates_guards_executes_and_au
             "execution_policy_version": scenario.source.execution_policy_version,
             "connector_profile_version": scenario.source.connector_profile_version,
         }.items() <= dumped.items()
+
+
+def test_postgresql_adapter_mlflow_failure_keeps_authoritative_preview_clean() -> None:
+    from app.services.postgresql_vertical_slice import run_postgresql_core_vertical_slice
+    from app.services.request_preview import PreviewAuditContext, PreviewSubmissionRequest
+
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-positive-approved-vendor-spend-top-vendors"
+    ]
+
+    class RecordingAdapter:
+        def generate_sql(self, request):
+            return _adapter_response(scenario.expected.canonical_sql)
+
+    def fake_query_runner(
+        *,
+        database_url: str,
+        canonical_sql: str,
+    ) -> list[dict[str, object]]:
+        return [{"vendor_name": "Northwind", "approved_amount": 4200}]
+
+    def failing_mlflow_sink(payload) -> None:
+        raise RuntimeError("mlflow unavailable")
+
+    with _session_scope() as session:
+        _seed_postgresql_source(session, scenario=scenario)
+
+        result = run_postgresql_core_vertical_slice(
+            payload=PreviewSubmissionRequest(
+                question=scenario.prompt,
+                source_id=scenario.source.source_id,
+            ),
+            authenticated_subject=AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session=session,
+            sql_generation_adapter=RecordingAdapter(),
+            business_postgres_url=POSTGRESQL_TEST_URL,
+            application_postgres_url=APPLICATION_POSTGRESQL_TEST_URL,
+            query_runner=fake_query_runner,
+            mlflow_adapter_run_export_enabled=True,
+            mlflow_adapter_run_export_sink=failing_mlflow_sink,
+            mlflow_run_id="mlflow-run-142",
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime.now(timezone.utc),
+                request_id="request-142-mlflow-failure",
+                correlation_id="correlation-142-mlflow-failure",
+                user_subject="user:alice",
+                session_id="session-142-mlflow-failure",
+                query_candidate_id="candidate-142-mlflow-failure",
+                candidate_owner_subject="user:alice",
+                guard_version="postgresql-guard-v1",
+                application_version="safequery-test",
+            ),
+        )
+        persisted_request = session.query(PreviewRequest).one()
+        persisted_candidate = session.query(PreviewCandidate).one()
+        persisted_events = (
+            session.query(PreviewAuditEvent)
+            .order_by(PreviewAuditEvent.lifecycle_order)
+            .all()
+        )
+
+    assert result.supplemental_mlflow_exports[0].suppressed is True
+    assert result.supplemental_mlflow_exports[0].reasons == (
+        "export_sink_failed:RuntimeError",
+    )
+    assert persisted_request.request_state == "previewed"
+    assert persisted_candidate.candidate_state == "preview_ready"
+    assert persisted_candidate.guard_status == "allow"
+    assert persisted_candidate.candidate_sql == scenario.expected.canonical_sql
+    assert persisted_candidate.adapter_run_id == "correlation-142-mlflow-failure"
+    assert [event.event_type for event in persisted_events] == [
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+    ]
+    serialized_events = str([event.audit_payload for event in persisted_events])
+    assert "mlflow unavailable" not in serialized_events
+    assert "mlflow_run_id" not in serialized_events
 
 
 def test_postgresql_core_vertical_slice_blocks_mssql_adapter_output_before_preview_ready() -> None:

--- a/backend/tests/test_mlflow_export_contract.py
+++ b/backend/tests/test_mlflow_export_contract.py
@@ -17,6 +17,7 @@ from app.features.mlflow_export import (
     MLflowEvaluationArtifactLink,
     MLflowRedactedSample,
     MLflowExportPayload,
+    export_adapter_run_trace_from_audit_event,
     prepare_mlflow_export_from_audit_event,
     prepare_mlflow_export_from_evaluation_scenario,
     build_mlflow_export_from_audit_event,
@@ -97,6 +98,82 @@ def test_mlflow_export_payload_serializes_source_aware_audit_metadata() -> None:
     assert "raw_result_set" not in serialized
     assert "user_subject" not in serialized
     assert serialized["safequery_audit_event_id"] != serialized["mlflow_run_id"]
+
+
+def test_mlflow_adapter_run_trace_exports_safe_supplemental_metadata() -> None:
+    audit_event = _execution_audit_event(
+        adapter_provider="local_llm",
+        adapter_model="safequery-test-sql",
+        adapter_version="test.local_llm.v1",
+        adapter_run_id="correlation-123",
+        prompt_version="sql_generation_adapter_request.v1",
+    )
+    exported: list[dict[str, object]] = []
+
+    decision = export_adapter_run_trace_from_audit_event(
+        audit_event,
+        enabled=True,
+        export_sink=lambda payload: exported.append(
+            payload.model_dump(exclude_none=True)
+        ),
+        mlflow_run_id="mlflow-run-123",
+    )
+
+    assert decision.payload is not None
+    assert decision.suppressed is False
+    assert len(exported) == 1
+    serialized = exported[0]
+    assert {
+        "adapter_provider": "local_llm",
+        "adapter_model": "safequery-test-sql",
+        "adapter_version": "test.local_llm.v1",
+        "adapter_run_id": "correlation-123",
+        "prompt_version": "sql_generation_adapter_request.v1",
+    }.items() <= serialized.items()
+    assert serialized["authority"] == "engineering_observability"
+    assert serialized["can_authorize_or_mutate_audit"] is False
+    assert "connection_reference" not in serialized
+    assert "credentials" not in serialized
+    assert "canonical_sql" not in serialized
+
+
+def test_mlflow_adapter_run_trace_disabled_does_not_export() -> None:
+    exported: list[MLflowExportPayload] = []
+
+    decision = export_adapter_run_trace_from_audit_event(
+        _execution_audit_event(),
+        enabled=False,
+        export_sink=exported.append,
+        mlflow_run_id="mlflow-run-123",
+    )
+
+    assert decision.payload is None
+    assert decision.suppressed is False
+    assert exported == []
+
+
+def test_mlflow_adapter_run_trace_failure_is_non_blocking() -> None:
+    audit_event = _execution_audit_event(
+        adapter_provider="local_llm",
+        adapter_model="safequery-test-sql",
+        adapter_run_id="correlation-123",
+    )
+
+    def failing_sink(payload: MLflowExportPayload) -> None:
+        raise RuntimeError("mlflow unavailable")
+
+    decision = export_adapter_run_trace_from_audit_event(
+        audit_event,
+        enabled=True,
+        export_sink=failing_sink,
+        mlflow_run_id="mlflow-run-123",
+    )
+
+    assert decision.payload is not None
+    assert decision.suppressed is True
+    assert decision.reasons == ("export_sink_failed:RuntimeError",)
+    assert decision.safequery_audit_event_id == audit_event.event_id
+    assert decision.request_id == audit_event.request_id
 
 
 def test_mlflow_export_audit_builder_rejects_missing_source_versions() -> None:
@@ -360,6 +437,7 @@ def test_mlflow_evaluation_export_rejects_inconsistent_token_counts() -> None:
         "execution_approval_state",
         "guard_decision",
         "identity_claims",
+        "connection_reference",
         "release_gate_status",
         "runtime_safety_state",
         "sql_guard_decision",
@@ -388,6 +466,26 @@ def test_mlflow_export_payload_rejects_prohibited_data_classes(
         f"MLflow export payload includes prohibited field(s): {prohibited_field}"
         in str(exc_info.value)
     )
+
+
+def test_mlflow_export_payload_rejects_raw_workstation_local_paths() -> None:
+    workstation_path = "/" + "/".join(("Users", "sample-operator", "SafeQuery"))
+
+    with pytest.raises(ValidationError) as exc_info:
+        MLflowExportPayload(
+            export_kind="audit_trace",
+            safequery_audit_event_id=uuid4(),
+            request_id="request-123",
+            source_id="business-mssql-source",
+            source_family="mssql",
+            source_flavor="sqlserver",
+            dataset_contract_version=3,
+            schema_snapshot_version=7,
+            execution_policy_version=2,
+            model_version=workstation_path,
+        )
+
+    assert "raw workstation-local path field(s): model_version" in str(exc_info.value)
 
 
 def test_mlflow_export_payload_rejects_mlflow_as_audit_authority() -> None:


### PR DESCRIPTION
## Summary
- add adapter run fields to supplemental MLflow audit trace payloads
- add a non-blocking adapter run trace export helper with disabled, success, and sink-failure behavior
- wire MSSQL and PostgreSQL adapter runs to the optional supplemental export sink while keeping SafeQuery audit/preview records authoritative

## Verification
- cd backend && python3 -m pytest tests/test_mlflow_export_contract.py tests/test_release_gate.py
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_audit_event_model.py
- cd backend && python3 -m pytest tests/test_evaluation_harness.py

Closes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting adapter run traces with enhanced metadata (adapter provider, model, and run identifiers)
  * Enhanced data security by restricting export of sensitive connection references and local file paths
  * Integrated trace export functionality across database operations with non-blocking error handling

* **Tests**
  * Added comprehensive validation tests for export scenarios and failure cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->