### PR TITLE
[P-F1] Render execute response rows and audit context

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -296,7 +296,6 @@ button:focus-visible {
 .guard-list,
 .evidence-list,
 .history-list,
-.result-table,
 .placeholder-block,
 .first-run-panel {
   display: grid;
@@ -508,10 +507,37 @@ button:disabled {
   border-color: rgba(255, 107, 122, 0.24);
 }
 
-.result-table {
+.result-table-wrap {
   overflow: hidden;
   border: 1px solid var(--border-soft);
   border-radius: 16px;
+  background: rgba(7, 11, 20, 0.38);
+}
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+}
+
+.result-table th,
+.result-table td {
+  padding: 12px 14px;
+  border-top: 1px solid rgba(163, 191, 250, 0.1);
+  text-align: left;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+.result-table th {
+  border-top: 0;
+  background: rgba(63, 208, 255, 0.08);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.result-table td {
+  color: var(--text-secondary);
 }
 
 .result-row {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -884,6 +884,236 @@ describe("HomePage", () => {
     }
   });
 
+  it("renders successful execute response rows and audit context without sensitive extras", async () => {
+    const csrfToken = document.createElement("meta");
+    csrfToken.name = "safequery-csrf-token";
+    csrfToken.content = "csrf-from-session-bootstrap";
+    document.head.appendChild(csrfToken);
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              history: [
+                {
+                  candidateSql: "select vendor_name, total_spend from approved_vendor_spend;",
+                  guardStatus: "passed",
+                  itemType: "candidate",
+                  label: "Selected candidate",
+                  lifecycleState: "preview_ready",
+                  occurredAt: "2026-04-21T14:24:00Z",
+                  recordId: "candidate-selected",
+                  requestId: "request-selected",
+                  sourceId: "sap-approved-spend",
+                  sourceLabel: "SAP spend cube / approved_vendor_spend"
+                }
+              ],
+              sources: workflowPayload().sources
+            })
+        });
+      }
+
+      if (url.endsWith("/candidates/candidate-selected/execute")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [
+                  {
+                    candidate_state: "executed",
+                    event_id: "00000000-0000-4000-8000-000000000298",
+                    event_type: "execution_completed",
+                    execution_row_count: 2,
+                    occurred_at: "2026-04-21T14:42:17+09:00",
+                    query_candidate_id: "candidate-selected",
+                    request_id: "request-selected",
+                    result_truncated: false,
+                    session_id: "session-secret-should-not-render",
+                    source_id: "sap-approved-spend"
+                  }
+                ],
+                session_token: "token-secret-should-not-render"
+              },
+              candidate_id: "candidate-selected",
+              connector_id: "postgresql_readonly",
+              metadata: {
+                candidate_id: "candidate-selected",
+                execution_run_id: "00000000-0000-4000-8000-000000000298",
+                result_truncated: false,
+                row_count: 2,
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend"
+              },
+              rows: [
+                {
+                  connection_string: "postgres://secret-should-not-render",
+                  total_spend: 1200,
+                  vendor_name: "Acme Supplies"
+                },
+                {
+                  session_token: "row-token-should-not-render",
+                  total_spend: 980,
+                  vendor_name: "Globex Services"
+                }
+              ],
+              source_id: "sap-approved-spend"
+            })
+        });
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-selected",
+          question: "Selected candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /execute reviewed candidate/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/execution completed/i).length).toBeGreaterThan(0);
+    });
+
+    const resultsSection = screen.getByRole("heading", { name: /completed result set/i }).closest("section");
+    expect(resultsSection).not.toBeNull();
+    const results = within(resultsSection!);
+    expect(results.getByRole("table", { name: /execute response result rows/i })).toBeInTheDocument();
+    expect(results.getByText("vendor_name")).toBeInTheDocument();
+    expect(results.getByText("total_spend")).toBeInTheDocument();
+    expect(results.getByText("Acme Supplies")).toBeInTheDocument();
+    expect(results.getByText("Globex Services")).toBeInTheDocument();
+    expect(results.getByText("1200")).toBeInTheDocument();
+
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("execution_completed");
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent(
+      "00000000-0000-4000-8000-000000000298"
+    );
+    expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent(
+      "backend_execution_result"
+    );
+    expect(screen.queryByText(/postgres:\/\/secret-should-not-render/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/row-token-should-not-render/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/session-secret-should-not-render/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/token-secret-should-not-render/i)).not.toBeInTheDocument();
+  });
+
+  it("renders zero-row execute response audit context on the empty state", async () => {
+    const csrfToken = document.createElement("meta");
+    csrfToken.name = "safequery-csrf-token";
+    csrfToken.content = "csrf-from-session-bootstrap";
+    document.head.appendChild(csrfToken);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend where 1 = 0;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Selected candidate",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-selected",
+                    requestId: "request-selected",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        if (url.endsWith("/candidates/candidate-selected/execute")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                audit: {
+                  events: [
+                    {
+                      candidate_state: "executed",
+                      event_id: "00000000-0000-4000-8000-000000000299",
+                      event_type: "execution_completed",
+                      execution_row_count: 0,
+                      occurred_at: "2026-04-21T14:43:17+09:00",
+                      query_candidate_id: "candidate-selected",
+                      request_id: "request-selected",
+                      result_truncated: false,
+                      source_id: "sap-approved-spend"
+                    }
+                  ]
+                },
+                candidate_id: "candidate-selected",
+                connector_id: "postgresql_readonly",
+                metadata: {
+                  candidate_id: "candidate-selected",
+                  execution_run_id: "00000000-0000-4000-8000-000000000299",
+                  result_truncated: false,
+                  row_count: 0,
+                  source_family: "postgresql",
+                  source_flavor: "warehouse",
+                  source_id: "sap-approved-spend"
+                },
+                rows: [],
+                source_id: "sap-approved-spend"
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-selected",
+          question: "Selected candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /execute reviewed candidate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /empty state/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/0 rows returned; result payload not truncated/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("execution_completed");
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent(
+      "00000000-0000-4000-8000-000000000299"
+    );
+    expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("0 rows");
+  });
+
   it("keeps execute disabled for non-authorized candidate states", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -157,6 +157,7 @@ type AuthoritativeRunContext = {
   primaryDenyCode?: string | null;
   retrievedCitations: OperatorWorkflowRetrievedCitation[];
   resultTruncated?: boolean | null;
+  resultRows?: ResultRow[];
   rowCount?: number | null;
   runIdentity: string;
   runState?: string | null;
@@ -169,12 +170,24 @@ type ApiErrorEnvelope = {
 };
 
 type ExecuteSubmissionResult = {
+  auditEvents: OperatorWorkflowAuditEvent[];
   candidateId: string;
+  executedEvidence: OperatorWorkflowExecutedEvidence[];
   executionRunId?: string;
   resultTruncated: boolean;
+  rows: ResultRow[];
   rowCount: number;
   sourceId: string;
 };
+
+type ResultCell = string | number | boolean | null;
+type ResultRow = Record<string, ResultCell>;
+
+const MAX_RENDERED_RESULT_ROWS = 10;
+const MAX_RENDERED_RESULT_COLUMNS = 8;
+
+const sensitiveResultFieldPattern =
+  /(secret|token|password|credential|connection|string|session|local[_-]?path|filepath|file[_-]?path|private[_-]?key|api[_-]?key)/i;
 
 const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
   canceled: {
@@ -338,6 +351,125 @@ function parseAuditEvents(value: unknown): Record<string, unknown>[] {
   return value.audit.events.filter(isObject);
 }
 
+function readOptionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readOptionalNonNegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function parseExecuteAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const eventId = readOptionalString(value.event_id);
+  const eventType = readOptionalString(value.event_type);
+  const occurredAt = readOptionalString(value.occurred_at);
+  const requestId = readOptionalString(value.request_id);
+  const sourceId = readOptionalString(value.source_id);
+
+  if (!eventId || !eventType || !occurredAt || !requestId || !sourceId) {
+    return null;
+  }
+
+  return {
+    candidateId: readOptionalString(value.query_candidate_id),
+    candidateState: readOptionalString(value.candidate_state),
+    eventId,
+    eventType,
+    occurredAt,
+    primaryDenyCode: readOptionalString(value.primary_deny_code),
+    requestId,
+    resultTruncated: typeof value.result_truncated === "boolean" ? value.result_truncated : null,
+    rowCount: readOptionalNonNegativeInteger(value.execution_row_count),
+    sourceId
+  };
+}
+
+function parseExecuteAuditEvents(value: unknown): OperatorWorkflowAuditEvent[] {
+  return parseAuditEvents(value)
+    .map(parseExecuteAuditEvent)
+    .filter((event): event is OperatorWorkflowAuditEvent => event !== null);
+}
+
+function isResultCell(value: unknown): value is ResultCell {
+  return (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  );
+}
+
+function parseExecuteRows(value: unknown): ResultRow[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const rows: ResultRow[] = [];
+  for (const item of value) {
+    if (!isObject(item)) {
+      return null;
+    }
+
+    const row: ResultRow = {};
+    for (const [key, cell] of Object.entries(item)) {
+      if (
+        typeof key !== "string" ||
+        key.trim().length === 0 ||
+        sensitiveResultFieldPattern.test(key) ||
+        !isResultCell(cell)
+      ) {
+        continue;
+      }
+      row[key] = cell;
+    }
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function buildExecutedEvidenceFromExecuteResponse(
+  result: {
+    auditEvents: OperatorWorkflowAuditEvent[];
+    candidateId: string;
+    resultTruncated: boolean;
+    rowCount: number;
+    sourceId: string;
+  },
+  metadata: Record<string, unknown>
+): OperatorWorkflowExecutedEvidence[] {
+  const completedEvent = result.auditEvents.find(
+    (event) =>
+      event.eventType === "execution_completed" &&
+      event.candidateId === result.candidateId &&
+      event.sourceId === result.sourceId
+  );
+  const sourceFamily = readOptionalString(metadata.source_family);
+
+  if (!completedEvent || !sourceFamily) {
+    return [];
+  }
+
+  return [
+    {
+      authority: "backend_execution_result",
+      canAuthorizeExecution: false,
+      candidateId: result.candidateId,
+      executionAuditEventId: completedEvent.eventId,
+      executionAuditEventType: "execution_completed",
+      resultTruncated: result.resultTruncated,
+      rowCount: result.rowCount,
+      sourceFamily,
+      sourceFlavor: readOptionalString(metadata.source_flavor),
+      sourceId: result.sourceId
+    }
+  ];
+}
+
 function hasCanceledAuditEvent(value: unknown): boolean {
   return parseAuditEvents(value).some((event) => event.candidate_state === "canceled");
 }
@@ -427,6 +559,7 @@ function parseExecuteSubmissionResult(
   const executionRunId = readRequiredString(value.metadata.execution_run_id);
   const rowCount = value.metadata.row_count;
   const resultTruncated = value.metadata.result_truncated;
+  const rows = parseExecuteRows(value.rows);
 
   if (
     candidateId !== expectedCandidateId ||
@@ -434,15 +567,29 @@ function parseExecuteSubmissionResult(
     typeof rowCount !== "number" ||
     !Number.isInteger(rowCount) ||
     rowCount < 0 ||
-    typeof resultTruncated !== "boolean"
+    typeof resultTruncated !== "boolean" ||
+    rows === null ||
+    rows.length !== rowCount
   ) {
     return null;
   }
 
-  return {
+  const auditEvents = parseExecuteAuditEvents(value);
+  const partialResult = {
+    auditEvents,
     candidateId,
+    resultTruncated,
+    rowCount,
+    sourceId
+  };
+
+  return {
+    auditEvents,
+    candidateId,
+    executedEvidence: buildExecutedEvidenceFromExecuteResponse(partialResult, value.metadata),
     executionRunId,
     resultTruncated,
+    rows,
     rowCount,
     sourceId
   };
@@ -915,6 +1062,70 @@ function getResultTitle(state: CanonicalWorkflowState): string {
   return "Results unavailable";
 }
 
+function resultColumns(rows: ResultRow[]): string[] {
+  const columns: string[] = [];
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!columns.includes(key)) {
+        columns.push(key);
+      }
+      if (columns.length >= MAX_RENDERED_RESULT_COLUMNS) {
+        return columns;
+      }
+    }
+  }
+  return columns;
+}
+
+function renderResultRows(rows: ResultRow[]) {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const displayedRows = rows.slice(0, MAX_RENDERED_RESULT_ROWS);
+  const columns = resultColumns(displayedRows);
+  const rowsTruncated = rows.length > displayedRows.length;
+
+  if (columns.length === 0) {
+    return (
+      <div className="state-callout state-callout-empty">
+        <p className="state-callout-title">Result rows contained no displayable fields</p>
+        <p>All returned fields were outside the bounded display contract.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="result-table-wrap">
+      <table aria-label="execute response result rows" className="result-table">
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th key={column} scope="col">
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {displayedRows.map((row, index) => (
+            <tr key={index}>
+              {columns.map((column) => (
+                <td key={column}>{String(row[column] ?? "")}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rowsTruncated ? (
+        <p className="section-copy">
+          Showing {displayedRows.length} of {rows.length} returned rows.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 function renderResultContent(
   state: CanonicalWorkflowState,
   runContext?: AuthoritativeRunContext | null
@@ -928,13 +1139,16 @@ function renderResultContent(
       runContext.resultTruncated !== undefined
     ) {
       return (
-        <div className="state-callout state-callout-success">
-          <p className="state-callout-title">Authoritative result metadata</p>
-          <p>
-            {runContext.rowCount} rows returned; result payload{" "}
-            {runContext.resultTruncated ? "truncated" : "not truncated"}.
-          </p>
-        </div>
+        <>
+          <div className="state-callout state-callout-success">
+            <p className="state-callout-title">Authoritative result metadata</p>
+            <p>
+              {runContext.rowCount} rows returned; result payload{" "}
+              {runContext.resultTruncated ? "truncated" : "not truncated"}.
+            </p>
+          </div>
+          {renderResultRows(runContext.resultRows ?? [])}
+        </>
       );
     }
 
@@ -963,13 +1177,21 @@ function renderResultContent(
 
   if (state === "empty") {
     return (
-      <div className="state-callout state-callout-empty">
-        <p className="state-callout-title">Empty state reached</p>
-        <p>
-          The approved workflow returned zero rows. Keep the question, SQL preview, and guard
-          history intact so the operator can revise without losing context.
-        </p>
-      </div>
+      <>
+        <div className="state-callout state-callout-empty">
+          <p className="state-callout-title">Empty state reached</p>
+          <p>
+            The approved workflow returned zero rows. Keep the question, SQL preview, and guard
+            history intact so the operator can revise without losing context.
+          </p>
+        </div>
+        {runContext?.rowCount === 0 && runContext.resultTruncated === false ? (
+          <div className="state-callout state-callout-success">
+            <p className="state-callout-title">Authoritative result metadata</p>
+            <p>0 rows returned; result payload not truncated.</p>
+          </div>
+        ) : null}
+      </>
     );
   }
 
@@ -1648,12 +1870,13 @@ export function QueryWorkflowShell({
       const nextState = result.rowCount === 0 ? "empty" : "completed";
       setSubmittedState(nextState);
       setSubmittedRunContext({
-        auditEvents: [],
-        executedEvidence: [],
+        auditEvents: result.auditEvents,
+        executedEvidence: result.executedEvidence,
         lifecycleState: nextState,
         lifecycleTimestamp: new Date().toISOString(),
         retrievedCitations: [],
         resultTruncated: result.resultTruncated,
+        resultRows: result.rows,
         rowCount: result.rowCount,
         runIdentity: result.executionRunId ?? result.candidateId,
         runState: nextState,


### PR DESCRIPTION
## Summary
- render successful execute response rows in a bounded result table
- populate completed/empty post-execute audit evidence from response audit events
- filter sensitive row/audit extras from operator-visible surfaces

## Verification
- cd frontend && npm test
- cd frontend && npm run build
- cd backend && python3 -m pytest tests/test_candidate_execute_api.py tests/test_operator_workflow_history.py
- bash tests/smoke/test-pilot-safety-ui-api-workflow.sh

Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured display of query execution results in table format with column headers and cell values
  * Proper handling and messaging for empty result states
  * Automatic filtering of sensitive information from result display

* **Style**
  * Enhanced result table styling with improved layout and visual consistency

* **Tests**
  * Added comprehensive test coverage for result table rendering and empty state handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->