### PR TITLE
Fix source mismatch on history reopen

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -379,6 +379,20 @@ describe("HomePage", () => {
     expect(screen.getByText("request-selected")).toBeInTheDocument();
     expect(screen.getByText("candidate-selected")).toBeInTheDocument();
     expect(screen.queryByText("select 'wrong candidate' as preview;")).not.toBeInTheDocument();
+    for (const completedLink of screen.getAllByRole("link", { name: /open completed state/i })) {
+      expect(completedLink).toHaveAttribute(
+        "href",
+        expect.stringContaining("history_item_type=candidate")
+      );
+      expect(completedLink).toHaveAttribute(
+        "href",
+        expect.stringContaining("history_record_id=candidate-selected")
+      );
+    }
+    expect(screen.getByRole("link", { name: /open empty state/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("history_record_id=candidate-selected")
+    );
   });
 
   it("keeps reopened history source separate from a mismatched draft source", async () => {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -381,6 +381,74 @@ describe("HomePage", () => {
     expect(screen.queryByText("select 'wrong candidate' as preview;")).not.toBeInTheDocument();
   });
 
+  it("keeps reopened history source separate from a mismatched draft source", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Selected SAP candidate",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-sap-selected",
+                    requestId: "request-sap-selected",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: [
+                  {
+                    activationPosture: "active",
+                    description: "Draft marketing source returned by the backend contract.",
+                    displayLabel: "Marketing campaigns / campaign_spend",
+                    sourceId: "marketing-campaign-spend"
+                  },
+                  {
+                    activationPosture: "active",
+                    description: "Candidate source returned by the backend contract.",
+                    displayLabel: "SAP spend cube / approved_vendor_spend",
+                    sourceId: "sap-approved-spend"
+                  }
+                ]
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-sap-selected",
+          question: "Draft marketing question",
+          source_id: "marketing-campaign-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    expect(screen.getByText("select vendor_name from approved_vendor_spend;")).toBeInTheDocument();
+    expect(screen.getAllByText("SAP spend cube / approved_vendor_spend").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Marketing campaigns / campaign_spend").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/selected draft source does not match the reopened candidate source/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /open completed state/i })).not.toBeInTheDocument();
+  });
+
   it("submits the selected source and question to the preview API", async () => {
     const csrfToken = document.createElement("meta");
     csrfToken.name = "safequery-csrf-token";

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -517,13 +517,17 @@ function findAuthoritativeCandidatePreview(
   sourceId?: string,
   historyRecordId?: string
 ): AuthoritativeCandidatePreview | null {
-  const candidates = history.filter(
-    (item) =>
-      item.itemType === "candidate" &&
-      (!sourceId || item.sourceId === sourceId) &&
-      (!historyRecordId || item.recordId === historyRecordId)
-  );
-  const candidate = candidates[0];
+  const candidate = history.find((item) => {
+    if (item.itemType !== "candidate") {
+      return false;
+    }
+
+    if (historyRecordId) {
+      return item.recordId === historyRecordId;
+    }
+
+    return !sourceId || item.sourceId === sourceId;
+  });
   if (!candidate) {
     return null;
   }
@@ -839,7 +843,8 @@ function renderResultContent(state: CanonicalWorkflowState) {
 function renderStatePanel(
   state: CanonicalWorkflowState,
   question: string,
-  sourceId?: string
+  sourceId?: string,
+  canOpenCompleted = false
 ) {
   if (state === "signin") {
     return (
@@ -869,14 +874,16 @@ function renderStatePanel(
           Query submission lands here first so generated SQL and guard posture can be reviewed
           before any future execution path is introduced.
         </p>
-        <div className="action-row">
-          <a className="action-link" href={buildStateHref("completed", question, sourceId)}>
-            Open completed state
-          </a>
-          <a className="ghost-link" href={buildStateHref("empty", question, sourceId)}>
-            Open empty state
-          </a>
-        </div>
+        {canOpenCompleted ? (
+          <div className="action-row">
+            <a className="action-link" href={buildStateHref("completed", question, sourceId)}>
+              Open completed state
+            </a>
+            <a className="ghost-link" href={buildStateHref("empty", question, sourceId)}>
+              Open empty state
+            </a>
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -1066,6 +1073,11 @@ export function QueryWorkflowShell({
     historyRecordId
   );
   const candidatePreview = submittedCandidatePreview ?? historyCandidatePreview;
+  const draftSource = findSourceOption(operatorWorkflow.sources, submittedSourceId);
+  const historySourceMismatch =
+    candidatePreview !== null &&
+    submittedSourceId !== undefined &&
+    candidatePreview.sourceId !== submittedSourceId;
   const workflowContext = getWorkflowContext(
     normalizedState,
     sourceBinding.source,
@@ -1074,6 +1086,9 @@ export function QueryWorkflowShell({
   );
   const sourceSelectVisible = normalizedState === "query";
   const boundSourceId = sourceBinding.source?.sourceId;
+  const candidateSourceId = candidatePreview?.sourceId ?? boundSourceId;
+  const canOpenCompletedFromPreview =
+    normalizedState === "preview" && candidatePreview !== null && !historySourceMismatch;
 
   async function submitPreview(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -1316,7 +1331,12 @@ export function QueryWorkflowShell({
         </aside>
         <div className="primary-column">
           <section className="surface surface-primary">
-            {renderStatePanel(normalizedState, question, boundSourceId)}
+            {renderStatePanel(
+              normalizedState,
+              question,
+              candidateSourceId,
+              canOpenCompletedFromPreview
+            )}
           </section>
 
           <section className="surface surface-primary">
@@ -1376,6 +1396,21 @@ export function QueryWorkflowShell({
                     <span className="meta-label">Source posture</span>
                     <strong>Read-only after preview binding</strong>
                   </div>
+                  {historySourceMismatch ? (
+                    <>
+                      <div className="guard-item">
+                        <span className="meta-label">Draft source</span>
+                        <strong>{draftSource?.displayLabel ?? submittedSourceId}</strong>
+                      </div>
+                      <div className="state-callout state-callout-danger">
+                        <p className="state-callout-title">Source mismatch blocked</p>
+                        <p>
+                          Selected draft source does not match the reopened candidate source, so
+                          execution affordances stay unavailable.
+                        </p>
+                      </div>
+                    </>
+                  ) : null}
                 </div>
               )}
               <label className="field-label" htmlFor="question">
@@ -1447,10 +1482,12 @@ export function QueryWorkflowShell({
                     ? "Submitting preview"
                     : "Submit for preview"}
                 </button>
-                {boundSourceId && previewSubmission.status !== "submitting" ? (
+                {boundSourceId &&
+                previewSubmission.status !== "submitting" &&
+                !historySourceMismatch ? (
                   <a
                     className="ghost-link"
-                    href={buildStateHref("completed", submittedQuestion, boundSourceId)}
+                    href={buildStateHref("completed", submittedQuestion, candidateSourceId)}
                   >
                     Open completed state
                   </a>

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -844,7 +844,8 @@ function renderStatePanel(
   state: CanonicalWorkflowState,
   question: string,
   sourceId?: string,
-  canOpenCompleted = false
+  canOpenCompleted = false,
+  context?: WorkflowHrefContext
 ) {
   if (state === "signin") {
     return (
@@ -876,10 +877,13 @@ function renderStatePanel(
         </p>
         {canOpenCompleted ? (
           <div className="action-row">
-            <a className="action-link" href={buildStateHref("completed", question, sourceId)}>
+            <a
+              className="action-link"
+              href={buildStateHref("completed", question, sourceId, context)}
+            >
               Open completed state
             </a>
-            <a className="ghost-link" href={buildStateHref("empty", question, sourceId)}>
+            <a className="ghost-link" href={buildStateHref("empty", question, sourceId, context)}>
               Open empty state
             </a>
           </div>
@@ -1089,6 +1093,13 @@ export function QueryWorkflowShell({
   const candidateSourceId = candidatePreview?.sourceId ?? boundSourceId;
   const canOpenCompletedFromPreview =
     normalizedState === "preview" && candidatePreview !== null && !historySourceMismatch;
+  const historyHrefContext =
+    normalizedState === "preview" && historyRecordId && historyCandidatePreview
+      ? {
+          historyItemType: "candidate" as const,
+          historyRecordId
+        }
+      : undefined;
 
   async function submitPreview(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -1335,7 +1346,8 @@ export function QueryWorkflowShell({
               normalizedState,
               question,
               candidateSourceId,
-              canOpenCompletedFromPreview
+              canOpenCompletedFromPreview,
+              historyHrefContext
             )}
           </section>
 
@@ -1487,7 +1499,12 @@ export function QueryWorkflowShell({
                 !historySourceMismatch ? (
                   <a
                     className="ghost-link"
-                    href={buildStateHref("completed", submittedQuestion, candidateSourceId)}
+                    href={buildStateHref(
+                      "completed",
+                      submittedQuestion,
+                      candidateSourceId,
+                      historyHrefContext
+                    )}
                   >
                     Open completed state
                   </a>


### PR DESCRIPTION
## Summary
- anchor reopened candidate previews by the selected history record before source filtering
- show draft/candidate source mismatches explicitly
- suppress preview-to-result affordances while a reopened candidate source conflicts with the draft source

## Tests
- cd frontend && npm test -- app/page.test.tsx
- cd frontend && npm test
- git diff --check

Closes #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of source mismatches when reopening history items: a visible warning appears when the draft source differs from the reopened candidate’s source, execution/open links are disabled in that state, and completed-state navigation is constructed safely to avoid invalid navigation.

* **Tests**
  * Added coverage verifying UI shows both source labels, preserves the reopened candidate content, displays the mismatch warning, and suppresses navigation when sources differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->