### PR TITLE
[Q-5] Add secret-safe support bundle

### DIFF
--- a/backend/app/cli/support_bundle.py
+++ b/backend/app/cli/support_bundle.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import sys
+
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.db.session import get_engine
+from app.services.health import check_database_health, check_sql_generation_runtime_health
+from app.services.support_bundle import build_support_bundle
+
+
+def main() -> None:
+    settings = get_settings()
+    database = check_database_health(str(settings.app_postgres_url))
+    sql_generation = check_sql_generation_runtime_health(settings.sql_generation)
+    with Session(get_engine(str(settings.app_postgres_url))) as session:
+        bundle = build_support_bundle(
+            session,
+            settings=settings,
+            database=database,
+            sql_generation=sql_generation,
+        )
+
+    print(json.dumps(bundle.model_dump(mode="json", by_alias=True), sort_keys=True))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -78,6 +78,7 @@ from app.services.operator_workflow import (
     OperatorWorkflowSnapshot,
     get_operator_workflow_snapshot,
 )
+from app.services.support_bundle import SupportBundle, build_support_bundle
 
 configure_logging()
 
@@ -509,6 +510,19 @@ def create_app() -> FastAPI:
         session: Session = Depends(require_preview_submission_session),
     ) -> FirstRunDoctorResult:
         return run_first_run_doctor(session, backend_probe_mode="served_route")
+
+    @app.get("/support/bundle", response_model=SupportBundle)
+    def read_support_bundle(
+        session: Session = Depends(require_preview_submission_session),
+    ) -> SupportBundle:
+        database = check_database_health(str(settings.app_postgres_url))
+        sql_generation = check_sql_generation_runtime_health(settings.sql_generation)
+        return build_support_bundle(
+            session,
+            settings=settings,
+            database=database,
+            sql_generation=sql_generation,
+        )
 
     @app.post("/requests/preview", response_model=PreviewSubmissionResponse)
     def create_request_preview(

--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings
+from app.db.models.dataset_contract import DatasetContract
+from app.db.models.schema_snapshot import SchemaSnapshot
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.services.first_run_doctor import _alembic_heads
+from app.services.health import build_operator_health
+from app.services.operator_workflow import get_operator_workflow_snapshot
+
+
+_APP_VERSION = "0.1.0"
+_WINDOWS_USER_PROFILE_SEGMENT = "Users"
+_FORBIDDEN_VALUE_PATTERNS = (
+    re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\\s\"']+"),
+    re.compile(r"(?i)\b(driver|server|database|uid|pwd)\s*="),
+    re.compile(r"(?i)\b(sk|pk|ghp|github_pat)-[a-z0-9][a-z0-9_-]{8,}"),
+    re.compile(r"(?i)(^|[\\/])Users[\\/][^\\/\"]+"),
+    re.compile(rf"(?i)[a-z]:\\{_WINDOWS_USER_PROFILE_SEGMENT}\\[^\\\"]+"),
+)
+
+
+class SupportBundleApplication(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    service: Literal["safequery-api"] = "safequery-api"
+    version: str
+    environment: str
+
+
+class SupportBundleMigrationPosture(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["current", "outdated", "unknown"]
+    detail: str
+    applied_revisions: list[str] = Field(
+        default_factory=list,
+        serialization_alias="appliedRevisions",
+    )
+    expected_heads: list[str] = Field(
+        default_factory=list,
+        serialization_alias="expectedHeads",
+    )
+
+
+class SupportBundleSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(serialization_alias="sourceId")
+    source_family: str = Field(serialization_alias="sourceFamily")
+    source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+    activation_posture: str = Field(serialization_alias="activationPosture")
+    dataset_contract_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="datasetContractVersion",
+    )
+    schema_snapshot_version: Optional[int] = Field(
+        default=None,
+        serialization_alias="schemaSnapshotVersion",
+    )
+
+
+class SupportBundleHealth(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    components: dict[str, object]
+
+
+class SupportBundleRecentWorkflowState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    item_type: str = Field(serialization_alias="itemType")
+    lifecycle_state: str = Field(serialization_alias="lifecycleState")
+    source_id: str = Field(serialization_alias="sourceId")
+
+
+class SupportBundleWorkflow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    history_count: int = Field(serialization_alias="historyCount")
+    recent_states: list[SupportBundleRecentWorkflowState] = Field(
+        serialization_alias="recentStates"
+    )
+    lifecycle_metrics: dict[str, object] = Field(serialization_alias="lifecycleMetrics")
+
+
+class SupportBundleAuditCompleteness(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["present", "empty", "error"]
+    recorded_events: int = Field(serialization_alias="recordedEvents")
+    sources_with_events: int = Field(serialization_alias="sourcesWithEvents")
+
+
+class SupportBundleRedaction(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    excluded: list[str]
+
+
+class SupportBundle(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bundle_version: Literal[1] = Field(default=1, serialization_alias="bundleVersion")
+    generated_at: datetime = Field(serialization_alias="generatedAt")
+    application: SupportBundleApplication
+    source_posture: dict[str, object] = Field(serialization_alias="sourcePosture")
+    migration_posture: SupportBundleMigrationPosture = Field(
+        serialization_alias="migrationPosture"
+    )
+    active_sources: list[SupportBundleSource] = Field(
+        serialization_alias="activeSources"
+    )
+    health: SupportBundleHealth
+    workflow: SupportBundleWorkflow
+    audit_completeness: SupportBundleAuditCompleteness = Field(
+        serialization_alias="auditCompleteness"
+    )
+    redaction: SupportBundleRedaction
+
+
+def _active_sources(session: Session) -> list[SupportBundleSource]:
+    sources = session.scalars(
+        select(RegisteredSource)
+        .where(RegisteredSource.activation_posture == SourceActivationPosture.ACTIVE)
+        .order_by(RegisteredSource.source_id)
+    )
+    bundle_sources: list[SupportBundleSource] = []
+    for source in sources:
+        contract = (
+            session.get(DatasetContract, source.dataset_contract_id)
+            if source.dataset_contract_id is not None
+            else None
+        )
+        snapshot = (
+            session.get(SchemaSnapshot, source.schema_snapshot_id)
+            if source.schema_snapshot_id is not None
+            else None
+        )
+        bundle_sources.append(
+            SupportBundleSource(
+                source_id=source.source_id,
+                source_family=source.source_family,
+                source_flavor=source.source_flavor,
+                activation_posture=source.activation_posture.value,
+                dataset_contract_version=(
+                    contract.contract_version if contract is not None else None
+                ),
+                schema_snapshot_version=(
+                    snapshot.snapshot_version if snapshot is not None else None
+                ),
+            )
+        )
+    return bundle_sources
+
+
+def _migration_posture(session: Session) -> SupportBundleMigrationPosture:
+    try:
+        applied_revisions = sorted(
+            str(row[0])
+            for row in session.execute(text("SELECT version_num FROM alembic_version"))
+        )
+    except SQLAlchemyError as exc:
+        return SupportBundleMigrationPosture(
+            status="unknown",
+            detail=exc.__class__.__name__,
+        )
+
+    try:
+        expected_heads = sorted(_alembic_heads())
+    except Exception as exc:
+        return SupportBundleMigrationPosture(
+            status="unknown",
+            detail=exc.__class__.__name__,
+            applied_revisions=applied_revisions,
+        )
+
+    if applied_revisions == expected_heads:
+        return SupportBundleMigrationPosture(
+            status="current",
+            detail="alembic_head_current",
+            applied_revisions=applied_revisions,
+            expected_heads=expected_heads,
+        )
+    return SupportBundleMigrationPosture(
+        status="outdated",
+        detail="alembic_head_mismatch",
+        applied_revisions=applied_revisions,
+        expected_heads=expected_heads,
+    )
+
+
+def _recent_workflow_states(
+    session: Session,
+    *,
+    limit: int = 8,
+) -> tuple[int, list[SupportBundleRecentWorkflowState]]:
+    snapshot = get_operator_workflow_snapshot(session)
+    return len(snapshot.history), [
+        SupportBundleRecentWorkflowState(
+            item_type=item.item_type,
+            lifecycle_state=item.lifecycle_state,
+            source_id=item.source_id,
+        )
+        for item in snapshot.history[:limit]
+    ]
+
+
+def _audit_completeness(metrics: Mapping[str, object]) -> SupportBundleAuditCompleteness:
+    audit_persistence = metrics.get("audit_persistence")
+    if not isinstance(audit_persistence, dict):
+        return SupportBundleAuditCompleteness(
+            status="error",
+            recorded_events=0,
+            sources_with_events=0,
+        )
+
+    recorded_events = audit_persistence.get("recorded_events")
+    sources_with_events = audit_persistence.get("sources_with_events")
+    recorded_event_count = recorded_events if isinstance(recorded_events, int) else 0
+    source_count = sources_with_events if isinstance(sources_with_events, int) else 0
+    return SupportBundleAuditCompleteness(
+        status="present" if recorded_event_count else "empty",
+        recorded_events=recorded_event_count,
+        sources_with_events=source_count,
+    )
+
+
+def _redaction_policy() -> SupportBundleRedaction:
+    return SupportBundleRedaction(
+        excluded=[
+            "connection_strings",
+            "raw_credentials",
+            "tokens",
+            "raw_result_rows",
+            "candidate_sql",
+            "workstation_local_paths",
+            "source_connection_references",
+        ]
+    )
+
+
+def _iter_strings(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for item in value.values():
+            strings.extend(_iter_strings(item))
+        return strings
+    if isinstance(value, list):
+        strings = []
+        for item in value:
+            strings.extend(_iter_strings(item))
+        return strings
+    return []
+
+
+def _assert_bundle_is_shareable(bundle: SupportBundle) -> None:
+    payload = bundle.model_dump(mode="json", by_alias=True, exclude_none=True)
+    for value in _iter_strings(payload):
+        for pattern in _FORBIDDEN_VALUE_PATTERNS:
+            if pattern.search(value):
+                raise ValueError(
+                    "Support bundle contains a non-shareable diagnostic value."
+                )
+
+
+def build_support_bundle(
+    session: Session,
+    *,
+    settings: Settings,
+    database: Mapping[str, str],
+    sql_generation: Mapping[str, object],
+    generated_at: datetime | None = None,
+) -> SupportBundle:
+    operator_health = build_operator_health(
+        session,
+        database=database,
+        sql_generation=sql_generation,
+    )
+    workflow_lifecycle_metrics = operator_health["workflow_lifecycle_metrics"]
+    assert isinstance(workflow_lifecycle_metrics, dict)
+    history_count, recent_states = _recent_workflow_states(session)
+
+    generated_at = generated_at or datetime.now(timezone.utc)
+    bundle = SupportBundle(
+        generated_at=generated_at.astimezone(timezone.utc),
+        application=SupportBundleApplication(
+            version=_APP_VERSION,
+            environment=settings.environment,
+        ),
+        source_posture=settings.source_posture_telemetry().model_dump(mode="json"),
+        migration_posture=_migration_posture(session),
+        active_sources=_active_sources(session),
+        health=SupportBundleHealth(
+            status=str(operator_health["status"]),
+            components=dict(operator_health["components"]),
+        ),
+        workflow=SupportBundleWorkflow(
+            history_count=history_count,
+            recent_states=recent_states,
+            lifecycle_metrics=workflow_lifecycle_metrics,
+        ),
+        audit_completeness=_audit_completeness(workflow_lifecycle_metrics),
+        redaction=_redaction_policy(),
+    )
+    _assert_bundle_is_shareable(bundle)
+    return bundle

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Iterator
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.core.config import get_settings
+from app.db.base import Base
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
+from app.db.models.source_registry import RegisteredSource
+from app.db.session import require_preview_submission_session
+from app.services.demo_source_seed import seed_demo_source_governance
+from app.services.support_bundle import build_support_bundle
+
+
+@contextmanager
+def _session_scope() -> Iterator[Session]:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        seed_demo_source_governance(session)
+        yield session
+    engine.dispose()
+
+
+def _client(session: Session) -> TestClient:
+    get_settings.cache_clear()
+    main_module = importlib.import_module("app.main")
+    app = main_module.create_app()
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    return TestClient(app)
+
+
+def _add_workflow_records_with_sensitive_payload(session: Session) -> None:
+    source = session.query(RegisteredSource).one()
+    preview_request = PreviewRequest(
+        id=uuid4(),
+        request_id="request-support-bundle",
+        registered_source_id=source.id,
+        source_id=source.source_id,
+        source_family=source.source_family,
+        source_flavor=source.source_flavor,
+        dataset_contract_id=source.dataset_contract_id,
+        dataset_contract_version=1,
+        schema_snapshot_id=source.schema_snapshot_id,
+        schema_snapshot_version=1,
+        authenticated_subject_id="user:demo-local-operator",
+        auth_source="test-helper",
+        session_id="session-support-bundle",
+        governance_bindings="group:safequery-demo-local-operators",
+        entitlement_decision="allow",
+        request_text="Show approved spend",
+        request_state="previewed",
+    )
+    session.add(preview_request)
+    session.flush()
+
+    preview_candidate = PreviewCandidate(
+        id=uuid4(),
+        candidate_id="candidate-support-bundle",
+        preview_request_id=preview_request.id,
+        request_id=preview_request.request_id,
+        registered_source_id=preview_request.registered_source_id,
+        source_id=preview_request.source_id,
+        source_family=preview_request.source_family,
+        source_flavor=preview_request.source_flavor,
+        dataset_contract_id=preview_request.dataset_contract_id,
+        dataset_contract_version=preview_request.dataset_contract_version,
+        schema_snapshot_id=preview_request.schema_snapshot_id,
+        schema_snapshot_version=preview_request.schema_snapshot_version,
+        authenticated_subject_id=preview_request.authenticated_subject_id,
+        candidate_sql="select * from raw_private_rows",
+        guard_status="passed",
+        candidate_state="preview_ready",
+    )
+    session.add(preview_candidate)
+    session.flush()
+
+    session.add(
+        PreviewAuditEvent(
+            event_id=uuid4(),
+            lifecycle_order=4,
+            preview_request_id=preview_request.id,
+            preview_candidate_id=preview_candidate.id,
+            request_id=preview_request.request_id,
+            candidate_id=preview_candidate.candidate_id,
+            event_type="guard_evaluated",
+            occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+            correlation_id="correlation-support-bundle",
+            authenticated_subject_id="user:demo-local-operator",
+            session_id="session-support-bundle",
+            auth_source="test-helper",
+            source_id=preview_request.source_id,
+            source_family=preview_request.source_family,
+            source_flavor=preview_request.source_flavor,
+            dataset_contract_version=preview_request.dataset_contract_version,
+            schema_snapshot_version=preview_request.schema_snapshot_version,
+            candidate_state="preview_ready",
+            audit_payload={
+                "raw_rows": [{"customer_secret": "sk-live-should-not-leak"}],
+                "debug_path": "/".join(
+                    ["", "Users", "example", ".safequery", "private.log"]
+                ),
+                "connection": "postgresql://reader:secret@db:5432/business",
+            },
+        )
+    )
+    session.commit()
+
+
+def _assert_secret_safe(serialized: str) -> None:
+    forbidden_fragments = (
+        "postgresql://",
+        "Driver={ODBC Driver 18 for SQL Server}",
+        "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING",
+        '"connection_reference"',
+        "raw_private_rows",
+        "raw_rows",
+        "customer_secret",
+        "sk-live-should-not-leak",
+        "/".join(["", "Users", "example"]),
+        "\\".join(["", "Users", "example"]),
+        "secret@",
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in serialized
+    assert not re.search(r"(?i)(password|api[_-]?key|secret)", serialized)
+
+
+def test_support_bundle_service_includes_bounded_diagnostics_without_secrets(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv(
+        "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        "postgresql://source_reader:source-secret@pg-source:5432/business",
+    )
+    monkeypatch.setenv(
+        "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING",
+        "Driver={ODBC Driver 18 for SQL Server};Server=tcp:mssql-source,1433;"
+        "Database=business;Uid=safequery_reader;Pwd=source-secret",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_workflow_records_with_sensitive_payload(session)
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )
+
+    payload = bundle.model_dump(mode="json", by_alias=True)
+    assert payload == {
+        "bundleVersion": 1,
+        "generatedAt": "2026-01-02T03:04:05Z",
+        "application": {
+            "service": "safequery-api",
+            "version": "0.1.0",
+            "environment": "development",
+        },
+        "sourcePosture": {
+            "source_posture": "coherent",
+            "configured_source_count": 3,
+            "source_roles": {
+                "application_postgres_persistence": "configured",
+                "business_postgres_source_generation": "configured",
+                "business_mssql_source_execution": "configured",
+            },
+        },
+        "migrationPosture": {
+            "status": "unknown",
+            "detail": "OperationalError",
+            "appliedRevisions": [],
+            "expectedHeads": [],
+        },
+        "activeSources": [
+            {
+                "sourceId": "demo-business-postgres",
+                "sourceFamily": "postgresql",
+                "sourceFlavor": "warehouse",
+                "activationPosture": "active",
+                "datasetContractVersion": 1,
+                "schemaSnapshotVersion": 1,
+            }
+        ],
+        "health": {
+            "status": "ok",
+            "components": {
+                "backend": {"status": "ok", "detail": "ready"},
+                "frontend_api_connection": {"status": "ok", "detail": "reachable"},
+                "generation_adapter": {
+                    "status": "disabled",
+                    "detail": "provider_disabled",
+                    "provider": "unknown",
+                },
+                "source_registry": {
+                    "status": "ok",
+                    "detail": "ready",
+                    "registered_source_count": 1,
+                    "active_source_count": 1,
+                    "postures": {
+                        "active": 1,
+                        "blocked": 0,
+                        "paused": 0,
+                        "retired": 0,
+                    },
+                },
+                "active_source_connectivity": {
+                    "status": "ok",
+                    "detail": "ready",
+                    "active_source_count": 1,
+                    "ready_source_count": 1,
+                    "unavailable_source_count": 0,
+                },
+                "audit_persistence": {"status": "ok", "detail": "ready"},
+            },
+        },
+        "workflow": {
+            "historyCount": 2,
+            "recentStates": [
+                {
+                    "itemType": "candidate",
+                    "lifecycleState": "preview_ready",
+                    "sourceId": "demo-business-postgres",
+                },
+                {
+                    "itemType": "request",
+                    "lifecycleState": "previewed",
+                    "sourceId": "demo-business-postgres",
+                },
+            ],
+            "lifecycleMetrics": {
+                "status": "active",
+                "audit_event_count": 1,
+                "preview": {
+                    "submitted": 0,
+                    "generation_completed": 0,
+                    "generation_failed": 0,
+                    "guard_evaluated": 1,
+                    "terminal_failures": {},
+                },
+                "execute": {
+                    "requested": 0,
+                    "completed": 0,
+                    "denied": 0,
+                    "failed": 0,
+                    "terminal_failures": {},
+                },
+                "audit_persistence": {
+                    "recorded_events": 1,
+                    "sources_with_events": 1,
+                },
+            },
+        },
+        "auditCompleteness": {
+            "status": "present",
+            "recordedEvents": 1,
+            "sourcesWithEvents": 1,
+        },
+        "redaction": {
+            "excluded": [
+                "connection_strings",
+                "raw_credentials",
+                "tokens",
+                "raw_result_rows",
+                "candidate_sql",
+                "workstation_local_paths",
+                "source_connection_references",
+            ]
+        },
+    }
+    _assert_secret_safe(json.dumps(payload, sort_keys=True))
+
+
+def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "check_database_health",
+        lambda _url: {"status": "ok", "detail": "ready"},
+    )
+
+    with _session_scope() as session:
+        response = _client(session).get("/support/bundle")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["bundleVersion"] == 1
+    assert payload["application"] == {
+        "service": "safequery-api",
+        "version": "0.1.0",
+        "environment": "development",
+    }
+    assert payload["activeSources"][0]["sourceId"] == "demo-business-postgres"
+    assert payload["redaction"]["excluded"] == [
+        "connection_strings",
+        "raw_credentials",
+        "tokens",
+        "raw_result_rows",
+        "candidate_sql",
+        "workstation_local_paths",
+        "source_connection_references",
+    ]
+    _assert_secret_safe(response.text)

--- a/docs/pilot-operations-runbook.md
+++ b/docs/pilot-operations-runbook.md
@@ -243,3 +243,47 @@ For degraded, maintenance, incident, and recovery states, record:
 
 Keep durable notes path-hygienic. Use repo-relative command forms and explicit
 placeholders rather than raw workstation-local absolute paths.
+
+## Secret-Safe Support Bundle
+
+Use the support bundle when a pilot reviewer needs bounded diagnostic context
+for normal, degraded, maintenance, or recovery triage and the operator does not
+need to share raw logs, direct database credentials, query result rows, or local
+machine paths.
+
+Generate the bundle from the backend environment that is already configured for
+SafeQuery:
+
+```bash
+cd backend
+python -m app.cli.support_bundle > support-bundle.json
+```
+
+If the backend API is already running, operators can capture the same bounded
+artifact from the served endpoint:
+
+```bash
+curl http://localhost:8000/support/bundle > support-bundle.json
+```
+
+The bundle is intended to include application version, environment, source
+posture, migration posture, active source ids, health components, recent
+workflow state summaries, lifecycle metrics, and audit completeness counts. It
+is intentionally not an export of operator prompts, raw SQL, raw result rows,
+connection strings, tokens, credentials, source connection references, or
+workstation-local absolute paths.
+
+Before sharing the artifact, inspect it as text and stop if it contains a
+credential, token, connection URL, connection string, raw row payload, private
+SQL text, or local user-profile path:
+
+```bash
+python -m json.tool support-bundle.json >/dev/null
+```
+
+Stop and escalate instead of sharing a bundle when the issue concerns suspected
+secret exposure, untrusted auth context, source-binding ambiguity, raw SQL
+execute exposure, missing audit coverage, mixed-snapshot state, or partial
+restore/export behavior. In those cases, preserve the affected request ids,
+candidate ids, audit ids, run ids, source ids, and command outputs, then follow
+the Incident or Recovery sections above.


### PR DESCRIPTION
## Summary
- add a bounded support bundle service, CLI, and GET /support/bundle endpoint
- include app/source/migration/health/workflow/audit summary metadata without raw SQL, rows, credentials, connection strings, source connection references, or local paths
- document pilot support generation, sharing checks, and escalation boundaries

## Verification
- cd backend && python3 -m pytest tests/test_support_bundle.py
- cd backend && python3 -m pytest tests/test_support_bundle.py tests/test_operator_health.py tests/test_operator_workflow_history.py
- cd backend && python3 -m pytest
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- git diff --check
- changed-file scans for raw /Users and \Users literals