### PR TITLE
[O-4] Guard business PostgreSQL execute source binding

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, ValidationError
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -23,6 +24,7 @@ from app.core.errors import (
 )
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
+from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
 from app.features.auth.dev import attach_dev_authenticated_subject
 from app.features.auth.context import (
@@ -33,6 +35,7 @@ from app.features.auth.session import (
     ApplicationSessionContext,
     require_application_session,
 )
+from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
 from app.features.execution import (
     ExecutableCandidateRecord,
     ExecutionAuditContext,
@@ -192,6 +195,38 @@ def _require_execution_connector_configuration(
                 "Candidate execution is unavailable.",
             )
         return
+
+
+def _require_source_bound_execution_connection_reference(
+    *,
+    session: Session,
+    source_id: str,
+    connector_id: str,
+) -> None:
+    expected_connection_reference_by_connector = {
+        "postgresql_readonly": "env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        "mssql_readonly": "env:SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING",
+    }
+    expected_connection_reference = expected_connection_reference_by_connector.get(
+        connector_id
+    )
+    if expected_connection_reference is None:
+        return
+
+    source = session.scalar(
+        select(RegisteredSource).where(RegisteredSource.source_id == source_id)
+    )
+    actual_connection_reference = (
+        source.connection_reference.strip() if source is not None else None
+    )
+    if actual_connection_reference != expected_connection_reference:
+        raise ExecutionConnectorExecutionError(
+            deny_code=DENY_SOURCE_BINDING_MISMATCH,
+            message=(
+                "The candidate-bound source is not bound to the backend-owned "
+                "execution connection reference."
+            ),
+        )
 
 
 def create_app() -> FastAPI:
@@ -450,6 +485,11 @@ def create_app() -> FastAPI:
                 )
                 prepared_selection = select_execution_connector(
                     candidate_source=prepared_candidate.source
+                )
+                _require_source_bound_execution_connection_reference(
+                    session=session,
+                    source_id=prepared_candidate.source.source_id,
+                    connector_id=prepared_selection.connector_id,
                 )
                 _require_execution_connector_configuration(
                     connector_id=prepared_selection.connector_id,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
 from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
+from app.features.audit import SourceAwareAuditEvent
 from app.features.auth.dev import attach_dev_authenticated_subject
 from app.features.auth.context import (
     AuthenticatedSubject,
@@ -50,6 +51,7 @@ from app.services.candidate_lifecycle import (
     CandidateLifecycleAuditContext,
     CandidateLifecycleRevalidationError,
     CandidateLifecycleRevalidationResult,
+    SourceBoundCandidateMetadata,
     revalidate_authoritative_candidate_approval,
 )
 from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
@@ -197,12 +199,51 @@ def _require_execution_connector_configuration(
         return
 
 
+def _build_execution_source_binding_denial_audit_event(
+    *,
+    candidate_source: SourceBoundCandidateMetadata,
+    audit_context: CandidateLifecycleAuditContext,
+) -> SourceAwareAuditEvent:
+    return SourceAwareAuditEvent(
+        event_id=audit_context.event_id,
+        event_type="execution_denied",
+        occurred_at=audit_context.occurred_at,
+        request_id=audit_context.request_id,
+        correlation_id=audit_context.correlation_id,
+        user_subject=audit_context.user_subject,
+        session_id=audit_context.session_id,
+        query_candidate_id=audit_context.query_candidate_id,
+        candidate_owner_subject=audit_context.candidate_owner_subject,
+        source_id=candidate_source.source_id,
+        source_family=candidate_source.source_family,
+        source_flavor=candidate_source.source_flavor,
+        dataset_contract_version=candidate_source.dataset_contract_version,
+        schema_snapshot_version=candidate_source.schema_snapshot_version,
+        execution_policy_version=candidate_source.execution_policy_version,
+        connector_profile_version=candidate_source.connector_profile_version,
+        primary_deny_code=DENY_SOURCE_BINDING_MISMATCH,
+        denial_cause="source_binding_mismatch",
+        candidate_state="denied",
+    )
+
+
 def _require_source_bound_execution_connection_reference(
     *,
     session: Session,
-    source_id: str,
+    candidate_source: SourceBoundCandidateMetadata,
     connector_id: str,
+    audit_context: CandidateLifecycleAuditContext,
 ) -> None:
+    def raise_source_binding_mismatch(message: str) -> None:
+        raise ExecutionConnectorExecutionError(
+            deny_code=DENY_SOURCE_BINDING_MISMATCH,
+            message=message,
+            audit_event=_build_execution_source_binding_denial_audit_event(
+                candidate_source=candidate_source,
+                audit_context=audit_context,
+            ),
+        )
+
     expected_connection_reference_by_connector = {
         "postgresql_readonly": "env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
         "mssql_readonly": "env:SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING",
@@ -211,21 +252,28 @@ def _require_source_bound_execution_connection_reference(
         connector_id
     )
     if expected_connection_reference is None:
-        return
+        raise_source_binding_mismatch(
+            "The candidate-bound source is not bound to a supported "
+            f"backend-owned execution connection reference for connector '{connector_id}'."
+        )
 
     source = session.scalar(
-        select(RegisteredSource).where(RegisteredSource.source_id == source_id)
+        select(RegisteredSource).where(
+            RegisteredSource.source_id == candidate_source.source_id
+        )
+    )
+    raw_connection_reference = (
+        source.connection_reference if source is not None else None
     )
     actual_connection_reference = (
-        source.connection_reference.strip() if source is not None else None
+        raw_connection_reference.strip()
+        if isinstance(raw_connection_reference, str)
+        else None
     )
     if actual_connection_reference != expected_connection_reference:
-        raise ExecutionConnectorExecutionError(
-            deny_code=DENY_SOURCE_BINDING_MISMATCH,
-            message=(
-                "The candidate-bound source is not bound to the backend-owned "
-                "execution connection reference."
-            ),
+        raise_source_binding_mismatch(
+            "The candidate-bound source is not bound to the backend-owned "
+            "execution connection reference."
         )
 
 
@@ -488,8 +536,9 @@ def create_app() -> FastAPI:
                 )
                 _require_source_bound_execution_connection_reference(
                     session=session,
-                    source_id=prepared_candidate.source.source_id,
+                    candidate_source=prepared_candidate.source,
                     connector_id=prepared_selection.connector_id,
+                    audit_context=lifecycle_audit_context,
                 )
                 _require_execution_connector_configuration(
                     connector_id=prepared_selection.connector_id,

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -433,6 +433,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             "DENY_SOURCE_BINDING_MISMATCH",
         )
         self.assertNotIn("safequery_exec:secret", response.text)
+        self.assertNotIn(os.environ["SAFEQUERY_APP_POSTGRES_URL"], response.text)
         self.assertEqual(calls, [])
         approval = (
             self.session.query(PreviewCandidateApproval)

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -426,8 +426,63 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()["error"]["code"], "execution_denied")
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_denied")
+        self.assertEqual(
+            payload["audit"]["events"][0]["primary_deny_code"],
+            "DENY_SOURCE_BINDING_MISMATCH",
+        )
         self.assertNotIn("safequery_exec:secret", response.text)
+        self.assertEqual(calls, [])
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
+
+    def test_execute_candidate_api_rejects_unknown_connector_without_consuming_approval(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        main_module = importlib.import_module("app.main")
+        unexpected_selection = main_module.ExecutionConnectorSelection(
+            source_id="demo-business-postgres",
+            source_family="postgresql",
+            source_flavor="warehouse",
+            connector_id="postgresql_readonly_shadow",
+            ownership="backend",
+        )
+
+        def query_runner(**_: object) -> list[dict[str, object]]:
+            calls.append("called")
+            return []
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        with patch.object(
+            main_module,
+            "select_execution_connector",
+            return_value=unexpected_selection,
+        ):
+            response = self._client(query_runner).post(
+                "/candidates/candidate-123/execute",
+                headers=app_session.headers,
+                cookies=app_session.cookies,
+                json={"selected_source_id": "demo-business-postgres"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_denied")
+        self.assertEqual(
+            payload["audit"]["events"][0]["primary_deny_code"],
+            "DENY_SOURCE_BINDING_MISMATCH",
+        )
+        self.assertEqual(
+            payload["audit"]["events"][0]["query_candidate_id"],
+            "candidate-123",
+        )
         self.assertEqual(calls, [])
         approval = (
             self.session.query(PreviewCandidateApproval)

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -94,7 +94,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             dataset_contract_id=None,
             schema_snapshot_id=None,
             execution_policy_id=None,
-            connection_reference="vault:demo-business-postgres",
+            connection_reference="env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
         )
         self.session.add(source)
         self.session.flush()
@@ -392,6 +392,42 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             payload["audit"]["events"][0]["query_candidate_id"],
             "candidate-123",
         )
+        self.assertEqual(calls, [])
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
+
+    def test_execute_candidate_api_rejects_application_postgres_connection_reference_without_leaking_secret(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        source = (
+            self.session.query(RegisteredSource)
+            .filter_by(source_id="demo-business-postgres")
+            .one()
+        )
+        source.connection_reference = "env:SAFEQUERY_APP_POSTGRES_URL"
+        self.session.commit()
+
+        def query_runner(**_: object) -> list[dict[str, object]]:
+            calls.append("called")
+            return []
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(query_runner).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "execution_denied")
+        self.assertNotIn("safequery_exec:secret", response.text)
         self.assertEqual(calls, [])
         approval = (
             self.session.query(PreviewCandidateApproval)


### PR DESCRIPTION
## Summary
- require candidate execute sources to be bound to the backend-owned execution connection reference before marking approvals executed
- reject application PostgreSQL env-reference reuse at the API preparation boundary without exposing configured secrets
- add a regression for app DB connection-reference reuse preserving approval state and skipping the runner

## Verification
- cd backend && python3 -m pytest tests/test_postgresql_execution_connector.py tests/test_application_postgres_guard.py tests/test_execution_connector_selection.py tests/test_source_bound_execute_path.py tests/test_candidate_execute_api.py
- cd backend && python3 -m pytest

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Execution now validates that a source's connection matches the expected execution connection during preparation. Mismatches cause execution to be denied early with a 403 response.

* **Tests**
  * Added tests covering execution denial for rebinding and unexpected execution connector selection, ensuring denial happens early, no runner is invoked, approvals remain unchanged, and secrets are not exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->