### PR TITLE
Remove placeholder workflow results

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -755,6 +755,74 @@ describe("HomePage", () => {
     expect(screen.queryByText(/results placeholder/i)).not.toBeInTheDocument();
   });
 
+  it("renders selected terminal run context from authoritative history", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    itemType: "run",
+                    label: "Selected completed run",
+                    lifecycleState: "completed",
+                    occurredAt: "2026-04-21T14:42:00Z",
+                    recordId: "run-authoritative-282",
+                    runState: null,
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "Authoritative run source / approved_vendor_spend"
+                  }
+                ],
+                sources: [
+                  {
+                    activationPosture: "active",
+                    description: "Registry fallback source label should not override selected run context.",
+                    displayLabel: "Registry fallback source label",
+                    sourceId: "sap-approved-spend"
+                  }
+                ]
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "run",
+          history_record_id: "run-authoritative-282",
+          question: "Selected completed run",
+          source_id: "sap-approved-spend",
+          state: "completed"
+        }
+      })
+    );
+
+    const lifecycleSection = screen
+      .getByRole("heading", { name: /source and lifecycle context/i })
+      .closest("section");
+    expect(lifecycleSection).not.toBeNull();
+    const lifecycleContext = within(lifecycleSection!);
+
+    expect(lifecycleContext.getByText("Authoritative run source / approved_vendor_spend")).toBeInTheDocument();
+    expect(lifecycleContext.getByText("run-authoritative-282")).toBeInTheDocument();
+    expect(lifecycleContext.getByText(/\d{4}-\d{2}-\d{2} \d{2}:/)).toHaveTextContent(
+      "2026-04-21 14:42 UTC"
+    );
+    expect(lifecycleContext.getByText("completed")).toBeInTheDocument();
+    expect(lifecycleContext.queryByText("Registry fallback source label")).not.toBeInTheDocument();
+    expect(screen.queryByText(/placeholder rows only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
+  });
+
   it("renders explicit empty and review-denied unavailable states", async () => {
     const { rerender } = render(
       await HomePage({

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -771,7 +771,7 @@ describe("HomePage", () => {
                     itemType: "run",
                     label: "Selected completed run",
                     lifecycleState: "completed",
-                    occurredAt: "2026-04-21T14:42:00Z",
+                    occurredAt: "2026-04-21T14:42:17+09:00",
                     recordId: "run-authoritative-282",
                     runState: null,
                     sourceId: "sap-approved-spend",
@@ -814,9 +814,8 @@ describe("HomePage", () => {
 
     expect(lifecycleContext.getByText("Authoritative run source / approved_vendor_spend")).toBeInTheDocument();
     expect(lifecycleContext.getByText("run-authoritative-282")).toBeInTheDocument();
-    expect(lifecycleContext.getByText(/\d{4}-\d{2}-\d{2} \d{2}:/)).toHaveTextContent(
-      "2026-04-21 14:42 UTC"
-    );
+    expect(lifecycleContext.getByText("2026-04-21T14:42:17+09:00")).toBeInTheDocument();
+    expect(lifecycleContext.queryByText("2026-04-21 05:42 UTC")).not.toBeInTheDocument();
     expect(lifecycleContext.getByText("completed")).toBeInTheDocument();
     expect(lifecycleContext.queryByText("Registry fallback source label")).not.toBeInTheDocument();
     expect(screen.queryByText(/placeholder rows only/i)).not.toBeInTheDocument();

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -731,7 +731,31 @@ describe("HomePage", () => {
     expect(screen.getAllByText(/sap spend cube \/ approved_vendor_spend/i)).not.toHaveLength(0);
   });
 
-  it("renders explicit empty and review-denied placeholder states", async () => {
+  it("does not render placeholder result rows or fabricated run context in product workflow views", async () => {
+    render(
+      await HomePage({
+        searchParams: {
+          question: "Show approved vendors by quarterly spend",
+          source_id: "sap-approved-spend",
+          state: "completed"
+        }
+      })
+    );
+
+    expect(screen.getByRole("heading", { name: /completed state/i })).toBeInTheDocument();
+    expect(screen.queryByText(/northwind health/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/harbor transit/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/blue summit labs/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/placeholder rows only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/run-sq-204/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/2026-04-21 14:/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/placeholder only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/authentication placeholder/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/results placeholder/i)).not.toBeInTheDocument();
+  });
+
+  it("renders explicit empty and review-denied unavailable states", async () => {
     const { rerender } = render(
       await HomePage({
         searchParams: {
@@ -771,30 +795,30 @@ describe("HomePage", () => {
       {
         state: "completed",
         heading: /completed state/i,
-        status: /execution completed with rows/i,
-        lifecycle: /run state/i,
-        identity: /run-sq-204/i
+        status: /execution completed/i,
+        lifecycle: /lifecycle posture/i,
+        identity: /No submitted record yet/i
       },
       {
         state: "failed",
         heading: /failed state/i,
         status: /execution failed after run start/i,
-        lifecycle: /run state/i,
-        identity: /run-sq-204/i
+        lifecycle: /lifecycle posture/i,
+        identity: /No submitted record yet/i
       },
       {
         state: "canceled",
         heading: /canceled state/i,
         status: /execution canceled before completion/i,
-        lifecycle: /run state/i,
-        identity: /run-sq-204/i
+        lifecycle: /lifecycle posture/i,
+        identity: /No submitted record yet/i
       },
       {
         state: "execution_denied",
         heading: /execution denied state/i,
         status: /execution denied at execute time/i,
-        lifecycle: /run state/i,
-        identity: /run-sq-204/i
+        lifecycle: /lifecycle posture/i,
+        identity: /No submitted record yet/i
       }
     ] as const;
 
@@ -811,7 +835,7 @@ describe("HomePage", () => {
       );
 
       expect(screen.getByRole("heading", { name: terminalState.heading })).toBeInTheDocument();
-      expect(screen.getByText(terminalState.status)).toBeInTheDocument();
+      expect(screen.getAllByText(terminalState.status).length).toBeGreaterThan(0);
       expect(screen.getByText(/source identity/i)).toBeInTheDocument();
       expect(screen.getByText(/request (identity|posture)/i)).toBeInTheDocument();
       expect(screen.getByText(terminalState.lifecycle)).toBeInTheDocument();

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -120,6 +120,12 @@ type AuthoritativeCandidatePreview = {
   sourceLabel?: string;
 };
 
+type AuthoritativeRunContext = {
+  lifecycleTimestamp: string;
+  runIdentity: string;
+  runState: string;
+};
+
 type ApiErrorEnvelope = {
   code: string;
   message: string;
@@ -131,7 +137,8 @@ const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
     label: "Canceled"
   },
   completed: {
-    description: "Execution completed and returned bounded rows for the reviewed run record.",
+    description:
+      "Execution completed for a reviewed run record; rows appear only when authoritative results are attached.",
     label: "Completed"
   },
   empty: {
@@ -530,6 +537,34 @@ function findAuthoritativeCandidatePreview(
   };
 }
 
+function findAuthoritativeRunContext(
+  history: OperatorHistoryItem[],
+  sourceId?: string,
+  historyRecordId?: string
+): AuthoritativeRunContext | null {
+  if (!sourceId || !historyRecordId) {
+    return null;
+  }
+
+  const run = history.find(
+    (item) =>
+      item.itemType === "run" &&
+      item.sourceId === sourceId &&
+      item.recordId === historyRecordId &&
+      item.runState
+  );
+
+  if (!run?.runState) {
+    return null;
+  }
+
+  return {
+    lifecycleTimestamp: run.occurredAt,
+    runIdentity: run.recordId,
+    runState: run.runState
+  };
+}
+
 function renderCandidateSqlPreview(preview: AuthoritativeCandidatePreview | null) {
   if (!preview) {
     return (
@@ -562,7 +597,8 @@ function renderCandidateSqlPreview(preview: AuthoritativeCandidatePreview | null
 function getWorkflowContext(
   state: CanonicalWorkflowState,
   source?: SourceOption,
-  candidatePreview?: AuthoritativeCandidatePreview | null
+  candidatePreview?: AuthoritativeCandidatePreview | null,
+  runContext?: AuthoritativeRunContext | null
 ): WorkflowContext {
   const sourceIdentity =
     candidatePreview?.sourceLabel ?? source?.displayLabel ?? "No source selected yet";
@@ -583,6 +619,22 @@ function getWorkflowContext(
     };
   }
 
+  if (
+    runContext &&
+    (state === "completed" ||
+      state === "empty" ||
+      state === "execution_denied" ||
+      state === "failed" ||
+      state === "canceled")
+  ) {
+    return {
+      lifecycleTimestamp: runContext.lifecycleTimestamp,
+      runIdentity: runContext.runIdentity,
+      runState: runContext.runState,
+      sourceIdentity
+    };
+  }
+
   if (state === "query" || state === "signin") {
     return {
       sourceIdentity
@@ -590,27 +642,6 @@ function getWorkflowContext(
   }
 
   return {
-    lifecycleTimestamp:
-      state === "completed"
-        ? "2026-04-21 14:32 JST"
-        : state === "empty"
-          ? "2026-04-21 14:34 JST"
-          : state === "execution_denied"
-            ? "2026-04-21 14:31 JST"
-            : state === "failed"
-              ? "2026-04-21 14:35 JST"
-              : "2026-04-21 14:33 JST",
-    runIdentity: "run-sq-204",
-    runState:
-      state === "completed"
-        ? "executed"
-        : state === "empty"
-          ? "executed_empty"
-          : state === "execution_denied"
-            ? "execution_denied"
-            : state === "failed"
-              ? "execution_failed"
-              : "execution_canceled",
     sourceIdentity
   };
 }
@@ -637,7 +668,7 @@ function getGuardHeadline(state: CanonicalWorkflowState): string {
   }
 
   if (state === "completed") {
-    return "Execution completed with rows";
+    return "Execution completed";
   }
 
   if (state === "empty") {
@@ -712,33 +743,18 @@ function getResultTitle(state: CanonicalWorkflowState): string {
     return "Execution canceled";
   }
 
-  return "Results placeholder";
+  return "Results unavailable";
 }
 
 function renderResultContent(state: CanonicalWorkflowState) {
   if (state === "completed") {
     return (
-      <div className="result-table" role="table" aria-label="Placeholder query results">
-        <div className="result-row result-row-head" role="row">
-          <span role="columnheader">Vendor</span>
-          <span role="columnheader">Quarterly spend</span>
-          <span role="columnheader">Guard note</span>
-        </div>
-        <div className="result-row" role="row">
-          <span role="cell">Northwind Health</span>
-          <span role="cell">$842,000</span>
-          <span role="cell">Within reviewed ceiling</span>
-        </div>
-        <div className="result-row" role="row">
-          <span role="cell">Harbor Transit</span>
-          <span role="cell">$611,000</span>
-          <span role="cell">Approved dataset projection</span>
-        </div>
-        <div className="result-row" role="row">
-          <span role="cell">Blue Summit Labs</span>
-          <span role="cell">$488,000</span>
-          <span role="cell">Placeholder rows only</span>
-        </div>
+      <div className="state-callout state-callout-empty">
+        <p className="state-callout-title">Execution results unavailable</p>
+        <p>
+          No backend result rows are attached to this shell view. SafeQuery withholds the table
+          until an authoritative execution payload is returned for the selected run.
+        </p>
       </div>
     );
   }
@@ -785,7 +801,7 @@ function renderResultContent(state: CanonicalWorkflowState) {
         <p className="state-callout-title">Failed state reached</p>
         <p>
           A run was created, but it ended in failure. The operator sees the run anchor and failure
-          posture instead of placeholder rows.
+          posture instead of invented rows.
         </p>
       </div>
     );
@@ -807,8 +823,8 @@ function renderResultContent(state: CanonicalWorkflowState) {
     <div className="placeholder-block">
       <p className="placeholder-title">Result preview pending</p>
       <p>
-        Submit the question to move into SQL review. Result placeholders stay separate from SQL
-        and guard context even before execution wiring exists.
+        Submit the question to move into SQL review. Results remain unavailable until execution
+        returns authoritative rows.
       </p>
     </div>
   );
@@ -822,7 +838,7 @@ function renderStatePanel(
   if (state === "signin") {
     return (
       <div className="state-hero">
-        <p className="eyebrow">Authentication placeholder</p>
+        <p className="eyebrow">Authentication required</p>
         <h2>Sign in state</h2>
         <p className="section-copy">
           This issue stops at the custom shell. The sign-in card is visible and reachable, but it
@@ -866,7 +882,7 @@ function renderStatePanel(
         <h2>Completed state</h2>
         <p className="section-copy">
           Execution-backed rows stay separate from preview and guard surfaces so completed output
-          is anchored to a specific run instead of a generic result placeholder.
+          is anchored to a specific run instead of generic result content.
         </p>
         <div className="action-row">
           <a className="action-link" href={buildStateHref("empty", question, sourceId)}>
@@ -1038,11 +1054,17 @@ export function QueryWorkflowShell({
     submittedSourceId,
     historyRecordId
   );
+  const historyRunContext = findAuthoritativeRunContext(
+    operatorWorkflow.history,
+    submittedSourceId,
+    historyRecordId
+  );
   const candidatePreview = submittedCandidatePreview ?? historyCandidatePreview;
   const workflowContext = getWorkflowContext(
     normalizedState,
     sourceBinding.source,
-    candidatePreview
+    candidatePreview,
+    historyRunContext
   );
   const sourceSelectVisible = normalizedState === "query";
   const boundSourceId = sourceBinding.source?.sourceId;
@@ -1228,7 +1250,9 @@ export function QueryWorkflowShell({
           <div className="meta-card">
             <span className="meta-label">Boundary mode</span>
             <strong>Fail closed</strong>
-            <span className="meta-copy">No auth or execution trust is inferred from placeholders.</span>
+            <span className="meta-copy">
+              No auth or execution trust is inferred from unavailable data.
+            </span>
           </div>
         </div>
 
@@ -1512,7 +1536,7 @@ export function QueryWorkflowShell({
             <div className="guard-list">
               <div className="guard-item">
                 <span className="meta-label">Auth</span>
-                <strong>Placeholder only</strong>
+                <strong>Not connected</strong>
               </div>
               <div className="guard-item">
                 <span className="meta-label">Candidate guard</span>

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -221,15 +221,6 @@ function readRequiredString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
-function formatLifecycleTimestamp(value: string): string {
-  const timestamp = new Date(value);
-  if (Number.isNaN(timestamp.getTime())) {
-    return value;
-  }
-
-  return `${timestamp.toISOString().slice(0, 16).replace("T", " ")} UTC`;
-}
-
 function readCsrfToken(): string | undefined {
   const token =
     document.querySelector<HTMLMetaElement>('meta[name="safequery-csrf-token"]')?.content ??
@@ -570,7 +561,7 @@ function findAuthoritativeRunContext(
 
   return {
     lifecycleState: run.lifecycleState,
-    lifecycleTimestamp: formatLifecycleTimestamp(run.occurredAt),
+    lifecycleTimestamp: run.occurredAt,
     runIdentity: run.recordId,
     runState: run.runState,
     sourceLabel: run.sourceLabel

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -55,7 +55,7 @@ type WorkflowContext = {
   lifecycleTimestamp?: string;
   requestIdentity?: string;
   runIdentity?: string;
-  runState?: string;
+  runState?: string | null;
   sourceIdentity: string;
 };
 
@@ -121,9 +121,11 @@ type AuthoritativeCandidatePreview = {
 };
 
 type AuthoritativeRunContext = {
+  lifecycleState: string;
   lifecycleTimestamp: string;
   runIdentity: string;
-  runState: string;
+  runState?: string | null;
+  sourceLabel: string;
 };
 
 type ApiErrorEnvelope = {
@@ -217,6 +219,15 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function readRequiredString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function formatLifecycleTimestamp(value: string): string {
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    return value;
+  }
+
+  return `${timestamp.toISOString().slice(0, 16).replace("T", " ")} UTC`;
 }
 
 function readCsrfToken(): string | undefined {
@@ -550,18 +561,19 @@ function findAuthoritativeRunContext(
     (item) =>
       item.itemType === "run" &&
       item.sourceId === sourceId &&
-      item.recordId === historyRecordId &&
-      item.runState
+      item.recordId === historyRecordId
   );
 
-  if (!run?.runState) {
+  if (!run) {
     return null;
   }
 
   return {
-    lifecycleTimestamp: run.occurredAt,
+    lifecycleState: run.lifecycleState,
+    lifecycleTimestamp: formatLifecycleTimestamp(run.occurredAt),
     runIdentity: run.recordId,
-    runState: run.runState
+    runState: run.runState,
+    sourceLabel: run.sourceLabel
   };
 }
 
@@ -601,7 +613,10 @@ function getWorkflowContext(
   runContext?: AuthoritativeRunContext | null
 ): WorkflowContext {
   const sourceIdentity =
-    candidatePreview?.sourceLabel ?? source?.displayLabel ?? "No source selected yet";
+    candidatePreview?.sourceLabel ??
+    runContext?.sourceLabel ??
+    source?.displayLabel ??
+    "No source selected yet";
 
   if (candidatePreview && (state === "preview" || state === "review_denied")) {
     return {
@@ -630,7 +645,7 @@ function getWorkflowContext(
     return {
       lifecycleTimestamp: runContext.lifecycleTimestamp,
       runIdentity: runContext.runIdentity,
-      runState: runContext.runState,
+      runState: runContext.runState ?? runContext.lifecycleState,
       sourceIdentity
     };
   }


### PR DESCRIPTION
## Summary
- remove hard-coded completed result rows from the operator workflow shell
- stop fabricating terminal run ids and lifecycle timestamps without selected live run history
- add focused page coverage that rejects placeholder rows, fake run context, and placeholder-only product labels

## Tests
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer terminal workflow status messaging and revised lifecycle/identity labels
  * Removed placeholder result rows; show a “Results unavailable” callout when appropriate
  * Updated headings and explanatory copy for completed/pending/failed/unavailable scenarios
  * Source and connectivity labels now prefer authoritative run info and indicate “Not connected” when data is unavailable

* **Tests**
  * Test suite updated to assert absence of placeholder content, verify displayed run details, and allow more flexible status matching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->