### PR TITLE
Add first-run empty state guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ from docs, service names, driver names, or placeholder configuration.
 For the full local startup workflow, including env setup, compose startup,
 migrations, and troubleshooting, use
 [docs/local-development.md](./docs/local-development.md).
+The same guide also defines the first-run UI empty states for missing source
+registry data, entitlement, workflow history, and backend readiness.
 
 Quick start:
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -73,6 +73,19 @@ remain extension tracks. They are not required for first-run Epic K activation
 and must not become execution, authorization, audit, or source-registry
 authorities.
 
+## First-run UI empty states
+
+The operator shell uses the same first-run setup path described in this guide.
+When a required backend-owned signal is missing, the UI stays blocked instead
+of inventing source, entitlement, history, preview, or result data.
+
+| UI state | What it means | Next action |
+| --- | --- | --- |
+| Source registry not configured | `/operator/workflow` is reachable but returned no source registry options. | Run migrations, seed the demo source, then run the first-run doctor before submitting preview requests. |
+| Source entitlement not available | The backend rejected the workflow context because the operator is not entitled to the selected source. | Confirm the signed-in operator has the dev/local entitlement binding for the selected source, then retry the workflow. |
+| No workflow history yet | At least one active source is available, but no authoritative request, candidate, or run summaries exist yet. | Submit a preview request against an active source; history appears only after the backend returns it. |
+| Backend workflow unavailable | The workflow payload is unavailable or malformed. | Confirm backend health, migrations, demo source seed, and first-run doctor before using the product shell. |
+
 ## Developer setup flow
 
 Use the numbered setup sections below when you need to build, migrate, test, or

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -297,7 +297,8 @@ button:focus-visible {
 .evidence-list,
 .history-list,
 .result-table,
-.placeholder-block {
+.placeholder-block,
+.first-run-panel {
   display: grid;
   gap: 12px;
 }
@@ -470,11 +471,25 @@ button:disabled {
 }
 
 .placeholder-title,
-.state-callout-title {
+.state-callout-title,
+.first-run-panel h3 {
   margin: 0;
   color: var(--text-primary);
   font-size: 1rem;
   font-weight: 600;
+}
+
+.first-run-panel {
+  padding: 18px;
+  border: 1px solid rgba(240, 193, 91, 0.28);
+  border-radius: 16px;
+  background: rgba(240, 193, 91, 0.08);
+}
+
+.first-run-panel p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 
 .state-callout {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -224,6 +224,133 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders first-run setup guidance when no sources are configured", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [],
+                sources: []
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(screen.getByRole("heading", { name: /source registry not configured/i })).toBeInTheDocument();
+    expect(screen.getByText(/run migrations, seed the demo source, then run the first-run doctor/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open first-run setup guide/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("docs/local-development.md#first-run-ui-empty-states")
+    );
+    expect(screen.getByRole("combobox", { name: /source/i })).toHaveValue("");
+    expect(screen.queryByRole("option", { name: /sap spend cube/i })).not.toBeInTheDocument();
+  });
+
+  it("renders a no-history first-run state without placeholder workflow rows", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [],
+                sources: [
+                  {
+                    activationPosture: "active",
+                    description: "Demo source returned by the backend contract.",
+                    displayLabel: "Demo business source",
+                    sourceId: "demo-business-source"
+                  }
+                ]
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(screen.getByRole("heading", { name: /no workflow history yet/i })).toBeInTheDocument();
+    expect(screen.getByText(/submit a preview request against an active source/i)).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Demo business source" })).toBeInTheDocument();
+    expect(screen.queryByText(/approved vendor spend/i)).not.toBeInTheDocument();
+  });
+
+  it("renders backend-unavailable setup guidance without falling back to placeholder sources", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.reject(new Error("backend down"));
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(screen.getByRole("heading", { name: /backend workflow unavailable/i })).toBeInTheDocument();
+    expect(screen.getByText(/confirm backend health, migrations, demo source seed, and first-run doctor/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open first-run setup guide/i })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /source/i })).toHaveValue("");
+    expect(screen.queryByRole("option", { name: /sap spend cube/i })).not.toBeInTheDocument();
+  });
+
+  it("renders entitlement setup guidance without treating placeholder access as valid", async () => {
+    const secretDetail = "sample-token-should-not-render";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: false,
+            json: () =>
+              Promise.resolve({
+                error: {
+                  code: "entitlement_denied",
+                  message: "The signed-in operator is not entitled to use that source.",
+                  raw: secretDetail
+                }
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(screen.getByRole("heading", { name: /source entitlement not available/i })).toBeInTheDocument();
+    expect(screen.getByText(/confirm the signed-in operator has the dev\/local entitlement binding/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open first-run setup guide/i })).toBeInTheDocument();
+    expect(screen.queryByText(secretDetail)).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /sap spend cube/i })).not.toBeInTheDocument();
+  });
+
   it("renders normalized auth and entitlement workflow failures without leaking sensitive details", async () => {
     const secretDetail = "idp-token-should-not-render";
     const failureCases = [

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -73,6 +73,11 @@ type WorkflowHrefContext = {
   historyRecordId?: string;
 };
 
+type FirstRunGuidance = {
+  body: string;
+  title: string;
+};
+
 type PreviewSubmissionStatus =
   | {
       status: "idle";
@@ -228,6 +233,9 @@ const workflowStateOrder: CanonicalWorkflowState[] = [
   "canceled"
 ];
 
+const FIRST_RUN_SETUP_GUIDE_HREF =
+  "https://github.com/TommyKammy/SafeQuery/blob/main/docs/local-development.md#first-run-ui-empty-states";
+
 export function resolveWorkflowState(value?: string): CanonicalWorkflowState {
   if (!value) {
     return "query";
@@ -242,6 +250,46 @@ export function resolveWorkflowState(value?: string): CanonicalWorkflowState {
   }
 
   return "query";
+}
+
+function getFirstRunGuidance(snapshot: OperatorWorkflowSnapshot): FirstRunGuidance | null {
+  if (snapshot.status === "unavailable" || snapshot.status === "malformed") {
+    return {
+      body:
+        "Confirm backend health, migrations, demo source seed, and first-run doctor before using the product shell.",
+      title: "Backend workflow unavailable"
+    };
+  }
+
+  if (snapshot.status === "entitlement_denied") {
+    return {
+      body:
+        "Confirm the signed-in operator has the dev/local entitlement binding for the selected source, then retry the workflow.",
+      title: "Source entitlement not available"
+    };
+  }
+
+  if (snapshot.status === "live" && snapshot.sources.length === 0) {
+    return {
+      body:
+        "Run migrations, seed the demo source, then run the first-run doctor before submitting preview requests.",
+      title: "Source registry not configured"
+    };
+  }
+
+  return null;
+}
+
+function renderFirstRunGuidance(guidance: FirstRunGuidance) {
+  return (
+    <div className="first-run-panel">
+      <h3>{guidance.title}</h3>
+      <p>{guidance.body}</p>
+      <a className="inline-link" href={FIRST_RUN_SETUP_GUIDE_HREF} rel="noreferrer" target="_blank">
+        Open first-run setup guide
+      </a>
+    </div>
+  );
 }
 
 function findSourceOption(
@@ -1333,6 +1381,7 @@ export function QueryWorkflowShell({
     historyRunContext?.executedEvidence ?? candidatePreview?.executedEvidence ?? [];
   const selectedRetrievedCitations =
     historyRunContext?.retrievedCitations ?? candidatePreview?.retrievedCitations ?? [];
+  const firstRunGuidance = getFirstRunGuidance(operatorWorkflow);
 
   async function submitPreview(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -1693,9 +1742,18 @@ export function QueryWorkflowShell({
                 <p>{operatorWorkflow.error.message}</p>
               </div>
             ) : null}
+            {firstRunGuidance ? renderFirstRunGuidance(firstRunGuidance) : null}
             <div className="history-list">
               {operatorWorkflow.history.length > 0 ? (
                 operatorWorkflow.history.map(renderHistoryItem)
+              ) : operatorWorkflow.status === "live" && operatorWorkflow.sources.length > 0 ? (
+                <div className="placeholder-block">
+                  <h3 className="placeholder-title">No workflow history yet</h3>
+                  <p>
+                    Submit a preview request against an active source. SafeQuery will show request,
+                    candidate, and run summaries here only after the backend returns them.
+                  </p>
+                </div>
               ) : (
                 <div className="placeholder-block">
                   <p className="placeholder-title">No live history rows</p>


### PR DESCRIPTION
## Summary
- Add first-run product UI guidance for missing source registry, entitlement denial, and backend workflow unavailability
- Add a distinct no-history empty state when an active source exists but no backend history rows have been returned
- Document the matching first-run UI empty-state next actions in local development docs and link README to that guidance

## Verification
- npm test -- app/page.test.tsx
- npm test
- npm run build
- bash tests/smoke/test-local-startup-docs.sh
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- rg path hygiene check for changed files

Closes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-run setup guidance panels displaying contextual help for initial configuration scenarios, including backend unavailability, entitlement issues, and empty source registry
  * Improved empty state messaging for "no workflow history yet" condition

* **Documentation**
  * Enhanced local development setup guide with specific remediation steps for operator shell blocked conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->