### PR TITLE
Add candidate-only execute API

### DIFF
--- a/backend/alembic/versions/0009_candidate_approval_records.py
+++ b/backend/alembic/versions/0009_candidate_approval_records.py
@@ -42,6 +42,7 @@ def upgrade() -> None:
         sa.Column("dataset_contract_version", sa.Integer(), nullable=False),
         sa.Column("schema_snapshot_version", sa.Integer(), nullable=False),
         sa.Column("execution_policy_version", sa.Integer(), nullable=False),
+        sa.Column("approved_sql", sa.Text(), nullable=True),
         sa.Column("owner_subject_id", sa.String(length=255), nullable=False),
         sa.Column("session_id", sa.String(length=255), nullable=True),
         sa.Column("approved_at", sa.DateTime(timezone=True), nullable=False),

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -19,6 +19,8 @@ _SAFE_API_ERROR_CODES = frozenset(
         "session_invalid",
         "csrf_failed",
         "entitlement_denied",
+        "execution_denied",
+        "execution_unavailable",
         "preview_generation_failed",
         "preview_source_malformed",
         "preview_source_unavailable",
@@ -46,6 +48,31 @@ _SAFE_ENTITLEMENT_DENIAL_AUDIT_FIELDS = frozenset(
         "schema_snapshot_version",
         "primary_deny_code",
         "denial_cause",
+    }
+)
+
+_SAFE_EXECUTION_AUDIT_FIELDS = frozenset(
+    {
+        "event_id",
+        "event_type",
+        "occurred_at",
+        "request_id",
+        "correlation_id",
+        "causation_event_id",
+        "user_subject",
+        "session_id",
+        "query_candidate_id",
+        "candidate_owner_subject",
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "primary_deny_code",
+        "denial_cause",
+        "candidate_state",
     }
 )
 
@@ -140,7 +167,14 @@ def _safe_http_exception_audit(
     *,
     code: str,
 ) -> dict[str, list[dict[str, Any]]] | None:
-    if exc.status_code != 403 or code != "entitlement_denied":
+    if exc.status_code == 403 and code == "entitlement_denied":
+        safe_fields = _SAFE_ENTITLEMENT_DENIAL_AUDIT_FIELDS
+    elif exc.status_code in {403, 503} and code in {
+        "execution_denied",
+        "execution_unavailable",
+    }:
+        safe_fields = _SAFE_EXECUTION_AUDIT_FIELDS
+    else:
         return None
 
     detail: Any = exc.detail
@@ -162,8 +196,7 @@ def _safe_http_exception_audit(
             {
                 key: value
                 for key, value in event.items()
-                if isinstance(key, str)
-                and key in _SAFE_ENTITLEMENT_DENIAL_AUDIT_FIELDS
+                if isinstance(key, str) and key in safe_fields
             }
             for event in events
         ]

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -194,6 +194,7 @@ class PreviewCandidateApproval(Base):
     dataset_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
     schema_snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
     execution_policy_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    approved_sql: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     owner_subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
     session_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     approved_at: Mapped[datetime] = mapped_column(

--- a/backend/app/features/execution/__init__.py
+++ b/backend/app/features/execution/__init__.py
@@ -7,6 +7,7 @@ from app.features.execution.connector_selection import (
 )
 from app.features.execution.runtime import (
     ExecutableCandidateRecord,
+    ExecutionAuditContext,
     ExecutionConnectorExecutionError,
     ExecutionRuntimeCancelledError,
     ExecutionRuntimeControls,
@@ -17,6 +18,7 @@ from app.features.execution.runtime import (
 
 __all__ = [
     "ExecutableCandidateRecord",
+    "ExecutionAuditContext",
     "ExecutionConnectorExecutionError",
     "ExecutionConnectorSelection",
     "ExecutionConnectorSelectionError",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,6 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, ValidationError
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -24,7 +23,6 @@ from app.core.errors import (
 )
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
-from app.db.models.preview import PreviewCandidate, PreviewCandidateApproval
 from app.db.session import require_preview_submission_session
 from app.features.auth.dev import attach_dev_authenticated_subject
 from app.features.auth.context import (
@@ -39,6 +37,7 @@ from app.features.execution import (
     ExecutableCandidateRecord,
     ExecutionAuditContext,
     ExecutionConnectorExecutionError,
+    ExecutionConnectorSelection,
     ExecutionConnectorSelectionError,
     ExecutionRuntimeCancelledError,
     execute_candidate_sql,
@@ -47,7 +46,7 @@ from app.features.execution import (
 from app.services.candidate_lifecycle import (
     CandidateLifecycleAuditContext,
     CandidateLifecycleRevalidationError,
-    SourceBoundCandidateMetadata,
+    CandidateLifecycleRevalidationResult,
     revalidate_authoritative_candidate_approval,
 )
 from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
@@ -167,53 +166,6 @@ def _serialize_execution_audit_events(
             )
         )
     return serialized
-
-
-def _load_executable_candidate_record(
-    *,
-    session: Session,
-    candidate_id: str,
-) -> ExecutableCandidateRecord:
-    row = (
-        session.execute(
-            select(PreviewCandidateApproval, PreviewCandidate)
-            .join(
-                PreviewCandidate,
-                PreviewCandidate.id == PreviewCandidateApproval.preview_candidate_id,
-            )
-            .where(PreviewCandidateApproval.candidate_id == candidate_id)
-        )
-        .one_or_none()
-    )
-    if row is None:
-        raise api_error(
-            403,
-            "execution_denied",
-            "Candidate execution was denied.",
-    )
-
-    approval, _preview_candidate = row
-    if (
-        not isinstance(approval.approved_sql, str)
-        or not approval.approved_sql.strip()
-    ):
-        raise api_error(
-            403,
-            "execution_denied",
-            "Candidate execution was denied.",
-        )
-
-    return ExecutableCandidateRecord(
-        canonical_sql=approval.approved_sql,
-        source=SourceBoundCandidateMetadata(
-            source_id=approval.source_id,
-            source_family=approval.source_family,
-            source_flavor=approval.source_flavor,
-            dataset_contract_version=approval.dataset_contract_version,
-            schema_snapshot_version=approval.schema_snapshot_version,
-            execution_policy_version=approval.execution_policy_version,
-        ),
-    )
 
 
 def _require_execution_connector_configuration(
@@ -478,18 +430,37 @@ def create_app() -> FastAPI:
             candidate_owner_subject=user_subject,
         )
         try:
-            candidate = _load_executable_candidate_record(
-                session=session,
-                candidate_id=candidate_id,
-            )
-            selection = select_execution_connector(candidate_source=candidate.source)
-            _require_execution_connector_configuration(
-                connector_id=selection.connector_id,
-                business_postgres_source_url=settings.business_postgres_source_url,
-                business_mssql_source_connection_string=(
-                    settings.business_mssql_source_connection_string
-                ),
-            )
+            candidate: ExecutableCandidateRecord | None = None
+            selection: ExecutionConnectorSelection | None = None
+
+            def prepare_execution(
+                revalidation_result: CandidateLifecycleRevalidationResult,
+            ) -> None:
+                nonlocal candidate, selection
+                approved_sql = revalidation_result.approved_sql
+                if approved_sql is None:
+                    raise api_error(
+                        403,
+                        "execution_denied",
+                        "Candidate execution was denied.",
+                    )
+                prepared_candidate = ExecutableCandidateRecord(
+                    canonical_sql=approved_sql,
+                    source=revalidation_result.source,
+                )
+                prepared_selection = select_execution_connector(
+                    candidate_source=prepared_candidate.source
+                )
+                _require_execution_connector_configuration(
+                    connector_id=prepared_selection.connector_id,
+                    business_postgres_source_url=settings.business_postgres_source_url,
+                    business_mssql_source_connection_string=(
+                        settings.business_mssql_source_connection_string
+                    ),
+                )
+                candidate = prepared_candidate
+                selection = prepared_selection
+
             revalidate_authoritative_candidate_approval(
                 session=session,
                 candidate_id=candidate_id,
@@ -497,7 +468,14 @@ def create_app() -> FastAPI:
                 as_of=occurred_at,
                 selected_source_id=payload.selected_source_id,
                 audit_context=lifecycle_audit_context,
+                before_mark_executed=prepare_execution,
             )
+            if candidate is None or selection is None:
+                raise api_error(
+                    403,
+                    "execution_denied",
+                    "Candidate execution was denied.",
+                )
             execution_audit_context = ExecutionAuditContext(
                 event_id=uuid4(),
                 occurred_at=occurred_at,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from time import perf_counter
+from typing import Any, Optional
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -20,6 +24,7 @@ from app.core.errors import (
 )
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
+from app.db.models.preview import PreviewCandidate, PreviewCandidateApproval
 from app.db.session import require_preview_submission_session
 from app.features.auth.dev import attach_dev_authenticated_subject
 from app.features.auth.context import (
@@ -30,11 +35,26 @@ from app.features.auth.session import (
     ApplicationSessionContext,
     require_application_session,
 )
+from app.features.execution import (
+    ExecutableCandidateRecord,
+    ExecutionAuditContext,
+    ExecutionConnectorExecutionError,
+    ExecutionConnectorSelectionError,
+    ExecutionRuntimeCancelledError,
+    execute_candidate_sql,
+    select_execution_connector,
+)
+from app.services.candidate_lifecycle import (
+    CandidateLifecycleAuditContext,
+    CandidateLifecycleRevalidationError,
+    SourceBoundCandidateMetadata,
+    revalidate_authoritative_candidate_approval,
+)
+from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
 from app.services.health import (
     check_database_health,
     check_sql_generation_runtime_health,
 )
-from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
 from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionContractError,
@@ -76,6 +96,48 @@ _ENTITLEMENT_DENIAL_AUDIT_FIELDS = frozenset(
     }
 )
 
+_EXECUTION_DENIAL_AUDIT_FIELDS = frozenset(
+    {
+        "event_id",
+        "event_type",
+        "occurred_at",
+        "request_id",
+        "correlation_id",
+        "causation_event_id",
+        "user_subject",
+        "session_id",
+        "query_candidate_id",
+        "candidate_owner_subject",
+        "source_id",
+        "source_family",
+        "source_flavor",
+        "dataset_contract_version",
+        "schema_snapshot_version",
+        "execution_policy_version",
+        "connector_profile_version",
+        "primary_deny_code",
+        "denial_cause",
+        "candidate_state",
+    }
+)
+
+
+class CandidateExecuteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    selected_source_id: Optional[str] = None
+
+
+class CandidateExecuteResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_id: str
+    source_id: str
+    connector_id: str
+    ownership: str
+    rows: list[dict[str, Any]]
+    audit: dict[str, list[dict[str, Any]]]
+
 
 def _serialize_entitlement_denial_audit_events(
     exc: PreviewSubmissionEntitlementError,
@@ -88,6 +150,96 @@ def _serialize_entitlement_denial_audit_events(
         )
         for event in exc.audit_events
     ]
+
+
+def _serialize_execution_audit_events(
+    events: list[object],
+) -> list[dict[str, object]]:
+    serialized: list[dict[str, object]] = []
+    for event in events:
+        if not hasattr(event, "model_dump"):
+            continue
+        serialized.append(
+            event.model_dump(
+                mode="json",
+                include=_EXECUTION_DENIAL_AUDIT_FIELDS,
+                exclude_none=True,
+            )
+        )
+    return serialized
+
+
+def _load_executable_candidate_record(
+    *,
+    session: Session,
+    candidate_id: str,
+) -> ExecutableCandidateRecord:
+    row = (
+        session.execute(
+            select(PreviewCandidateApproval, PreviewCandidate)
+            .join(
+                PreviewCandidate,
+                PreviewCandidate.id == PreviewCandidateApproval.preview_candidate_id,
+            )
+            .where(PreviewCandidateApproval.candidate_id == candidate_id)
+        )
+        .one_or_none()
+    )
+    if row is None:
+        raise api_error(
+            403,
+            "execution_denied",
+            "Candidate execution was denied.",
+    )
+
+    approval, preview_candidate = row
+    if (
+        not isinstance(preview_candidate.candidate_sql, str)
+        or not preview_candidate.candidate_sql.strip()
+    ):
+        raise api_error(
+            403,
+            "execution_denied",
+            "Candidate execution was denied.",
+        )
+
+    return ExecutableCandidateRecord(
+        canonical_sql=preview_candidate.candidate_sql,
+        source=SourceBoundCandidateMetadata(
+            source_id=approval.source_id,
+            source_family=approval.source_family,
+            source_flavor=approval.source_flavor,
+            dataset_contract_version=approval.dataset_contract_version,
+            schema_snapshot_version=approval.schema_snapshot_version,
+            execution_policy_version=approval.execution_policy_version,
+        ),
+    )
+
+
+def _require_execution_connector_configuration(
+    *,
+    connector_id: str,
+    business_postgres_source_url: object | None,
+    business_mssql_source_connection_string: str | None,
+) -> None:
+    if connector_id == "postgresql_readonly":
+        if business_postgres_source_url is None:
+            raise api_error(
+                503,
+                "execution_unavailable",
+                "Candidate execution is unavailable.",
+            )
+        return
+
+    if connector_id == "mssql_readonly":
+        connection_string = business_mssql_source_connection_string
+        if connection_string is None or not connection_string.strip():
+            raise api_error(
+                503,
+                "execution_unavailable",
+                "Candidate execution is unavailable.",
+            )
+        return
 
 
 def create_app() -> FastAPI:
@@ -289,6 +441,141 @@ def create_app() -> FastAPI:
                     exc.public_message,
                 ) from exc
             raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    @app.post(
+        "/candidates/{candidate_id}/execute",
+        response_model=CandidateExecuteResponse,
+    )
+    def execute_candidate_preview(
+        http_request: Request,
+        candidate_id: str,
+        payload: CandidateExecuteRequest,
+        authenticated_subject: AuthenticatedSubject = Depends(
+            require_authenticated_subject
+        ),
+        application_session: ApplicationSessionContext = Depends(
+            require_application_session
+        ),
+        session: Session = Depends(require_preview_submission_session),
+    ) -> CandidateExecuteResponse:
+        request_id = getattr(http_request.state, "request_id", None)
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise HTTPException(
+                status_code=500,
+                detail="Request audit context is unavailable.",
+            )
+
+        occurred_at = datetime.now(timezone.utc)
+        user_subject = authenticated_subject.normalized_subject_id()
+        lifecycle_audit_context = CandidateLifecycleAuditContext(
+            event_id=uuid4(),
+            occurred_at=occurred_at,
+            request_id=request_id,
+            correlation_id=str(uuid4()),
+            user_subject=user_subject,
+            session_id=application_session.audit_session_id,
+            query_candidate_id=candidate_id,
+            candidate_owner_subject=user_subject,
+        )
+        try:
+            candidate = _load_executable_candidate_record(
+                session=session,
+                candidate_id=candidate_id,
+            )
+            selection = select_execution_connector(candidate_source=candidate.source)
+            _require_execution_connector_configuration(
+                connector_id=selection.connector_id,
+                business_postgres_source_url=settings.business_postgres_source_url,
+                business_mssql_source_connection_string=(
+                    settings.business_mssql_source_connection_string
+                ),
+            )
+            revalidate_authoritative_candidate_approval(
+                session=session,
+                candidate_id=candidate_id,
+                authenticated_subject=authenticated_subject,
+                as_of=occurred_at,
+                selected_source_id=payload.selected_source_id,
+                audit_context=lifecycle_audit_context,
+            )
+            execution_audit_context = ExecutionAuditContext(
+                event_id=uuid4(),
+                occurred_at=occurred_at,
+                request_id=request_id,
+                correlation_id=lifecycle_audit_context.correlation_id,
+                user_subject=user_subject,
+                session_id=application_session.audit_session_id,
+                query_candidate_id=candidate_id,
+                candidate_owner_subject=user_subject,
+                execution_policy_version=candidate.source.execution_policy_version,
+                connector_profile_version=candidate.source.connector_profile_version,
+            )
+            query_runner = getattr(
+                http_request.app.state,
+                "execution_query_runner",
+                None,
+            )
+            result = execute_candidate_sql(
+                candidate=candidate,
+                selection=selection,
+                business_mssql_connection_string=(
+                    settings.business_mssql_source_connection_string
+                ),
+                business_postgres_url=(
+                    str(settings.business_postgres_source_url)
+                    if settings.business_postgres_source_url is not None
+                    else None
+                ),
+                application_postgres_url=str(settings.app_postgres_url),
+                query_runner=query_runner,
+                audit_context=execution_audit_context,
+            )
+        except CandidateLifecycleRevalidationError as exc:
+            audit_events = (
+                _serialize_execution_audit_events([exc.audit_event])
+                if exc.audit_event is not None
+                else None
+            )
+            raise api_error(
+                403,
+                "execution_denied",
+                "Candidate execution was denied.",
+                audit_events=audit_events,
+            ) from exc
+        except (
+            ExecutionConnectorExecutionError,
+            ExecutionConnectorSelectionError,
+        ) as exc:
+            audit_events = _serialize_execution_audit_events(exc.audit_events)
+            raise api_error(
+                403,
+                "execution_denied",
+                "Candidate execution was denied.",
+                audit_events=audit_events or None,
+            ) from exc
+        except ExecutionRuntimeCancelledError as exc:
+            audit_events = _serialize_execution_audit_events(exc.audit_events)
+            raise api_error(
+                503,
+                "execution_unavailable",
+                "Candidate execution is unavailable.",
+                audit_events=audit_events or None,
+            ) from exc
+        except RuntimeError as exc:
+            raise api_error(
+                503,
+                "execution_unavailable",
+                "Candidate execution is unavailable.",
+            ) from exc
+
+        return CandidateExecuteResponse(
+            candidate_id=candidate_id,
+            source_id=result.source_id,
+            connector_id=result.connector_id,
+            ownership=result.ownership,
+            rows=result.rows,
+            audit={"events": _serialize_execution_audit_events(result.audit_events)},
+        )
 
     @app.get("/operator/workflow", response_model=OperatorWorkflowSnapshot)
     def read_operator_workflow(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -192,10 +192,10 @@ def _load_executable_candidate_record(
             "Candidate execution was denied.",
     )
 
-    approval, preview_candidate = row
+    approval, _preview_candidate = row
     if (
-        not isinstance(preview_candidate.candidate_sql, str)
-        or not preview_candidate.candidate_sql.strip()
+        not isinstance(approval.approved_sql, str)
+        or not approval.approved_sql.strip()
     ):
         raise api_error(
             403,
@@ -204,7 +204,7 @@ def _load_executable_candidate_record(
         )
 
     return ExecutableCandidateRecord(
-        canonical_sql=preview_candidate.candidate_sql,
+        canonical_sql=approval.approved_sql,
         source=SourceBoundCandidateMetadata(
             source_id=approval.source_id,
             source_family=approval.source_family,

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Literal, Optional
 from uuid import UUID
@@ -78,6 +79,8 @@ class CandidateLifecycleRevalidationResult(BaseModel):
 
     source_id: str
     state: Literal["execution_eligible"]
+    source: SourceBoundCandidateMetadata
+    approved_sql: Optional[str] = None
 
 
 class CandidateLifecycleRevalidationError(PermissionError):
@@ -342,6 +345,7 @@ def revalidate_candidate_lifecycle(
     return CandidateLifecycleRevalidationResult(
         source_id=source.source_id,
         state="execution_eligible",
+        source=candidate.source,
     )
 
 
@@ -423,6 +427,21 @@ def _candidate_lifecycle_from_approval(
     )
 
 
+def _approved_sql_from_approval(
+    approval: PreviewCandidateApproval,
+    *,
+    audit_context: CandidateLifecycleAuditContext | None,
+) -> str:
+    if not isinstance(approval.approved_sql, str) or not approval.approved_sql.strip():
+        _raise_authoritative_approval_error(
+            deny_code=DENY_CANDIDATE_NOT_APPROVED,
+            message="Candidate approval snapshot is unavailable for execution.",
+            approval=approval,
+            audit_context=audit_context,
+        )
+    return approval.approved_sql
+
+
 def revalidate_authoritative_candidate_approval(
     *,
     session: Session,
@@ -432,6 +451,9 @@ def revalidate_authoritative_candidate_approval(
     selected_source_id: str | None = None,
     audit_context: CandidateLifecycleAuditContext | None = None,
     mark_executed: bool = True,
+    before_mark_executed: (
+        Callable[[CandidateLifecycleRevalidationResult], None] | None
+    ) = None,
 ) -> CandidateLifecycleRevalidationResult:
     approval = (
         session.execute(
@@ -485,6 +507,10 @@ def revalidate_authoritative_candidate_approval(
             approval=approval,
             audit_context=audit_context,
         )
+    approved_sql = _approved_sql_from_approval(
+        approval,
+        audit_context=audit_context,
+    )
 
     result = revalidate_candidate_lifecycle(
         candidate=_candidate_lifecycle_from_approval(approval),
@@ -494,6 +520,9 @@ def revalidate_authoritative_candidate_approval(
         selected_source_id=selected_source_id,
         audit_context=audit_context,
     )
+    result = result.model_copy(update={"approved_sql": approved_sql})
+    if before_mark_executed is not None:
+        before_mark_executed(result)
     if mark_executed:
         approval.executed_at = _persisted_datetime(as_of)
         approval.approval_state = "executed"

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -541,6 +541,7 @@ def _persist_candidate_approval_record(
         existing.invalidated_at = effective_occurred_at
     elif guard_status in {None, "allow", PREVIEW_PENDING_GUARD_STATUS}:
         existing.approval_state = "approved"
+        existing.approved_sql = preview_candidate.candidate_sql
         existing.invalidated_at = None
         existing.approval_expires_at = effective_occurred_at + timedelta(minutes=5)
 

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import importlib
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.core.config import get_settings
+from app.db.base import Base
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.preview import (
+    PreviewCandidate,
+    PreviewCandidateApproval,
+    PreviewRequest,
+)
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.db.session import require_preview_submission_session
+from app.features.auth.dev import build_dev_authenticated_subject
+from app.features.auth.session import create_test_application_session
+from app.services.candidate_lifecycle import (
+    CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY,
+)
+
+
+class CandidateExecuteApiTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._previous_env = {
+            name: os.environ.get(name)
+            for name in (
+                "SAFEQUERY_APP_POSTGRES_URL",
+                "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+                "SAFEQUERY_ENVIRONMENT",
+                "SAFEQUERY_DEV_AUTH_ENABLED",
+                "SAFEQUERY_SESSION_SIGNING_KEY",
+            )
+        }
+        os.environ["SAFEQUERY_APP_POSTGRES_URL"] = (
+            "postgresql://safequery:safequery@app-postgres:5432/safequery"
+        )
+        os.environ["SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"] = (
+            "postgresql://safequery_exec:secret@business-postgres-source:5432/business"
+        )
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        os.environ.pop("SAFEQUERY_SESSION_SIGNING_KEY", None)
+        get_settings.cache_clear()
+
+        self.engine = create_engine(
+            "sqlite+pysqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(self.engine)
+        self.session = Session(self.engine)
+        self._seed_approved_candidate()
+
+    def tearDown(self) -> None:
+        self.session.close()
+        self.engine.dispose()
+        for name, value in self._previous_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        get_settings.cache_clear()
+
+    def _client(self, query_runner) -> TestClient:
+        main_module = importlib.import_module("app.main")
+        app = main_module.create_app()
+        app.dependency_overrides[require_preview_submission_session] = (
+            lambda: self.session
+        )
+        app.state.execution_query_runner = query_runner
+        return TestClient(app)
+
+    def _seed_approved_candidate(self) -> None:
+        source = RegisteredSource(
+            id=uuid4(),
+            source_id="demo-business-postgres",
+            display_label="Demo business PostgreSQL",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            activation_posture=SourceActivationPosture.ACTIVE,
+            connector_profile_id=None,
+            dialect_profile_id=None,
+            dataset_contract_id=None,
+            schema_snapshot_id=None,
+            execution_policy_id=None,
+            connection_reference="vault:demo-business-postgres",
+        )
+        self.session.add(source)
+        self.session.flush()
+
+        snapshot = SchemaSnapshot(
+            id=uuid4(),
+            registered_source_id=source.id,
+            snapshot_version=7,
+            review_status=SchemaSnapshotReviewStatus.APPROVED,
+            reviewed_at=datetime.now(timezone.utc),
+        )
+        self.session.add(snapshot)
+        self.session.flush()
+
+        contract = DatasetContract(
+            id=uuid4(),
+            registered_source_id=source.id,
+            schema_snapshot_id=snapshot.id,
+            contract_version=3,
+            display_name="Demo business contract",
+            owner_binding="group:safequery-demo-local-operators",
+            security_review_binding=None,
+            exception_policy_binding=None,
+        )
+        self.session.add(contract)
+        self.session.flush()
+
+        source.dataset_contract_id = contract.id
+        source.schema_snapshot_id = snapshot.id
+
+        request = PreviewRequest(
+            id=uuid4(),
+            request_id="request-123",
+            registered_source_id=source.id,
+            source_id=source.source_id,
+            source_family=source.source_family,
+            source_flavor=source.source_flavor,
+            dataset_contract_id=contract.id,
+            dataset_contract_version=contract.contract_version,
+            schema_snapshot_id=snapshot.id,
+            schema_snapshot_version=snapshot.snapshot_version,
+            authenticated_subject_id="user:demo-local-operator",
+            auth_source="test-helper",
+            session_id="session-123",
+            governance_bindings="group:safequery-demo-local-operators",
+            entitlement_decision="allow",
+            request_text="Show approved spend",
+            request_state="previewed",
+        )
+        self.session.add(request)
+        self.session.flush()
+
+        candidate = PreviewCandidate(
+            id=uuid4(),
+            candidate_id="candidate-123",
+            preview_request_id=request.id,
+            request_id=request.request_id,
+            registered_source_id=source.id,
+            source_id=source.source_id,
+            source_family=source.source_family,
+            source_flavor=source.source_flavor,
+            dataset_contract_id=contract.id,
+            dataset_contract_version=contract.contract_version,
+            schema_snapshot_id=snapshot.id,
+            schema_snapshot_version=snapshot.snapshot_version,
+            authenticated_subject_id="user:demo-local-operator",
+            candidate_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1",
+            guard_status="allow",
+            candidate_state="preview_ready",
+        )
+        self.session.add(candidate)
+        self.session.flush()
+
+        now = datetime.now(timezone.utc)
+        self.session.add(
+            PreviewCandidateApproval(
+                id=uuid4(),
+                approval_id="approval-candidate-123",
+                preview_candidate_id=candidate.id,
+                candidate_id=candidate.candidate_id,
+                request_id=request.request_id,
+                registered_source_id=source.id,
+                source_id=source.source_id,
+                source_family=source.source_family,
+                source_flavor=source.source_flavor,
+                dataset_contract_version=contract.contract_version,
+                schema_snapshot_version=snapshot.snapshot_version,
+                execution_policy_version=CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY[
+                    source.source_family
+                ],
+                owner_subject_id="user:demo-local-operator",
+                session_id="session-123",
+                approved_at=now - timedelta(minutes=1),
+                approval_expires_at=now + timedelta(minutes=10),
+                approval_state="approved",
+            )
+        )
+        self.session.commit()
+
+    def test_execute_candidate_api_runs_only_approved_candidate_identifier(self) -> None:
+        calls: list[str] = []
+
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            calls.append(canonical_sql)
+            return [{"vendor_name": "Acme"}]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(query_runner).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["candidate_id"], "candidate-123")
+        self.assertEqual(payload["source_id"], "demo-business-postgres")
+        self.assertEqual(payload["connector_id"], "postgresql_readonly")
+        self.assertEqual(payload["rows"], [{"vendor_name": "Acme"}])
+        self.assertEqual(
+            calls,
+            ["SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"],
+        )
+
+    def test_execute_candidate_api_rejects_raw_sql_before_runner_invocation(self) -> None:
+        calls: list[str] = []
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(lambda **_: calls.append("called")).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "selected_source_id": "demo-business-postgres",
+                "canonical_sql": "SELECT 1",
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertEqual(calls, [])
+
+    def test_execute_candidate_api_rejects_source_switch_without_consuming_approval(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(lambda **_: calls.append("called")).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "another-business-source"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_denied")
+        self.assertEqual(
+            payload["audit"]["events"][0]["primary_deny_code"],
+            "DENY_SOURCE_BINDING_MISMATCH",
+        )
+        self.assertEqual(
+            payload["audit"]["events"][0]["query_candidate_id"],
+            "candidate-123",
+        )
+        self.assertEqual(calls, [])
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
+
+    def test_execute_candidate_api_replay_fails_before_runner_invocation(self) -> None:
+        calls: list[str] = []
+
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            calls.append(canonical_sql)
+            return [{"vendor_name": "Acme"}]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        client = self._client(query_runner)
+        first_response = client.post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+        second_response = client.post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 403)
+        self.assertEqual(second_response.json()["error"]["code"], "execution_denied")
+        self.assertEqual(
+            calls,
+            ["SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import unittest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
@@ -252,6 +253,52 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             ["SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"],
         )
 
+    def test_execute_candidate_api_uses_snapshot_returned_by_lifecycle_revalidation(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        main_module = importlib.import_module("app.main")
+        original_revalidate = main_module.revalidate_authoritative_candidate_approval
+
+        def revalidate_after_approval_refresh(**kwargs: object) -> object:
+            approval = (
+                self.session.query(PreviewCandidateApproval)
+                .filter_by(candidate_id="candidate-123")
+                .one()
+            )
+            approval.approved_sql = (
+                "SELECT vendor_name FROM finance.approved_vendor_spend "
+                "WHERE vendor_name = 'Revalidated' LIMIT 1"
+            )
+            self.session.commit()
+            return original_revalidate(**kwargs)
+
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            calls.append(canonical_sql)
+            return [{"vendor_name": "Revalidated"}]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        with patch.object(
+            main_module,
+            "revalidate_authoritative_candidate_approval",
+            side_effect=revalidate_after_approval_refresh,
+        ):
+            response = self._client(query_runner).post(
+                "/candidates/candidate-123/execute",
+                headers=app_session.headers,
+                cookies=app_session.cookies,
+                json={"selected_source_id": "demo-business-postgres"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            calls,
+            [
+                "SELECT vendor_name FROM finance.approved_vendor_spend "
+                "WHERE vendor_name = 'Revalidated' LIMIT 1"
+            ],
+        )
+
     def test_execute_candidate_api_rejects_missing_approved_snapshot_before_runner(
         self,
     ) -> None:
@@ -275,6 +322,35 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()["error"]["code"], "execution_denied")
         self.assertEqual(calls, [])
+        self.session.refresh(approval)
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
+
+    def test_execute_candidate_api_rejects_missing_connector_config_without_consuming_approval(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        os.environ.pop("SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL", None)
+        get_settings.cache_clear()
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(lambda **_: calls.append("called")).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "execution_unavailable")
+        self.assertEqual(calls, [])
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
 
     def test_execute_candidate_api_rejects_raw_sql_before_runner_invocation(self) -> None:
         calls: list[str] = []

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -184,6 +184,9 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
                 execution_policy_version=CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY[
                     source.source_family
                 ],
+                approved_sql=(
+                    "SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"
+                ),
                 owner_subject_id="user:demo-local-operator",
                 session_id="session-123",
                 approved_at=now - timedelta(minutes=1),
@@ -218,6 +221,60 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             calls,
             ["SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"],
         )
+
+    def test_execute_candidate_api_runs_approved_snapshot_after_preview_row_drift(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        candidate = (
+            self.session.query(PreviewCandidate)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        candidate.candidate_sql = "SELECT unapproved_column FROM drifted_preview"
+        self.session.commit()
+
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            calls.append(canonical_sql)
+            return [{"vendor_name": "Acme"}]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(query_runner).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            calls,
+            ["SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"],
+        )
+
+    def test_execute_candidate_api_rejects_missing_approved_snapshot_before_runner(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        approval.approved_sql = None
+        self.session.commit()
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(lambda **_: calls.append("called")).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "execution_denied")
+        self.assertEqual(calls, [])
 
     def test_execute_candidate_api_rejects_raw_sql_before_runner_invocation(self) -> None:
         calls: list[str] = []

--- a/backend/tests/test_candidate_lifecycle_revalidation.py
+++ b/backend/tests/test_candidate_lifecycle_revalidation.py
@@ -221,6 +221,7 @@ def _seed_preview_candidate_approval(
             if execution_policy_version is not None
             else CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY[source.source_family]
         ),
+        approved_sql="SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50",
         owner_subject_id=owner_subject_id,
         session_id="session-123",
         approved_at=now,

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -229,6 +229,7 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         assert persisted_approval.owner_subject_id == "user:alice"
         assert persisted_approval.session_id == "application-session-redacted"
         assert persisted_approval.execution_policy_version == 3
+        assert persisted_approval.approved_sql is None
         assert persisted_approval.approval_state == "approved"
         assert persisted_approval.approved_at is not None
         assert persisted_approval.approval_expires_at > persisted_approval.approved_at
@@ -363,6 +364,10 @@ def test_http_preview_submission_persists_adapter_generated_candidate(
         )
 
         assert persisted_candidate.candidate_sql == candidate_sql
+        persisted_approval = session.execute(
+            select(PreviewCandidateApproval)
+        ).scalar_one()
+        assert persisted_approval.approved_sql == candidate_sql
         assert persisted_candidate.adapter_provider == "local_llm"
         assert persisted_candidate.adapter_model == "safequery-test-sql"
         assert persisted_candidate.adapter_version == "test.local_llm.v1"


### PR DESCRIPTION
## Summary
- publish POST /candidates/{candidate_id}/execute for approved candidate execution
- revalidate authoritative candidate approval, source binding, owner, policy freshness, and entitlement before runner invocation
- return safe execution denial/unavailable errors with sanitized audit events
- add API regression coverage for success, raw SQL rejection, source switching, and replay

## Verification
- cd backend && python3 -m pytest tests/test_source_bound_execute_path.py tests/test_candidate_lifecycle_revalidation.py tests/test_api_errors.py tests/test_execution_connector_selection.py tests/test_candidate_execute_api.py

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /candidates/{candidate_id}/execute to run approved candidates and return query rows plus audit events.
  * Enforces selected-source binding, uses authoritative approved SQL, and provides replay protection.

* **Bug Fixes**
  * Improved error mapping and filtered audit payloads for denied/unavailable executions.

* **Chores**
  * Approval records now persist an approved SQL when present (DB migration).

* **Tests**
  * New tests cover execute flows, validations, replay protection, and connector-availability handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->