### PR TITLE
[Q-6] Align pilot doctor smoke assumptions

### DIFF
--- a/docs/pilot-operations-runbook.md
+++ b/docs/pilot-operations-runbook.md
@@ -45,6 +45,23 @@ signals are blocked states, not soft passes.
 5. Stop or escalate when an execute, guard, audit, source-binding, auth, or
    mixed-state boundary is unclear.
 
+## Command-backed classification signals
+
+Use command-backed evidence when a state depends on local first-run health or
+workflow availability:
+
+| Assumption | Command-backed signal | Manual/operator judgment |
+| --- | --- | --- |
+| First-run control-plane readiness | `python -m app.cli.first_run_doctor` reports `status: pass` and includes `database`, `migrations`, `source_registry`, `dataset_contract`, `schema_snapshot`, `entitlement_seed`, `execution_connector`, `backend`, and `frontend` checks. | Decide whether the current pilot window is allowed to rely on local first-run evidence or needs production deployment evidence. |
+| Live backend health | `curl http://localhost:8000/health` reports `status: ok` with healthy database and operator health components for the local stack. | Decide whether degraded optional components affect the specific pilot path. |
+| Source selector workflow availability | `curl http://localhost:8000/operator/workflow` returns a non-empty active source selector from backend records. | Decide whether the selected source is in the approved pilot scope for the current operator group. |
+| Pilot workflow safety smoke | `bash tests/smoke/test-pilot-safety-ui-api-workflow.sh` passes the local unit-contract smoke path without Docker. | Decide whether compose-backed or real-source smokes are also required for the affected pilot window. |
+| Compose-backed first-run path | `bash tests/smoke/test-compose-operator-workflow-source-selector.sh` passes when Docker and `docker-compose` are available. | Decide whether unavailable host dependencies make this a deferred manual check instead of a failed product signal. |
+
+If a row has no current command-backed signal, record it as Manual/operator
+judgment in the pilot note. Do not infer normal, degraded, maintenance,
+incident, or recovery posture from UI text alone.
+
 ## Incident State Taxonomy
 
 | State | Operational meaning | Pilot posture |

--- a/docs/pilot-safety-verification-checklist.md
+++ b/docs/pilot-safety-verification-checklist.md
@@ -45,6 +45,22 @@ Before Epic K is signed off, a non-developer evaluator should be able to:
 6. Confirm preview submission remains source-scoped and entitlement-gated, while
    execute authority remains candidate-only and not exposed as raw SQL input.
 
+The first-run doctor check names used by docs, smokes, and operator evidence
+are:
+
+- `database`
+- `migrations`
+- `source_registry`
+- `dataset_contract`
+- `schema_snapshot`
+- `entitlement_seed`
+- `execution_connector`
+- `backend`
+- `frontend`
+
+The compose-backed source selector smoke must see each check name in the doctor
+payload before it treats `status: pass` as first-run evidence.
+
 The gate is product-readiness only. It is separate from later Epic L-P work:
 
 - real auth and session bridge wiring

--- a/tests/smoke/test-compose-operator-workflow-source-selector.sh
+++ b/tests/smoke/test-compose-operator-workflow-source-selector.sh
@@ -63,6 +63,22 @@ url = sys.argv[1]
 response_path = sys.argv[2]
 with open(response_path, encoding="utf-8") as response_file:
     payload = json.load(response_file)
+expected_checks = {
+    "database",
+    "migrations",
+    "source_registry",
+    "dataset_contract",
+    "schema_snapshot",
+    "entitlement_seed",
+    "execution_connector",
+    "backend",
+    "frontend",
+}
+actual_checks = {
+    check.get("name")
+    for check in payload.get("checks", [])
+    if isinstance(check, dict)
+}
 if payload.get("status") != "pass":
     failing = [
         {
@@ -76,6 +92,12 @@ if payload.get("status") != "pass":
     raise SystemExit(
         "compose smoke first-run doctor failed: "
         f"{url} reported {json.dumps(failing, sort_keys=True)}"
+    )
+missing_checks = sorted(expected_checks - actual_checks)
+if missing_checks:
+    raise SystemExit(
+        "compose smoke first-run doctor failed: "
+        f"{url} omitted required checks {json.dumps(missing_checks)}"
     )
 PY
 }

--- a/tests/smoke/test-compose-source-selector-doctor-retry.sh
+++ b/tests/smoke/test-compose-source-selector-doctor-retry.sh
@@ -22,6 +22,23 @@ smoke_sleep() {
   :
 }
 
+passing_doctor_payload() {
+  printf '%s\n' '{
+    "status": "pass",
+    "checks": [
+      {"name": "database", "status": "pass", "message": "Application database connectivity is ready."},
+      {"name": "migrations", "status": "pass", "message": "Alembic migration posture is current."},
+      {"name": "source_registry", "status": "pass", "message": "Active demo source registry record is present."},
+      {"name": "dataset_contract", "status": "pass", "message": "Demo source dataset contract linkage is ready."},
+      {"name": "schema_snapshot", "status": "pass", "message": "Demo source schema snapshot is approved."},
+      {"name": "entitlement_seed", "status": "pass", "message": "Dev/local entitlement seed is present."},
+      {"name": "execution_connector", "status": "pass", "message": "Demo source execution connector binding is ready."},
+      {"name": "backend", "status": "pass", "message": "Backend health endpoint is reachable and healthy."},
+      {"name": "frontend", "status": "pass", "message": "Frontend app surface is reachable."}
+    ]
+  }'
+}
+
 doctor_attempts=0
 curl() {
   doctor_attempts=$((doctor_attempts + 1))
@@ -30,7 +47,7 @@ curl() {
     return 0
   fi
 
-  printf '%s\n' '{"status":"pass","checks":[{"name":"frontend","status":"pass","message":"Frontend app is reachable."}]}'
+  passing_doctor_payload
 }
 
 if ! wait_for_first_run_doctor "http://backend.example/doctor/first-run" 3; then
@@ -59,7 +76,7 @@ if [[ "$doctor_attempts" -ne 2 ]]; then
   exit 1
 fi
 
-for expected in '"name": "frontend"' '"status": "fail"' "Frontend app surface is not reachable yet."; do
+for expected in "frontend" "fail" "Frontend app surface is not reachable yet."; do
   if ! grep -Fq "$expected" "$stderr_file"; then
     echo "doctor retry test failed: persistent failure output missing $expected" >&2
     exit 1

--- a/tests/smoke/test-pilot-safety-checklist.sh
+++ b/tests/smoke/test-pilot-safety-checklist.sh
@@ -117,11 +117,15 @@ runbook_required_patterns=(
   "stop or escalate"
   "Command-backed classification signals"
   "Manual/operator judgment"
+  "database"
+  "migrations"
   "source_registry"
   "dataset_contract"
   "schema_snapshot"
   "entitlement_seed"
   "execution_connector"
+  "backend"
+  "frontend"
 )
 
 for pattern in "${runbook_required_patterns[@]}"; do

--- a/tests/smoke/test-pilot-safety-checklist.sh
+++ b/tests/smoke/test-pilot-safety-checklist.sh
@@ -42,6 +42,12 @@ required_patterns=(
   "first-run doctor"
   "backend health"
   "frontend health"
+  "database"
+  "source_registry"
+  "dataset_contract"
+  "schema_snapshot"
+  "entitlement_seed"
+  "execution_connector"
   "non-empty active source selector"
   "does not mean real LLM generation or real SQL execution is production-ready"
   "MSSQL"
@@ -109,6 +115,13 @@ runbook_required_patterns=(
   "operator-facing symptoms"
   "safe first checks"
   "stop or escalate"
+  "Command-backed classification signals"
+  "Manual/operator judgment"
+  "source_registry"
+  "dataset_contract"
+  "schema_snapshot"
+  "entitlement_seed"
+  "execution_connector"
 )
 
 for pattern in "${runbook_required_patterns[@]}"; do


### PR DESCRIPTION
## Summary
- require the compose first-run doctor smoke to see the shared doctor check-name contract before accepting `status: pass`
- document the same doctor check names in the pilot checklist
- add runbook guidance that separates command-backed classification signals from Manual/operator judgment

## Verification
- `bash tests/smoke/test-pilot-safety-checklist.sh`
- `bash tests/smoke/test-local-startup-docs.sh`
- `bash tests/smoke/test-compose-source-selector-doctor-retry.sh`
- `cd backend && python3 -m pytest tests/test_first_run_doctor.py -q`
- `bash tests/smoke/test-pilot-safety-ui-api-workflow.sh`

Closes #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance to classify pilots using command-backed health checks and require recording manual/operator judgment when no command signal exists
  * Documented the set of required system check names and validation rules for safety verification
  * Expanded runbook and checklist coverage for storage, execution connectors, database/migrations, and backend/frontend sections

* **Tests**
  * Tightened smoke tests to verify required check names in health responses and ensure updated documentation content appears in safety docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->