### PR TITLE
[O-7] Add operator runtime controls

### DIFF
--- a/backend/app/features/execution/__init__.py
+++ b/backend/app/features/execution/__init__.py
@@ -18,6 +18,7 @@ from app.features.execution.runtime import (
     MSSQLExecutionRuntimeUnavailable,
     check_mssql_execution_runtime_readiness,
     execute_candidate_sql,
+    preflight_execution_runtime_controls,
 )
 
 __all__ = [
@@ -35,5 +36,6 @@ __all__ = [
     "MSSQLExecutionRuntimeUnavailable",
     "check_mssql_execution_runtime_readiness",
     "execute_candidate_sql",
+    "preflight_execution_runtime_controls",
     "select_execution_connector",
 ]

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -646,6 +646,41 @@ def _require_runtime_safety_controls_allow_execution(
         )
 
 
+def preflight_execution_runtime_controls(
+    *,
+    candidate_source: SourceBoundCandidateMetadata,
+    selection: ExecutionConnectorSelection,
+    cancellation_probe: CancellationProbe | None = None,
+    runtime_safety_state: ExecutionRuntimeSafetyState | None = None,
+    audit_context: ExecutionAuditContext | None = None,
+) -> None:
+    try:
+        runtime_controls = _resolve_runtime_controls(
+            selection=selection,
+            cancellation_probe=cancellation_probe,
+        )
+        _raise_if_cancelled(
+            runtime_controls=runtime_controls,
+            message="Execution canceled before the backend-owned query runner started.",
+        )
+        _require_runtime_safety_controls_allow_execution(
+            candidate_source=candidate_source,
+            runtime_safety_state=runtime_safety_state,
+        )
+    except ExecutionRuntimeCancelledError as exc:
+        raise _attach_cancellation_audit_event(
+            error=exc,
+            candidate_source=candidate_source,
+            audit_context=audit_context,
+        ) from exc
+    except (ExecutionConnectorExecutionError, ExecutionConnectorSelectionError) as exc:
+        raise _attach_execution_denial_audit_event(
+            error=exc,
+            candidate_source=candidate_source,
+            audit_context=audit_context,
+        ) from exc
+
+
 def _raise_if_cancelled(
     *,
     runtime_controls: ExecutionRuntimeControls,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -166,9 +166,16 @@ def _operator_runtime_safety_state(request: Request) -> ExecutionRuntimeSafetySt
 
 def _operator_control_values(values: object) -> frozenset[str]:
     if isinstance(values, (set, frozenset, list, tuple)):
-        normalized = frozenset(str(value).strip() for value in values)
-        if all(normalized):
-            return normalized
+        normalized_values: set[str] = set()
+        for value in values:
+            if not isinstance(value, str):
+                break
+            normalized = value.strip()
+            if not normalized:
+                break
+            normalized_values.add(normalized)
+        else:
+            return frozenset(normalized_values)
     raise api_error(
         503,
         "execution_unavailable",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from time import perf_counter
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -46,7 +46,9 @@ from app.features.execution import (
     ExecutionConnectorSelectionError,
     ExecutionRuntimeCancelledError,
     ExecutionRuntimeFailureError,
+    ExecutionRuntimeSafetyState,
     execute_candidate_sql,
+    preflight_execution_runtime_controls,
     select_execution_connector,
 )
 from app.services.candidate_lifecycle import (
@@ -147,6 +149,58 @@ class CandidateExecuteResponse(BaseModel):
     rows: list[dict[str, Any]]
     metadata: dict[str, Any]
     audit: dict[str, list[dict[str, Any]]]
+
+
+def _operator_runtime_safety_state(request: Request) -> ExecutionRuntimeSafetyState | None:
+    state = getattr(request.app.state, "execution_runtime_safety_state", None)
+    if state is None:
+        return None
+    if not isinstance(state, ExecutionRuntimeSafetyState):
+        raise api_error(
+            503,
+            "execution_unavailable",
+            "Candidate execution is unavailable.",
+        )
+    return state
+
+
+def _operator_control_values(values: object) -> frozenset[str]:
+    if isinstance(values, (set, frozenset, list, tuple)):
+        normalized = frozenset(str(value).strip() for value in values)
+        if all(normalized):
+            return normalized
+    raise api_error(
+        503,
+        "execution_unavailable",
+        "Candidate execution is unavailable.",
+    )
+
+
+def _operator_cancellation_probe(
+    request: Request,
+    *,
+    candidate_id: str,
+    source_id: str,
+) -> Callable[[], bool]:
+    cancelled_candidate_ids = _operator_control_values(
+        getattr(
+            request.app.state,
+            "execution_cancelled_candidate_ids",
+            frozenset(),
+        )
+    )
+    cancelled_source_ids = _operator_control_values(
+        getattr(
+            request.app.state,
+            "execution_cancelled_source_ids",
+            frozenset(),
+        )
+    )
+
+    def probe() -> bool:
+        return candidate_id in cancelled_candidate_ids or source_id in cancelled_source_ids
+
+    return probe
 
 
 def _serialize_entitlement_denial_audit_events(
@@ -529,11 +583,13 @@ def create_app() -> FastAPI:
         try:
             candidate: ExecutableCandidateRecord | None = None
             selection: ExecutionConnectorSelection | None = None
+            cancellation_probe = None
+            runtime_safety_state = _operator_runtime_safety_state(http_request)
 
             def prepare_execution(
                 revalidation_result: CandidateLifecycleRevalidationResult,
             ) -> None:
-                nonlocal candidate, selection
+                nonlocal candidate, selection, cancellation_probe
                 approved_sql = revalidation_result.approved_sql
                 if approved_sql is None:
                     raise api_error(
@@ -554,6 +610,34 @@ def create_app() -> FastAPI:
                     connector_id=prepared_selection.connector_id,
                     audit_context=lifecycle_audit_context,
                 )
+                prepared_cancellation_probe = _operator_cancellation_probe(
+                    http_request,
+                    candidate_id=candidate_id,
+                    source_id=prepared_candidate.source.source_id,
+                )
+                preflight_audit_context = ExecutionAuditContext(
+                    event_id=uuid4(),
+                    occurred_at=occurred_at,
+                    request_id=audit_request_id,
+                    correlation_id=lifecycle_audit_context.correlation_id,
+                    user_subject=user_subject,
+                    session_id=application_session.audit_session_id,
+                    query_candidate_id=candidate_id,
+                    candidate_owner_subject=user_subject,
+                    execution_policy_version=(
+                        prepared_candidate.source.execution_policy_version
+                    ),
+                    connector_profile_version=(
+                        prepared_candidate.source.connector_profile_version
+                    ),
+                )
+                preflight_execution_runtime_controls(
+                    candidate_source=prepared_candidate.source,
+                    selection=prepared_selection,
+                    cancellation_probe=prepared_cancellation_probe,
+                    runtime_safety_state=runtime_safety_state,
+                    audit_context=preflight_audit_context,
+                )
                 _require_execution_connector_configuration(
                     connector_id=prepared_selection.connector_id,
                     business_postgres_source_url=settings.business_postgres_source_url,
@@ -563,6 +647,7 @@ def create_app() -> FastAPI:
                 )
                 candidate = prepared_candidate
                 selection = prepared_selection
+                cancellation_probe = prepared_cancellation_probe
 
             revalidate_authoritative_candidate_approval(
                 session=session,
@@ -609,6 +694,8 @@ def create_app() -> FastAPI:
                 ),
                 application_postgres_url=str(settings.app_postgres_url),
                 query_runner=query_runner,
+                cancellation_probe=cancellation_probe,
+                runtime_safety_state=runtime_safety_state,
                 audit_context=execution_audit_context,
             )
         except CandidateLifecycleRevalidationError as exc:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -182,22 +182,21 @@ def _operator_cancellation_probe(
     candidate_id: str,
     source_id: str,
 ) -> Callable[[], bool]:
-    cancelled_candidate_ids = _operator_control_values(
-        getattr(
-            request.app.state,
-            "execution_cancelled_candidate_ids",
-            frozenset(),
-        )
-    )
-    cancelled_source_ids = _operator_control_values(
-        getattr(
-            request.app.state,
-            "execution_cancelled_source_ids",
-            frozenset(),
-        )
-    )
-
     def probe() -> bool:
+        cancelled_candidate_ids = _operator_control_values(
+            getattr(
+                request.app.state,
+                "execution_cancelled_candidate_ids",
+                frozenset(),
+            )
+        )
+        cancelled_source_ids = _operator_control_values(
+            getattr(
+                request.app.state,
+                "execution_cancelled_source_ids",
+                frozenset(),
+            )
+        )
         return candidate_id in cancelled_candidate_ids or source_id in cancelled_source_ids
 
     return probe

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -733,6 +733,46 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(approval.approval_state, "approved")
         self.assertIsNone(approval.executed_at)
 
+    def test_execute_candidate_api_cancellation_probe_reads_operator_state_updates(
+        self,
+    ) -> None:
+        from app.features.execution.runtime import ExecutionRuntimeCancelledError
+
+        calls: list[str] = []
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+
+        def query_runner(*, runtime_controls, **_: object) -> list[dict[str, object]]:
+            calls.append("started")
+            client.app.state.execution_cancelled_candidate_ids = frozenset(
+                {"candidate-123"}
+            )
+            if runtime_controls.cancellation_probe is not None:
+                cancellation_requested = runtime_controls.cancellation_probe()
+                calls.append(f"cancelled={cancellation_requested}")
+                if cancellation_requested:
+                    raise ExecutionRuntimeCancelledError(
+                        "Execution canceled before the PostgreSQL result set was read."
+                    )
+            return []
+
+        client = self._client(query_runner)
+
+        response = client.post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_unavailable")
+        self.assertEqual(
+            payload["audit"]["events"][-1]["candidate_state"],
+            "canceled",
+        )
+        self.assertEqual(calls, ["started", "cancelled=True"])
+
     def test_execute_candidate_api_replay_fails_before_runner_invocation(self) -> None:
         calls: list[str] = []
 

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -657,6 +657,82 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(approval.approval_state, "approved")
         self.assertIsNone(approval.executed_at)
 
+    def test_execute_candidate_api_applies_operator_runtime_kill_switch_without_consuming_approval(
+        self,
+    ) -> None:
+        from app.features.execution.runtime import ExecutionRuntimeSafetyState
+
+        calls: list[str] = []
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+
+        def query_runner(**_: object) -> list[dict[str, object]]:
+            calls.append("called")
+            return []
+
+        client = self._client(query_runner)
+        client.app.state.execution_runtime_safety_state = ExecutionRuntimeSafetyState(
+            disabled_source_ids=frozenset({"demo-business-postgres"})
+        )
+
+        response = client.post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_denied")
+        self.assertEqual(
+            payload["audit"]["events"][-1]["primary_deny_code"],
+            "DENY_RUNTIME_KILL_SWITCH",
+        )
+        self.assertEqual(calls, [])
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
+
+    def test_execute_candidate_api_applies_candidate_bound_operator_cancellation_without_consuming_approval(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+
+        def query_runner(**_: object) -> list[dict[str, object]]:
+            calls.append("called")
+            return []
+
+        client = self._client(query_runner)
+        client.app.state.execution_cancelled_candidate_ids = frozenset({"candidate-123"})
+
+        response = client.post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_unavailable")
+        self.assertEqual(
+            payload["audit"]["events"][-1]["candidate_state"],
+            "canceled",
+        )
+        self.assertEqual(calls, [])
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
+
     def test_execute_candidate_api_replay_fails_before_runner_invocation(self) -> None:
         calls: list[str] = []
 

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -733,6 +733,33 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(approval.approval_state, "approved")
         self.assertIsNone(approval.executed_at)
 
+    def test_execute_candidate_api_rejects_malformed_operator_cancellation_state(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+
+        client = self._client(lambda **_: calls.append("called"))
+        client.app.state.execution_cancelled_candidate_ids = ["candidate-123", None]
+
+        response = client.post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "execution_unavailable")
+        self.assertEqual(calls, [])
+        approval = (
+            self.session.query(PreviewCandidateApproval)
+            .filter_by(candidate_id="candidate-123")
+            .one()
+        )
+        self.assertEqual(approval.approval_state, "approved")
+        self.assertIsNone(approval.executed_at)
+
     def test_execute_candidate_api_cancellation_probe_reads_operator_state_updates(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- wire operator runtime safety state into candidate execution
- preflight kill switch/rate/concurrency/cancellation before approval consumption
- add API regressions for kill switch and candidate-bound cancellation safe state

## Verification
- cd backend && python3 -m pytest tests/test_execution_runtime_controls.py tests/test_source_bound_execute_path.py -q
- cd backend && python3 -m pytest tests/test_operator_history_payloads.py tests/test_api_errors.py -q
- cd backend && python3 -m pytest tests/test_candidate_execute_api.py -q
- cd backend && python3 -m pytest -q

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a reusable preflight helper for runtime execution gating.
  * Execution flow now enforces runtime safety and cancellation checks before running candidates; endpoints return 503 when execution is unavailable and 403 when safety controls deny execution, with audits preventing runner invocation or approval consumption.

* **Tests**
  * Added API tests covering gating, denial, malformed cancellation, and probe-driven cancellation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->