### PR TITLE
[Q-3] Add workflow lifecycle metrics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -473,6 +473,17 @@ def create_app() -> FastAPI:
             database=database,
             sql_generation=sql_generation,
         )
+        get_logger().info(
+            "operator.workflow_lifecycle_metrics",
+            extra={
+                "event_data": {
+                    "event": "operator.workflow_lifecycle_metrics",
+                    "workflow_lifecycle_metrics": operator_health[
+                        "workflow_lifecycle_metrics"
+                    ],
+                }
+            },
+        )
         sql_generation_status = sql_generation["status"]
         healthy = database["status"] == "ok" and sql_generation_status in {
             "ok",

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from collections.abc import Mapping
 import json
 from urllib.error import HTTPError, URLError
@@ -240,6 +241,98 @@ def _audit_persistence_component(session: Session) -> dict[str, object]:
     return {"status": "ok", "detail": "ready"}
 
 
+def _bounded_counts(counter: Counter[str], *, limit: int = 8) -> dict[str, int]:
+    return {
+        key: count
+        for key, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[
+            :limit
+        ]
+    }
+
+
+def _terminal_failure_key(event: PreviewAuditEvent) -> str:
+    for value in (
+        event.denial_cause,
+        event.primary_deny_code,
+        event.candidate_state,
+        event.event_type,
+    ):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
+def _workflow_lifecycle_metrics(session: Session) -> dict[str, object]:
+    events = list(
+        session.scalars(
+            select(PreviewAuditEvent).order_by(
+                PreviewAuditEvent.event_type,
+                PreviewAuditEvent.source_id,
+            )
+        )
+    )
+    event_count = len(events)
+    preview_terminal_failures: Counter[str] = Counter()
+    execute_terminal_failures: Counter[str] = Counter()
+    source_ids: set[str] = set()
+
+    metrics: dict[str, object] = {
+        "status": "active" if event_count else "no_traffic",
+        "audit_event_count": event_count,
+        "preview": {
+            "submitted": 0,
+            "generation_completed": 0,
+            "generation_failed": 0,
+            "guard_evaluated": 0,
+            "terminal_failures": {},
+        },
+        "execute": {
+            "requested": 0,
+            "completed": 0,
+            "denied": 0,
+            "failed": 0,
+            "terminal_failures": {},
+        },
+        "audit_persistence": {
+            "recorded_events": event_count,
+            "sources_with_events": 0,
+        },
+    }
+    preview = metrics["preview"]
+    execute = metrics["execute"]
+    assert isinstance(preview, dict)
+    assert isinstance(execute, dict)
+
+    for event in events:
+        source_ids.add(event.source_id)
+        if event.event_type == "query_submitted":
+            preview["submitted"] = int(preview["submitted"]) + 1
+        elif event.event_type == "generation_completed":
+            preview["generation_completed"] = int(preview["generation_completed"]) + 1
+        elif event.event_type == "generation_failed":
+            preview["generation_failed"] = int(preview["generation_failed"]) + 1
+            preview_terminal_failures[_terminal_failure_key(event)] += 1
+        elif event.event_type == "guard_evaluated":
+            preview["guard_evaluated"] = int(preview["guard_evaluated"]) + 1
+        elif event.event_type == "execution_requested":
+            execute["requested"] = int(execute["requested"]) + 1
+        elif event.event_type == "execution_completed":
+            execute["completed"] = int(execute["completed"]) + 1
+        elif event.event_type == "execution_denied":
+            execute["denied"] = int(execute["denied"]) + 1
+            execute_terminal_failures[_terminal_failure_key(event)] += 1
+        elif event.event_type == "execution_failed":
+            execute["failed"] = int(execute["failed"]) + 1
+            execute_terminal_failures[_terminal_failure_key(event)] += 1
+
+    preview["terminal_failures"] = _bounded_counts(preview_terminal_failures)
+    execute["terminal_failures"] = _bounded_counts(execute_terminal_failures)
+    audit_persistence = metrics["audit_persistence"]
+    assert isinstance(audit_persistence, dict)
+    audit_persistence["sources_with_events"] = len(source_ids)
+    return metrics
+
+
 def build_operator_health(
     session: Session,
     *,
@@ -261,6 +354,7 @@ def build_operator_health(
             _active_source_connectivity_component(session, sources)
         )
         components["audit_persistence"] = _audit_persistence_component(session)
+        workflow_lifecycle_metrics = _workflow_lifecycle_metrics(session)
     except SQLAlchemyError as exc:
         detail = {"status": "error", "detail": exc.__class__.__name__}
         components["source_registry"] = detail
@@ -272,9 +366,14 @@ def build_operator_health(
             "status": "error",
             "detail": "audit_persistence_unavailable",
         }
+        workflow_lifecycle_metrics = {
+            "status": "error",
+            "detail": "audit_persistence_unavailable",
+        }
 
     return {
         "status": _aggregate_operator_status(components),
         "can_authorize_execution": False,
         "components": components,
+        "workflow_lifecycle_metrics": workflow_lifecycle_metrics,
     }

--- a/backend/app/services/health.py
+++ b/backend/app/services/health.py
@@ -250,52 +250,83 @@ def _bounded_counts(counter: Counter[str], *, limit: int = 8) -> dict[str, int]:
     }
 
 
-def _terminal_failure_key(event: PreviewAuditEvent) -> str:
-    for value in (
-        event.denial_cause,
-        event.primary_deny_code,
-        event.candidate_state,
-        event.event_type,
-    ):
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    return "unknown"
+def _terminal_failure_counts(
+    session: Session,
+    *,
+    event_types: tuple[str, ...],
+) -> Counter[str]:
+    failure_key = func.coalesce(
+        func.nullif(func.trim(PreviewAuditEvent.denial_cause), ""),
+        func.nullif(func.trim(PreviewAuditEvent.primary_deny_code), ""),
+        func.nullif(func.trim(PreviewAuditEvent.candidate_state), ""),
+        func.nullif(func.trim(PreviewAuditEvent.event_type), ""),
+        "unknown",
+    ).label("failure_key")
+    failure_count = func.count().label("failure_count")
+    return Counter(
+        {
+            str(key): int(count)
+            for key, count in session.execute(
+                select(failure_key, failure_count)
+                .select_from(PreviewAuditEvent)
+                .where(PreviewAuditEvent.event_type.in_(event_types))
+                .group_by(failure_key)
+                .order_by(failure_count.desc(), failure_key.asc())
+                .limit(8)
+            )
+        }
+    )
 
 
 def _workflow_lifecycle_metrics(session: Session) -> dict[str, object]:
-    events = list(
-        session.scalars(
-            select(PreviewAuditEvent).order_by(
-                PreviewAuditEvent.event_type,
-                PreviewAuditEvent.source_id,
+    event_count = int(
+        session.scalar(select(func.count()).select_from(PreviewAuditEvent)) or 0
+    )
+    source_count = int(
+        session.scalar(
+            select(func.count(func.distinct(PreviewAuditEvent.source_id))).select_from(
+                PreviewAuditEvent
             )
         )
+        or 0
     )
-    event_count = len(events)
-    preview_terminal_failures: Counter[str] = Counter()
-    execute_terminal_failures: Counter[str] = Counter()
-    source_ids: set[str] = set()
+    event_type_counts = {
+        str(event_type): int(count)
+        for event_type, count in session.execute(
+            select(PreviewAuditEvent.event_type, func.count())
+            .select_from(PreviewAuditEvent)
+            .group_by(PreviewAuditEvent.event_type)
+        )
+    }
+    preview_terminal_failures = _terminal_failure_counts(
+        session,
+        event_types=("generation_failed",),
+    )
+    execute_terminal_failures = _terminal_failure_counts(
+        session,
+        event_types=("execution_denied", "execution_failed"),
+    )
 
     metrics: dict[str, object] = {
         "status": "active" if event_count else "no_traffic",
         "audit_event_count": event_count,
         "preview": {
-            "submitted": 0,
-            "generation_completed": 0,
-            "generation_failed": 0,
-            "guard_evaluated": 0,
+            "submitted": event_type_counts.get("query_submitted", 0),
+            "generation_completed": event_type_counts.get("generation_completed", 0),
+            "generation_failed": event_type_counts.get("generation_failed", 0),
+            "guard_evaluated": event_type_counts.get("guard_evaluated", 0),
             "terminal_failures": {},
         },
         "execute": {
-            "requested": 0,
-            "completed": 0,
-            "denied": 0,
-            "failed": 0,
+            "requested": event_type_counts.get("execution_requested", 0),
+            "completed": event_type_counts.get("execution_completed", 0),
+            "denied": event_type_counts.get("execution_denied", 0),
+            "failed": event_type_counts.get("execution_failed", 0),
             "terminal_failures": {},
         },
         "audit_persistence": {
             "recorded_events": event_count,
-            "sources_with_events": 0,
+            "sources_with_events": source_count,
         },
     }
     preview = metrics["preview"]
@@ -303,33 +334,8 @@ def _workflow_lifecycle_metrics(session: Session) -> dict[str, object]:
     assert isinstance(preview, dict)
     assert isinstance(execute, dict)
 
-    for event in events:
-        source_ids.add(event.source_id)
-        if event.event_type == "query_submitted":
-            preview["submitted"] = int(preview["submitted"]) + 1
-        elif event.event_type == "generation_completed":
-            preview["generation_completed"] = int(preview["generation_completed"]) + 1
-        elif event.event_type == "generation_failed":
-            preview["generation_failed"] = int(preview["generation_failed"]) + 1
-            preview_terminal_failures[_terminal_failure_key(event)] += 1
-        elif event.event_type == "guard_evaluated":
-            preview["guard_evaluated"] = int(preview["guard_evaluated"]) + 1
-        elif event.event_type == "execution_requested":
-            execute["requested"] = int(execute["requested"]) + 1
-        elif event.event_type == "execution_completed":
-            execute["completed"] = int(execute["completed"]) + 1
-        elif event.event_type == "execution_denied":
-            execute["denied"] = int(execute["denied"]) + 1
-            execute_terminal_failures[_terminal_failure_key(event)] += 1
-        elif event.event_type == "execution_failed":
-            execute["failed"] = int(execute["failed"]) + 1
-            execute_terminal_failures[_terminal_failure_key(event)] += 1
-
     preview["terminal_failures"] = _bounded_counts(preview_terminal_failures)
     execute["terminal_failures"] = _bounded_counts(execute_terminal_failures)
-    audit_persistence = metrics["audit_persistence"]
-    assert isinstance(audit_persistence, dict)
-    audit_persistence["sources_with_events"] = len(source_ids)
     return metrics
 
 

--- a/backend/tests/test_operator_health.py
+++ b/backend/tests/test_operator_health.py
@@ -7,7 +7,7 @@ from typing import Iterator
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
@@ -17,6 +17,7 @@ from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRe
 from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
 from app.services.demo_source_seed import seed_demo_source_governance
+from app.services.health import _workflow_lifecycle_metrics
 
 
 @contextmanager
@@ -421,3 +422,59 @@ def test_health_exposes_bounded_workflow_lifecycle_metrics(
     } in structured_logs
     assert "safequery_exec" not in str(structured_logs)
     assert "postgresql://" not in str(structured_logs)
+
+
+def test_workflow_lifecycle_metrics_does_not_hydrate_audit_events() -> None:
+    with _session_scope() as session:
+        preview_request = _add_preview_request(
+            session,
+            request_id="request-preview-failure-bounds",
+            request_state="preview_generation_failed",
+        )
+        session.add_all(
+            [
+                _audit_event(
+                    preview_request=preview_request,
+                    lifecycle_order=index + 1,
+                    event_type="generation_failed",
+                    denial_cause=f"failure-{index}",
+                )
+                for index in range(10)
+            ]
+        )
+        session.commit()
+        session.expunge_all()
+        loaded_audit_event_types: list[str] = []
+
+        def _record_loaded(_session: Session, instance: object) -> None:
+            if isinstance(instance, PreviewAuditEvent):
+                loaded_audit_event_types.append(instance.event_type)
+
+        event.listen(session, "loaded_as_persistent", _record_loaded)
+        try:
+            metrics = _workflow_lifecycle_metrics(session)
+        finally:
+            event.remove(session, "loaded_as_persistent", _record_loaded)
+
+    assert loaded_audit_event_types == []
+    assert metrics["audit_event_count"] == 10
+    assert metrics["audit_persistence"] == {
+        "recorded_events": 10,
+        "sources_with_events": 1,
+    }
+    assert metrics["preview"] == {
+        "submitted": 0,
+        "generation_completed": 0,
+        "generation_failed": 10,
+        "guard_evaluated": 0,
+        "terminal_failures": {
+            "failure-0": 1,
+            "failure-1": 1,
+            "failure-2": 1,
+            "failure-3": 1,
+            "failure-4": 1,
+            "failure-5": 1,
+            "failure-6": 1,
+            "failure-7": 1,
+        },
+    }

--- a/backend/tests/test_operator_health.py
+++ b/backend/tests/test_operator_health.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import importlib
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from typing import Iterator
+from uuid import uuid4
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -11,6 +13,8 @@ from sqlalchemy.pool import StaticPool
 
 from app.core.config import get_settings
 from app.db.base import Base
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
+from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
 from app.services.demo_source_seed import seed_demo_source_governance
 
@@ -35,6 +39,108 @@ def _client(session: Session) -> TestClient:
     app = main_module.create_app()
     app.dependency_overrides[require_preview_submission_session] = lambda: session
     return TestClient(app)
+
+
+def _add_preview_request(
+    session: Session,
+    *,
+    request_id: str,
+    request_state: str,
+) -> PreviewRequest:
+    source = session.query(RegisteredSource).one()
+    preview_request = PreviewRequest(
+        id=uuid4(),
+        request_id=request_id,
+        registered_source_id=source.id,
+        source_id=source.source_id,
+        source_family=source.source_family,
+        source_flavor=source.source_flavor,
+        dataset_contract_id=source.dataset_contract_id,
+        dataset_contract_version=1,
+        schema_snapshot_id=source.schema_snapshot_id,
+        schema_snapshot_version=1,
+        authenticated_subject_id="user:demo-local-operator",
+        auth_source="test-helper",
+        session_id="session-redacted",
+        governance_bindings="group:safequery-demo-local-operators",
+        entitlement_decision="allow",
+        request_text="Show approved spend",
+        request_state=request_state,
+    )
+    session.add(preview_request)
+    session.flush()
+    return preview_request
+
+
+def _add_preview_candidate(
+    session: Session,
+    *,
+    preview_request: PreviewRequest,
+    candidate_id: str,
+    candidate_state: str,
+) -> PreviewCandidate:
+    preview_candidate = PreviewCandidate(
+        id=uuid4(),
+        candidate_id=candidate_id,
+        preview_request_id=preview_request.id,
+        request_id=preview_request.request_id,
+        registered_source_id=preview_request.registered_source_id,
+        source_id=preview_request.source_id,
+        source_family=preview_request.source_family,
+        source_flavor=preview_request.source_flavor,
+        dataset_contract_id=preview_request.dataset_contract_id,
+        dataset_contract_version=preview_request.dataset_contract_version,
+        schema_snapshot_id=preview_request.schema_snapshot_id,
+        schema_snapshot_version=preview_request.schema_snapshot_version,
+        authenticated_subject_id=preview_request.authenticated_subject_id,
+        guard_status="pending",
+        candidate_state=candidate_state,
+    )
+    session.add(preview_candidate)
+    session.flush()
+    return preview_candidate
+
+
+def _audit_event(
+    *,
+    preview_request: PreviewRequest,
+    preview_candidate: PreviewCandidate | None = None,
+    lifecycle_order: int,
+    event_type: str,
+    candidate_state: str | None = None,
+    primary_deny_code: str | None = None,
+    denial_cause: str | None = None,
+) -> PreviewAuditEvent:
+    payload = {"event_type": event_type}
+    if denial_cause is not None:
+        payload["denial_cause"] = denial_cause
+    return PreviewAuditEvent(
+        event_id=uuid4(),
+        lifecycle_order=lifecycle_order,
+        preview_request_id=preview_request.id,
+        preview_candidate_id=(
+            preview_candidate.id if preview_candidate is not None else None
+        ),
+        request_id=preview_request.request_id,
+        candidate_id=(
+            preview_candidate.candidate_id if preview_candidate is not None else None
+        ),
+        event_type=event_type,
+        occurred_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        correlation_id=f"correlation-{preview_request.request_id}",
+        authenticated_subject_id="user:demo-local-operator",
+        session_id="session-redacted",
+        auth_source="test-helper",
+        source_id=preview_request.source_id,
+        source_family=preview_request.source_family,
+        source_flavor=preview_request.source_flavor,
+        dataset_contract_version=preview_request.dataset_contract_version,
+        schema_snapshot_version=preview_request.schema_snapshot_version,
+        primary_deny_code=primary_deny_code,
+        denial_cause=denial_cause,
+        candidate_state=candidate_state,
+        audit_payload=payload,
+    )
 
 
 def test_health_exposes_bounded_operator_aggregate_without_sensitive_fields(
@@ -94,6 +200,28 @@ def test_health_exposes_bounded_operator_aggregate_without_sensitive_fields(
                 "detail": "ready",
             },
         },
+        "workflow_lifecycle_metrics": {
+            "status": "no_traffic",
+            "audit_event_count": 0,
+            "preview": {
+                "submitted": 0,
+                "generation_completed": 0,
+                "generation_failed": 0,
+                "guard_evaluated": 0,
+                "terminal_failures": {},
+            },
+            "execute": {
+                "requested": 0,
+                "completed": 0,
+                "denied": 0,
+                "failed": 0,
+                "terminal_failures": {},
+            },
+            "audit_persistence": {
+                "recorded_events": 0,
+                "sources_with_events": 0,
+            },
+        },
     }
     assert "connection_reference" not in response.text
     assert "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL" not in response.text
@@ -151,3 +279,145 @@ def test_health_degrades_operator_aggregate_when_sources_are_unavailable(
         "ready_source_count": 0,
         "unavailable_source_count": 0,
     }
+
+
+def test_health_exposes_bounded_workflow_lifecycle_metrics(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "check_database_health",
+        lambda _url: {"status": "ok", "detail": "ready"},
+    )
+    structured_logs: list[dict[str, object]] = []
+
+    class _RecordingLogger:
+        def info(self, _message: str, *, extra: dict[str, object]) -> None:
+            event_data = extra.get("event_data")
+            if isinstance(event_data, dict):
+                structured_logs.append(event_data)
+
+    monkeypatch.setattr(main_module, "get_logger", lambda: _RecordingLogger())
+
+    with _session_scope() as session:
+        preview_success_request = _add_preview_request(
+            session,
+            request_id="request-preview-success",
+            request_state="previewed",
+        )
+        preview_success_candidate = _add_preview_candidate(
+            session,
+            preview_request=preview_success_request,
+            candidate_id="candidate-preview-success",
+            candidate_state="preview_ready",
+        )
+        preview_failed_request = _add_preview_request(
+            session,
+            request_id="request-preview-failed",
+            request_state="preview_generation_failed",
+        )
+        execute_success_request = _add_preview_request(
+            session,
+            request_id="request-execute-success",
+            request_state="previewed",
+        )
+        execute_success_candidate = _add_preview_candidate(
+            session,
+            preview_request=execute_success_request,
+            candidate_id="candidate-execute-success",
+            candidate_state="preview_ready",
+        )
+        execute_failed_request = _add_preview_request(
+            session,
+            request_id="request-execute-failed",
+            request_state="previewed",
+        )
+        execute_failed_candidate = _add_preview_candidate(
+            session,
+            preview_request=execute_failed_request,
+            candidate_id="candidate-execute-failed",
+            candidate_state="failed",
+        )
+        session.add_all(
+            [
+                _audit_event(
+                    preview_request=preview_success_request,
+                    preview_candidate=preview_success_candidate,
+                    lifecycle_order=1,
+                    event_type="query_submitted",
+                ),
+                _audit_event(
+                    preview_request=preview_success_request,
+                    preview_candidate=preview_success_candidate,
+                    lifecycle_order=2,
+                    event_type="guard_evaluated",
+                    candidate_state="preview_ready",
+                ),
+                _audit_event(
+                    preview_request=preview_failed_request,
+                    lifecycle_order=1,
+                    event_type="generation_failed",
+                    primary_deny_code="DENY_SQL_GENERATION_FAILED",
+                    denial_cause="sql_generation_runtime_unhealthy",
+                ),
+                _audit_event(
+                    preview_request=execute_success_request,
+                    preview_candidate=execute_success_candidate,
+                    lifecycle_order=3,
+                    event_type="execution_completed",
+                ),
+                _audit_event(
+                    preview_request=execute_failed_request,
+                    preview_candidate=execute_failed_candidate,
+                    lifecycle_order=3,
+                    event_type="execution_failed",
+                    candidate_state="failed",
+                ),
+            ]
+        )
+        session.commit()
+        response = _client(session).get("/health")
+
+    assert response.status_code == 200
+    metrics = response.json()["operator_health"]["workflow_lifecycle_metrics"]
+    assert metrics == {
+        "status": "active",
+        "audit_event_count": 5,
+        "preview": {
+            "submitted": 1,
+            "generation_completed": 0,
+            "generation_failed": 1,
+            "guard_evaluated": 1,
+            "terminal_failures": {
+                "sql_generation_runtime_unhealthy": 1,
+            },
+        },
+        "execute": {
+            "requested": 0,
+            "completed": 1,
+            "denied": 0,
+            "failed": 1,
+            "terminal_failures": {
+                "failed": 1,
+            },
+        },
+        "audit_persistence": {
+            "recorded_events": 5,
+            "sources_with_events": 1,
+        },
+    }
+    assert "safequery_exec" not in response.text
+    assert "postgresql://" not in response.text
+    assert {
+        "event": "operator.workflow_lifecycle_metrics",
+        "workflow_lifecycle_metrics": metrics,
+    } in structured_logs
+    assert "safequery_exec" not in str(structured_logs)
+    assert "postgresql://" not in str(structured_logs)


### PR DESCRIPTION
## Summary
- add bounded workflow lifecycle metrics to operator health output
- emit the same non-secret diagnostic payload as a structured health log event
- cover active/no-traffic health metrics and structured log safety in focused tests

## Verification
- PYTHONPATH=backend python3 -m pytest backend/tests/test_operator_health.py backend/tests/test_preview_persistence.py backend/tests/test_candidate_execute_api.py -q
- bash tests/smoke/test-pilot-safety-checklist.sh

Refs #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health check now returns workflow lifecycle metrics: preview vs. execution event counts and aggregated terminal-failure summaries, and these metrics are emitted in structured health logs.

* **Tests**
  * Added coverage verifying lifecycle metrics output, terminal-failure aggregation, and that sensitive strings are not present in responses or structured logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->