### PR TITLE
Wire adapter SQL into HTTP preview

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -19,6 +19,7 @@ _SAFE_API_ERROR_CODES = frozenset(
         "session_invalid",
         "csrf_failed",
         "entitlement_denied",
+        "preview_generation_failed",
         "preview_source_malformed",
         "preview_source_unavailable",
     }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,7 @@ from app.services.request_preview import (
     PreviewSubmissionResponse,
     submit_preview_request,
 )
+from app.services.sql_generation_adapter import resolve_sql_generation_adapter
 from app.services.operator_workflow import (
     OperatorWorkflowSnapshot,
     get_operator_workflow_snapshot,
@@ -130,6 +131,11 @@ def create_app() -> FastAPI:
         version="0.1.0",
         summary="Minimum SafeQuery control-plane baseline.",
         lifespan=lifespan,
+    )
+    sql_generation_adapter = (
+        None
+        if settings.sql_generation.provider == "disabled"
+        else resolve_sql_generation_adapter(settings.sql_generation)
     )
 
     app.add_middleware(
@@ -266,6 +272,7 @@ def create_app() -> FastAPI:
                 authenticated_subject,
                 session,
                 audit_context=audit_context,
+                sql_generation_adapter=sql_generation_adapter,
             )
         except PreviewSubmissionEntitlementError as exc:
             raise api_error(

--- a/backend/app/services/generation_context.py
+++ b/backend/app/services/generation_context.py
@@ -66,6 +66,15 @@ class PreparedGenerationContext(BaseModel):
 class GenerationContextPreparationError(ValueError):
     """Raised when curated generation context cannot be prepared safely."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "sql_generation_context_unavailable",
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+
 
 def prepare_generation_context(
     *,
@@ -85,8 +94,16 @@ def prepare_generation_context(
             source,
             dataset_contract,
         )
-    except (SourceGovernanceResolutionError, SourceEntitlementError) as exc:
-        raise GenerationContextPreparationError(str(exc)) from exc
+    except SourceGovernanceResolutionError as exc:
+        raise GenerationContextPreparationError(
+            str(exc),
+            code="governance_resolution_failed",
+        ) from exc
+    except SourceEntitlementError as exc:
+        raise GenerationContextPreparationError(
+            str(exc),
+            code="entitlement_check_failed",
+        ) from exc
 
     approved_datasets = session.execute(
         select(DatasetContractDataset)
@@ -98,7 +115,8 @@ def prepare_generation_context(
     ).scalars().all()
     if not approved_datasets:
         raise GenerationContextPreparationError(
-            f"Registered source '{resolved_source.source_id}' has no approved datasets in the active contract."
+            f"Registered source '{resolved_source.source_id}' has no approved datasets in the active contract.",
+            code="no_approved_datasets",
         )
 
     return PreparedGenerationContext(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -26,7 +26,18 @@ from app.services.source_governance import (
     resolve_authoritative_source_governance,
 )
 from app.services.source_registry import SourceRegistryPostureError
-from app.services.sql_generation_adapter import SQLGenerationAdapterRunMetadata
+from app.services.generation_context import (
+    GenerationContextPreparationError,
+    prepare_generation_context,
+)
+from app.services.sql_generation_adapter import (
+    SQLGenerationAdapter,
+    SQLGenerationAdapterConfigurationError,
+    SQLGenerationAdapterRunMetadata,
+    build_sql_generation_adapter_request,
+    build_sql_generation_adapter_run_metadata,
+    normalize_adapter_generated_sql,
+)
 
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
@@ -145,6 +156,7 @@ def _build_preview_lifecycle_audit_events(
     dataset_contract: DatasetContract,
     schema_snapshot: SchemaSnapshot,
     audit_context: PreviewAuditContext | None,
+    adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
         return []
@@ -186,12 +198,52 @@ def _build_preview_lifecycle_audit_events(
                 audit_context.guard_version if event_type == "guard_evaluated" else None
             ),
             application_version=audit_context.application_version,
+            adapter_provider=(
+                adapter_metadata.adapter_provider
+                if adapter_metadata is not None
+                and event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
+            adapter_model=(
+                adapter_metadata.adapter_model
+                if adapter_metadata is not None
+                and event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
+            adapter_version=(
+                adapter_metadata.adapter_version
+                if adapter_metadata is not None
+                and event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
+            adapter_run_id=(
+                adapter_metadata.adapter_run_id
+                if adapter_metadata is not None
+                and event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
+            prompt_version=(
+                adapter_metadata.prompt_version
+                if adapter_metadata is not None
+                and event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
+            prompt_fingerprint=(
+                adapter_metadata.prompt_fingerprint
+                if adapter_metadata is not None
+                and event_type in {"generation_completed", "guard_evaluated"}
+                else None
+            ),
             source_id=resolved_source.source_id,
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
-            candidate_state="preview_ready" if event_type == "guard_evaluated" else None,
+            candidate_state=(
+                "generated"
+                if adapter_metadata is not None and event_type == "generation_completed"
+                else "preview_ready" if event_type == "guard_evaluated" else None
+            ),
         )
         causation_event_id = event.event_id
         events.append(event)
@@ -306,6 +358,44 @@ def _build_preview_unavailable_audit_event(
     ]
 
 
+def _build_preview_generation_failed_audit_event(
+    *,
+    resolved_source: RegisteredSource,
+    dataset_contract: DatasetContract,
+    schema_snapshot: SchemaSnapshot,
+    audit_context: PreviewAuditContext | None,
+    failure_code: str,
+) -> list[SourceAwareAuditEvent]:
+    if audit_context is None:
+        return []
+
+    return [
+        SourceAwareAuditEvent(
+            event_id=uuid4(),
+            event_type="generation_failed",
+            occurred_at=audit_context.occurred_at,
+            request_id=audit_context.request_id,
+            correlation_id=audit_context.correlation_id,
+            user_subject=audit_context.user_subject,
+            session_id=audit_context.session_id,
+            auth_source=audit_context.auth_source,
+            governance_bindings=audit_context.governance_bindings or None,
+            entitlement_decision=audit_context.entitlement_decision,
+            entitlement_source_bindings=(
+                audit_context.entitlement_source_bindings or None
+            ),
+            application_version=audit_context.application_version,
+            source_id=resolved_source.source_id,
+            source_family=resolved_source.source_family,
+            source_flavor=resolved_source.source_flavor,
+            dataset_contract_version=dataset_contract.contract_version,
+            schema_snapshot_version=schema_snapshot.snapshot_version,
+            primary_deny_code="DENY_SQL_GENERATION_FAILED",
+            denial_cause=failure_code,
+        )
+    ]
+
+
 def _joined_governance_bindings(bindings: list[str]) -> str | None:
     return ",".join(sorted(bindings)) if bindings else None
 
@@ -381,6 +471,10 @@ def _persist_preview_submission_records(
     authenticated_subject: AuthenticatedSubject,
     audit_context: PreviewAuditContext | None,
     audit_events: list[SourceAwareAuditEvent],
+    candidate_sql: str | None = None,
+    adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
+    request_state: str = "previewed",
+    candidate_state: str = "preview_ready",
 ) -> tuple[str, str]:
     request_id = (
         audit_context.request_id
@@ -433,7 +527,7 @@ def _persist_preview_submission_records(
             preview_request.governance_bindings = governance_bindings
             preview_request.entitlement_decision = "allow"
             preview_request.request_text = payload.question
-            preview_request.request_state = "previewed"
+            preview_request.request_state = request_state
             session.flush()
 
             preview_candidate = session.execute(
@@ -488,15 +582,27 @@ def _persist_preview_submission_records(
             preview_candidate.schema_snapshot_id = schema_snapshot.id
             preview_candidate.schema_snapshot_version = schema_snapshot.snapshot_version
             preview_candidate.authenticated_subject_id = subject_id
-            preview_candidate.candidate_sql = None
-            preview_candidate.adapter_provider = None
-            preview_candidate.adapter_model = None
-            preview_candidate.adapter_version = None
-            preview_candidate.adapter_run_id = None
-            preview_candidate.prompt_version = None
-            preview_candidate.prompt_fingerprint = None
+            preview_candidate.candidate_sql = candidate_sql
+            preview_candidate.adapter_provider = (
+                adapter_metadata.adapter_provider if adapter_metadata is not None else None
+            )
+            preview_candidate.adapter_model = (
+                adapter_metadata.adapter_model if adapter_metadata is not None else None
+            )
+            preview_candidate.adapter_version = (
+                adapter_metadata.adapter_version if adapter_metadata is not None else None
+            )
+            preview_candidate.adapter_run_id = (
+                adapter_metadata.adapter_run_id if adapter_metadata is not None else None
+            )
+            preview_candidate.prompt_version = (
+                adapter_metadata.prompt_version if adapter_metadata is not None else None
+            )
+            preview_candidate.prompt_fingerprint = (
+                adapter_metadata.prompt_fingerprint if adapter_metadata is not None else None
+            )
             preview_candidate.guard_status = PREVIEW_PENDING_GUARD_STATUS
-            preview_candidate.candidate_state = "preview_ready"
+            preview_candidate.candidate_state = candidate_state
             session.flush()
             _persist_preview_audit_events(
                 session,
@@ -586,6 +692,7 @@ def _persist_preview_denial_records(
     audit_context: PreviewAuditContext | None,
     audit_events: list[SourceAwareAuditEvent],
     request_state: str = "preview_denied",
+    entitlement_decision: str = "deny",
 ) -> None:
     request_id = (
         audit_context.request_id
@@ -626,7 +733,7 @@ def _persist_preview_denial_records(
             audit_context.session_id if audit_context is not None else None
         )
         preview_request.governance_bindings = governance_bindings
-        preview_request.entitlement_decision = "deny"
+        preview_request.entitlement_decision = entitlement_decision
         preview_request.request_text = payload.question
         preview_request.request_state = request_state
         session.flush()
@@ -649,6 +756,7 @@ def submit_preview_request(
     authenticated_subject: AuthenticatedSubject,
     session: Session,
     audit_context: PreviewAuditContext | None = None,
+    sql_generation_adapter: SQLGenerationAdapter | None = None,
 ) -> PreviewSubmissionResponse:
     source, dataset_contract, schema_snapshot = _resolve_authoritative_source_governance(
         session,
@@ -747,6 +855,64 @@ def submit_preview_request(
         entitlement_decision="allow",
     )
 
+    candidate_sql: str | None = None
+    adapter_metadata: SQLGenerationAdapterRunMetadata | None = None
+    if sql_generation_adapter is not None:
+        if audit_context is None:
+            raise PreviewSubmissionContractError(
+                "SQL generation preview requires an audit context."
+            )
+        try:
+            prepared_context = prepare_generation_context(
+                request_id=audit_context.request_id,
+                question=payload.question,
+                source_id=resolved_source.source_id,
+                authenticated_subject=authenticated_subject,
+                session=session,
+            )
+            adapter_request = build_sql_generation_adapter_request(prepared_context)
+            adapter_response = sql_generation_adapter.generate_sql(adapter_request)
+            candidate_sql = normalize_adapter_generated_sql(
+                adapter_response.candidate_sql
+            )
+            adapter_metadata = build_sql_generation_adapter_run_metadata(
+                adapter_request=adapter_request,
+                adapter_response=adapter_response,
+                adapter_run_id=audit_context.correlation_id,
+            )
+        except (
+            GenerationContextPreparationError,
+            SQLGenerationAdapterConfigurationError,
+        ) as exc:
+            failure_code = getattr(exc, "code", "sql_generation_context_unavailable")
+            audit_events = _build_preview_generation_failed_audit_event(
+                resolved_source=resolved_source,
+                dataset_contract=dataset_contract,
+                schema_snapshot=schema_snapshot,
+                audit_context=audit_context,
+                failure_code=failure_code,
+            )
+            _persist_preview_denial_records(
+                session,
+                payload=payload,
+                resolved_source=resolved_source,
+                dataset_contract=dataset_contract,
+                schema_snapshot=schema_snapshot,
+                authenticated_subject=authenticated_subject,
+                audit_context=audit_context,
+                audit_events=audit_events,
+                request_state="preview_generation_failed",
+                entitlement_decision="allow",
+            )
+            raise PreviewSubmissionContractError(
+                str(exc),
+                public_code="preview_generation_failed",
+                public_message=(
+                    "SQL generation failed before an authoritative preview "
+                    "candidate was created."
+                ),
+            ) from exc
+
     audit = AuditRecord(
         source_id=resolved_source.source_id,
         state="recorded",
@@ -755,6 +921,7 @@ def submit_preview_request(
             dataset_contract=dataset_contract,
             schema_snapshot=schema_snapshot,
             audit_context=audit_context,
+            adapter_metadata=adapter_metadata,
         ),
     )
     request_id, candidate_id = _persist_preview_submission_records(
@@ -766,6 +933,8 @@ def submit_preview_request(
         authenticated_subject=authenticated_subject,
         audit_context=audit_context,
         audit_events=audit.events,
+        candidate_sql=candidate_sql,
+        adapter_metadata=adapter_metadata,
     )
 
     return PreviewSubmissionResponse(
@@ -777,7 +946,7 @@ def submit_preview_request(
         ),
         candidate=CandidateRecord(
             candidate_id=candidate_id,
-            candidate_sql=None,
+            candidate_sql=candidate_sql,
             guard_status=PREVIEW_PENDING_GUARD_STATUS,
             source_id=resolved_source.source_id,
             source_family=resolved_source.source_family,

--- a/backend/tests/test_generation_context_preparation.py
+++ b/backend/tests/test_generation_context_preparation.py
@@ -43,6 +43,7 @@ def _seed_source_governance(
     source_id: str,
     owner_binding: str = "group:finance-analysts",
     snapshot_status: SchemaSnapshotReviewStatus = SchemaSnapshotReviewStatus.APPROVED,
+    include_datasets: bool = True,
     link_active_contract: bool = True,
     link_active_snapshot: bool = True,
     link_contract_snapshot: bool = True,
@@ -99,24 +100,25 @@ def _seed_source_governance(
     session.add(contract)
     session.flush()
 
-    session.add_all(
-        [
-            DatasetContractDataset(
-                id=uuid4(),
-                dataset_contract_id=contract.id,
-                schema_name="finance",
-                dataset_name=f"{source_id}_spend",
-                dataset_kind=DatasetContractDatasetKind.TABLE,
-            ),
-            DatasetContractDataset(
-                id=uuid4(),
-                dataset_contract_id=contract.id,
-                schema_name="analytics",
-                dataset_name=f"{source_id}_summary",
-                dataset_kind=DatasetContractDatasetKind.VIEW,
-            ),
-        ]
-    )
+    if include_datasets:
+        session.add_all(
+            [
+                DatasetContractDataset(
+                    id=uuid4(),
+                    dataset_contract_id=contract.id,
+                    schema_name="finance",
+                    dataset_name=f"{source_id}_spend",
+                    dataset_kind=DatasetContractDatasetKind.TABLE,
+                ),
+                DatasetContractDataset(
+                    id=uuid4(),
+                    dataset_contract_id=contract.id,
+                    schema_name="analytics",
+                    dataset_name=f"{source_id}_summary",
+                    dataset_kind=DatasetContractDatasetKind.VIEW,
+                ),
+            ]
+        )
 
     if link_active_contract:
         source.dataset_contract_id = contract.id
@@ -195,7 +197,7 @@ def test_prepare_generation_context_rejects_missing_active_contract_linkage() ->
         with pytest.raises(
             GenerationContextPreparationError,
             match=r"Registered source 'sap-approved-spend' has no active dataset contract\.",
-        ):
+        ) as exc_info:
             prepare_generation_context(
                 request_id="req_preview_80",
                 question="Show approved vendors by quarterly spend",
@@ -206,6 +208,8 @@ def test_prepare_generation_context_rejects_missing_active_contract_linkage() ->
                 ),
                 session=session,
             )
+
+    assert exc_info.value.code == "governance_resolution_failed"
 
 
 def test_prepare_generation_context_rejects_non_approved_schema_snapshot() -> None:
@@ -221,7 +225,7 @@ def test_prepare_generation_context_rejects_non_approved_schema_snapshot() -> No
             match=(
                 r"Registered source 'sap-approved-spend' requires an approved schema snapshot\."
             ),
-        ):
+        ) as exc_info:
             prepare_generation_context(
                 request_id="req_preview_80",
                 question="Show approved vendors by quarterly spend",
@@ -232,6 +236,8 @@ def test_prepare_generation_context_rejects_non_approved_schema_snapshot() -> No
                 ),
                 session=session,
             )
+
+    assert exc_info.value.code == "governance_resolution_failed"
 
 
 def test_prepare_generation_context_rejects_contract_snapshot_drift() -> None:
@@ -248,7 +254,7 @@ def test_prepare_generation_context_rejects_contract_snapshot_drift() -> None:
                 r"Registered source 'sap-approved-spend' is missing "
                 r"authoritative source-scoped governance artifacts\."
             ),
-        ):
+        ) as exc_info:
             prepare_generation_context(
                 request_id="req_preview_80",
                 question="Show approved vendors by quarterly spend",
@@ -259,3 +265,62 @@ def test_prepare_generation_context_rejects_contract_snapshot_drift() -> None:
                 ),
                 session=session,
             )
+
+    assert exc_info.value.code == "governance_resolution_failed"
+
+
+def test_prepare_generation_context_rejects_unentitled_subject_with_specific_code() -> None:
+    with _session_scope() as session:
+        _seed_source_governance(
+            session,
+            source_id="sap-approved-spend",
+        )
+
+        with pytest.raises(
+            GenerationContextPreparationError,
+            match=(
+                r"Authenticated subject 'user:alice' is not entitled to use "
+                r"registered source 'sap-approved-spend'\."
+            ),
+        ) as exc_info:
+            prepare_generation_context(
+                request_id="req_preview_80",
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:sales-analysts"}),
+                ),
+                session=session,
+            )
+
+    assert exc_info.value.code == "entitlement_check_failed"
+
+
+def test_prepare_generation_context_rejects_missing_datasets_with_specific_code() -> None:
+    with _session_scope() as session:
+        _seed_source_governance(
+            session,
+            source_id="sap-approved-spend",
+            include_datasets=False,
+        )
+
+        with pytest.raises(
+            GenerationContextPreparationError,
+            match=(
+                r"Registered source 'sap-approved-spend' has no approved datasets "
+                r"in the active contract\."
+            ),
+        ) as exc_info:
+            prepare_generation_context(
+                request_id="req_preview_80",
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+            )
+
+    assert exc_info.value.code == "no_approved_datasets"

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -38,6 +38,7 @@ from app.services.sql_generation_adapter import (
 def _seed_authoritative_source_governance(
     session: Session,
     *,
+    include_datasets: bool = True,
     source_posture: SourceActivationPosture = SourceActivationPosture.ACTIVE,
 ) -> None:
     source = RegisteredSource(
@@ -80,15 +81,16 @@ def _seed_authoritative_source_governance(
     session.add(contract)
     session.flush()
 
-    session.add(
-        DatasetContractDataset(
-            id=uuid4(),
-            dataset_contract_id=contract.id,
-            schema_name="finance",
-            dataset_name="approved_vendor_spend",
-            dataset_kind=DatasetContractDatasetKind.TABLE,
+    if include_datasets:
+        session.add(
+            DatasetContractDataset(
+                id=uuid4(),
+                dataset_contract_id=contract.id,
+                schema_name="finance",
+                dataset_name="approved_vendor_spend",
+                dataset_kind=DatasetContractDatasetKind.TABLE,
+            )
         )
-    )
 
     source.dataset_contract_id = contract.id
     source.schema_snapshot_id = snapshot.id
@@ -438,6 +440,79 @@ def test_http_preview_adapter_failure_persists_authoritative_failure(
         assert persisted_events[0].event_type == "generation_failed"
         assert persisted_events[0].primary_deny_code == "DENY_SQL_GENERATION_FAILED"
         assert persisted_events[0].denial_cause == "sql_generation_runtime_unhealthy"
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+def test_http_preview_context_failure_persists_specific_failure_code(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: _RecordingHTTPPreviewAdapter(),
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session, include_datasets=False)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 422
+
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
+        persisted_events = session.execute(select(PreviewAuditEvent)).scalars().all()
+        persisted_candidates = session.execute(select(PreviewCandidate)).scalars().all()
+
+        assert persisted_request.request_id == response.headers["X-Request-ID"]
+        assert persisted_request.request_state == "preview_generation_failed"
+        assert persisted_request.entitlement_decision == "allow"
+        assert persisted_candidates == []
+        assert len(persisted_events) == 1
+        assert persisted_events[0].event_type == "generation_failed"
+        assert persisted_events[0].primary_deny_code == "DENY_SQL_GENERATION_FAILED"
+        assert persisted_events[0].denial_cause == "no_approved_datasets"
     finally:
         session.close()
         engine.dispose()

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -500,6 +500,15 @@ def test_http_preview_context_failure_persists_specific_failure_code(
         )
 
         assert response.status_code == 422
+        assert response.json() == {
+            "error": {
+                "code": "preview_generation_failed",
+                "message": (
+                    "SQL generation failed before an authoritative preview "
+                    "candidate was created."
+                ),
+            }
+        }
 
         persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_events = session.execute(select(PreviewAuditEvent)).scalars().all()

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -12,7 +12,11 @@ from sqlalchemy.pool import StaticPool
 
 from app.core.config import get_settings
 from app.db.base import Base
-from app.db.models.dataset_contract import DatasetContract
+from app.db.models.dataset_contract import (
+    DatasetContract,
+    DatasetContractDataset,
+    DatasetContractDatasetKind,
+)
 from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
@@ -24,6 +28,10 @@ from app.services.request_preview import (
     PreviewSubmissionContractError,
     PreviewSubmissionRequest,
     submit_preview_request,
+)
+from app.services.sql_generation_adapter import (
+    SQLGenerationAdapterConfigurationError,
+    SQLGenerationAdapterResponse,
 )
 
 
@@ -72,9 +80,43 @@ def _seed_authoritative_source_governance(
     session.add(contract)
     session.flush()
 
+    session.add(
+        DatasetContractDataset(
+            id=uuid4(),
+            dataset_contract_id=contract.id,
+            schema_name="finance",
+            dataset_name="approved_vendor_spend",
+            dataset_kind=DatasetContractDatasetKind.TABLE,
+        )
+    )
+
     source.dataset_contract_id = contract.id
     source.schema_snapshot_id = snapshot.id
     session.commit()
+
+
+class _RecordingHTTPPreviewAdapter:
+    def __init__(self) -> None:
+        self.adapter_request = None
+
+    def generate_sql(self, request):
+        self.adapter_request = request
+        return SQLGenerationAdapterResponse(
+            candidate_sql=(
+                " SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50; "
+            ),
+            provider="local_llm",
+            adapter_version="test.local_llm.v1",
+            model="safequery-test-sql",
+        )
+
+
+class _FailingHTTPPreviewAdapter:
+    def generate_sql(self, request):
+        raise SQLGenerationAdapterConfigurationError(
+            "sql_generation_runtime_unhealthy",
+            "SQL generation runtime is unavailable.",
+        )
 
 
 def test_http_preview_submission_persists_request_and_candidate_records() -> None:
@@ -202,6 +244,204 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
                 os.environ.pop(name, None)
             else:
                 os.environ[name] = value
+        get_settings.cache_clear()
+
+
+def test_http_preview_submission_persists_adapter_generated_candidate(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    adapter = _RecordingHTTPPreviewAdapter()
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: adapter,
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 200
+        response_payload = response.json()
+        request_id = response.headers["X-Request-ID"]
+        candidate_sql = "SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50"
+
+        assert response_payload["request"]["request_id"] == request_id
+        assert response_payload["candidate"]["candidate_sql"] == candidate_sql
+        assert response_payload["candidate"]["guard_status"] == "pending"
+        assert response_payload["candidate"]["state"] == "preview_ready"
+
+        adapter_payload = adapter.adapter_request.model_dump(mode="json")
+        assert adapter_payload["request_id"] == request_id
+        assert adapter_payload["source"] == {
+            "source_id": "sap-approved-spend",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+        }
+        assert adapter_payload["context"]["datasets"] == [
+            {
+                "schema_name": "finance",
+                "dataset_name": "approved_vendor_spend",
+                "dataset_kind": "table",
+            }
+        ]
+        assert "vault:sap-approved-spend" not in str(adapter_payload)
+        assert "connection_reference" not in str(adapter_payload)
+        assert "connection_string" not in str(adapter_payload)
+        assert "credentials" not in str(adapter_payload).lower()
+
+        persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_generation_event = (
+            session.execute(
+                select(PreviewAuditEvent).where(
+                    PreviewAuditEvent.event_type == "generation_completed"
+                )
+            )
+            .scalars()
+            .one()
+        )
+
+        assert persisted_candidate.candidate_sql == candidate_sql
+        assert persisted_candidate.adapter_provider == "local_llm"
+        assert persisted_candidate.adapter_model == "safequery-test-sql"
+        assert persisted_candidate.adapter_version == "test.local_llm.v1"
+        assert persisted_candidate.adapter_run_id
+        assert persisted_candidate.prompt_version == "sql_generation_adapter_request.v1"
+        assert persisted_candidate.prompt_fingerprint is not None
+        assert "Show approved vendors" not in persisted_candidate.prompt_fingerprint
+        assert {
+            "adapter_provider": "local_llm",
+            "adapter_model": "safequery-test-sql",
+            "adapter_version": "test.local_llm.v1",
+            "adapter_run_id": persisted_candidate.adapter_run_id,
+            "prompt_version": "sql_generation_adapter_request.v1",
+            "prompt_fingerprint": persisted_candidate.prompt_fingerprint,
+        }.items() <= persisted_generation_event.audit_payload.items()
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+def test_http_preview_adapter_failure_persists_authoritative_failure(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: _FailingHTTPPreviewAdapter(),
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "error": {
+                "code": "preview_generation_failed",
+                "message": (
+                    "SQL generation failed before an authoritative preview "
+                    "candidate was created."
+                ),
+            }
+        }
+
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
+        persisted_events = session.execute(select(PreviewAuditEvent)).scalars().all()
+        persisted_candidates = session.execute(select(PreviewCandidate)).scalars().all()
+
+        assert persisted_request.request_id == response.headers["X-Request-ID"]
+        assert persisted_request.request_state == "preview_generation_failed"
+        assert persisted_request.entitlement_decision == "allow"
+        assert persisted_candidates == []
+        assert len(persisted_events) == 1
+        assert persisted_events[0].event_type == "generation_failed"
+        assert persisted_events[0].primary_deny_code == "DENY_SQL_GENERATION_FAILED"
+        assert persisted_events[0].denial_cause == "sql_generation_runtime_unhealthy"
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
         get_settings.cache_clear()
 
 


### PR DESCRIPTION
## Summary
- Resolve the configured SQL generation adapter for the HTTP preview route
- Build curated source-scoped generation context before preview persistence
- Persist generated candidate SQL and adapter metadata, with fail-closed generation failure records

## Verification
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_request_source_selection.py tests/test_sql_generation_adapter_request.py tests/test_generation_context_preparation.py
- cd backend && python3 -m pytest tests/test_vertical_slice_lifecycle_revalidation.py tests/test_evaluation_harness.py
- cd frontend && npm test

Closes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview requests can optionally run SQL generation via configurable adapters; generated SQL and adapter metadata are persisted and shown in lifecycle audit events.

* **Bug Fixes**
  * Improved failure handling for generation: explicit failure events, preview state persisted as failed, and a clear public error code ("preview_generation_failed") is now recognized.

* **Tests**
  * Added tests for successful generation, adapter runtime/configuration failures, and no-approved-datasets scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->