### PR TITLE
[Q-2] Add operator aggregate health posture

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,6 +60,7 @@ from app.services.candidate_lifecycle import (
 )
 from app.services.first_run_doctor import FirstRunDoctorResult, run_first_run_doctor
 from app.services.health import (
+    build_operator_health,
     check_database_health,
     check_sql_generation_runtime_health,
 )
@@ -462,23 +463,33 @@ def create_app() -> FastAPI:
         }
 
     @app.get("/health")
-    def read_health() -> JSONResponse:
+    def read_health(
+        session: Session = Depends(require_preview_submission_session),
+    ) -> JSONResponse:
         database = check_database_health(str(settings.app_postgres_url))
         sql_generation = check_sql_generation_runtime_health(settings.sql_generation)
+        operator_health = build_operator_health(
+            session,
+            database=database,
+            sql_generation=sql_generation,
+        )
         sql_generation_status = sql_generation["status"]
         healthy = database["status"] == "ok" and sql_generation_status in {
             "ok",
             "disabled",
             "unchecked",
         }
+        backend_healthy = healthy
+        aggregate_healthy = healthy and operator_health["status"] == "ok"
 
         return JSONResponse(
-            status_code=200 if healthy else 503,
+            status_code=200 if backend_healthy else 503,
             content={
-                "status": "ok" if healthy else "degraded",
+                "status": "ok" if aggregate_healthy else "degraded",
                 "service": "safequery-api",
                 "database": database,
                 "sql_generation": sql_generation,
+                "operator_health": operator_health,
             },
         )
 

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -5,8 +5,20 @@ from urllib.parse import urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
 import psycopg
+from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from app.core.config import SQLGenerationSettings
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.preview import PreviewAuditEvent
+from app.db.models.schema_snapshot import SchemaSnapshot
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.execution import (
+    ExecutionConnectorSelectionError,
+    select_execution_connector,
+)
+from app.services.candidate_lifecycle import SourceBoundCandidateMetadata
 
 
 def check_database_health(database_url: str) -> Mapping[str, str]:
@@ -109,4 +121,160 @@ def check_sql_generation_runtime_health(
         **payload,
         "status": "ok",
         "detail": "ready",
+    }
+
+
+def _component_status(component: Mapping[str, object]) -> str:
+    status = component.get("status")
+    return status if isinstance(status, str) else "error"
+
+
+def _aggregate_operator_status(
+    components: Mapping[str, Mapping[str, object]],
+) -> str:
+    statuses = {_component_status(component) for component in components.values()}
+    if "error" in statuses:
+        return "error"
+    if statuses - {"ok", "disabled", "unchecked"}:
+        return "degraded"
+    return "ok"
+
+
+def _backend_component(database: Mapping[str, str]) -> dict[str, object]:
+    if database.get("status") != "ok":
+        return {"status": "error", "detail": "database_unavailable"}
+    return {"status": "ok", "detail": "ready"}
+
+
+def _generation_adapter_component(
+    sql_generation: Mapping[str, object],
+) -> dict[str, object]:
+    status = sql_generation.get("status")
+    detail = sql_generation.get("detail")
+    provider = sql_generation.get("provider")
+    return {
+        "status": status if isinstance(status, str) else "error",
+        "detail": detail if isinstance(detail, str) else "malformed_health_payload",
+        "provider": provider if isinstance(provider, str) else "unknown",
+    }
+
+
+def _source_registry_component(
+    sources: list[RegisteredSource],
+) -> dict[str, object]:
+    postures = {
+        posture.value: sum(
+            1 for source in sources if source.activation_posture is posture
+        )
+        for posture in SourceActivationPosture
+    }
+    active_source_count = postures[SourceActivationPosture.ACTIVE.value]
+    return {
+        "status": "ok" if active_source_count > 0 else "degraded",
+        "detail": "ready" if active_source_count > 0 else "no_active_sources",
+        "registered_source_count": len(sources),
+        "active_source_count": active_source_count,
+        "postures": postures,
+    }
+
+
+def _source_has_backend_owned_connector(session: Session, source: RegisteredSource) -> bool:
+    if source.dataset_contract_id is None or source.schema_snapshot_id is None:
+        return False
+    contract = session.get(DatasetContract, source.dataset_contract_id)
+    snapshot = session.get(SchemaSnapshot, source.schema_snapshot_id)
+    if contract is None or snapshot is None:
+        return False
+
+    try:
+        select_execution_connector(
+            candidate_source=SourceBoundCandidateMetadata(
+                source_id=source.source_id,
+                source_family=source.source_family,
+                source_flavor=source.source_flavor,
+                dataset_contract_version=contract.contract_version,
+                schema_snapshot_version=snapshot.snapshot_version,
+            )
+        )
+    except ExecutionConnectorSelectionError:
+        return False
+    return True
+
+
+def _active_source_connectivity_component(
+    session: Session,
+    sources: list[RegisteredSource],
+) -> dict[str, object]:
+    active_sources = [
+        source
+        for source in sources
+        if source.activation_posture is SourceActivationPosture.ACTIVE
+    ]
+    ready_source_count = sum(
+        1
+        for source in active_sources
+        if _source_has_backend_owned_connector(session, source)
+    )
+    unavailable_source_count = len(active_sources) - ready_source_count
+    if not active_sources:
+        status = "degraded"
+        detail = "no_active_sources"
+    elif unavailable_source_count:
+        status = "degraded"
+        detail = "active_source_connector_unavailable"
+    else:
+        status = "ok"
+        detail = "ready"
+
+    return {
+        "status": status,
+        "detail": detail,
+        "active_source_count": len(active_sources),
+        "ready_source_count": ready_source_count,
+        "unavailable_source_count": unavailable_source_count,
+    }
+
+
+def _audit_persistence_component(session: Session) -> dict[str, object]:
+    session.scalar(select(func.count()).select_from(PreviewAuditEvent))
+    return {"status": "ok", "detail": "ready"}
+
+
+def build_operator_health(
+    session: Session,
+    *,
+    database: Mapping[str, str],
+    sql_generation: Mapping[str, object],
+) -> dict[str, object]:
+    components: dict[str, dict[str, object]] = {
+        "backend": _backend_component(database),
+        "frontend_api_connection": {"status": "ok", "detail": "reachable"},
+        "generation_adapter": _generation_adapter_component(sql_generation),
+    }
+
+    try:
+        sources = list(
+            session.scalars(select(RegisteredSource).order_by(RegisteredSource.source_id))
+        )
+        components["source_registry"] = _source_registry_component(sources)
+        components["active_source_connectivity"] = (
+            _active_source_connectivity_component(session, sources)
+        )
+        components["audit_persistence"] = _audit_persistence_component(session)
+    except SQLAlchemyError as exc:
+        detail = {"status": "error", "detail": exc.__class__.__name__}
+        components["source_registry"] = detail
+        components["active_source_connectivity"] = {
+            "status": "error",
+            "detail": "source_registry_unavailable",
+        }
+        components["audit_persistence"] = {
+            "status": "error",
+            "detail": "audit_persistence_unavailable",
+        }
+
+    return {
+        "status": _aggregate_operator_status(components),
+        "can_authorize_execution": False,
+        "components": components,
     }

--- a/backend/tests/test_operator_health.py
+++ b/backend/tests/test_operator_health.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import importlib
+from contextlib import contextmanager
+from typing import Iterator
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.core.config import get_settings
+from app.db.base import Base
+from app.db.session import require_preview_submission_session
+from app.services.demo_source_seed import seed_demo_source_governance
+
+
+@contextmanager
+def _session_scope() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        seed_demo_source_governance(session)
+        yield session
+    engine.dispose()
+
+
+def _client(session: Session) -> TestClient:
+    get_settings.cache_clear()
+    main_module = importlib.import_module("app.main")
+    app = main_module.create_app()
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    return TestClient(app)
+
+
+def test_health_exposes_bounded_operator_aggregate_without_sensitive_fields(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "check_database_health",
+        lambda _url: {"status": "ok", "detail": "ready"},
+    )
+
+    with _session_scope() as session:
+        response = _client(session).get("/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["operator_health"] == {
+        "status": "ok",
+        "can_authorize_execution": False,
+        "components": {
+            "backend": {"status": "ok", "detail": "ready"},
+            "frontend_api_connection": {"status": "ok", "detail": "reachable"},
+            "source_registry": {
+                "status": "ok",
+                "detail": "ready",
+                "registered_source_count": 1,
+                "active_source_count": 1,
+                "postures": {
+                    "active": 1,
+                    "blocked": 0,
+                    "paused": 0,
+                    "retired": 0,
+                },
+            },
+            "active_source_connectivity": {
+                "status": "ok",
+                "detail": "ready",
+                "active_source_count": 1,
+                "ready_source_count": 1,
+                "unavailable_source_count": 0,
+            },
+            "generation_adapter": {
+                "status": "disabled",
+                "detail": "provider_disabled",
+                "provider": "disabled",
+            },
+            "audit_persistence": {
+                "status": "ok",
+                "detail": "ready",
+            },
+        },
+    }
+    assert "connection_reference" not in response.text
+    assert "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL" not in response.text
+    assert "postgresql://" not in response.text
+    assert "/Users/" not in response.text
+
+
+def test_health_degrades_operator_aggregate_when_sources_are_unavailable(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "check_database_health",
+        lambda _url: {"status": "ok", "detail": "ready"},
+    )
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        response = _client(session).get("/health")
+    engine.dispose()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "degraded"
+    assert payload["operator_health"]["status"] == "degraded"
+    assert payload["operator_health"]["can_authorize_execution"] is False
+    assert payload["operator_health"]["components"]["source_registry"] == {
+        "status": "degraded",
+        "detail": "no_active_sources",
+        "registered_source_count": 0,
+        "active_source_count": 0,
+        "postures": {
+            "active": 0,
+            "blocked": 0,
+            "paused": 0,
+            "retired": 0,
+        },
+    }
+    assert payload["operator_health"]["components"]["active_source_connectivity"] == {
+        "status": "degraded",
+        "detail": "no_active_sources",
+        "active_source_count": 0,
+        "ready_source_count": 0,
+        "unavailable_source_count": 0,
+    }

--- a/frontend/components/health-status-card.test.tsx
+++ b/frontend/components/health-status-card.test.tsx
@@ -52,4 +52,39 @@ describe("HealthStatusCard", () => {
 
     expect(screen.getByText(/not reachable from the frontend yet/i)).toBeInTheDocument();
   });
+
+  it("summarizes the bounded operator aggregate without rendering raw details", async () => {
+    const secretDetail = "postgresql://safequery:secret@db/safequery";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          database: { status: "ok" },
+          operator_health: {
+            components: {
+              active_source_connectivity: { status: "degraded", raw: secretDetail },
+              audit_persistence: { status: "ok" },
+              generation_adapter: { status: "disabled" },
+              source_registry: { status: "ok" }
+            },
+            status: "degraded"
+          },
+          status: "degraded"
+        })
+      }))
+    );
+
+    render(<HealthStatusCard apiUrl="http://127.0.0.1:8000" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("degraded")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/source registry ok/i)).toBeInTheDocument();
+    expect(screen.getByText(/active source connectivity degraded/i)).toBeInTheDocument();
+    expect(screen.getByText(/generation adapter disabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/audit persistence ok/i)).toBeInTheDocument();
+    expect(screen.queryByText(secretDetail)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/lib/health.ts
+++ b/frontend/lib/health.ts
@@ -5,6 +5,10 @@ export type HealthSnapshot = {
 
 export type HealthPayload = {
   database?: { status?: string };
+  operator_health?: {
+    components?: Record<string, { status?: string }>;
+    status?: string;
+  };
   status?: string;
 };
 
@@ -28,8 +32,29 @@ export function getMalformedHealthSnapshot(): HealthSnapshot {
 }
 
 export function getHealthSnapshotFromPayload(payload: HealthPayload): HealthSnapshot {
+  const operatorHealth = payload.operator_health;
+  if (operatorHealth && typeof operatorHealth.status !== "string") {
+    return getMalformedHealthSnapshot();
+  }
+
+  const components = operatorHealth?.components;
+  if (components && (typeof components !== "object" || Array.isArray(components))) {
+    return getMalformedHealthSnapshot();
+  }
+
+  const componentSummary = components
+    ? [
+        ["source registry", components.source_registry?.status],
+        ["active source connectivity", components.active_source_connectivity?.status],
+        ["generation adapter", components.generation_adapter?.status],
+        ["audit persistence", components.audit_persistence?.status]
+      ]
+        .map(([label, status]) => `${label} ${typeof status === "string" ? status : "unknown"}`)
+        .join("; ")
+    : "operator aggregate unavailable";
+
   return {
-    detail: `Backend is ${payload.status ?? "unknown"} and PostgreSQL is ${payload.database?.status ?? "unknown"}.`,
+    detail: `Backend is ${payload.status ?? "unknown"}, PostgreSQL is ${payload.database?.status ?? "unknown"}, and ${componentSummary}.`,
     status: payload.status === "ok" ? "ok" : "degraded"
   };
 }


### PR DESCRIPTION
## Summary
- add a bounded operator_health aggregate to /health for backend, frontend/API, source registry, active source connectivity, generation adapter, and audit persistence posture
- keep the aggregate diagnostic only with can_authorize_execution=false and no connection references, credentials, raw source URLs, or workstation-local paths
- summarize aggregate component statuses in the existing frontend health card without rendering raw detail fields

## Verification
- backend: python3 -m pytest -q
- frontend: npm test

Closes #302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health endpoint now monitors operator-level components including database, SQL generation, source registry, connectivity, and audit persistence.
  * Health status displays as "ok" or "degraded" based on aggregate component health.
  * UI now displays human-readable health summaries for each monitored component with sensitive data filtered.

* **Tests**
  * Added tests for operator health aggregation and degradation scenarios.
  * Added UI tests to verify sensitive data is excluded from health displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->