### PR TITLE
[P-4] Connect workflow panels to backend payloads

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -35,6 +35,15 @@ class OperatorWorkflowHistoryItem(BaseModel):
     candidate_sql: Optional[str] = Field(default=None, serialization_alias="candidateSql")
     request_id: Optional[str] = Field(default=None, serialization_alias="requestId")
     guard_status: Optional[str] = Field(default=None, serialization_alias="guardStatus")
+    primary_deny_code: Optional[str] = Field(
+        default=None,
+        serialization_alias="primaryDenyCode",
+    )
+    result_truncated: Optional[bool] = Field(
+        default=None,
+        serialization_alias="resultTruncated",
+    )
+    row_count: Optional[int] = Field(default=None, serialization_alias="rowCount")
     run_state: Optional[str] = Field(default=None, serialization_alias="runState")
 
 
@@ -123,6 +132,25 @@ def _run_state_for_event(event: PreviewAuditEvent) -> str | None:
     return None
 
 
+def _run_row_count_for_event(event: PreviewAuditEvent, run_state: str) -> int | None:
+    if run_state not in {"completed", "empty"}:
+        return None
+
+    row_count = event.audit_payload.get("execution_row_count")
+    return row_count if isinstance(row_count, int) and row_count >= 0 else None
+
+
+def _run_result_truncated_for_event(
+    event: PreviewAuditEvent,
+    run_state: str,
+) -> bool | None:
+    if run_state not in {"completed", "empty"}:
+        return None
+
+    result_truncated = event.audit_payload.get("result_truncated")
+    return result_truncated if isinstance(result_truncated, bool) else None
+
+
 def _terminal_run_events(
     audit_events: list[PreviewAuditEvent],
 ) -> list[tuple[PreviewAuditEvent, str]]:
@@ -183,6 +211,9 @@ def _build_operator_history(
                 lifecycle_state=run_state,
                 occurred_at=_as_utc_datetime(event.occurred_at),
                 request_id=event.request_id,
+                primary_deny_code=event.primary_deny_code,
+                result_truncated=_run_result_truncated_for_event(event, run_state),
+                row_count=_run_row_count_for_event(event, run_state),
                 run_state=run_state,
             )
         )

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -326,6 +326,8 @@ def test_operator_workflow_history_includes_execution_run_records() -> None:
         "lifecycleState": "empty",
         "occurredAt": "2026-01-02T03:05:03Z",
         "requestId": "preview-request-234",
+        "resultTruncated": False,
+        "rowCount": 0,
         "runState": "empty",
     }
 

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -904,6 +904,75 @@ describe("HomePage", () => {
     expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
   });
 
+  it("renders completed result metadata only from the selected authoritative run", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    itemType: "run",
+                    label: "Selected completed run",
+                    lifecycleState: "completed",
+                    occurredAt: "2026-04-21T14:42:17+09:00",
+                    recordId: "run-authoritative-282",
+                    resultTruncated: true,
+                    rowCount: 12,
+                    runState: "completed",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "Authoritative run source / approved_vendor_spend"
+                  },
+                  {
+                    itemType: "run",
+                    label: "Sibling completed run",
+                    lifecycleState: "completed",
+                    occurredAt: "2026-04-21T14:43:17+09:00",
+                    recordId: "run-sibling-283",
+                    resultTruncated: false,
+                    rowCount: 99,
+                    runState: "completed",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "Authoritative run source / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "run",
+          history_record_id: "run-authoritative-282",
+          question: "Selected completed run",
+          source_id: "sap-approved-spend",
+          state: "completed"
+        }
+      })
+    );
+
+    const resultsSection = screen.getByRole("heading", { name: /completed result set/i }).closest("section");
+    expect(resultsSection).not.toBeNull();
+    const results = within(resultsSection!);
+
+    expect(results.getByText(/authoritative result metadata/i)).toBeInTheDocument();
+    expect(results.getByText(/12 rows/i)).toBeInTheDocument();
+    expect(results.getByText(/truncated/i)).toBeInTheDocument();
+    expect(results.queryByText(/99 rows/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
+  });
+
   it("renders explicit empty and review-denied unavailable states", async () => {
     const { rerender } = render(
       await HomePage({

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -123,6 +123,9 @@ type AuthoritativeCandidatePreview = {
 type AuthoritativeRunContext = {
   lifecycleState: string;
   lifecycleTimestamp: string;
+  primaryDenyCode?: string | null;
+  resultTruncated?: boolean | null;
+  rowCount?: number | null;
   runIdentity: string;
   runState?: string | null;
   sourceLabel: string;
@@ -566,6 +569,9 @@ function findAuthoritativeRunContext(
   return {
     lifecycleState: run.lifecycleState,
     lifecycleTimestamp: run.occurredAt,
+    primaryDenyCode: run.primaryDenyCode,
+    resultTruncated: run.resultTruncated,
+    rowCount: run.rowCount,
     runIdentity: run.recordId,
     runState: run.runState,
     sourceLabel: run.sourceLabel
@@ -756,8 +762,29 @@ function getResultTitle(state: CanonicalWorkflowState): string {
   return "Results unavailable";
 }
 
-function renderResultContent(state: CanonicalWorkflowState) {
+function renderResultContent(
+  state: CanonicalWorkflowState,
+  runContext?: AuthoritativeRunContext | null
+) {
   if (state === "completed") {
+    if (
+      runContext &&
+      runContext.rowCount !== null &&
+      runContext.rowCount !== undefined &&
+      runContext.resultTruncated !== null &&
+      runContext.resultTruncated !== undefined
+    ) {
+      return (
+        <div className="state-callout state-callout-success">
+          <p className="state-callout-title">Authoritative result metadata</p>
+          <p>
+            {runContext.rowCount} rows returned; result payload{" "}
+            {runContext.resultTruncated ? "truncated" : "not truncated"}.
+          </p>
+        </div>
+      );
+    }
+
     return (
       <div className="state-callout state-callout-empty">
         <p className="state-callout-title">Execution results unavailable</p>
@@ -801,6 +828,7 @@ function renderResultContent(state: CanonicalWorkflowState) {
           The shell preserves the denied run record and keeps execution closed instead of implying
           that an earlier preview automatically became successful output.
         </p>
+        {runContext?.primaryDenyCode ? <p>Deny code: {runContext.primaryDenyCode}</p> : null}
       </div>
     );
   }
@@ -1619,7 +1647,7 @@ export function QueryWorkflowShell({
                 API health
               </a>
             </div>
-            {renderResultContent(normalizedState)}
+            {renderResultContent(normalizedState, historyRunContext)}
           </section>
         </aside>
       </section>

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -16,8 +16,11 @@ export type OperatorHistoryItem = {
   label: string;
   lifecycleState: string;
   occurredAt: string;
+  primaryDenyCode?: string | null;
   recordId: string;
   requestId?: string | null;
+  resultTruncated?: boolean | null;
+  rowCount?: number | null;
   runState?: string | null;
   sourceId: string;
   sourceLabel: string;
@@ -52,6 +55,10 @@ function isActivationPosture(value: unknown): value is SourceActivationPosture {
 
 function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function readOptionalNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
 function parseSourceOption(value: unknown): SourceOption | null {
@@ -109,8 +116,12 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     label,
     lifecycleState,
     occurredAt,
+    primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
     recordId,
     requestId: readOptionalString(value.requestId) ?? null,
+    resultTruncated:
+      typeof value.resultTruncated === "boolean" ? value.resultTruncated : null,
+    rowCount: readOptionalNonNegativeInteger(value.rowCount) ?? null,
     runState: readOptionalString(value.runState) ?? null,
     sourceId,
     sourceLabel


### PR DESCRIPTION
## Summary
- expose authoritative run result metadata through the operator workflow DTO
- parse selected run metadata in the frontend workflow snapshot
- render completed result metadata only for the selected authoritative run while preserving fail-closed non-result states

## Verification
- npm test
- cd backend && python3 -m pytest tests/test_operator_workflow_history.py tests/test_operator_history_payloads.py

Closes #285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enhanced metadata display for workflow run results: execution row count, result truncation indicator, and denial reason details
  * Results panel now shows additional execution insights for completed and denied workflow runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->