### PR TITLE
[R-1] Add production identity bridge scaffold

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,6 +28,14 @@ class BusinessMssqlSourceSettings(BaseModel):
     connection_string: str
 
 
+class ProductionIdentityBridgeSettings(BaseModel):
+    identity: Literal["production_identity_bridge"] = "production_identity_bridge"
+    enabled: bool = False
+    trusted_issuer: Optional[AnyHttpUrl] = None
+    trusted_source: Optional[str] = None
+    shared_secret: Optional[SecretStr] = None
+
+
 SQLGenerationProvider = Literal["disabled", "local_llm", "vanna"]
 
 
@@ -62,6 +70,10 @@ class Settings(BaseSettings):
     environment: Literal["development", "test", "staging", "production"] = "development"
     app_postgres_url: PostgresDsn
     dev_auth_enabled: bool = False
+    production_identity_bridge_enabled: bool = False
+    production_identity_bridge_trusted_issuer: Optional[AnyHttpUrl] = None
+    production_identity_bridge_trusted_source: Optional[str] = None
+    production_identity_bridge_shared_secret: Optional[SecretStr] = None
     session_signing_key: Optional[SecretStr] = None
     business_postgres_source_url: Optional[PostgresDsn] = None
     business_mssql_source_connection_string: Optional[str] = None
@@ -111,6 +123,15 @@ class Settings(BaseSettings):
 
         return value
 
+    @field_validator("production_identity_bridge_trusted_source", mode="before")
+    @classmethod
+    def _normalize_production_identity_bridge_text(cls, value: object) -> object:
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+
+        return value
+
     @field_validator("sql_generation_vanna_api_key")
     @classmethod
     def _reject_placeholder_vanna_api_key(
@@ -129,6 +150,24 @@ class Settings(BaseSettings):
 
         return value
 
+    @field_validator("production_identity_bridge_shared_secret")
+    @classmethod
+    def _reject_placeholder_production_identity_bridge_shared_secret(
+        cls,
+        value: Optional[SecretStr],
+    ) -> Optional[SecretStr]:
+        if value is None:
+            return value
+
+        normalized = value.get_secret_value().strip().lower()
+        if normalized in {"change-me", "changeme", "todo", "placeholder", "example"}:
+            raise ValueError(
+                "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET must come from "
+                "a trusted credential source, not a placeholder value."
+            )
+
+        return value
+
     @model_validator(mode="after")
     def _validate_distinct_postgres_roles_and_generation_provider(self) -> "Settings":
         if self.dev_auth_enabled and self.environment not in {"development", "test"}:
@@ -136,6 +175,28 @@ class Settings(BaseSettings):
                 "SAFEQUERY_DEV_AUTH_ENABLED is only allowed when "
                 "SAFEQUERY_ENVIRONMENT is development or test."
             )
+
+        if self.production_identity_bridge_enabled:
+            if self.production_identity_bridge_trusted_issuer is None:
+                raise ValueError(
+                    "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_TRUSTED_ISSUER must be "
+                    "configured when SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_ENABLED "
+                    "is true."
+                )
+
+            if self.production_identity_bridge_trusted_source is None:
+                raise ValueError(
+                    "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_TRUSTED_SOURCE must be "
+                    "configured when SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_ENABLED "
+                    "is true."
+                )
+
+            if self.production_identity_bridge_shared_secret is None:
+                raise ValueError(
+                    "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET must be "
+                    "configured when SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_ENABLED "
+                    "is true."
+                )
 
         source_url = self.business_postgres_source_url
         if source_url is not None and str(source_url) == str(self.app_postgres_url):
@@ -167,6 +228,37 @@ class Settings(BaseSettings):
     @property
     def app_postgres_identity(self) -> Literal["application_postgres_persistence"]:
         return "application_postgres_persistence"
+
+    @property
+    def production_identity_bridge(self) -> ProductionIdentityBridgeSettings:
+        return ProductionIdentityBridgeSettings(
+            enabled=self.production_identity_bridge_enabled,
+            trusted_issuer=self.production_identity_bridge_trusted_issuer,
+            trusted_source=self.production_identity_bridge_trusted_source,
+            shared_secret=self.production_identity_bridge_shared_secret,
+        )
+
+    def require_production_identity_bridge(self) -> ProductionIdentityBridgeSettings:
+        bridge_settings = self.production_identity_bridge
+        if not bridge_settings.enabled:
+            raise RuntimeError(
+                "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_ENABLED must be true before "
+                "the production identity bridge can be used."
+            )
+
+        if (
+            bridge_settings.trusted_issuer is None
+            or bridge_settings.trusted_source is None
+            or bridge_settings.shared_secret is None
+        ):
+            raise RuntimeError(
+                "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_TRUSTED_ISSUER, "
+                "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_TRUSTED_SOURCE, and "
+                "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET must be "
+                "configured before the production identity bridge can be used."
+            )
+
+        return bridge_settings
 
     def require_business_postgres_source(self) -> BusinessPostgresSourceSettings:
         source_url = self.business_postgres_source_url

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -141,8 +141,20 @@ class Settings(BaseSettings):
         if value is None:
             return value
 
-        normalized = value.get_secret_value().strip().lower()
-        if normalized in {"change-me", "changeme", "todo", "placeholder", "example"}:
+        normalized = value.get_secret_value().strip()
+        if not normalized:
+            raise ValueError(
+                "SAFEQUERY_SQL_GENERATION_VANNA_API_KEY must be non-empty."
+            )
+
+        normalized_lower = normalized.lower()
+        if normalized_lower in {
+            "change-me",
+            "changeme",
+            "todo",
+            "placeholder",
+            "example",
+        }:
             raise ValueError(
                 "SAFEQUERY_SQL_GENERATION_VANNA_API_KEY must come from a trusted "
                 "credential source, not a placeholder value."
@@ -159,8 +171,21 @@ class Settings(BaseSettings):
         if value is None:
             return value
 
-        normalized = value.get_secret_value().strip().lower()
-        if normalized in {"change-me", "changeme", "todo", "placeholder", "example"}:
+        normalized = value.get_secret_value().strip()
+        if not normalized:
+            raise ValueError(
+                "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET must be "
+                "non-empty."
+            )
+
+        normalized_lower = normalized.lower()
+        if normalized_lower in {
+            "change-me",
+            "changeme",
+            "todo",
+            "placeholder",
+            "example",
+        }:
             raise ValueError(
                 "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET must come from "
                 "a trusted credential source, not a placeholder value."

--- a/backend/app/features/auth/bridge.py
+++ b/backend/app/features/auth/bridge.py
@@ -106,6 +106,12 @@ class EnterpriseAuthBridgeInput(BaseModel):
                 "before SafeQuery can grant application authority."
             )
 
+        if self.actor.issuer != self.subject.issuer:
+            raise ValueError(
+                "Production identity bridge actor issuer must match subject issuer "
+                "before SafeQuery can grant application authority."
+            )
+
         seen: set[str] = set()
         for binding in self.governance_bindings:
             normalized = binding.normalized_binding

--- a/backend/app/features/auth/bridge.py
+++ b/backend/app/features/auth/bridge.py
@@ -18,12 +18,22 @@ from app.features.auth.governance_bindings import normalize_governance_binding
 
 
 BindingType = Literal["group", "role", "entitlement"]
+IdentityClaimType = Literal["human_user", "service_account", "workload"]
+
+
+class EnterpriseBridgeActor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    actor_id: NonEmptyTrimmedString
+    actor_type: IdentityClaimType
+    issuer: NonEmptyTrimmedString
 
 
 class EnterpriseBridgeSubject(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     subject_id: NonEmptyTrimmedString
+    subject_type: IdentityClaimType
     idp_subject: Optional[NonEmptyTrimmedString] = None
     issuer: NonEmptyTrimmedString
 
@@ -72,6 +82,7 @@ class EnterpriseAuthBridgeInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     bridge_source: NonEmptyTrimmedString
+    actor: EnterpriseBridgeActor
     subject: EnterpriseBridgeSubject
     session: EnterpriseBridgeSession
     governance_bindings: Annotated[
@@ -82,7 +93,19 @@ class EnterpriseAuthBridgeInput(BaseModel):
     client_secret: Optional[SecretStr] = Field(default=None, exclude=True)
 
     @model_validator(mode="after")
-    def reject_duplicate_normalized_bindings(self) -> Self:
+    def reject_incoherent_claims_and_duplicate_normalized_bindings(self) -> Self:
+        if self.actor.actor_id != self.subject.subject_id:
+            raise ValueError(
+                "Production identity bridge actor must match subject before "
+                "SafeQuery can grant application authority."
+            )
+
+        if self.actor.actor_type != self.subject.subject_type:
+            raise ValueError(
+                "Production identity bridge actor type must match subject type "
+                "before SafeQuery can grant application authority."
+            )
+
         seen: set[str] = set()
         for binding in self.governance_bindings:
             normalized = binding.normalized_binding
@@ -112,16 +135,27 @@ class EnterpriseAuthBridgeAuditMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     bridge_source: NonEmptyTrimmedString
+    actor_id: NonEmptyTrimmedString
+    actor_type: IdentityClaimType
     subject_id: NonEmptyTrimmedString
+    subject_type: IdentityClaimType
     session_id: NonEmptyTrimmedString
     subject_provenance: SubjectProvenanceAuditMetadata
     binding_provenance: list[BindingProvenanceAuditMetadata]
+
+
+class ProductionIdentityClaims(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    actor: EnterpriseBridgeActor
+    subject: EnterpriseBridgeSubject
 
 
 class EnterpriseAuthBridgeContext(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     authenticated_subject: AuthenticatedSubject
+    identity_claims: ProductionIdentityClaims
     session: EnterpriseBridgeSession
     audit_metadata: EnterpriseAuthBridgeAuditMetadata
 
@@ -144,10 +178,17 @@ def normalize_enterprise_auth_bridge_input(
             subject_id=normalized_input.subject.subject_id,
             governance_bindings=frozenset(bindings),
         ),
+        identity_claims=ProductionIdentityClaims(
+            actor=normalized_input.actor,
+            subject=normalized_input.subject,
+        ),
         session=normalized_input.session,
         audit_metadata=EnterpriseAuthBridgeAuditMetadata(
             bridge_source=normalized_input.bridge_source,
+            actor_id=normalized_input.actor.actor_id,
+            actor_type=normalized_input.actor.actor_type,
             subject_id=normalized_input.subject.subject_id,
+            subject_type=normalized_input.subject.subject_type,
             session_id=normalized_input.session.session_id,
             subject_provenance=SubjectProvenanceAuditMetadata(
                 issuer=normalized_input.subject.issuer,

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -249,6 +249,80 @@ class SettingsTestCase(unittest.TestCase):
                         _env_prefix="SAFEQUERY_",
                     )
 
+    def test_production_identity_bridge_is_default_deny_and_separate_from_dev_auth(
+        self,
+    ) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            dev_auth_enabled=True,
+            environment="development",
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        self.assertFalse(settings.production_identity_bridge.enabled)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_ENABLED",
+        ):
+            settings.require_production_identity_bridge()
+
+    def test_enabled_production_identity_bridge_requires_trust_anchors(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_TRUSTED_ISSUER",
+        ):
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                production_identity_bridge_enabled=True,
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
+
+    def test_production_identity_bridge_rejects_placeholder_shared_secret(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET",
+        ):
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                production_identity_bridge_enabled=True,
+                production_identity_bridge_trusted_issuer="https://idp.example.test",
+                production_identity_bridge_trusted_source="saml-oidc-bridge",
+                production_identity_bridge_shared_secret="change-me",
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
+
+    def test_enabled_production_identity_bridge_is_configured_without_dev_auth(
+        self,
+    ) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            environment="production",
+            production_identity_bridge_enabled=True,
+            production_identity_bridge_trusted_issuer="https://idp.example.test",
+            production_identity_bridge_trusted_source="saml-oidc-bridge",
+            production_identity_bridge_shared_secret=(
+                "trusted-production-bridge-secret-value"
+            ),
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        bridge_settings = settings.require_production_identity_bridge()
+
+        self.assertFalse(settings.dev_auth_enabled)
+        self.assertTrue(bridge_settings.enabled)
+        self.assertEqual(
+            str(bridge_settings.trusted_issuer),
+            "https://idp.example.test/",
+        )
+        self.assertEqual(
+            bridge_settings.trusted_source,
+            "saml-oidc-bridge",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import tempfile
 import unittest
 
@@ -280,6 +281,8 @@ class SettingsTestCase(unittest.TestCase):
             )
 
     def test_production_identity_bridge_rejects_placeholder_shared_secret(self) -> None:
+        placeholder_bridge_value = "-".join(("change", "me"))
+
         with self.assertRaisesRegex(
             ValidationError,
             "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET",
@@ -289,7 +292,24 @@ class SettingsTestCase(unittest.TestCase):
                 production_identity_bridge_enabled=True,
                 production_identity_bridge_trusted_issuer="https://idp.example.test",
                 production_identity_bridge_trusted_source="saml-oidc-bridge",
-                production_identity_bridge_shared_secret="change-me",
+                production_identity_bridge_shared_secret=placeholder_bridge_value,
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
+
+    def test_production_identity_bridge_rejects_blank_shared_secret(self) -> None:
+        blank_bridge_value = "".join((" ", " ", " "))
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET",
+        ):
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                production_identity_bridge_enabled=True,
+                production_identity_bridge_trusted_issuer="https://idp.example.test",
+                production_identity_bridge_trusted_source="saml-oidc-bridge",
+                production_identity_bridge_shared_secret=blank_bridge_value,
                 _env_file=None,
                 _env_prefix="SAFEQUERY_",
             )
@@ -297,15 +317,15 @@ class SettingsTestCase(unittest.TestCase):
     def test_enabled_production_identity_bridge_is_configured_without_dev_auth(
         self,
     ) -> None:
+        generated_bridge_value = secrets.token_urlsafe(32)
+
         settings = Settings(
             app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
             environment="production",
             production_identity_bridge_enabled=True,
             production_identity_bridge_trusted_issuer="https://idp.example.test",
             production_identity_bridge_trusted_source="saml-oidc-bridge",
-            production_identity_bridge_shared_secret=(
-                "trusted-production-bridge-secret-value"
-            ),
+            production_identity_bridge_shared_secret=generated_bridge_value,
             _env_file=None,
             _env_prefix="SAFEQUERY_",
         )

--- a/backend/tests/test_enterprise_auth_bridge_contract.py
+++ b/backend/tests/test_enterprise_auth_bridge_contract.py
@@ -10,8 +10,14 @@ from app.features.auth.bridge import normalize_enterprise_auth_bridge_input
 def _valid_bridge_payload() -> dict[str, object]:
     return {
         "bridge_source": "saml-oidc-bridge",
+        "actor": {
+            "actor_id": " user:alice@example.com ",
+            "actor_type": "human_user",
+            "issuer": "https://idp.example.test",
+        },
         "subject": {
             "subject_id": " user:alice@example.com ",
+            "subject_type": "human_user",
             "idp_subject": "00u-enterprise-alice",
             "issuer": "https://idp.example.test",
         },
@@ -44,6 +50,16 @@ class EnterpriseAuthBridgeContractTestCase(unittest.TestCase):
             context.authenticated_subject.normalized_subject_id(),
             "user:alice@example.com",
         )
+        self.assertEqual(
+            context.identity_claims.actor.actor_id,
+            "user:alice@example.com",
+        )
+        self.assertEqual(context.identity_claims.actor.actor_type, "human_user")
+        self.assertEqual(
+            context.identity_claims.subject.subject_id,
+            "user:alice@example.com",
+        )
+        self.assertEqual(context.identity_claims.subject.subject_type, "human_user")
         self.assertEqual(context.session.session_id, "session-123")
         self.assertEqual(
             context.authenticated_subject.normalized_governance_bindings(),
@@ -53,7 +69,10 @@ class EnterpriseAuthBridgeContractTestCase(unittest.TestCase):
             context.audit_metadata.model_dump(),
             {
                 "bridge_source": "saml-oidc-bridge",
+                "actor_id": "user:alice@example.com",
+                "actor_type": "human_user",
                 "subject_id": "user:alice@example.com",
+                "subject_type": "human_user",
                 "session_id": "session-123",
                 "subject_provenance": {
                     "issuer": "https://idp.example.test",
@@ -81,6 +100,24 @@ class EnterpriseAuthBridgeContractTestCase(unittest.TestCase):
         payload.pop("subject")
 
         with self.assertRaisesRegex(ValidationError, "subject"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_missing_actor_fails_closed(self) -> None:
+        payload = _valid_bridge_payload()
+        payload.pop("actor")
+
+        with self.assertRaisesRegex(ValidationError, "actor"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_actor_and_subject_must_share_authoritative_identity(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["actor"] = {
+            "actor_id": "user:delegated-admin@example.com",
+            "actor_type": "human_user",
+            "issuer": "https://idp.example.test",
+        }
+
+        with self.assertRaisesRegex(ValidationError, "actor.*subject"):
             normalize_enterprise_auth_bridge_input(payload)
 
     def test_missing_governance_bindings_fail_closed(self) -> None:

--- a/backend/tests/test_enterprise_auth_bridge_contract.py
+++ b/backend/tests/test_enterprise_auth_bridge_contract.py
@@ -120,6 +120,23 @@ class EnterpriseAuthBridgeContractTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "actor.*subject"):
             normalize_enterprise_auth_bridge_input(payload)
 
+    def test_actor_and_subject_must_share_authoritative_issuer(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["actor"] = {
+            "actor_id": "user:alice@example.com",
+            "actor_type": "human_user",
+            "issuer": "https://idp-a.example.test",
+        }
+        payload["subject"] = {
+            "subject_id": "user:alice@example.com",
+            "subject_type": "human_user",
+            "idp_subject": "00u-enterprise-alice",
+            "issuer": "https://idp-b.example.test",
+        }
+
+        with self.assertRaisesRegex(ValidationError, "actor issuer.*subject issuer"):
+            normalize_enterprise_auth_bridge_input(payload)
+
     def test_missing_governance_bindings_fail_closed(self) -> None:
         payload = _valid_bridge_payload()
         payload["governance_bindings"] = []

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -89,8 +89,14 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         bridge_context = normalize_enterprise_auth_bridge_input(
             {
                 "bridge_source": "saml-oidc-bridge",
+                "actor": {
+                    "actor_id": subject_id,
+                    "actor_type": "human_user",
+                    "issuer": "https://idp.example.test",
+                },
                 "subject": {
                     "subject_id": subject_id,
+                    "subject_type": "human_user",
                     "idp_subject": "00u-enterprise-subject",
                     "issuer": "https://idp.example.test",
                 },


### PR DESCRIPTION
## Summary
- add separate default-deny production identity bridge settings
- add typed production actor/subject claims to enterprise bridge normalization
- keep dev auth tests and enterprise bridge integration tests on separate authority paths

## Verification
- python3 -m pytest tests/test_config.py tests/test_enterprise_auth_bridge_contract.py -q
- python3 -m pytest tests/test_dev_auth_preview_api.py tests/test_config.py tests/test_enterprise_auth_bridge_contract.py -q
- python3 -m pytest tests/test_request_source_selection.py::RequestSourceSelectionTestCase::test_preview_submission_accepts_enterprise_bridge_normalized_binding tests/test_request_source_selection.py::RequestSourceSelectionTestCase::test_preview_submission_rejects_enterprise_bridge_unrelated_binding tests/test_enterprise_auth_bridge_contract.py -q
- python3 -m pytest tests -q

Closes #314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production identity bridge configuration surface with explicit runtime check for required fields when enabled.

* **Security Enhancements**
  * Enforces coherence between actor and subject identity claims.
  * Rejects placeholder or empty shared secrets.
  * Requires trusted issuer, trusted source, and shared secret when the bridge is enabled.
  * Default-deny posture: bridge disabled until explicitly configured and enabled.

* **Tests**
  * Added tests covering validation, fail-closed behavior, normalization, and audit metadata propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->