### PR TITLE
Add verifiable enterprise governance mappings

### DIFF
--- a/backend/app/features/auth/bridge.py
+++ b/backend/app/features/auth/bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Literal, Mapping, Optional
 
 from pydantic import (
@@ -19,6 +20,29 @@ from app.features.auth.governance_bindings import normalize_governance_binding
 
 BindingType = Literal["group", "role", "entitlement"]
 IdentityClaimType = Literal["human_user", "service_account", "workload"]
+MappingState = Literal["valid", "stale", "missing", "ambiguous", "unsupported"]
+
+
+_WORKSTATION_LOCAL_PATH_RE = re.compile(
+    r"(^|\s)(/Users/[^/\s]+/|/home/[^/\s]+/|[A-Za-z]:\\Users\\[^\\\s]+\\)"
+)
+_SECRET_MARKERS = frozenset(
+    {"-----begin", "client_secret", "password", "private_key", "secret=", "token="}
+)
+
+
+def _reject_unsafe_evidence_text(value: str) -> str:
+    if _WORKSTATION_LOCAL_PATH_RE.search(value):
+        raise ValueError(
+            "Enterprise mapping evidence must not contain workstation-local paths."
+        )
+
+    lowered = value.lower()
+    if any(marker in lowered for marker in _SECRET_MARKERS):
+        raise ValueError(
+            "Enterprise mapping evidence must not contain secrets or credentials."
+        )
+    return value
 
 
 class EnterpriseBridgeActor(BaseModel):
@@ -51,6 +75,8 @@ class EnterpriseGovernanceBindingInput(BaseModel):
     binding_type: BindingType
     value: NonEmptyTrimmedString
     source_claim: NonEmptyTrimmedString
+    mapping_state: MappingState = "valid"
+    mapping_evidence: Optional["EnterpriseGovernanceMappingEvidence"] = None
 
     @field_validator("value")
     @classmethod
@@ -62,12 +88,47 @@ class EnterpriseGovernanceBindingInput(BaseModel):
             )
         return value
 
+    @model_validator(mode="after")
+    def require_verifiable_current_mapping(self) -> Self:
+        if self.mapping_state != "valid":
+            raise ValueError(
+                "Enterprise governance mapping is "
+                f"{self.mapping_state}; explicit review is required before "
+                "SafeQuery can grant application authority."
+            )
+
+        if self.mapping_evidence is None:
+            raise ValueError(
+                "Enterprise governance mapping evidence is missing; explicit "
+                "review is required before SafeQuery can grant application authority."
+            )
+        return self
+
     @property
     def normalized_binding(self) -> str:
         normalized = normalize_governance_binding(f"{self.binding_type}:{self.value}")
         if normalized is None:
             raise ValueError("Governance binding is malformed.")
         return normalized
+
+
+class EnterpriseGovernanceMappingEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    claim_issuer: NonEmptyTrimmedString
+    claim_value_fingerprint: NonEmptyTrimmedString
+    mapping_rule_id: NonEmptyTrimmedString
+    review_state: NonEmptyTrimmedString
+
+    @field_validator(
+        "claim_issuer",
+        "claim_value_fingerprint",
+        "mapping_rule_id",
+        "review_state",
+    )
+    @classmethod
+    def reject_unsafe_evidence_text(cls, value: str) -> str:
+        return _reject_unsafe_evidence_text(value)
 
 
 class EnterpriseAuthBridgeInput(BaseModel):
@@ -135,6 +196,8 @@ class BindingProvenanceAuditMetadata(BaseModel):
     binding_type: BindingType
     source_claim: NonEmptyTrimmedString
     bridge_source: NonEmptyTrimmedString
+    mapping_state: MappingState
+    mapping_evidence: EnterpriseGovernanceMappingEvidence
 
 
 class EnterpriseAuthBridgeAuditMetadata(BaseModel):
@@ -206,6 +269,8 @@ def normalize_enterprise_auth_bridge_input(
                     binding_type=binding.binding_type,
                     source_claim=binding.source_claim,
                     bridge_source=normalized_input.bridge_source,
+                    mapping_state=binding.mapping_state,
+                    mapping_evidence=binding.mapping_evidence,
                 )
                 for binding in normalized_input.governance_bindings
             ],

--- a/backend/app/features/auth/bridge.py
+++ b/backend/app/features/auth/bridge.py
@@ -23,8 +23,15 @@ IdentityClaimType = Literal["human_user", "service_account", "workload"]
 MappingState = Literal["valid", "stale", "missing", "ambiguous", "unsupported"]
 
 
+_POSIX_USER_HOME_PATH_PATTERNS = (
+    "/" + "Users" + r"/[^/\s]+/",
+    "/" + "home" + r"/[^/\s]+/",
+)
+_WINDOWS_USER_HOME_PATH_PATTERN = r"[A-Za-z]:\\" + "Users" + r"\\[^\\\s]+\\"
 _WORKSTATION_LOCAL_PATH_RE = re.compile(
-    r"(^|\s)(/Users/[^/\s]+/|/home/[^/\s]+/|[A-Za-z]:\\Users\\[^\\\s]+\\)"
+    r"(^|\s)("
+    + "|".join((*_POSIX_USER_HOME_PATH_PATTERNS, _WINDOWS_USER_HOME_PATH_PATTERN))
+    + r")"
 )
 _SECRET_MARKERS = frozenset(
     {"-----begin", "client_secret", "password", "private_key", "secret=", "token="}

--- a/backend/tests/test_enterprise_auth_bridge_contract.py
+++ b/backend/tests/test_enterprise_auth_bridge_contract.py
@@ -7,6 +7,15 @@ from pydantic import ValidationError
 from app.features.auth.bridge import normalize_enterprise_auth_bridge_input
 
 
+def _mapping_evidence(rule_id: str, review_state: str = "current") -> dict[str, str]:
+    return {
+        "claim_issuer": "https://idp.example.test",
+        "claim_value_fingerprint": f"sha256:{rule_id}",
+        "mapping_rule_id": rule_id,
+        "review_state": review_state,
+    }
+
+
 def _valid_bridge_payload() -> dict[str, object]:
     return {
         "bridge_source": "saml-oidc-bridge",
@@ -30,11 +39,15 @@ def _valid_bridge_payload() -> dict[str, object]:
                 "binding_type": "group",
                 "value": " finance-analysts ",
                 "source_claim": "groups",
+                "mapping_state": "valid",
+                "mapping_evidence": _mapping_evidence("rule-finance-analysts-v1"),
             },
             {
                 "binding_type": "role",
                 "value": " sql-reviewer ",
                 "source_claim": "roles",
+                "mapping_state": "valid",
+                "mapping_evidence": _mapping_evidence("rule-sql-reviewer-v1"),
             },
         ],
         "raw_token": "<bridge-token-redacted>",
@@ -84,16 +97,187 @@ class EnterpriseAuthBridgeContractTestCase(unittest.TestCase):
                         "binding_type": "group",
                         "source_claim": "groups",
                         "bridge_source": "saml-oidc-bridge",
+                        "mapping_state": "valid",
+                        "mapping_evidence": {
+                            "claim_issuer": "https://idp.example.test",
+                            "claim_value_fingerprint": (
+                                "sha256:rule-finance-analysts-v1"
+                            ),
+                            "mapping_rule_id": "rule-finance-analysts-v1",
+                            "review_state": "current",
+                        },
                     },
                     {
                         "binding": "role:sql-reviewer",
                         "binding_type": "role",
                         "source_claim": "roles",
                         "bridge_source": "saml-oidc-bridge",
+                        "mapping_state": "valid",
+                        "mapping_evidence": {
+                            "claim_issuer": "https://idp.example.test",
+                            "claim_value_fingerprint": "sha256:rule-sql-reviewer-v1",
+                            "mapping_rule_id": "rule-sql-reviewer-v1",
+                            "review_state": "current",
+                        },
                     },
                 ],
             },
         )
+
+    def test_valid_enterprise_mapping_produces_typed_binding_evidence(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+                "mapping_state": "valid",
+                "mapping_evidence": {
+                    "claim_issuer": "https://idp.example.test",
+                    "claim_value_fingerprint": "sha256:finance-analysts",
+                    "mapping_rule_id": "rule-finance-analysts-v1",
+                    "review_state": "current",
+                },
+            }
+        ]
+
+        context = normalize_enterprise_auth_bridge_input(payload)
+
+        self.assertEqual(
+            context.authenticated_subject.normalized_governance_bindings(),
+            frozenset({"group:finance-analysts"}),
+        )
+        self.assertEqual(
+            context.audit_metadata.binding_provenance[0].model_dump(),
+            {
+                "binding": "group:finance-analysts",
+                "binding_type": "group",
+                "source_claim": "groups",
+                "bridge_source": "saml-oidc-bridge",
+                "mapping_state": "valid",
+                "mapping_evidence": {
+                    "claim_issuer": "https://idp.example.test",
+                    "claim_value_fingerprint": "sha256:finance-analysts",
+                    "mapping_rule_id": "rule-finance-analysts-v1",
+                    "review_state": "current",
+                },
+            },
+        )
+
+    def test_stale_mapping_fails_closed_with_explicit_state(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+                "mapping_state": "stale",
+                "mapping_evidence": {
+                    "claim_issuer": "https://idp.example.test",
+                    "claim_value_fingerprint": "sha256:finance-analysts",
+                    "mapping_rule_id": "rule-finance-analysts-v1",
+                    "review_state": "expired",
+                },
+            }
+        ]
+
+        with self.assertRaisesRegex(ValidationError, "stale"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_ambiguous_mapping_fails_closed_with_explicit_state(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+                "mapping_state": "ambiguous",
+                "mapping_evidence": {
+                    "claim_issuer": "https://idp.example.test",
+                    "claim_value_fingerprint": "sha256:finance-analysts",
+                    "mapping_rule_id": "rule-conflict-v1",
+                    "review_state": "multiple_matches",
+                },
+            }
+        ]
+
+        with self.assertRaisesRegex(ValidationError, "ambiguous"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_unsupported_mapping_fails_closed_with_explicit_state(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+                "mapping_state": "unsupported",
+                "mapping_evidence": {
+                    "claim_issuer": "https://idp.example.test",
+                    "claim_value_fingerprint": "sha256:finance-analysts",
+                    "mapping_rule_id": "rule-unsupported-v1",
+                    "review_state": "unsupported_claim",
+                },
+            }
+        ]
+
+        with self.assertRaisesRegex(ValidationError, "unsupported"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_missing_mapping_evidence_fails_closed(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+                "mapping_state": "missing",
+            }
+        ]
+
+        with self.assertRaisesRegex(ValidationError, "missing"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_mapping_evidence_rejects_workstation_local_paths(self) -> None:
+        payload = _valid_bridge_payload()
+        local_path = "/" + "Users" + "/" + "alice" + "/SafeQuery/mapping.json"
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+                "mapping_state": "valid",
+                "mapping_evidence": {
+                    "claim_issuer": "https://idp.example.test",
+                    "claim_value_fingerprint": "sha256:finance-analysts",
+                    "mapping_rule_id": local_path,
+                    "review_state": "current",
+                },
+            }
+        ]
+
+        with self.assertRaisesRegex(ValidationError, "workstation-local paths"):
+            normalize_enterprise_auth_bridge_input(payload)
+
+    def test_mapping_evidence_rejects_secret_markers(self) -> None:
+        payload = _valid_bridge_payload()
+        payload["governance_bindings"] = [
+            {
+                "binding_type": "group",
+                "value": "finance-analysts",
+                "source_claim": "groups",
+                "mapping_state": "valid",
+                "mapping_evidence": {
+                    "claim_issuer": "https://idp.example.test",
+                    "claim_value_fingerprint": "token=raw-idp-token",
+                    "mapping_rule_id": "rule-finance-analysts-v1",
+                    "review_state": "current",
+                },
+            }
+        ]
+
+        with self.assertRaisesRegex(ValidationError, "secrets or credentials"):
+            normalize_enterprise_auth_bridge_input(payload)
 
     def test_missing_subject_fails_closed(self) -> None:
         payload = _valid_bridge_payload()
@@ -151,11 +335,15 @@ class EnterpriseAuthBridgeContractTestCase(unittest.TestCase):
                 "binding_type": "group",
                 "value": "finance-analysts",
                 "source_claim": "groups",
+                "mapping_state": "valid",
+                "mapping_evidence": _mapping_evidence("rule-finance-analysts-v1"),
             },
             {
                 "binding_type": "group",
                 "value": " finance-analysts ",
                 "source_claim": "groups",
+                "mapping_state": "valid",
+                "mapping_evidence": _mapping_evidence("rule-finance-analysts-copy-v1"),
             },
         ]
 

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -109,6 +109,13 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                         "binding_type": binding_type,
                         "value": binding_value,
                         "source_claim": "groups",
+                        "mapping_state": "valid",
+                        "mapping_evidence": {
+                            "claim_issuer": "https://idp.example.test",
+                            "claim_value_fingerprint": f"sha256:{binding_value}",
+                            "mapping_rule_id": f"rule-{binding_value}-v1",
+                            "review_state": "current",
+                        },
                     },
                 ],
             }


### PR DESCRIPTION
## Summary
- require enterprise governance mappings to include typed current mapping evidence before creating authenticated bindings
- fail closed for stale, missing, ambiguous, unsupported, workstation-local path, and credential-marker mapping evidence states
- update enterprise bridge request-selection fixtures to preserve existing entitlement-gate coverage

## Verification
- cd backend && python3 -m pytest tests/test_enterprise_auth_bridge_contract.py
- cd backend && python3 -m pytest tests/test_enterprise_auth_bridge_contract.py tests/test_source_entitlements.py tests/test_audit_event_model.py tests/test_dev_auth_preview_api.py tests/test_preview_source_governance_resolution.py
- cd backend && python3 -m pytest tests/test_request_source_selection.py tests/test_enterprise_auth_bridge_contract.py
- cd backend && python3 -m pytest
- python3 -m pytest tests/test_check_repository_hygiene.py

Closes #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced enterprise governance mapping validation with state tracking and evidence verification
  * Added security checks to prevent unsafe mapping configurations containing local paths or credential markers
  * Improved audit logging to capture governance mapping status and supporting evidence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->