### PR TITLE
[R-3] Generate source-aware audit export bundles

### DIFF
--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -400,6 +400,8 @@ def _audit_event_sort_key(event: PreviewAuditEvent) -> tuple[datetime, int, str]
 
 def _payload_non_negative_int(payload: Mapping[str, object], key: str) -> int | None:
     value = payload.get(key)
+    if isinstance(value, bool):
+        return None
     return value if isinstance(value, int) and value >= 0 else None
 
 

--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -12,6 +12,12 @@ from sqlalchemy.orm import Session
 
 from app.core.config import Settings
 from app.db.models.dataset_contract import DatasetContract
+from app.db.models.preview import (
+    PreviewAuditEvent,
+    PreviewCandidate,
+    PreviewCandidateApproval,
+    PreviewRequest,
+)
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.services.first_run_doctor import _alembic_heads
@@ -109,6 +115,124 @@ class SupportBundleRedaction(BaseModel):
     excluded: list[str]
 
 
+class GovernanceReviewLifecycleEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_type: str = Field(serialization_alias="eventType")
+    occurred_at: datetime = Field(serialization_alias="occurredAt")
+    lifecycle_order: int = Field(serialization_alias="lifecycleOrder")
+    candidate_state: Optional[str] = Field(
+        default=None,
+        serialization_alias="candidateState",
+    )
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+
+
+class GovernanceReviewActorEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    authenticated_subject_id: str = Field(serialization_alias="authenticatedSubjectId")
+    auth_source: Optional[str] = Field(default=None, serialization_alias="authSource")
+    governance_bindings: list[str] = Field(serialization_alias="governanceBindings")
+    entitlement_decision: str = Field(serialization_alias="entitlementDecision")
+
+
+class GovernanceReviewAdapterEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["subordinate_adapter"] = "subordinate_adapter"
+    adapter_provider: Optional[str] = Field(
+        default=None,
+        serialization_alias="adapterProvider",
+    )
+    adapter_model: Optional[str] = Field(default=None, serialization_alias="adapterModel")
+    adapter_version: Optional[str] = Field(
+        default=None,
+        serialization_alias="adapterVersion",
+    )
+    adapter_run_id: Optional[str] = Field(default=None, serialization_alias="adapterRunId")
+    prompt_version: Optional[str] = Field(default=None, serialization_alias="promptVersion")
+    prompt_fingerprint: Optional[str] = Field(
+        default=None,
+        serialization_alias="promptFingerprint",
+    )
+
+
+class GovernanceReviewCandidateEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    candidate_state: str = Field(serialization_alias="candidateState")
+    guard_status: str = Field(serialization_alias="guardStatus")
+    adapter_evidence: GovernanceReviewAdapterEvidence = Field(
+        serialization_alias="adapterEvidence",
+    )
+
+
+class GovernanceReviewApprovalEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    approval_id: str = Field(serialization_alias="approvalId")
+    approval_state: str = Field(serialization_alias="approvalState")
+    owner_subject_id: str = Field(serialization_alias="ownerSubjectId")
+    approved_at: datetime = Field(serialization_alias="approvedAt")
+    approval_expires_at: datetime = Field(serialization_alias="approvalExpiresAt")
+    invalidated_at: Optional[datetime] = Field(
+        default=None,
+        serialization_alias="invalidatedAt",
+    )
+    executed_at: Optional[datetime] = Field(default=None, serialization_alias="executedAt")
+    execution_policy_version: int = Field(serialization_alias="executionPolicyVersion")
+
+
+class GovernanceReviewExecuteResultEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    event_type: str = Field(serialization_alias="eventType")
+    occurred_at: datetime = Field(serialization_alias="occurredAt")
+    row_count: Optional[int] = Field(default=None, serialization_alias="rowCount")
+    result_truncated: Optional[bool] = Field(
+        default=None,
+        serialization_alias="resultTruncated",
+    )
+
+
+class GovernanceReviewEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    record_type: Literal["workflow_lifecycle"] = Field(
+        default="workflow_lifecycle",
+        serialization_alias="recordType",
+    )
+    request_id: str = Field(serialization_alias="requestId")
+    candidate_id: Optional[str] = Field(default=None, serialization_alias="candidateId")
+    source_id: str = Field(serialization_alias="sourceId")
+    source_family: str = Field(serialization_alias="sourceFamily")
+    source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+    dataset_contract_version: int = Field(serialization_alias="datasetContractVersion")
+    schema_snapshot_version: int = Field(serialization_alias="schemaSnapshotVersion")
+    lifecycle: list[GovernanceReviewLifecycleEvent]
+    actor: GovernanceReviewActorEvidence
+    candidate: Optional[GovernanceReviewCandidateEvidence] = None
+    review: Optional[GovernanceReviewApprovalEvidence] = None
+    execute_result: Optional[GovernanceReviewExecuteResultEvidence] = Field(
+        default=None,
+        serialization_alias="executeResult",
+    )
+
+
+class GovernanceReviewBundle(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    evidence: list[GovernanceReviewEvidence]
+    limitations: list[str]
+
+
 class SupportBundle(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -126,6 +250,9 @@ class SupportBundle(BaseModel):
     workflow: SupportBundleWorkflow
     audit_completeness: SupportBundleAuditCompleteness = Field(
         serialization_alias="auditCompleteness"
+    )
+    governance_review: GovernanceReviewBundle = Field(
+        serialization_alias="governanceReview",
     )
     redaction: SupportBundleRedaction
 
@@ -251,6 +378,201 @@ def _redaction_policy() -> SupportBundleRedaction:
     )
 
 
+def _as_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _split_bindings(value: str | None) -> list[str]:
+    if not isinstance(value, str):
+        return []
+    return sorted(item.strip() for item in value.split(",") if item.strip())
+
+
+def _audit_event_sort_key(event: PreviewAuditEvent) -> tuple[datetime, int, str]:
+    return (
+        _as_utc_datetime(event.occurred_at),
+        event.lifecycle_order,
+        str(event.event_id),
+    )
+
+
+def _payload_non_negative_int(payload: Mapping[str, object], key: str) -> int | None:
+    value = payload.get(key)
+    return value if isinstance(value, int) and value >= 0 else None
+
+
+def _payload_bool(payload: Mapping[str, object], key: str) -> bool | None:
+    value = payload.get(key)
+    return value if isinstance(value, bool) else None
+
+
+def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
+    requests = (
+        session.execute(select(PreviewRequest).order_by(PreviewRequest.created_at))
+        .scalars()
+        .all()
+    )
+    candidates = (
+        session.execute(select(PreviewCandidate).order_by(PreviewCandidate.created_at))
+        .scalars()
+        .all()
+    )
+    approvals = (
+        session.execute(
+            select(PreviewCandidateApproval).order_by(PreviewCandidateApproval.approved_at)
+        )
+        .scalars()
+        .all()
+    )
+    events = (
+        session.execute(
+            select(PreviewAuditEvent).order_by(
+                PreviewAuditEvent.occurred_at,
+                PreviewAuditEvent.lifecycle_order,
+                PreviewAuditEvent.event_id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    candidates_by_request: dict[str, list[PreviewCandidate]] = {}
+    for candidate in candidates:
+        candidates_by_request.setdefault(candidate.request_id, []).append(candidate)
+
+    approvals_by_candidate_id = {
+        approval.candidate_id: approval for approval in approvals
+    }
+    events_by_request: dict[str, list[PreviewAuditEvent]] = {}
+    for event in events:
+        events_by_request.setdefault(event.request_id, []).append(event)
+
+    evidence: list[GovernanceReviewEvidence] = []
+    for request in requests:
+        request_candidates: list[PreviewCandidate | None] = (
+            candidates_by_request.get(request.request_id) or [None]
+        )
+        request_events = events_by_request.get(request.request_id, [])
+        for candidate in request_candidates:
+            candidate_id = candidate.candidate_id if candidate is not None else None
+            lifecycle_events = [
+                event
+                for event in request_events
+                if event.candidate_id in (None, candidate_id)
+            ]
+            lifecycle = [
+                GovernanceReviewLifecycleEvent(
+                    event_type=event.event_type,
+                    occurred_at=_as_utc_datetime(event.occurred_at),
+                    lifecycle_order=event.lifecycle_order,
+                    candidate_state=event.candidate_state,
+                )
+                for event in lifecycle_events
+            ]
+            approval = (
+                approvals_by_candidate_id.get(candidate.candidate_id)
+                if candidate is not None
+                else None
+            )
+            execution_event = next(
+                (
+                    event
+                    for event in sorted(
+                        lifecycle_events,
+                        key=_audit_event_sort_key,
+                        reverse=True,
+                    )
+                    if event.event_type.startswith("execution_")
+                ),
+                None,
+            )
+            evidence.append(
+                GovernanceReviewEvidence(
+                    request_id=request.request_id,
+                    candidate_id=candidate_id,
+                    source_id=request.source_id,
+                    source_family=request.source_family,
+                    source_flavor=request.source_flavor,
+                    dataset_contract_version=request.dataset_contract_version,
+                    schema_snapshot_version=request.schema_snapshot_version,
+                    lifecycle=lifecycle,
+                    actor=GovernanceReviewActorEvidence(
+                        authenticated_subject_id=request.authenticated_subject_id,
+                        auth_source=request.auth_source,
+                        governance_bindings=_split_bindings(request.governance_bindings),
+                        entitlement_decision=request.entitlement_decision,
+                    ),
+                    candidate=(
+                        GovernanceReviewCandidateEvidence(
+                            candidate_state=candidate.candidate_state,
+                            guard_status=candidate.guard_status,
+                            adapter_evidence=GovernanceReviewAdapterEvidence(
+                                adapter_provider=candidate.adapter_provider,
+                                adapter_model=candidate.adapter_model,
+                                adapter_version=candidate.adapter_version,
+                                adapter_run_id=candidate.adapter_run_id,
+                                prompt_version=candidate.prompt_version,
+                                prompt_fingerprint=candidate.prompt_fingerprint,
+                            ),
+                        )
+                        if candidate is not None
+                        else None
+                    ),
+                    review=(
+                        GovernanceReviewApprovalEvidence(
+                            approval_id=approval.approval_id,
+                            approval_state=approval.approval_state,
+                            owner_subject_id=approval.owner_subject_id,
+                            approved_at=_as_utc_datetime(approval.approved_at),
+                            approval_expires_at=_as_utc_datetime(
+                                approval.approval_expires_at
+                            ),
+                            invalidated_at=(
+                                _as_utc_datetime(approval.invalidated_at)
+                                if approval.invalidated_at is not None
+                                else None
+                            ),
+                            executed_at=(
+                                _as_utc_datetime(approval.executed_at)
+                                if approval.executed_at is not None
+                                else None
+                            ),
+                            execution_policy_version=approval.execution_policy_version,
+                        )
+                        if approval is not None
+                        else None
+                    ),
+                    execute_result=(
+                        GovernanceReviewExecuteResultEvidence(
+                            event_type=execution_event.event_type,
+                            occurred_at=_as_utc_datetime(execution_event.occurred_at),
+                            row_count=_payload_non_negative_int(
+                                execution_event.audit_payload,
+                                "execution_row_count",
+                            ),
+                            result_truncated=_payload_bool(
+                                execution_event.audit_payload,
+                                "result_truncated",
+                            ),
+                        )
+                        if execution_event is not None
+                        else None
+                    ),
+                )
+            )
+
+    return GovernanceReviewBundle(
+        evidence=evidence,
+        limitations=[
+            "Bundle is read-only review evidence and does not authorize execution.",
+            "Subordinate adapter, LLM, search, analyst, MLflow, UI, and external evidence is labeled as non-authoritative.",
+            "Raw SQL, result rows, credentials, connection references, tokens, and workstation-local paths are excluded.",
+        ],
+    )
+
+
 def _iter_strings(value: object) -> list[str]:
     if isinstance(value, str):
         return [value]
@@ -314,6 +636,7 @@ def build_support_bundle(
             lifecycle_metrics=workflow_lifecycle_metrics,
         ),
         audit_completeness=_audit_completeness(workflow_lifecycle_metrics),
+        governance_review=_governance_review_bundle(session),
         redaction=_redaction_policy(),
     )
     _assert_bundle_is_shareable(bundle)

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -15,7 +15,12 @@ from sqlalchemy.pool import StaticPool
 
 from app.core.config import get_settings
 from app.db.base import Base
-from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
+from app.db.models.preview import (
+    PreviewAuditEvent,
+    PreviewCandidate,
+    PreviewCandidateApproval,
+    PreviewRequest,
+)
 from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
 from app.services.demo_source_seed import seed_demo_source_governance
@@ -121,6 +126,140 @@ def _add_workflow_records_with_sensitive_payload(session: Session) -> None:
     session.commit()
 
 
+def _add_governance_review_workflow_records(session: Session) -> None:
+    source = session.query(RegisteredSource).one()
+    preview_request = PreviewRequest(
+        id=uuid4(),
+        request_id="request-governance-bundle",
+        registered_source_id=source.id,
+        source_id=source.source_id,
+        source_family=source.source_family,
+        source_flavor=source.source_flavor,
+        dataset_contract_id=source.dataset_contract_id,
+        dataset_contract_version=1,
+        schema_snapshot_id=source.schema_snapshot_id,
+        schema_snapshot_version=1,
+        authenticated_subject_id="user:demo-local-operator",
+        auth_source="test-helper",
+        session_id="session-governance-bundle",
+        governance_bindings="group:safequery-demo-local-operators",
+        entitlement_decision="allow",
+        request_text="Show approved spend",
+        request_state="executed",
+    )
+    session.add(preview_request)
+    session.flush()
+
+    preview_candidate = PreviewCandidate(
+        id=uuid4(),
+        candidate_id="candidate-governance-bundle",
+        preview_request_id=preview_request.id,
+        request_id=preview_request.request_id,
+        registered_source_id=preview_request.registered_source_id,
+        source_id=preview_request.source_id,
+        source_family=preview_request.source_family,
+        source_flavor=preview_request.source_flavor,
+        dataset_contract_id=preview_request.dataset_contract_id,
+        dataset_contract_version=preview_request.dataset_contract_version,
+        schema_snapshot_id=preview_request.schema_snapshot_id,
+        schema_snapshot_version=preview_request.schema_snapshot_version,
+        authenticated_subject_id=preview_request.authenticated_subject_id,
+        candidate_sql="select * from raw_private_rows",
+        adapter_provider="fixture-adapter",
+        adapter_model="fixture-model",
+        adapter_version="fixture-version",
+        adapter_run_id="adapter-run-316",
+        prompt_version="prompt-v1",
+        prompt_fingerprint="prompt-fingerprint-316",
+        guard_status="passed",
+        candidate_state="executed",
+    )
+    session.add(preview_candidate)
+    session.flush()
+
+    session.add(
+        PreviewCandidateApproval(
+            id=uuid4(),
+            approval_id="approval-governance-bundle",
+            preview_candidate_id=preview_candidate.id,
+            candidate_id=preview_candidate.candidate_id,
+            request_id=preview_request.request_id,
+            registered_source_id=preview_request.registered_source_id,
+            source_id=preview_request.source_id,
+            source_family=preview_request.source_family,
+            source_flavor=preview_request.source_flavor,
+            dataset_contract_version=preview_request.dataset_contract_version,
+            schema_snapshot_version=preview_request.schema_snapshot_version,
+            execution_policy_version=3,
+            approved_sql="select * from raw_private_rows",
+            owner_subject_id=preview_request.authenticated_subject_id,
+            session_id=preview_request.session_id,
+            approved_at=datetime(2026, 1, 2, 3, 4, 10, tzinfo=timezone.utc),
+            approval_expires_at=datetime(2026, 1, 2, 3, 9, 10, tzinfo=timezone.utc),
+            executed_at=datetime(2026, 1, 2, 3, 5, 3, tzinfo=timezone.utc),
+            approval_state="executed",
+        )
+    )
+
+    lifecycle_events = [
+        ("query_submitted", 1, None, None),
+        ("generation_completed", 3, preview_candidate.candidate_id, "preview_ready"),
+        ("guard_evaluated", 4, preview_candidate.candidate_id, "preview_ready"),
+        ("execution_completed", 7, preview_candidate.candidate_id, "executed"),
+    ]
+    for event_type, lifecycle_order, candidate_id, candidate_state in lifecycle_events:
+        session.add(
+            PreviewAuditEvent(
+                event_id=uuid4(),
+                lifecycle_order=lifecycle_order,
+                preview_request_id=preview_request.id,
+                preview_candidate_id=(
+                    preview_candidate.id if candidate_id is not None else None
+                ),
+                request_id=preview_request.request_id,
+                candidate_id=candidate_id,
+                event_type=event_type,
+                occurred_at=datetime(
+                    2026,
+                    1,
+                    2,
+                    3,
+                    4 + lifecycle_order,
+                    5,
+                    tzinfo=timezone.utc,
+                ),
+                correlation_id="correlation-governance-bundle",
+                authenticated_subject_id=preview_request.authenticated_subject_id,
+                session_id=preview_request.session_id,
+                auth_source=preview_request.auth_source,
+                governance_bindings=preview_request.governance_bindings,
+                entitlement_decision=preview_request.entitlement_decision,
+                adapter_provider=preview_candidate.adapter_provider,
+                adapter_model=preview_candidate.adapter_model,
+                adapter_version=preview_candidate.adapter_version,
+                adapter_run_id=preview_candidate.adapter_run_id,
+                prompt_version=preview_candidate.prompt_version,
+                prompt_fingerprint=preview_candidate.prompt_fingerprint,
+                source_id=preview_request.source_id,
+                source_family=preview_request.source_family,
+                source_flavor=preview_request.source_flavor,
+                dataset_contract_version=preview_request.dataset_contract_version,
+                schema_snapshot_version=preview_request.schema_snapshot_version,
+                candidate_state=candidate_state,
+                audit_payload={
+                    "execution_row_count": 12,
+                    "result_truncated": False,
+                    "raw_rows": [{"customer_secret": "sk-live-should-not-leak"}],
+                    "debug_path": "/".join(
+                        ["", "Users", "example", ".safequery", "private.log"]
+                    ),
+                    "connection": "postgresql://reader:secret@db:5432/business",
+                },
+            )
+        )
+    session.commit()
+
+
 def _assert_secret_safe(serialized: str) -> None:
     forbidden_fragments = (
         "postgresql://",
@@ -171,6 +310,18 @@ def test_support_bundle_service_includes_bounded_diagnostics_without_secrets(
         )
 
     payload = bundle.model_dump(mode="json", by_alias=True)
+    governance_review = payload.pop("governanceReview")
+    assert governance_review["authority"] == "safequery_control_plane"
+    assert governance_review["limitations"] == [
+        "Bundle is read-only review evidence and does not authorize execution.",
+        "Subordinate adapter, LLM, search, analyst, MLflow, UI, and external evidence is labeled as non-authoritative.",
+        "Raw SQL, result rows, credentials, connection references, tokens, and workstation-local paths are excluded.",
+    ]
+    assert governance_review["evidence"][0]["sourceId"] == "demo-business-postgres"
+    assert governance_review["evidence"][0]["authority"] == "safequery_control_plane"
+    assert governance_review["evidence"][0]["candidate"]["adapterEvidence"][
+        "authority"
+    ] == "subordinate_adapter"
     assert payload == {
         "bundleVersion": 1,
         "generatedAt": "2026-01-02T03:04:05Z",
@@ -291,6 +442,118 @@ def test_support_bundle_service_includes_bounded_diagnostics_without_secrets(
         },
     }
     _assert_secret_safe(json.dumps(payload, sort_keys=True))
+
+
+def test_support_bundle_includes_source_aware_governance_review_evidence(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session)
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    payload = bundle.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert payload["governanceReview"]["authority"] == "safequery_control_plane"
+    assert payload["governanceReview"]["limitations"] == [
+        "Bundle is read-only review evidence and does not authorize execution.",
+        "Subordinate adapter, LLM, search, analyst, MLflow, UI, and external evidence is labeled as non-authoritative.",
+        "Raw SQL, result rows, credentials, connection references, tokens, and workstation-local paths are excluded.",
+    ]
+    assert payload["governanceReview"]["evidence"] == [
+        {
+            "authority": "safequery_control_plane",
+            "recordType": "workflow_lifecycle",
+            "requestId": "request-governance-bundle",
+            "candidateId": "candidate-governance-bundle",
+            "sourceId": "demo-business-postgres",
+            "sourceFamily": "postgresql",
+            "sourceFlavor": "warehouse",
+            "datasetContractVersion": 1,
+            "schemaSnapshotVersion": 1,
+            "lifecycle": [
+                {
+                    "eventType": "query_submitted",
+                    "occurredAt": "2026-01-02T03:05:05Z",
+                    "lifecycleOrder": 1,
+                    "authority": "safequery_control_plane",
+                },
+                {
+                    "eventType": "generation_completed",
+                    "occurredAt": "2026-01-02T03:07:05Z",
+                    "lifecycleOrder": 3,
+                    "candidateState": "preview_ready",
+                    "authority": "safequery_control_plane",
+                },
+                {
+                    "eventType": "guard_evaluated",
+                    "occurredAt": "2026-01-02T03:08:05Z",
+                    "lifecycleOrder": 4,
+                    "candidateState": "preview_ready",
+                    "authority": "safequery_control_plane",
+                },
+                {
+                    "eventType": "execution_completed",
+                    "occurredAt": "2026-01-02T03:11:05Z",
+                    "lifecycleOrder": 7,
+                    "candidateState": "executed",
+                    "authority": "safequery_control_plane",
+                },
+            ],
+            "actor": {
+                "authority": "safequery_control_plane",
+                "authenticatedSubjectId": "user:demo-local-operator",
+                "authSource": "test-helper",
+                "governanceBindings": ["group:safequery-demo-local-operators"],
+                "entitlementDecision": "allow",
+            },
+            "candidate": {
+                "authority": "safequery_control_plane",
+                "candidateState": "executed",
+                "guardStatus": "passed",
+                "adapterEvidence": {
+                    "authority": "subordinate_adapter",
+                    "adapterProvider": "fixture-adapter",
+                    "adapterModel": "fixture-model",
+                    "adapterVersion": "fixture-version",
+                    "adapterRunId": "adapter-run-316",
+                    "promptVersion": "prompt-v1",
+                    "promptFingerprint": "prompt-fingerprint-316",
+                },
+            },
+            "review": {
+                "authority": "safequery_control_plane",
+                "approvalId": "approval-governance-bundle",
+                "approvalState": "executed",
+                "ownerSubjectId": "user:demo-local-operator",
+                "approvedAt": "2026-01-02T03:04:10Z",
+                "approvalExpiresAt": "2026-01-02T03:09:10Z",
+                "executedAt": "2026-01-02T03:05:03Z",
+                "executionPolicyVersion": 3,
+            },
+            "executeResult": {
+                "authority": "safequery_control_plane",
+                "eventType": "execution_completed",
+                "occurredAt": "2026-01-02T03:11:05Z",
+                "rowCount": 12,
+                "resultTruncated": False,
+            },
+        }
+    ]
+    serialized = json.dumps(payload, sort_keys=True)
+    _assert_secret_safe(serialized)
+    assert "raw_private_rows" not in serialized
 
 
 def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -126,7 +126,11 @@ def _add_workflow_records_with_sensitive_payload(session: Session) -> None:
     session.commit()
 
 
-def _add_governance_review_workflow_records(session: Session) -> None:
+def _add_governance_review_workflow_records(
+    session: Session,
+    *,
+    execution_row_count: object = 12,
+) -> None:
     source = session.query(RegisteredSource).one()
     preview_request = PreviewRequest(
         id=uuid4(),
@@ -247,7 +251,7 @@ def _add_governance_review_workflow_records(session: Session) -> None:
                 schema_snapshot_version=preview_request.schema_snapshot_version,
                 candidate_state=candidate_state,
                 audit_payload={
-                    "execution_row_count": 12,
+                    "execution_row_count": execution_row_count,
                     "result_truncated": False,
                     "raw_rows": [{"customer_secret": "sk-live-should-not-leak"}],
                     "debug_path": "/".join(
@@ -554,6 +558,32 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
     serialized = json.dumps(payload, sort_keys=True)
     _assert_secret_safe(serialized)
     assert "raw_private_rows" not in serialized
+
+
+def test_governance_review_execute_result_rejects_boolean_row_count(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session, execution_row_count=True)
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    payload = bundle.model_dump(mode="json", by_alias=True, exclude_none=True)
+    execute_result = payload["governanceReview"]["evidence"][0]["executeResult"]
+    assert "rowCount" not in execute_result
+    assert execute_result["resultTruncated"] is False
 
 
 def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:

--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -47,51 +47,53 @@ This reading order is intended to help new contributors understand SafeQuery fro
     Use this to understand the minimum deny scenarios the pilot must continue to block.
 19. [design/audit-event-model.md](./design/audit-event-model.md)
     Read this before implementing persistence, replay, or operational diagnostics.
+20. [design/audit-governance-export-bundle.md](./design/audit-governance-export-bundle.md)
+    Read this before generating or reviewing source-aware governance export bundles.
 
 ### 3. UX Foundation
 
-20. [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md)
+21. [design/operator-workflow-information-architecture.md](./design/operator-workflow-information-architecture.md)
     Read the operator shell contract before changing navigation, composition, preview, or result surfaces in the current baseline.
-21. [../DESIGN.md](../DESIGN.md)
+22. [../DESIGN.md](../DESIGN.md)
     Read the visual design contract after the workflow contract so shell hierarchy, typography, spacing, and interaction posture stay aligned.
-22. [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md)
+23. [design/query-lifecycle-state-machine.md](./design/query-lifecycle-state-machine.md)
     Read the lifecycle state model before implementing UI states or backend transitions that must share the same authoritative vocabulary.
 
 ### 4. Source-Aware and Evaluation Baseline
 
-23. [adr/ADR-0010-mlflow-observability-and-evaluation-plane.md](./adr/ADR-0010-mlflow-observability-and-evaluation-plane.md)
+24. [adr/ADR-0010-mlflow-observability-and-evaluation-plane.md](./adr/ADR-0010-mlflow-observability-and-evaluation-plane.md)
     Review why MLflow is used for tracing, evaluation, and model-lifecycle support without becoming the trusted control plane in the current baseline.
-24. [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md)
+25. [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md)
     Review how the current source-aware baseline adds governed search and analyst-style capabilities without moving trust boundaries out of the application.
-25. [design/evaluation-harness.md](./design/evaluation-harness.md)
+26. [design/evaluation-harness.md](./design/evaluation-harness.md)
     Use this to understand how NL2SQL quality should be measured safely in the current source-aware baseline.
-26. [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md)
+27. [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md)
     Use this as the 2-source core path pilot-readiness checklist after the source-aware implementation slices are complete.
-27. [pilot-operations-runbook.md](./pilot-operations-runbook.md)
+28. [pilot-operations-runbook.md](./pilot-operations-runbook.md)
     Use this to classify normal, degraded, maintenance, incident, and recovery posture during limited pilot operation without treating UI, LLM, adapter, MLflow, Search, Analyst, or external evidence as authoritative.
 
 ### 5. Approved Follow-on Direction
 
-28. [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md)
+29. [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md)
     Read first in this section to understand how SafeQuery expands beyond one hard-coded business source while keeping request, candidate, and execution paths single-source.
-29. [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md)
+30. [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md)
     Review how source families, flavors, connector profiles, and guard profiles are separated so future onboarding does not redesign the control plane.
-30. [design/target-source-registry.md](./design/target-source-registry.md)
+31. [design/target-source-registry.md](./design/target-source-registry.md)
     Use this to understand the concrete registry model, source lifecycle expectations, and application PostgreSQL separation guardrails.
-31. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
+32. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
     Review the family and flavor rollout matrix before planning connector, guard, or evaluation work for additional sources.
-32. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
+33. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
     Read this to understand why the product shell is workflow-first and why the Epic A shell remains a developer state demo.
-33. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
+34. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
     Review how SafeQuery may borrow OSS ergonomics without turning the product into a generic chat shell or moving trust boundaries.
-34. [implementation-roadmap.md](./implementation-roadmap.md)
+35. [implementation-roadmap.md](./implementation-roadmap.md)
     Finish this section with the current implementation sequence so roadmap work stays aligned with the reviewed docs direction.
 
 ### 6. Local Setup and Threat Review
 
-35. [local-development.md](./local-development.md)
+36. [local-development.md](./local-development.md)
     Use this once the document set is clear so local startup follows the reviewed topology and role split.
-36. [security/threat-model.md](./security/threat-model.md)
+37. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks for the current source-aware and UX-foundation baseline before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [design/sql-guard-deny-catalog.md](./design/sql-guard-deny-catalog.md): machine-readable deny code catalog for SQL Guard
 - [design/sql-guard-deny-corpus.md](./design/sql-guard-deny-corpus.md): representative deny scenarios required for guard testing
 - [design/audit-event-model.md](./design/audit-event-model.md): audit event taxonomy and required fields
+- [design/audit-governance-export-bundle.md](./design/audit-governance-export-bundle.md): reviewer expectations and limitations for source-aware governance export bundles
 
 ### UX Foundation
 

--- a/docs/design/audit-governance-export-bundle.md
+++ b/docs/design/audit-governance-export-bundle.md
@@ -1,0 +1,59 @@
+# Audit Governance Export Bundle
+
+The support bundle includes a `governanceReview` section for read-only lifecycle
+review. It is generated from persisted SafeQuery control-plane records and can
+be produced from local fixture data without live source, adapter, search,
+analyst, MLflow, or LLM services.
+
+## Reviewer Expectations
+
+Reviewers should treat `governanceReview.authority` and each evidence
+`authority` value as the first trust boundary signal:
+
+- `safequery_control_plane` records are authoritative SafeQuery records persisted
+  by the backend control plane.
+- `subordinate_adapter` metadata is supporting generation context. It can help
+  identify which adapter, model, prompt version, or run produced a candidate, but
+  it does not authorize execution.
+- UI, external connector, LLM, search, analyst, and MLflow evidence must remain
+  subordinate unless a future control-plane record explicitly promotes a field
+  into an authoritative SafeQuery record.
+
+Each evidence item is scoped to one request and, when present, one candidate. The
+bundle carries source identity, source family and flavor, dataset contract
+version, schema snapshot version, lifecycle event order, actor metadata,
+candidate guard state, review approval metadata, and execution result metadata.
+
+## Export Limitations
+
+The bundle is review evidence only. It does not approve, re-approve, or authorize
+execution. Reviewers must not use it as a bypass for candidate approval,
+entitlement checks, SQL Guard, source activation posture, or execution policy
+revalidation.
+
+The export intentionally excludes raw SQL, raw result rows, connection strings,
+raw credentials, tokens, source connection references, and workstation-local
+paths. A missing field should be interpreted as unavailable or intentionally
+redacted, not as proof that an action was safe.
+
+The bundle summarizes a committed database snapshot at generation time. It does
+not prove that external services were reachable later, that a subordinate
+adapter's own logs are complete, or that an external system retained matching
+evidence.
+
+## Local Verification
+
+Focused verification should use local persisted records or fixture-backed tests:
+
+```bash
+cd backend
+python3 -m pytest tests/test_support_bundle.py
+```
+
+Generated exports should be inspected for:
+
+- lifecycle completeness across request, candidate, review, and execution
+  records
+- clear authority labels on control-plane and subordinate evidence
+- absence of raw SQL, result rows, credentials, tokens, connection references,
+  and workstation-local paths


### PR DESCRIPTION
## Summary
- add a source-aware `governanceReview` section to support bundles from persisted SafeQuery control-plane records
- label authoritative control-plane evidence separately from subordinate adapter metadata
- document reviewer expectations, limitations, and local verification for governance exports

## Reproduced failure
- focused test initially failed with `KeyError: 'governanceReview'`, proving the existing bundle lacked governance-review evidence

## Verification
- `cd backend && python3 -m pytest tests/test_support_bundle.py tests/test_operator_workflow_history.py -q`
- `bash tests/smoke/test-doc-entrypoints-current-set.sh`
- `python3 -m pytest tests/test_check_repository_hygiene.py -q`
- `python3 scripts/ci/check_repository_hygiene.py`
- `git diff --check`

Closes #316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support bundles now always include a governanceReview section capturing workflow lifecycle, participants, candidates, approvals, and execution results with authority labeling; evidence items are grouped per request/candidate.

* **Documentation**
  * Added design doc and reading-order entry describing the governance export bundle, trust boundaries, exclusions, and verification checklist.

* **Tests**
  * Added end-to-end and unit tests validating governance evidence shape, ordering, authority flags, secret-safety, and executeResult shaping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->