### PR TITLE
[P-2] Implement live request, candidate, and run history navigation

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -75,11 +75,17 @@ def _audit_event_sort_key(event: PreviewAuditEvent) -> tuple[datetime, int, str]
     )
 
 
+def _is_execution_event(event: PreviewAuditEvent) -> bool:
+    return event.event_type.startswith("execution_")
+
+
 def _latest_request_events(
     audit_events: list[PreviewAuditEvent],
 ) -> dict[str, PreviewAuditEvent]:
     latest: dict[str, PreviewAuditEvent] = {}
     for event in audit_events:
+        if _is_execution_event(event):
+            continue
         current = latest.get(event.request_id)
         if current is None or _audit_event_sort_key(event) > _audit_event_sort_key(
             current
@@ -93,7 +99,7 @@ def _latest_candidate_events(
 ) -> dict[str, PreviewAuditEvent]:
     latest: dict[str, PreviewAuditEvent] = {}
     for event in audit_events:
-        if event.candidate_id is None:
+        if event.candidate_id is None or _is_execution_event(event):
             continue
         current = latest.get(event.candidate_id)
         if current is None or _audit_event_sort_key(event) > _audit_event_sort_key(
@@ -101,6 +107,37 @@ def _latest_candidate_events(
         ):
             latest[event.candidate_id] = event
     return latest
+
+
+def _run_state_for_event(event: PreviewAuditEvent) -> str | None:
+    if event.event_type == "execution_completed":
+        row_count = event.audit_payload.get("execution_row_count")
+        return "empty" if row_count == 0 else "completed"
+
+    if event.event_type == "execution_denied":
+        return "execution_denied"
+
+    if event.event_type == "execution_failed":
+        return "canceled" if event.candidate_state == "canceled" else "failed"
+
+    return None
+
+
+def _terminal_run_events(
+    audit_events: list[PreviewAuditEvent],
+) -> list[tuple[PreviewAuditEvent, str]]:
+    terminal_events: list[tuple[PreviewAuditEvent, str]] = []
+    for event in audit_events:
+        if event.candidate_id is None:
+            continue
+
+        run_state = _run_state_for_event(event)
+        if run_state is None:
+            continue
+
+        terminal_events.append((event, run_state))
+
+    return terminal_events
 
 
 def _history_occurred_at(
@@ -135,6 +172,21 @@ def _build_operator_history(
     candidate_events = _latest_candidate_events(audit_events)
 
     history: list[OperatorWorkflowHistoryItem] = []
+    for event, run_state in _terminal_run_events(audit_events):
+        history.append(
+            OperatorWorkflowHistoryItem(
+                item_type="run",
+                record_id=str(event.event_id),
+                label=request_labels.get(event.request_id, "Execution run"),
+                source_id=event.source_id,
+                source_label=source_labels.get(event.source_id, event.source_id),
+                lifecycle_state=run_state,
+                occurred_at=_as_utc_datetime(event.occurred_at),
+                request_id=event.request_id,
+                run_state=run_state,
+            )
+        )
+
     for candidate in candidates:
         history.append(
             OperatorWorkflowHistoryItem(

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -15,6 +15,7 @@ from app.db.models.preview import PreviewAuditEvent
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
+from app.features.audit.event_model import SourceAwareAuditEvent
 from app.services.operator_workflow import (
     _latest_candidate_events,
     _latest_request_events,
@@ -24,6 +25,7 @@ from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionContractError,
     PreviewSubmissionRequest,
+    persist_execution_audit_events,
     submit_preview_request,
 )
 
@@ -128,6 +130,34 @@ def _audit_event(
         source_family="postgresql",
         source_flavor="warehouse",
         audit_payload={"event_type": event_type},
+    )
+
+
+def _execution_audit_event(
+    *,
+    event_id: UUID,
+    event_type: str,
+    occurred_at: datetime,
+    result_truncated: bool | None = None,
+    row_count: int | None = None,
+) -> SourceAwareAuditEvent:
+    return SourceAwareAuditEvent(
+        event_id=event_id,
+        event_type=event_type,
+        occurred_at=occurred_at,
+        request_id="preview-request-234",
+        correlation_id="preview-request-234-correlation",
+        user_subject="user:alice",
+        session_id="preview-request-234-session",
+        query_candidate_id="preview-candidate-234",
+        candidate_owner_subject="user:alice",
+        source_id="sap-approved-spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        dataset_contract_version=1,
+        schema_snapshot_version=1,
+        execution_row_count=row_count,
+        result_truncated=result_truncated,
     )
 
 
@@ -236,6 +266,68 @@ def test_operator_workflow_history_is_built_from_preview_request_and_candidate_r
             "occurredAt": "2026-01-02T03:04:05Z",
         },
     ]
+
+
+def test_operator_workflow_history_includes_execution_run_records() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-234",
+                candidate_id="preview-candidate-234",
+            ),
+        )
+        persist_execution_audit_events(
+            session,
+            candidate_id="preview-candidate-234",
+            audit_events=[
+                _execution_audit_event(
+                    event_id=UUID("00000000-0000-4000-8000-000000000010"),
+                    event_type="execution_requested",
+                    occurred_at=datetime(2026, 1, 2, 3, 5, 1, tzinfo=timezone.utc),
+                ),
+                _execution_audit_event(
+                    event_id=UUID("00000000-0000-4000-8000-000000000011"),
+                    event_type="execution_started",
+                    occurred_at=datetime(2026, 1, 2, 3, 5, 2, tzinfo=timezone.utc),
+                ),
+                _execution_audit_event(
+                    event_id=UUID("00000000-0000-4000-8000-000000000012"),
+                    event_type="execution_completed",
+                    occurred_at=datetime(2026, 1, 2, 3, 5, 3, tzinfo=timezone.utc),
+                    row_count=0,
+                    result_truncated=False,
+                ),
+            ],
+        )
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    history = [
+        item.model_dump(mode="json", by_alias=True, exclude_none=True)
+        for item in snapshot.history
+    ]
+    assert history[0] == {
+        "itemType": "run",
+        "recordId": "00000000-0000-4000-8000-000000000012",
+        "label": "Show approved vendors by quarterly spend",
+        "sourceId": "sap-approved-spend",
+        "sourceLabel": "SAP spend cube / approved_vendor_spend",
+        "lifecycleState": "empty",
+        "occurredAt": "2026-01-02T03:05:03Z",
+        "requestId": "preview-request-234",
+        "runState": "empty",
+    }
 
 
 def test_operator_workflow_history_includes_audit_safe_unavailable_preview_denials() -> None:


### PR DESCRIPTION
## Summary
- add live execution run records to the operator workflow history projection
- keep request and candidate history timestamps anchored to non-execution lifecycle events
- add a focused backend regression for persisted execution audit events producing run navigation records

## Verification
- cd backend && python3 -m pytest tests/test_operator_workflow_history.py tests/test_operator_history_payloads.py -q
- npm test -- --run app/page.test.tsx

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Execution events are now tracked and recorded in workflow history, providing comprehensive visibility into all execution runs without affecting request or candidate history tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->