### PR TITLE
Add execute controls to operator UI

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -632,6 +632,181 @@ describe("HomePage", () => {
     }
   });
 
+  it("executes only preview-ready candidates and maps denied or canceled execute responses to recovery states", async () => {
+    const csrfToken = document.createElement("meta");
+    csrfToken.name = "safequery-csrf-token";
+    csrfToken.content = "csrf-from-session-bootstrap";
+    document.head.appendChild(csrfToken);
+
+    const executeResponses = [
+      {
+        body: {
+          error: {
+            code: "execution_denied",
+            message: "Candidate execution was denied.",
+            raw: "driver-secret-should-not-render"
+          }
+        },
+        expectedHeading: /execution denied state/i,
+        expectedStatus: /execute denied/i,
+        status: 403
+      },
+      {
+        body: {
+          audit: {
+            events: [
+              {
+                candidate_state: "canceled",
+                event_type: "execution_failed",
+                query_candidate_id: "candidate-selected"
+              }
+            ]
+          },
+          error: {
+            code: "execution_unavailable",
+            message: "Candidate execution is unavailable."
+          }
+        },
+        expectedHeading: /canceled state/i,
+        expectedStatus: /execution canceled/i,
+        status: 503
+      }
+    ] as const;
+
+    for (const executeResponse of executeResponses) {
+      cleanup();
+      document.head.appendChild(csrfToken);
+      const fetchMock = vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Selected candidate",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-selected",
+                    requestId: "request-selected",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        if (url.endsWith("/candidates/candidate-selected/execute")) {
+          return Promise.resolve({
+            ok: false,
+            status: executeResponse.status,
+            json: () => Promise.resolve(executeResponse.body)
+          });
+        }
+
+        return new Promise(() => {});
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      render(
+        await HomePage({
+          searchParams: {
+            history_item_type: "candidate",
+            history_record_id: "candidate-selected",
+            question: "Selected candidate",
+            source_id: "sap-approved-spend",
+            state: "preview"
+          }
+        })
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /execute reviewed candidate/i }));
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "http://127.0.0.1:8000/candidates/candidate-selected/execute",
+          expect.objectContaining({
+            body: JSON.stringify({
+              selected_source_id: "sap-approved-spend"
+            }),
+            credentials: "same-origin",
+            headers: expect.objectContaining({
+              "content-type": "application/json",
+              "x-safequery-csrf": "csrf-from-session-bootstrap"
+            }),
+            method: "POST"
+          })
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getAllByText(executeResponse.expectedStatus).length).toBeGreaterThan(0);
+      });
+      expect(
+        screen.getByRole("heading", { name: executeResponse.expectedHeading })
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/execution completed/i)).not.toBeInTheDocument();
+      expect(screen.queryByText("driver-secret-should-not-render")).not.toBeInTheDocument();
+    }
+  });
+
+  it("keeps execute disabled for non-authorized candidate states", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: null,
+                    guardStatus: "pending",
+                    itemType: "candidate",
+                    label: "Pending candidate",
+                    lifecycleState: "pending_generation",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-pending",
+                    requestId: "request-pending",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-pending",
+          question: "Pending candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    expect(screen.getByRole("button", { name: /execute reviewed candidate/i })).toBeDisabled();
+    expect(screen.getByText(/no executable candidate/i)).toBeInTheDocument();
+  });
+
   it("maps malformed and unavailable preview submission failures distinctly", async () => {
     const failureCases = [
       {

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -100,6 +100,24 @@ type PreviewSubmissionStatus =
       status: "succeeded";
     };
 
+type ExecuteSubmissionStatus =
+  | {
+      status: "idle";
+    }
+  | {
+      status: "executing";
+    }
+  | {
+      code: string;
+      message: string;
+      status: "denied" | "failed";
+    }
+  | {
+      candidateId: string;
+      rowCount: number;
+      status: "canceled" | "succeeded";
+    };
+
 type PreviewSubmissionResult = {
   candidateId: string;
   candidateSql: string | null;
@@ -134,6 +152,14 @@ type AuthoritativeRunContext = {
 type ApiErrorEnvelope = {
   code: string;
   message: string;
+};
+
+type ExecuteSubmissionResult = {
+  candidateId: string;
+  executionRunId?: string;
+  resultTruncated: boolean;
+  rowCount: number;
+  sourceId: string;
 };
 
 const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
@@ -247,6 +273,18 @@ function parseApiErrorEnvelope(value: unknown): ApiErrorEnvelope | null {
   return { code, message };
 }
 
+function parseAuditEvents(value: unknown): Record<string, unknown>[] {
+  if (!isObject(value) || !isObject(value.audit) || !Array.isArray(value.audit.events)) {
+    return [];
+  }
+
+  return value.audit.events.filter(isObject);
+}
+
+function hasCanceledAuditEvent(value: unknown): boolean {
+  return parseAuditEvents(value).some((event) => event.candidate_state === "canceled");
+}
+
 function previewSubmissionStatusForApiError(
   error: ApiErrorEnvelope | null
 ): PreviewSubmissionStatus {
@@ -318,6 +356,41 @@ function parsePreviewSubmissionResult(
   };
 }
 
+function parseExecuteSubmissionResult(
+  value: unknown,
+  expectedCandidateId: string,
+  expectedSourceId: string
+): ExecuteSubmissionResult | null {
+  if (!isObject(value) || !isObject(value.metadata)) {
+    return null;
+  }
+
+  const candidateId = readRequiredString(value.candidate_id);
+  const sourceId = readRequiredString(value.source_id);
+  const executionRunId = readRequiredString(value.metadata.execution_run_id);
+  const rowCount = value.metadata.row_count;
+  const resultTruncated = value.metadata.result_truncated;
+
+  if (
+    candidateId !== expectedCandidateId ||
+    sourceId !== expectedSourceId ||
+    typeof rowCount !== "number" ||
+    !Number.isInteger(rowCount) ||
+    rowCount < 0 ||
+    typeof resultTruncated !== "boolean"
+  ) {
+    return null;
+  }
+
+  return {
+    candidateId,
+    executionRunId,
+    resultTruncated,
+    rowCount,
+    sourceId
+  };
+}
+
 function isPendingPreviewState(result: PreviewSubmissionResult): boolean {
   const requestState = result.requestState.toLowerCase();
   const candidateState = result.candidateState.toLowerCase();
@@ -347,6 +420,23 @@ function isDeniedPreviewState(result: PreviewSubmissionResult): boolean {
 
 function isReadyPreviewState(result: PreviewSubmissionResult): boolean {
   return result.candidateState.toLowerCase() === "preview_ready";
+}
+
+function canExecuteCandidate(
+  state: CanonicalWorkflowState,
+  candidatePreview: AuthoritativeCandidatePreview | null,
+  hasSourceMismatch: boolean
+): candidatePreview is AuthoritativeCandidatePreview {
+  if (state !== "preview" || candidatePreview === null || hasSourceMismatch) {
+    return false;
+  }
+
+  const candidateState = candidatePreview.candidateState.toLowerCase();
+  const guardStatus = candidatePreview.guardStatus.toLowerCase();
+  return (
+    candidateState === "preview_ready" &&
+    (guardStatus === "allow" || guardStatus === "passed")
+  );
 }
 
 function resolveSourceBinding(
@@ -1038,8 +1128,8 @@ function renderStatePanel(
           <a className="action-link" href={buildStateHref("query", question, sourceId)}>
             Start a new draft
           </a>
-          <a className="ghost-link" href={buildStateHref("completed", question, sourceId)}>
-            Compare completed state
+          <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
+            Back to SQL preview
           </a>
         </div>
       </div>
@@ -1071,8 +1161,14 @@ export function QueryWorkflowShell({
   const [previewSubmission, setPreviewSubmission] = useState<PreviewSubmissionStatus>({
     status: "idle"
   });
+  const [executeSubmission, setExecuteSubmission] = useState<ExecuteSubmissionStatus>({
+    status: "idle"
+  });
   const [submittedCandidatePreview, setSubmittedCandidatePreview] =
     useState<AuthoritativeCandidatePreview | null>(null);
+  const [submittedRunContext, setSubmittedRunContext] = useState<AuthoritativeRunContext | null>(
+    null
+  );
   const [submittedQuestion, setSubmittedQuestion] = useState(question);
   const [submittedSourceId, setSubmittedSourceId] = useState(sourceId);
   const [submittedState, setSubmittedState] = useState(requestedState);
@@ -1082,7 +1178,9 @@ export function QueryWorkflowShell({
     setSubmittedSourceId(sourceId);
     setSubmittedState(requestedState);
     setPreviewSubmission({ status: "idle" });
+    setExecuteSubmission({ status: "idle" });
     setSubmittedCandidatePreview(null);
+    setSubmittedRunContext(null);
   }, [question, requestedState, sourceId]);
 
   const sourceBinding = resolveSourceBinding(
@@ -1092,18 +1190,22 @@ export function QueryWorkflowShell({
   );
   const normalizedState = sourceBinding.state;
   const activeState = workflowStates[normalizedState];
-  const queryLocked = normalizedState === "signin" || previewSubmission.status === "submitting";
+  const queryLocked =
+    normalizedState === "signin" ||
+    previewSubmission.status === "submitting" ||
+    executeSubmission.status === "executing";
   const guardTone = getGuardTone(normalizedState);
   const historyCandidatePreview = findAuthoritativeCandidatePreview(
     operatorWorkflow.history,
     submittedSourceId,
     historyRecordId
   );
-  const historyRunContext = findAuthoritativeRunContext(
+  const selectedHistoryRunContext = findAuthoritativeRunContext(
     operatorWorkflow.history,
     submittedSourceId,
     historyRecordId
   );
+  const historyRunContext = submittedRunContext ?? selectedHistoryRunContext;
   const candidatePreview = submittedCandidatePreview ?? historyCandidatePreview;
   const draftSource = findSourceOption(operatorWorkflow.sources, submittedSourceId);
   const historySourceMismatch =
@@ -1121,6 +1223,11 @@ export function QueryWorkflowShell({
   const candidateSourceId = candidatePreview?.sourceId ?? boundSourceId;
   const canOpenCompletedFromPreview =
     normalizedState === "preview" && candidatePreview !== null && !historySourceMismatch;
+  const executeEnabled = canExecuteCandidate(
+    normalizedState,
+    candidatePreview,
+    historySourceMismatch
+  );
   const historyHrefContext =
     normalizedState === "preview" && historyRecordId && historyCandidatePreview
       ? {
@@ -1282,6 +1389,126 @@ export function QueryWorkflowShell({
         code: "preview_submission_unavailable",
         message: "Preview submission transport is unavailable.",
         status: "unavailable"
+      });
+    }
+  }
+
+  async function executeCandidate() {
+    if (!executeEnabled || !submittedSourceId) {
+      return;
+    }
+
+    setExecuteSubmission({ status: "executing" });
+
+    const headers: Record<string, string> = {
+      "content-type": "application/json"
+    };
+    const csrfToken = readCsrfToken();
+    if (csrfToken) {
+      headers["x-safequery-csrf"] = csrfToken;
+    }
+
+    try {
+      const response = await fetch(`${apiUrl}/candidates/${candidatePreview.candidateId}/execute`, {
+        body: JSON.stringify({
+          selected_source_id: candidatePreview.sourceId
+        }),
+        credentials: "same-origin",
+        headers,
+        method: "POST"
+      });
+      let payload: unknown;
+      try {
+        payload = (await response.json()) as unknown;
+      } catch {
+        setSubmittedState("failed");
+        setExecuteSubmission({
+          code: "execution_unavailable",
+          message: "Candidate execution did not return an authoritative payload.",
+          status: "failed"
+        });
+        return;
+      }
+
+      if (!response.ok) {
+        const error = parseApiErrorEnvelope(payload);
+        if (hasCanceledAuditEvent(payload)) {
+          setSubmittedState("canceled");
+          setSubmittedRunContext({
+            lifecycleState: "canceled",
+            lifecycleTimestamp: new Date().toISOString(),
+            runIdentity: candidatePreview.candidateId,
+            runState: "canceled",
+            sourceLabel:
+              candidatePreview.sourceLabel ??
+              sourceBinding.source?.displayLabel ??
+              candidatePreview.sourceId
+          });
+          setExecuteSubmission({
+            candidateId: candidatePreview.candidateId,
+            rowCount: 0,
+            status: "canceled"
+          });
+          return;
+        }
+
+        if (error?.code === "execution_denied") {
+          setSubmittedState("execution_denied");
+          setExecuteSubmission({
+            code: error.code,
+            message: error.message,
+            status: "denied"
+          });
+          return;
+        }
+
+        setSubmittedState("failed");
+        setExecuteSubmission({
+          code: error?.code ?? "execution_unavailable",
+          message: error?.message ?? "Candidate execution is unavailable.",
+          status: "failed"
+        });
+        return;
+      }
+
+      const result = parseExecuteSubmissionResult(
+        payload,
+        candidatePreview.candidateId,
+        candidatePreview.sourceId
+      );
+      if (!result) {
+        setSubmittedState("failed");
+        setExecuteSubmission({
+          code: "malformed_execute_response",
+          message: "Execute response did not match the selected candidate and source binding.",
+          status: "failed"
+        });
+        return;
+      }
+
+      const nextState = result.rowCount === 0 ? "empty" : "completed";
+      setSubmittedState(nextState);
+      setSubmittedRunContext({
+        lifecycleState: nextState,
+        lifecycleTimestamp: new Date().toISOString(),
+        resultTruncated: result.resultTruncated,
+        rowCount: result.rowCount,
+        runIdentity: result.executionRunId ?? result.candidateId,
+        runState: nextState,
+        sourceLabel:
+          candidatePreview.sourceLabel ?? sourceBinding.source?.displayLabel ?? result.sourceId
+      });
+      setExecuteSubmission({
+        candidateId: result.candidateId,
+        rowCount: result.rowCount,
+        status: "succeeded"
+      });
+    } catch {
+      setSubmittedState("failed");
+      setExecuteSubmission({
+        code: "execution_unavailable",
+        message: "Candidate execution transport is unavailable.",
+        status: "failed"
       });
     }
   }
@@ -1516,13 +1743,61 @@ export function QueryWorkflowShell({
                   <p>{previewSubmission.message}</p>
                 </div>
               ) : null}
+              {executeSubmission.status === "executing" ? (
+                <div className="state-callout state-callout-warning" role="status">
+                  <p className="state-callout-title">Execution in progress</p>
+                  <p>The reviewed candidate is locked while execute-time checks run.</p>
+                </div>
+              ) : null}
+              {executeSubmission.status === "succeeded" ? (
+                <div className="state-callout state-callout-success" role="status">
+                  <p className="state-callout-title">Execution completed</p>
+                  <p>
+                    Candidate {executeSubmission.candidateId} returned {executeSubmission.rowCount}{" "}
+                    rows.
+                  </p>
+                </div>
+              ) : null}
+              {executeSubmission.status === "denied" ? (
+                <div className="state-callout state-callout-danger" role="status">
+                  <p className="state-callout-title">Execute denied</p>
+                  <p>{executeSubmission.message}</p>
+                </div>
+              ) : null}
+              {executeSubmission.status === "canceled" ? (
+                <div className="state-callout" role="status">
+                  <p className="state-callout-title">Execution canceled</p>
+                  <p>
+                    Candidate {executeSubmission.candidateId} did not complete and no successful
+                    result payload is shown.
+                  </p>
+                </div>
+              ) : null}
+              {executeSubmission.status === "failed" ? (
+                <div className="state-callout state-callout-danger" role="alert">
+                  <p className="state-callout-title">{executeSubmission.code}</p>
+                  <p>{executeSubmission.message}</p>
+                </div>
+              ) : null}
               <div className="form-actions">
                 <button disabled={queryLocked} type="submit">
                   {previewSubmission.status === "submitting"
                     ? "Submitting preview"
                     : "Submit for preview"}
                 </button>
-                {boundSourceId &&
+                {candidatePreview ? (
+                  <button
+                    disabled={!executeEnabled || executeSubmission.status === "executing"}
+                    onClick={executeCandidate}
+                    type="button"
+                  >
+                    {executeSubmission.status === "executing"
+                      ? "Executing candidate"
+                      : "Execute reviewed candidate"}
+                  </button>
+                ) : null}
+                {canOpenCompletedFromPreview &&
+                boundSourceId &&
                 previewSubmission.status !== "submitting" &&
                 !historySourceMismatch ? (
                   <a
@@ -1632,7 +1907,9 @@ export function QueryWorkflowShell({
               </div>
               <div className="guard-item">
                 <span className="meta-label">Execution path</span>
-                <strong>Blocked in this issue</strong>
+                <strong>
+                  {executeEnabled ? "Candidate execute available" : "No executable candidate"}
+                </strong>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- add candidate-only execute control for preview-ready, guard-allowed candidates
- map execute denial and cancellation responses to recoverable terminal UI states without auto-retry
- keep execute disabled for non-authorized candidate states and avoid stale success affordances after cancellation

## Tests
- cd frontend && npm test -- --run
- cd frontend && npm run build
- cd backend && python3 -m pytest tests/test_candidate_execute_api.py

Closes #286