### PR TITLE
Show audit evidence on operator surface

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -45,6 +45,93 @@ class OperatorWorkflowHistoryItem(BaseModel):
     )
     row_count: Optional[int] = Field(default=None, serialization_alias="rowCount")
     run_state: Optional[str] = Field(default=None, serialization_alias="runState")
+    audit_events: list["OperatorWorkflowAuditEventSummary"] = Field(
+        default_factory=list,
+        serialization_alias="auditEvents",
+    )
+    executed_evidence: list["OperatorWorkflowExecutedEvidence"] = Field(
+        default_factory=list,
+        serialization_alias="executedEvidence",
+    )
+    retrieved_citations: list["OperatorWorkflowRetrievedCitation"] = Field(
+        default_factory=list,
+        serialization_alias="retrievedCitations",
+    )
+
+
+class OperatorWorkflowAuditEventSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str = Field(serialization_alias="eventId")
+    event_type: str = Field(serialization_alias="eventType")
+    occurred_at: datetime = Field(serialization_alias="occurredAt")
+    request_id: str = Field(serialization_alias="requestId")
+    candidate_id: Optional[str] = Field(default=None, serialization_alias="candidateId")
+    source_id: str = Field(serialization_alias="sourceId")
+    candidate_state: Optional[str] = Field(default=None, serialization_alias="candidateState")
+    primary_deny_code: Optional[str] = Field(default=None, serialization_alias="primaryDenyCode")
+    row_count: Optional[int] = Field(default=None, serialization_alias="rowCount")
+    result_truncated: Optional[bool] = Field(default=None, serialization_alias="resultTruncated")
+
+
+class OperatorWorkflowExecutedEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["backend_execution_result"] = "backend_execution_result"
+    can_authorize_execution: Literal[False] = Field(
+        default=False,
+        serialization_alias="canAuthorizeExecution",
+    )
+    candidate_id: str = Field(serialization_alias="candidateId")
+    execution_audit_event_id: str = Field(serialization_alias="executionAuditEventId")
+    execution_audit_event_type: Literal["execution_completed"] = Field(
+        serialization_alias="executionAuditEventType",
+    )
+    row_count: int = Field(serialization_alias="rowCount")
+    result_truncated: bool = Field(serialization_alias="resultTruncated")
+    source_id: str = Field(serialization_alias="sourceId")
+    source_family: str = Field(serialization_alias="sourceFamily")
+    source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+    dataset_contract_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="datasetContractVersion",
+    )
+    schema_snapshot_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="schemaSnapshotVersion",
+    )
+    execution_policy_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="executionPolicyVersion",
+    )
+    connector_profile_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="connectorProfileVersion",
+    )
+
+
+class OperatorWorkflowRetrievedCitation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asset_id: str = Field(serialization_alias="assetId")
+    asset_kind: str = Field(serialization_alias="assetKind")
+    authority: Literal["advisory_context"] = "advisory_context"
+    can_authorize_execution: Literal[False] = Field(
+        default=False,
+        serialization_alias="canAuthorizeExecution",
+    )
+    citation_label: str = Field(serialization_alias="citationLabel")
+    source_id: str = Field(serialization_alias="sourceId")
+    source_family: str = Field(serialization_alias="sourceFamily")
+    source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+    dataset_contract_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="datasetContractVersion",
+    )
+    schema_snapshot_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="schemaSnapshotVersion",
+    )
 
 
 class OperatorWorkflowSnapshot(BaseModel):
@@ -151,6 +238,144 @@ def _run_result_truncated_for_event(
     return result_truncated if isinstance(result_truncated, bool) else None
 
 
+def _read_text(value: object) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _read_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _read_non_negative_int(value: object) -> int | None:
+    return value if isinstance(value, int) and value >= 0 else None
+
+
+def _read_positive_int(value: object) -> int | None:
+    return value if isinstance(value, int) and value > 0 else None
+
+
+def _read_payload_items(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _audit_event_summary(event: PreviewAuditEvent) -> OperatorWorkflowAuditEventSummary:
+    return OperatorWorkflowAuditEventSummary(
+        event_id=str(event.event_id),
+        event_type=event.event_type,
+        occurred_at=_as_utc_datetime(event.occurred_at),
+        request_id=event.request_id,
+        candidate_id=event.candidate_id,
+        source_id=event.source_id,
+        candidate_state=event.candidate_state,
+        primary_deny_code=event.primary_deny_code,
+        row_count=_read_non_negative_int(event.audit_payload.get("execution_row_count")),
+        result_truncated=_read_bool(event.audit_payload.get("result_truncated")),
+    )
+
+
+def _executed_evidence_for_event(
+    event: PreviewAuditEvent,
+) -> list[OperatorWorkflowExecutedEvidence]:
+    evidence: list[OperatorWorkflowExecutedEvidence] = []
+    for item in _read_payload_items(event.audit_payload.get("executed_evidence")):
+        if (
+            item.get("type") != "executed_evidence"
+            or item.get("authority") != "backend_execution_result"
+            or item.get("can_authorize_execution") is not False
+        ):
+            continue
+
+        candidate_id = _read_text(item.get("candidate_id"))
+        execution_audit_event_id = _read_text(item.get("execution_audit_event_id"))
+        row_count = _read_non_negative_int(item.get("row_count"))
+        result_truncated = _read_bool(item.get("result_truncated"))
+        source_id = _read_text(item.get("source_id"))
+        source_family = _read_text(item.get("source_family"))
+        if (
+            candidate_id is None
+            or execution_audit_event_id is None
+            or item.get("execution_audit_event_type") != "execution_completed"
+            or row_count is None
+            or result_truncated is None
+            or source_id != event.source_id
+            or source_family is None
+        ):
+            continue
+
+        evidence.append(
+            OperatorWorkflowExecutedEvidence(
+                candidate_id=candidate_id,
+                execution_audit_event_id=execution_audit_event_id,
+                execution_audit_event_type="execution_completed",
+                row_count=row_count,
+                result_truncated=result_truncated,
+                source_id=source_id,
+                source_family=source_family,
+                source_flavor=_read_text(item.get("source_flavor")),
+                dataset_contract_version=_read_positive_int(
+                    item.get("dataset_contract_version")
+                ),
+                schema_snapshot_version=_read_positive_int(
+                    item.get("schema_snapshot_version")
+                ),
+                execution_policy_version=_read_positive_int(
+                    item.get("execution_policy_version")
+                ),
+                connector_profile_version=_read_positive_int(
+                    item.get("connector_profile_version")
+                ),
+            )
+        )
+    return evidence
+
+
+def _retrieved_citations_for_event(
+    event: PreviewAuditEvent,
+) -> list[OperatorWorkflowRetrievedCitation]:
+    citations: list[OperatorWorkflowRetrievedCitation] = []
+    for item in _read_payload_items(event.audit_payload.get("retrieved_citations")):
+        if (
+            item.get("authority") != "advisory_context"
+            or item.get("can_authorize_execution") is not False
+        ):
+            continue
+
+        asset_id = _read_text(item.get("asset_id"))
+        asset_kind = _read_text(item.get("asset_kind"))
+        citation_label = _read_text(item.get("citation_label"))
+        source_id = _read_text(item.get("source_id"))
+        source_family = _read_text(item.get("source_family"))
+        if (
+            asset_id is None
+            or asset_kind is None
+            or citation_label is None
+            or source_id != event.source_id
+            or source_family is None
+        ):
+            continue
+
+        citations.append(
+            OperatorWorkflowRetrievedCitation(
+                asset_id=asset_id,
+                asset_kind=asset_kind,
+                citation_label=citation_label,
+                source_id=source_id,
+                source_family=source_family,
+                source_flavor=_read_text(item.get("source_flavor")),
+                dataset_contract_version=_read_positive_int(
+                    item.get("dataset_contract_version")
+                ),
+                schema_snapshot_version=_read_positive_int(
+                    item.get("schema_snapshot_version")
+                ),
+            )
+        )
+    return citations
+
+
 def _terminal_run_events(
     audit_events: list[PreviewAuditEvent],
 ) -> list[tuple[PreviewAuditEvent, str]]:
@@ -215,10 +440,14 @@ def _build_operator_history(
                 result_truncated=_run_result_truncated_for_event(event, run_state),
                 row_count=_run_row_count_for_event(event, run_state),
                 run_state=run_state,
+                audit_events=[_audit_event_summary(event)],
+                executed_evidence=_executed_evidence_for_event(event),
+                retrieved_citations=_retrieved_citations_for_event(event),
             )
         )
 
     for candidate in candidates:
+        candidate_event = candidate_events.get(candidate.candidate_id)
         history.append(
             OperatorWorkflowHistoryItem(
                 item_type="candidate",
@@ -228,16 +457,26 @@ def _build_operator_history(
                 source_label=source_labels.get(candidate.source_id, candidate.source_id),
                 lifecycle_state=candidate.candidate_state,
                 occurred_at=_history_occurred_at(
-                    candidate_events.get(candidate.candidate_id),
+                    candidate_event,
                     candidate.updated_at or candidate.created_at,
                 ),
                 candidate_sql=candidate.candidate_sql,
                 request_id=candidate.request_id,
                 guard_status=candidate.guard_status,
+                audit_events=(
+                    [_audit_event_summary(candidate_event)] if candidate_event else []
+                ),
+                executed_evidence=(
+                    _executed_evidence_for_event(candidate_event) if candidate_event else []
+                ),
+                retrieved_citations=(
+                    _retrieved_citations_for_event(candidate_event) if candidate_event else []
+                ),
             )
         )
 
     for request in requests:
+        request_event = request_events.get(request.request_id)
         history.append(
             OperatorWorkflowHistoryItem(
                 item_type="request",
@@ -247,8 +486,17 @@ def _build_operator_history(
                 source_label=source_labels.get(request.source_id, request.source_id),
                 lifecycle_state=request.request_state,
                 occurred_at=_history_occurred_at(
-                    request_events.get(request.request_id),
+                    request_event,
                     request.updated_at or request.created_at,
+                ),
+                audit_events=(
+                    [_audit_event_summary(request_event)] if request_event else []
+                ),
+                executed_evidence=(
+                    _executed_evidence_for_event(request_event) if request_event else []
+                ),
+                retrieved_citations=(
+                    _retrieved_citations_for_event(request_event) if request_event else []
                 ),
             )
         )

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -138,6 +138,8 @@ def _execution_audit_event(
     event_id: UUID,
     event_type: str,
     occurred_at: datetime,
+    executed_evidence: list[dict[str, object]] | None = None,
+    retrieved_citations: list[dict[str, object]] | None = None,
     result_truncated: bool | None = None,
     row_count: int | None = None,
 ) -> SourceAwareAuditEvent:
@@ -156,6 +158,8 @@ def _execution_audit_event(
         source_flavor="warehouse",
         dataset_contract_version=1,
         schema_snapshot_version=1,
+        retrieved_citations=retrieved_citations,
+        executed_evidence=executed_evidence,
         execution_row_count=row_count,
         result_truncated=result_truncated,
     )
@@ -244,28 +248,29 @@ def test_operator_workflow_history_is_built_from_preview_request_and_candidate_r
         item.model_dump(mode="json", by_alias=True, exclude_none=True)
         for item in snapshot.history
     ]
-    assert history == [
-        {
-            "itemType": "candidate",
-            "recordId": "preview-candidate-234",
-            "label": "Show approved vendors by quarterly spend",
-            "sourceId": "sap-approved-spend",
-            "sourceLabel": "SAP spend cube / approved_vendor_spend",
-            "lifecycleState": "preview_ready",
-            "occurredAt": "2026-01-02T03:04:05Z",
-            "requestId": "preview-request-234",
-            "guardStatus": "pending",
-        },
-        {
-            "itemType": "request",
-            "recordId": "preview-request-234",
-            "label": "Show approved vendors by quarterly spend",
-            "sourceId": "sap-approved-spend",
-            "sourceLabel": "SAP spend cube / approved_vendor_spend",
-            "lifecycleState": "previewed",
-            "occurredAt": "2026-01-02T03:04:05Z",
-        },
-    ]
+    assert {
+        "itemType": "candidate",
+        "recordId": "preview-candidate-234",
+        "label": "Show approved vendors by quarterly spend",
+        "sourceId": "sap-approved-spend",
+        "sourceLabel": "SAP spend cube / approved_vendor_spend",
+        "lifecycleState": "preview_ready",
+        "occurredAt": "2026-01-02T03:04:05Z",
+        "requestId": "preview-request-234",
+        "guardStatus": "pending",
+    }.items() <= history[0].items()
+    assert {
+        "itemType": "request",
+        "recordId": "preview-request-234",
+        "label": "Show approved vendors by quarterly spend",
+        "sourceId": "sap-approved-spend",
+        "sourceLabel": "SAP spend cube / approved_vendor_spend",
+        "lifecycleState": "previewed",
+        "occurredAt": "2026-01-02T03:04:05Z",
+    }.items() <= history[1].items()
+    assert history[0]["auditEvents"][0]["eventType"] == "guard_evaluated"
+    assert history[0]["auditEvents"][0]["candidateId"] == "preview-candidate-234"
+    assert history[1]["auditEvents"][0]["eventType"] == "guard_evaluated"
 
 
 def test_operator_workflow_history_includes_execution_run_records() -> None:
@@ -317,7 +322,7 @@ def test_operator_workflow_history_includes_execution_run_records() -> None:
         item.model_dump(mode="json", by_alias=True, exclude_none=True)
         for item in snapshot.history
     ]
-    assert history[0] == {
+    assert {
         "itemType": "run",
         "recordId": "00000000-0000-4000-8000-000000000012",
         "label": "Show approved vendors by quarterly spend",
@@ -329,7 +334,135 @@ def test_operator_workflow_history_includes_execution_run_records() -> None:
         "resultTruncated": False,
         "rowCount": 0,
         "runState": "empty",
-    }
+    }.items() <= history[0].items()
+    assert history[0]["auditEvents"] == [
+        {
+            "eventId": "00000000-0000-4000-8000-000000000012",
+            "eventType": "execution_completed",
+            "occurredAt": "2026-01-02T03:05:03Z",
+            "requestId": "preview-request-234",
+            "candidateId": "preview-candidate-234",
+            "sourceId": "sap-approved-spend",
+            "rowCount": 0,
+            "resultTruncated": False,
+        }
+    ]
+
+
+def test_operator_workflow_history_surfaces_safe_audit_evidence_and_citations() -> None:
+    execution_event_id = UUID("00000000-0000-4000-8000-000000000012")
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-234",
+                candidate_id="preview-candidate-234",
+            ),
+        )
+        persist_execution_audit_events(
+            session,
+            candidate_id="preview-candidate-234",
+            audit_events=[
+                _execution_audit_event(
+                    event_id=execution_event_id,
+                    event_type="execution_completed",
+                    occurred_at=datetime(2026, 1, 2, 3, 5, 3, tzinfo=timezone.utc),
+                    retrieved_citations=[
+                        {
+                            "asset_id": "spend-metric-definition",
+                            "asset_kind": "metric_definition",
+                            "citation_label": "Approved spend metric definition",
+                            "source_id": "sap-approved-spend",
+                            "source_family": "postgresql",
+                            "source_flavor": "warehouse",
+                            "dataset_contract_version": 1,
+                            "schema_snapshot_version": 1,
+                            "authority": "advisory_context",
+                            "can_authorize_execution": False,
+                        }
+                    ],
+                    executed_evidence=[
+                        {
+                            "type": "executed_evidence",
+                            "source_id": "sap-approved-spend",
+                            "source_family": "postgresql",
+                            "source_flavor": "warehouse",
+                            "dataset_contract_version": 1,
+                            "schema_snapshot_version": 1,
+                            "candidate_id": "preview-candidate-234",
+                            "execution_audit_event_id": str(execution_event_id),
+                            "execution_audit_event_type": "execution_completed",
+                            "row_count": 12,
+                            "result_truncated": False,
+                            "authority": "backend_execution_result",
+                            "can_authorize_execution": False,
+                        }
+                    ],
+                    row_count=12,
+                    result_truncated=False,
+                ),
+            ],
+        )
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    run = snapshot.history[0].model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert run["auditEvents"] == [
+        {
+            "eventId": str(execution_event_id),
+            "eventType": "execution_completed",
+            "occurredAt": "2026-01-02T03:05:03Z",
+            "requestId": "preview-request-234",
+            "candidateId": "preview-candidate-234",
+            "sourceId": "sap-approved-spend",
+            "rowCount": 12,
+            "resultTruncated": False,
+        }
+    ]
+    assert run["executedEvidence"] == [
+        {
+            "authority": "backend_execution_result",
+            "canAuthorizeExecution": False,
+            "candidateId": "preview-candidate-234",
+            "executionAuditEventId": str(execution_event_id),
+            "executionAuditEventType": "execution_completed",
+            "rowCount": 12,
+            "resultTruncated": False,
+            "sourceId": "sap-approved-spend",
+            "sourceFamily": "postgresql",
+            "sourceFlavor": "warehouse",
+            "datasetContractVersion": 1,
+            "schemaSnapshotVersion": 1,
+        }
+    ]
+    assert run["retrievedCitations"] == [
+        {
+            "assetId": "spend-metric-definition",
+            "assetKind": "metric_definition",
+            "authority": "advisory_context",
+            "canAuthorizeExecution": False,
+            "citationLabel": "Approved spend metric definition",
+            "sourceId": "sap-approved-spend",
+            "sourceFamily": "postgresql",
+            "sourceFlavor": "warehouse",
+            "datasetContractVersion": 1,
+            "schemaSnapshotVersion": 1,
+        }
+    ]
+    serialized_run = str(run).lower()
+    assert "session" not in serialized_run
+    assert "secret" not in serialized_run
+    assert "token" not in serialized_run
 
 
 def test_operator_workflow_history_includes_audit_safe_unavailable_preview_denials() -> None:
@@ -359,17 +492,17 @@ def test_operator_workflow_history_includes_audit_safe_unavailable_preview_denia
         item.model_dump(mode="json", by_alias=True, exclude_none=True)
         for item in snapshot.history
     ]
-    assert history == [
-        {
-            "itemType": "request",
-            "recordId": "preview-request-denied-234",
-            "label": "Show approved vendors by quarterly spend",
-            "sourceId": "sap-approved-spend",
-            "sourceLabel": "SAP spend cube / approved_vendor_spend",
-            "lifecycleState": "preview_unavailable",
-            "occurredAt": "2026-01-02T03:04:05Z",
-        }
-    ]
+    assert {
+        "itemType": "request",
+        "recordId": "preview-request-denied-234",
+        "label": "Show approved vendors by quarterly spend",
+        "sourceId": "sap-approved-spend",
+        "sourceLabel": "SAP spend cube / approved_vendor_spend",
+        "lifecycleState": "preview_unavailable",
+        "occurredAt": "2026-01-02T03:04:05Z",
+    }.items() <= history[0].items()
+    assert history[0]["auditEvents"][0]["eventType"] == "generation_failed"
+    assert history[0]["auditEvents"][0]["primaryDenyCode"] == "DENY_SOURCE_UNAVAILABLE"
     serialized_history = str(history).lower()
     assert "csrf" not in serialized_history
     assert "cookie" not in serialized_history

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -294,6 +294,7 @@ button:focus-visible {
 .signin-actions,
 .action-row,
 .guard-list,
+.evidence-list,
 .history-list,
 .result-table,
 .placeholder-block {
@@ -452,6 +453,20 @@ button:disabled {
   border: 1px solid var(--border-soft);
   border-radius: 14px;
   background: rgba(7, 11, 20, 0.38);
+}
+
+.evidence-item {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: rgba(7, 11, 20, 0.38);
+  overflow-wrap: anywhere;
+}
+
+.evidence-item strong {
+  color: var(--text-primary);
 }
 
 .placeholder-title,

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1148,6 +1148,116 @@ describe("HomePage", () => {
     expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
   });
 
+  it("renders audit context, executed evidence, and retrieved citations without sensitive fields", async () => {
+    const unsafeLocalPath = "/" + ["Users", "example", "secret-should-not-render"].join("/");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    auditEvents: [
+                      {
+                        eventId: "00000000-0000-4000-8000-000000000012",
+                        eventType: "execution_completed",
+                        occurredAt: "2026-04-21T14:42:17+09:00",
+                        requestId: "request-selected",
+                        candidateId: "candidate-selected",
+                        sourceId: "sap-approved-spend",
+                        rowCount: 12,
+                        resultTruncated: false,
+                        sessionId: "session-secret-should-not-render"
+                      }
+                    ],
+                    executedEvidence: [
+                      {
+                        authority: "backend_execution_result",
+                        canAuthorizeExecution: false,
+                        candidateId: "candidate-selected",
+                        executionAuditEventId: "00000000-0000-4000-8000-000000000012",
+                        executionAuditEventType: "execution_completed",
+                        rowCount: 12,
+                        resultTruncated: false,
+                        sourceId: "sap-approved-spend",
+                        sourceFamily: "postgresql",
+                        sourceFlavor: "warehouse",
+                        connectionString: "postgres://secret-should-not-render"
+                      }
+                    ],
+                    itemType: "run",
+                    label: "Selected completed run",
+                    lifecycleState: "completed",
+                    occurredAt: "2026-04-21T14:42:17+09:00",
+                    recordId: "run-authoritative-287",
+                    retrievedCitations: [
+                      {
+                        assetId: "spend-metric-definition",
+                        assetKind: "metric_definition",
+                        authority: "advisory_context",
+                        canAuthorizeExecution: false,
+                        citationLabel: "Approved spend metric definition",
+                        sourceId: "sap-approved-spend",
+                        sourceFamily: "postgresql",
+                        sourceFlavor: "warehouse",
+                        localPath: unsafeLocalPath
+                      }
+                    ],
+                    resultTruncated: false,
+                    rowCount: 12,
+                    runState: "completed",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "run",
+          history_record_id: "run-authoritative-287",
+          question: "Selected completed run",
+          source_id: "sap-approved-spend",
+          state: "completed"
+        }
+      })
+    );
+
+    expect(screen.getByRole("heading", { name: /operator evidence context/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("execution_completed");
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent(
+      "00000000-0000-4000-8000-000000000012"
+    );
+    expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent(
+      "backend_execution_result"
+    );
+    expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("12 rows");
+    expect(screen.getByLabelText(/retrieved citation context/i)).toHaveTextContent(
+      "Approved spend metric definition"
+    );
+    expect(screen.getByLabelText(/retrieved citation context/i)).toHaveTextContent(
+      "advisory_context"
+    );
+    expect(screen.getAllByText(/cannot authorize execution: false/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/session-secret-should-not-render/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/postgres:\/\/secret-should-not-render/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(unsafeLocalPath)).not.toBeInTheDocument();
+  });
+
   it("renders explicit empty and review-denied unavailable states", async () => {
     const { rerender } = render(
       await HomePage({

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -4,7 +4,10 @@ import { type FormEvent, useEffect, useState } from "react";
 import { HealthStatusCard } from "./health-status-card";
 import type { HealthSnapshot } from "../lib/health";
 import type {
+  OperatorWorkflowAuditEvent,
+  OperatorWorkflowExecutedEvidence,
   OperatorHistoryItem,
+  OperatorWorkflowRetrievedCitation,
   OperatorWorkflowSnapshot,
   SourceOption
 } from "../lib/operator-workflow";
@@ -129,19 +132,25 @@ type PreviewSubmissionResult = {
 };
 
 type AuthoritativeCandidatePreview = {
+  auditEvents: OperatorWorkflowAuditEvent[];
   candidateId: string;
   candidateSql: string | null;
   candidateState: string;
+  executedEvidence: OperatorWorkflowExecutedEvidence[];
   guardStatus: string;
   requestId?: string;
+  retrievedCitations: OperatorWorkflowRetrievedCitation[];
   sourceId: string;
   sourceLabel?: string;
 };
 
 type AuthoritativeRunContext = {
+  auditEvents: OperatorWorkflowAuditEvent[];
+  executedEvidence: OperatorWorkflowExecutedEvidence[];
   lifecycleState: string;
   lifecycleTimestamp: string;
   primaryDenyCode?: string | null;
+  retrievedCitations: OperatorWorkflowRetrievedCitation[];
   resultTruncated?: boolean | null;
   rowCount?: number | null;
   runIdentity: string;
@@ -626,11 +635,14 @@ function findAuthoritativeCandidatePreview(
   }
 
   return {
+    auditEvents: candidate.auditEvents,
     candidateId: candidate.recordId,
     candidateSql: candidate.candidateSql ?? null,
     candidateState: candidate.lifecycleState,
+    executedEvidence: candidate.executedEvidence,
     guardStatus: candidate.guardStatus ?? "pending",
     requestId: candidate.requestId ?? undefined,
+    retrievedCitations: candidate.retrievedCitations,
     sourceId: candidate.sourceId,
     sourceLabel: candidate.sourceLabel
   };
@@ -657,9 +669,12 @@ function findAuthoritativeRunContext(
   }
 
   return {
+    auditEvents: run.auditEvents,
+    executedEvidence: run.executedEvidence,
     lifecycleState: run.lifecycleState,
     lifecycleTimestamp: run.occurredAt,
     primaryDenyCode: run.primaryDenyCode,
+    retrievedCitations: run.retrievedCitations,
     resultTruncated: run.resultTruncated,
     rowCount: run.rowCount,
     runIdentity: run.recordId,
@@ -958,6 +973,83 @@ function renderResultContent(
   );
 }
 
+function renderAuditEvidencePanel(
+  auditEvents: OperatorWorkflowAuditEvent[],
+  executedEvidence: OperatorWorkflowExecutedEvidence[],
+  retrievedCitations: OperatorWorkflowRetrievedCitation[]
+) {
+  return (
+    <section className="surface surface-secondary">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Audit and evidence</p>
+          <h2 className="panel-title">Operator evidence context</h2>
+        </div>
+        <span className="surface-badge surface-badge-code">Read only</span>
+      </div>
+
+      {auditEvents.length === 0 &&
+      executedEvidence.length === 0 &&
+      retrievedCitations.length === 0 ? (
+        <div className="placeholder-block">
+          <p className="placeholder-title">No audit evidence selected</p>
+          <p>Open a history row with persisted audit context to inspect lifecycle evidence.</p>
+        </div>
+      ) : null}
+
+      {auditEvents.length > 0 ? (
+        <div className="evidence-list" aria-label="audit lifecycle events">
+          {auditEvents.map((event) => (
+            <div className="evidence-item" key={event.eventId}>
+              <span className="meta-label">Audit event</span>
+              <strong>{event.eventType}</strong>
+              <span>{event.eventId}</span>
+              <span>{event.occurredAt}</span>
+              <span>Request {event.requestId}</span>
+              {event.candidateId ? <span>Candidate {event.candidateId}</span> : null}
+              {event.rowCount !== null ? <span>{event.rowCount} rows</span> : null}
+              {event.resultTruncated !== null ? (
+                <span>{event.resultTruncated ? "Result truncated" : "Result not truncated"}</span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {executedEvidence.length > 0 ? (
+        <div className="evidence-list" aria-label="executed evidence">
+          {executedEvidence.map((evidence) => (
+            <div className="evidence-item" key={evidence.executionAuditEventId}>
+              <span className="meta-label">Executed evidence</span>
+              <strong>{evidence.authority}</strong>
+              <span>{evidence.sourceId}</span>
+              <span>Candidate {evidence.candidateId}</span>
+              <span>{evidence.rowCount} rows</span>
+              <span>{evidence.resultTruncated ? "Result truncated" : "Result not truncated"}</span>
+              <span>Cannot authorize execution: {String(evidence.canAuthorizeExecution)}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {retrievedCitations.length > 0 ? (
+        <div className="evidence-list" aria-label="retrieved citation context">
+          {retrievedCitations.map((citation) => (
+            <div className="evidence-item" key={`${citation.assetKind}:${citation.assetId}`}>
+              <span className="meta-label">Retrieved citation context</span>
+              <strong>{citation.citationLabel}</strong>
+              <span>{citation.assetKind}</span>
+              <span>{citation.assetId}</span>
+              <span>{citation.authority}</span>
+              <span>Cannot authorize execution: {String(citation.canAuthorizeExecution)}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function renderStatePanel(
   state: CanonicalWorkflowState,
   question: string,
@@ -1235,6 +1327,12 @@ export function QueryWorkflowShell({
           historyRecordId
         }
       : undefined;
+  const selectedAuditEvents =
+    historyRunContext?.auditEvents ?? candidatePreview?.auditEvents ?? [];
+  const selectedExecutedEvidence =
+    historyRunContext?.executedEvidence ?? candidatePreview?.executedEvidence ?? [];
+  const selectedRetrievedCitations =
+    historyRunContext?.retrievedCitations ?? candidatePreview?.retrievedCitations ?? [];
 
   async function submitPreview(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -1319,11 +1417,14 @@ export function QueryWorkflowShell({
         setSubmittedSourceId(result.sourceId);
         setSubmittedState("review_denied");
         setSubmittedCandidatePreview({
+          auditEvents: [],
           candidateId: result.candidateId,
           candidateSql: result.candidateSql,
           candidateState: result.candidateState,
+          executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
+          retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
         });
@@ -1340,11 +1441,14 @@ export function QueryWorkflowShell({
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
         setSubmittedCandidatePreview({
+          auditEvents: [],
           candidateId: result.candidateId,
           candidateSql: result.candidateSql,
           candidateState: result.candidateState,
+          executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
+          retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
         });
@@ -1370,11 +1474,14 @@ export function QueryWorkflowShell({
       setSubmittedSourceId(result.sourceId);
       setSubmittedState("preview");
       setSubmittedCandidatePreview({
+        auditEvents: [],
         candidateId: result.candidateId,
         candidateSql: result.candidateSql,
         candidateState: result.candidateState,
+        executedEvidence: [],
         guardStatus: result.guardStatus,
         requestId: result.requestId,
+        retrievedCitations: [],
         sourceId: result.sourceId,
         sourceLabel: selectedSource.displayLabel
       });
@@ -1435,8 +1542,11 @@ export function QueryWorkflowShell({
         if (hasCanceledAuditEvent(payload)) {
           setSubmittedState("canceled");
           setSubmittedRunContext({
+            auditEvents: [],
+            executedEvidence: [],
             lifecycleState: "canceled",
             lifecycleTimestamp: new Date().toISOString(),
+            retrievedCitations: [],
             runIdentity: candidatePreview.candidateId,
             runState: "canceled",
             sourceLabel:
@@ -1489,8 +1599,11 @@ export function QueryWorkflowShell({
       const nextState = result.rowCount === 0 ? "empty" : "completed";
       setSubmittedState(nextState);
       setSubmittedRunContext({
+        auditEvents: [],
+        executedEvidence: [],
         lifecycleState: nextState,
         lifecycleTimestamp: new Date().toISOString(),
+        retrievedCitations: [],
         resultTruncated: result.resultTruncated,
         rowCount: result.rowCount,
         runIdentity: result.executionRunId ?? result.candidateId,
@@ -1913,6 +2026,12 @@ export function QueryWorkflowShell({
               </div>
             </div>
           </section>
+
+          {renderAuditEvidencePanel(
+            selectedAuditEvents,
+            selectedExecutedEvidence,
+            selectedRetrievedCitations
+          )}
 
           <section className="surface surface-secondary">
             <div className="section-header">

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -9,8 +9,47 @@ export type SourceOption = {
   sourceId: string;
 };
 
+export type OperatorWorkflowAuditEvent = {
+  candidateId: string | null;
+  candidateState: string | null;
+  eventId: string;
+  eventType: string;
+  occurredAt: string;
+  primaryDenyCode: string | null;
+  requestId: string;
+  resultTruncated: boolean | null;
+  rowCount: number | null;
+  sourceId: string;
+};
+
+export type OperatorWorkflowExecutedEvidence = {
+  authority: "backend_execution_result";
+  canAuthorizeExecution: false;
+  candidateId: string;
+  executionAuditEventId: string;
+  executionAuditEventType: "execution_completed";
+  rowCount: number;
+  resultTruncated: boolean;
+  sourceId: string;
+  sourceFamily: string;
+  sourceFlavor: string | null;
+};
+
+export type OperatorWorkflowRetrievedCitation = {
+  assetId: string;
+  assetKind: string;
+  authority: "advisory_context";
+  canAuthorizeExecution: false;
+  citationLabel: string;
+  sourceId: string;
+  sourceFamily: string;
+  sourceFlavor: string | null;
+};
+
 export type OperatorHistoryItem = {
+  auditEvents: OperatorWorkflowAuditEvent[];
   candidateSql?: string | null;
+  executedEvidence: OperatorWorkflowExecutedEvidence[];
   guardStatus?: string | null;
   itemType: "request" | "candidate" | "run";
   label: string;
@@ -24,6 +63,7 @@ export type OperatorHistoryItem = {
   runState?: string | null;
   sourceId: string;
   sourceLabel: string;
+  retrievedCitations: OperatorWorkflowRetrievedCitation[];
 };
 
 export type OperatorWorkflowSnapshot = {
@@ -61,6 +101,122 @@ function readOptionalNonNegativeInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
+function parseArray<T>(value: unknown, parser: (item: unknown) => T | null): T[] | null {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const parsed = value.map(parser);
+  return parsed.every((item): item is T => item !== null) ? parsed : null;
+}
+
+function parseAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const eventId = readOptionalString(value.eventId);
+  const eventType = readOptionalString(value.eventType);
+  const occurredAt = readOptionalString(value.occurredAt);
+  const requestId = readOptionalString(value.requestId);
+  const sourceId = readOptionalString(value.sourceId);
+
+  if (!eventId || !eventType || !occurredAt || !requestId || !sourceId) {
+    return null;
+  }
+
+  return {
+    candidateId: readOptionalString(value.candidateId) ?? null,
+    candidateState: readOptionalString(value.candidateState) ?? null,
+    eventId,
+    eventType,
+    occurredAt,
+    primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
+    requestId,
+    resultTruncated: typeof value.resultTruncated === "boolean" ? value.resultTruncated : null,
+    rowCount: readOptionalNonNegativeInteger(value.rowCount) ?? null,
+    sourceId
+  };
+}
+
+function parseExecutedEvidence(value: unknown): OperatorWorkflowExecutedEvidence | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const candidateId = readOptionalString(value.candidateId);
+  const executionAuditEventId = readOptionalString(value.executionAuditEventId);
+  const rowCount = readOptionalNonNegativeInteger(value.rowCount);
+  const sourceId = readOptionalString(value.sourceId);
+  const sourceFamily = readOptionalString(value.sourceFamily);
+
+  if (
+    value.authority !== "backend_execution_result" ||
+    value.canAuthorizeExecution !== false ||
+    !candidateId ||
+    !executionAuditEventId ||
+    value.executionAuditEventType !== "execution_completed" ||
+    rowCount === undefined ||
+    typeof value.resultTruncated !== "boolean" ||
+    !sourceId ||
+    !sourceFamily
+  ) {
+    return null;
+  }
+
+  return {
+    authority: "backend_execution_result",
+    canAuthorizeExecution: false,
+    candidateId,
+    executionAuditEventId,
+    executionAuditEventType: "execution_completed",
+    rowCount,
+    resultTruncated: value.resultTruncated,
+    sourceId,
+    sourceFamily,
+    sourceFlavor: readOptionalString(value.sourceFlavor) ?? null
+  };
+}
+
+function parseRetrievedCitation(value: unknown): OperatorWorkflowRetrievedCitation | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const assetId = readOptionalString(value.assetId);
+  const assetKind = readOptionalString(value.assetKind);
+  const citationLabel = readOptionalString(value.citationLabel);
+  const sourceId = readOptionalString(value.sourceId);
+  const sourceFamily = readOptionalString(value.sourceFamily);
+
+  if (
+    value.authority !== "advisory_context" ||
+    value.canAuthorizeExecution !== false ||
+    !assetId ||
+    !assetKind ||
+    !citationLabel ||
+    !sourceId ||
+    !sourceFamily
+  ) {
+    return null;
+  }
+
+  return {
+    assetId,
+    assetKind,
+    authority: "advisory_context",
+    canAuthorizeExecution: false,
+    citationLabel,
+    sourceId,
+    sourceFamily,
+    sourceFlavor: readOptionalString(value.sourceFlavor) ?? null
+  };
+}
+
 function parseSourceOption(value: unknown): SourceOption | null {
   if (!isObject(value)) {
     return null;
@@ -96,6 +252,9 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   const sourceLabel = readOptionalString(value.sourceLabel);
   const lifecycleState = readOptionalString(value.lifecycleState);
   const occurredAt = readOptionalString(value.occurredAt);
+  const auditEvents = parseArray(value.auditEvents, parseAuditEvent);
+  const executedEvidence = parseArray(value.executedEvidence, parseExecutedEvidence);
+  const retrievedCitations = parseArray(value.retrievedCitations, parseRetrievedCitation);
 
   if (
     (itemType !== "request" && itemType !== "candidate" && itemType !== "run") ||
@@ -104,13 +263,18 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     !sourceId ||
     !sourceLabel ||
     !lifecycleState ||
-    !occurredAt
+    !occurredAt ||
+    auditEvents === null ||
+    executedEvidence === null ||
+    retrievedCitations === null
   ) {
     return null;
   }
 
   return {
+    auditEvents,
     candidateSql: readOptionalString(value.candidateSql) ?? null,
+    executedEvidence,
     guardStatus: readOptionalString(value.guardStatus) ?? null,
     itemType,
     label,
@@ -124,7 +288,8 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     rowCount: readOptionalNonNegativeInteger(value.rowCount) ?? null,
     runState: readOptionalString(value.runState) ?? null,
     sourceId,
-    sourceLabel
+    sourceLabel,
+    retrievedCitations
   };
 }
 


### PR DESCRIPTION
## Summary
- surface sanitized audit event summaries, executed evidence, and retrieved citation context in the operator workflow API
- parse and render the evidence context in the workflow shell without exposing sensitive raw fields
- add focused backend/frontend regression coverage for populated evidence, advisory citations, and redaction

## Verification
- cd backend && python3 -m pytest tests/test_operator_workflow_history.py
- cd frontend && npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of audit events, executed evidence, and retrieved citations within operator workflow history.
  * New evidence panel shows audit context and execution details in the workflow interface.

* **Style**
  * Enhanced styling for evidence list presentation with improved spacing and card layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->