### PR TITLE
[R-4] Surface governance binding drift

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -4,11 +4,28 @@ from datetime import datetime, timezone
 from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.db.models.dataset_contract import DatasetContract
 from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
+from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
+from app.features.auth.governance_bindings import normalize_governance_binding
+
+
+GovernanceBindingState = Literal[
+    "valid",
+    "missing",
+    "ambiguous",
+    "stale",
+    "drifted",
+]
+GovernanceBindingRole = Literal[
+    "owner",
+    "security_review",
+    "exception_policy",
+]
 
 
 class OperatorWorkflowSourceOption(BaseModel):
@@ -20,6 +37,20 @@ class OperatorWorkflowSourceOption(BaseModel):
     activation_posture: str = Field(serialization_alias="activationPosture")
     source_family: str = Field(serialization_alias="sourceFamily")
     source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+    governance_bindings: list["OperatorWorkflowGovernanceBindingStatus"] = Field(
+        default_factory=list,
+        serialization_alias="governanceBindings",
+    )
+
+
+class OperatorWorkflowGovernanceBindingStatus(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role: GovernanceBindingRole
+    state: GovernanceBindingState
+    affects_entitlement: bool = Field(serialization_alias="affectsEntitlement")
+    summary: str
+    recovery: str
 
 
 class OperatorWorkflowHistoryItem(BaseModel):
@@ -147,6 +178,104 @@ def _source_description(source: RegisteredSource) -> str:
         f"{source.source_family}{flavor} source with "
         f"{source.activation_posture.value} activation posture."
     )
+
+
+def _governance_binding_status(
+    *,
+    role: GovernanceBindingRole,
+    raw_binding: str | None,
+    state: GovernanceBindingState,
+    affects_entitlement: bool,
+) -> OperatorWorkflowGovernanceBindingStatus:
+    role_label = role.replace("_", " ")
+    summaries = {
+        "valid": f"{role_label.title()} binding is current and normalized.",
+        "missing": f"{role_label.title()} binding is missing or malformed.",
+        "ambiguous": f"{role_label.title()} binding overlaps another governance role.",
+        "stale": f"{role_label.title()} binding is attached to a stale contract version.",
+        "drifted": f"{role_label.title()} binding no longer matches the active source linkage.",
+    }
+    recoveries = {
+        "valid": "No operator recovery is required for this binding.",
+        "missing": "Reconcile the authoritative dataset contract before granting access.",
+        "ambiguous": "Split or re-review role mappings before treating the binding as current.",
+        "stale": "Promote or rebind the latest reviewed governance contract before retrying.",
+        "drifted": "Repair source-to-contract and source-to-schema links before retrying.",
+    }
+    normalized = normalize_governance_binding(raw_binding)
+    effective_state = "missing" if normalized is None and state == "valid" else state
+    return OperatorWorkflowGovernanceBindingStatus(
+        role=role,
+        state=effective_state,
+        affects_entitlement=affects_entitlement,
+        summary=summaries[effective_state],
+        recovery=recoveries[effective_state],
+    )
+
+
+def _source_governance_bindings(
+    *,
+    source: RegisteredSource,
+    contract: DatasetContract | None,
+    schema_snapshot: SchemaSnapshot | None,
+    latest_contract_version: int | None,
+) -> list[OperatorWorkflowGovernanceBindingStatus]:
+    roles: list[tuple[GovernanceBindingRole, str | None, bool]] = [
+        ("owner", contract.owner_binding if contract is not None else None, True),
+        (
+            "security_review",
+            contract.security_review_binding if contract is not None else None,
+            False,
+        ),
+        (
+            "exception_policy",
+            contract.exception_policy_binding if contract is not None else None,
+            False,
+        ),
+    ]
+    normalized_counts: dict[str, int] = {}
+    for _, raw_binding, _ in roles:
+        normalized = normalize_governance_binding(raw_binding)
+        if normalized is not None:
+            normalized_counts[normalized] = normalized_counts.get(normalized, 0) + 1
+
+    drifted = (
+        contract is None
+        or schema_snapshot is None
+        or source.dataset_contract_id != contract.id
+        or source.schema_snapshot_id != schema_snapshot.id
+        or contract.registered_source_id != source.id
+        or schema_snapshot.registered_source_id != source.id
+        or contract.schema_snapshot_id != schema_snapshot.id
+    )
+    stale = (
+        not drifted
+        and latest_contract_version is not None
+        and contract is not None
+        and contract.contract_version < latest_contract_version
+    )
+
+    statuses: list[OperatorWorkflowGovernanceBindingStatus] = []
+    for role, raw_binding, affects_entitlement in roles:
+        normalized = normalize_governance_binding(raw_binding)
+        state: GovernanceBindingState = "valid"
+        if drifted:
+            state = "drifted"
+        elif stale:
+            state = "stale"
+        elif normalized is None:
+            state = "missing"
+        elif normalized_counts.get(normalized, 0) > 1:
+            state = "ambiguous"
+        statuses.append(
+            _governance_binding_status(
+                role=role,
+                raw_binding=raw_binding,
+                state=state,
+                affects_entitlement=affects_entitlement,
+            )
+        )
+    return statuses
 
 
 def _as_utc_datetime(value: datetime) -> datetime:
@@ -514,10 +643,29 @@ def _build_operator_history(
 
 
 def get_operator_workflow_snapshot(session: Session) -> OperatorWorkflowSnapshot:
-    sources = (
-        session.execute(select(RegisteredSource).order_by(RegisteredSource.source_id))
-        .scalars()
+    source_rows = (
+        session.execute(
+            select(RegisteredSource, DatasetContract, SchemaSnapshot)
+            .outerjoin(
+                DatasetContract,
+                DatasetContract.id == RegisteredSource.dataset_contract_id,
+            )
+            .outerjoin(
+                SchemaSnapshot,
+                SchemaSnapshot.id == RegisteredSource.schema_snapshot_id,
+            )
+            .order_by(RegisteredSource.source_id)
+        )
         .all()
+    )
+    sources = [row[0] for row in source_rows]
+    latest_contract_versions = dict(
+        session.execute(
+            select(
+                DatasetContract.registered_source_id,
+                func.max(DatasetContract.contract_version),
+            ).group_by(DatasetContract.registered_source_id)
+        ).all()
     )
 
     source_options = [
@@ -528,8 +676,14 @@ def get_operator_workflow_snapshot(session: Session) -> OperatorWorkflowSnapshot
             activation_posture=source.activation_posture.value,
             source_family=source.source_family,
             source_flavor=source.source_flavor,
+            governance_bindings=_source_governance_bindings(
+                source=source,
+                contract=dataset_contract,
+                schema_snapshot=schema_snapshot,
+                latest_contract_version=latest_contract_versions.get(source.id),
+            ),
         )
-        for source in sources
+        for source, dataset_contract, schema_snapshot in source_rows
     ]
 
     return OperatorWorkflowSnapshot(

--- a/backend/app/services/source_governance.py
+++ b/backend/app/services/source_governance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.models.dataset_contract import DatasetContract
@@ -53,6 +53,19 @@ def resolve_authoritative_source_governance(
         raise SourceGovernanceResolutionError(
             f"Registered source '{source.source_id}' is missing "
             "authoritative source-scoped governance artifacts."
+        )
+    latest_contract_version = session.execute(
+        select(func.max(DatasetContract.contract_version)).where(
+            DatasetContract.registered_source_id == source.id
+        )
+    ).scalar_one()
+    if (
+        latest_contract_version is not None
+        and dataset_contract.contract_version < latest_contract_version
+    ):
+        raise SourceGovernanceResolutionError(
+            f"Registered source '{source.source_id}' is linked to a stale "
+            "source-scoped governance contract."
         )
 
     if schema_snapshot is None or schema_snapshot.registered_source_id != source.id:

--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -22,7 +22,10 @@ from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.services.first_run_doctor import _alembic_heads
 from app.services.health import build_operator_health
-from app.services.operator_workflow import get_operator_workflow_snapshot
+from app.services.operator_workflow import (
+    OperatorWorkflowGovernanceBindingStatus,
+    get_operator_workflow_snapshot,
+)
 
 
 _APP_VERSION = "0.1.0"
@@ -73,6 +76,10 @@ class SupportBundleSource(BaseModel):
     schema_snapshot_version: Optional[int] = Field(
         default=None,
         serialization_alias="schemaSnapshotVersion",
+    )
+    governance_bindings: list[OperatorWorkflowGovernanceBindingStatus] = Field(
+        default_factory=list,
+        serialization_alias="governanceBindings",
     )
 
 
@@ -258,9 +265,15 @@ class SupportBundle(BaseModel):
 
 
 def _active_sources(session: Session) -> list[SupportBundleSource]:
+    workflow_snapshot = get_operator_workflow_snapshot(session)
+    sources_by_id = {
+        source.source_id: source
+        for source in workflow_snapshot.sources
+        if source.activation_posture == SourceActivationPosture.ACTIVE.value
+    }
     sources = session.scalars(
         select(RegisteredSource)
-        .where(RegisteredSource.activation_posture == SourceActivationPosture.ACTIVE)
+        .where(RegisteredSource.source_id.in_(sources_by_id))
         .order_by(RegisteredSource.source_id)
     )
     bundle_sources: list[SupportBundleSource] = []
@@ -287,6 +300,9 @@ def _active_sources(session: Session) -> list[SupportBundleSource]:
                 schema_snapshot_version=(
                     snapshot.snapshot_version if snapshot is not None else None
                 ),
+                governance_bindings=sources_by_id[
+                    source.source_id
+                ].governance_bindings,
             )
         )
     return bundle_sources

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -28,6 +28,10 @@ from app.services.request_preview import (
     persist_execution_audit_events,
     submit_preview_request,
 )
+from app.services.source_governance import (
+    SourceGovernanceResolutionError,
+    resolve_authoritative_source_governance,
+)
 
 
 @contextmanager
@@ -90,6 +94,87 @@ def _seed_authoritative_source_governance(
 
     source.dataset_contract_id = contract.id
     source.schema_snapshot_id = snapshot.id
+    session.commit()
+
+
+def _seed_source_with_governance_state(
+    session: Session,
+    *,
+    source_id: str,
+    owner_binding: str | None,
+    security_review_binding: str | None = None,
+    contract_version: int = 1,
+    linked_contract_version: int | None = None,
+    drift_contract_snapshot: bool = False,
+) -> None:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id=source_id,
+        display_label=source_id.replace("-", " ").title(),
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference=f"vault:{source_id}",
+    )
+    session.add(source)
+    session.flush()
+
+    active_snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=1,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(active_snapshot)
+    session.flush()
+
+    contract_snapshot = active_snapshot
+    if drift_contract_snapshot:
+        contract_snapshot = SchemaSnapshot(
+            id=uuid4(),
+            registered_source_id=source.id,
+            snapshot_version=2,
+            review_status=SchemaSnapshotReviewStatus.APPROVED,
+            reviewed_at=datetime.now(timezone.utc),
+        )
+        session.add(contract_snapshot)
+        session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=contract_snapshot.id,
+        contract_version=linked_contract_version or contract_version,
+        display_name=f"{source_id} contract",
+        owner_binding=owner_binding,
+        security_review_binding=security_review_binding,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+
+    if linked_contract_version is not None:
+        latest_contract = DatasetContract(
+            id=uuid4(),
+            registered_source_id=source.id,
+            schema_snapshot_id=active_snapshot.id,
+            contract_version=contract_version,
+            display_name=f"{source_id} latest contract",
+            owner_binding=owner_binding,
+            security_review_binding=security_review_binding,
+            exception_policy_binding=None,
+        )
+        session.add(latest_contract)
+        session.flush()
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = active_snapshot.id
     session.commit()
 
 
@@ -508,3 +593,82 @@ def test_operator_workflow_history_includes_audit_safe_unavailable_preview_denia
     assert "cookie" not in serialized_history
     assert "token" not in serialized_history
     assert "secret" not in serialized_history
+
+
+def test_operator_workflow_sources_surface_sanitized_governance_binding_states() -> None:
+    with _session_scope() as session:
+        _seed_source_with_governance_state(
+            session,
+            source_id="valid-source",
+            owner_binding="group:finance-analysts",
+        )
+        _seed_source_with_governance_state(
+            session,
+            source_id="missing-source",
+            owner_binding=None,
+        )
+        _seed_source_with_governance_state(
+            session,
+            source_id="ambiguous-source",
+            owner_binding="group:finance-analysts",
+            security_review_binding="group:finance-analysts",
+        )
+        _seed_source_with_governance_state(
+            session,
+            source_id="stale-source",
+            owner_binding="group:finance-analysts",
+            contract_version=2,
+            linked_contract_version=1,
+        )
+        _seed_source_with_governance_state(
+            session,
+            source_id="drifted-source",
+            owner_binding="group:finance-analysts",
+            drift_contract_snapshot=True,
+        )
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    payload = snapshot.model_dump(mode="json", by_alias=True)
+    states_by_source = {
+        source["sourceId"]: {
+            binding["role"]: binding["state"]
+            for binding in source["governanceBindings"]
+        }
+        for source in payload["sources"]
+    }
+    assert states_by_source["valid-source"]["owner"] == "valid"
+    assert states_by_source["missing-source"]["owner"] == "missing"
+    assert states_by_source["ambiguous-source"]["owner"] == "ambiguous"
+    assert states_by_source["stale-source"]["owner"] == "stale"
+    assert states_by_source["drifted-source"]["owner"] == "drifted"
+
+    owner_binding = next(
+        binding
+        for source in payload["sources"]
+        if source["sourceId"] == "stale-source"
+        for binding in source["governanceBindings"]
+        if binding["role"] == "owner"
+    )
+    assert owner_binding["affectsEntitlement"] is True
+    serialized = str(payload).lower()
+    assert "group:finance-analysts" not in serialized
+    assert "token" not in serialized
+    assert "secret" not in serialized
+
+
+def test_source_governance_resolution_fails_closed_on_stale_contract_linkage() -> None:
+    with _session_scope() as session:
+        _seed_source_with_governance_state(
+            session,
+            source_id="stale-source",
+            owner_binding="group:finance-analysts",
+            contract_version=2,
+            linked_contract_version=1,
+        )
+
+        with pytest.raises(SourceGovernanceResolutionError, match="stale"):
+            resolve_authoritative_source_governance(
+                session,
+                source_id="stale-source",
+            )

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -357,6 +357,29 @@ def test_support_bundle_service_includes_bounded_diagnostics_without_secrets(
                 "activationPosture": "active",
                 "datasetContractVersion": 1,
                 "schemaSnapshotVersion": 1,
+                "governanceBindings": [
+                    {
+                        "role": "owner",
+                        "state": "valid",
+                        "affectsEntitlement": True,
+                        "summary": "Owner binding is current and normalized.",
+                        "recovery": "No operator recovery is required for this binding.",
+                    },
+                    {
+                        "role": "security_review",
+                        "state": "valid",
+                        "affectsEntitlement": False,
+                        "summary": "Security Review binding is current and normalized.",
+                        "recovery": "No operator recovery is required for this binding.",
+                    },
+                    {
+                        "role": "exception_policy",
+                        "state": "missing",
+                        "affectsEntitlement": False,
+                        "summary": "Exception Policy binding is missing or malformed.",
+                        "recovery": "Reconcile the authoritative dataset contract before granting access.",
+                    },
+                ],
             }
         ],
         "health": {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -21,12 +21,14 @@ function workflowPayload(sourceLabel = "SAP spend cube / approved_vendor_spend")
         activationPosture: "active",
         description: "Approved finance spend cube for governed preview and single-source execution.",
         displayLabel: sourceLabel,
+        governanceBindings: [],
         sourceId: "sap-approved-spend"
       },
       {
         activationPosture: "paused",
         description: "Historical archive is visible for posture review but not executable for preview.",
         displayLabel: "Legacy finance archive",
+        governanceBindings: [],
         sourceId: "legacy-finance-archive"
       }
     ]
@@ -99,6 +101,7 @@ describe("HomePage", () => {
                     activationPosture: "active",
                     description: "Live source returned by the backend contract.",
                     displayLabel: "ERP approved spend / live contract",
+                    governanceBindings: [],
                     sourceId: "erp-approved-spend"
                   }
                 ]
@@ -292,6 +295,43 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("fails closed when source governance bindings are omitted", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [],
+                sources: [
+                  {
+                    activationPosture: "active",
+                    description: "Source payload without explicit governance binding status.",
+                    displayLabel: "Missing governance source",
+                    sourceId: "missing-governance-source"
+                  }
+                ]
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(screen.getByLabelText(/operator history/i)).toHaveTextContent("malformed");
+    expect(
+      screen.getByText(/backend workflow payload was malformed, so the source selector remains blocked/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Missing governance source" })).not.toBeInTheDocument();
+  });
+
   it("renders first-run setup guidance when no sources are configured", async () => {
     vi.stubGlobal(
       "fetch",
@@ -342,6 +382,7 @@ describe("HomePage", () => {
                     activationPosture: "active",
                     description: "Demo source returned by the backend contract.",
                     displayLabel: "Demo business source",
+                    governanceBindings: [],
                     sourceId: "demo-business-source"
                   }
                 ]
@@ -644,12 +685,14 @@ describe("HomePage", () => {
                     activationPosture: "active",
                     description: "Draft marketing source returned by the backend contract.",
                     displayLabel: "Marketing campaigns / campaign_spend",
+                    governanceBindings: [],
                     sourceId: "marketing-campaign-spend"
                   },
                   {
                     activationPosture: "active",
                     description: "Candidate source returned by the backend contract.",
                     displayLabel: "SAP spend cube / approved_vendor_spend",
+                    governanceBindings: [],
                     sourceId: "sap-approved-spend"
                   }
                 ]
@@ -1489,6 +1532,7 @@ describe("HomePage", () => {
                     activationPosture: "active",
                     description: "Registry fallback source label should not override selected run context.",
                     displayLabel: "Registry fallback source label",
+                    governanceBindings: [],
                     sourceId: "sap-approved-spend"
                   }
                 ]

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -118,6 +118,74 @@ describe("HomePage", () => {
     expect(screen.queryByRole("option", { name: /SAP spend cube/i })).not.toBeInTheDocument();
   });
 
+  it("renders stale and drifted governance binding status without raw identity payloads", async () => {
+    const rawBinding = "group:finance-analysts";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [],
+                sources: [
+                  {
+                    activationPosture: "active",
+                    description: "Live source with stale governance status.",
+                    displayLabel: "ERP approved spend / live contract",
+                    governanceBindings: [
+                      {
+                        affectsEntitlement: true,
+                        recovery:
+                          "Promote or rebind the latest reviewed governance contract before retrying.",
+                        role: "owner",
+                        state: "stale",
+                        summary: "Owner binding is attached to a stale contract version."
+                      },
+                      {
+                        affectsEntitlement: false,
+                        recovery: "Repair source-to-contract and source-to-schema links before retrying.",
+                        role: "security_review",
+                        state: "drifted",
+                        summary:
+                          "Security review binding no longer matches the active source linkage."
+                      }
+                    ],
+                    rawBinding,
+                    sourceId: "erp-approved-spend"
+                  }
+                ]
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          source_id: "erp-approved-spend",
+          state: "query"
+        }
+      })
+    );
+
+    const status = screen.getByLabelText(/governance binding status/i);
+    expect(status).toHaveTextContent(/governance binding review required/i);
+    expect(status).toHaveTextContent(/owner: stale/i);
+    expect(status).toHaveTextContent(/security review: drifted/i);
+    expect(status).toHaveTextContent(/promote or rebind the latest reviewed governance contract/i);
+    expect(
+      screen.getByText(/resolve entitlement-affecting governance binding status before preview/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(rawBinding)).not.toBeInTheDocument();
+  });
+
   it("renders source-aware history rows from the live operator workflow payload", async () => {
     render(await HomePage({}));
 

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -92,6 +92,7 @@ function pilotWorkflowPayload() {
         activationPosture: "active",
         description: "Pilot source returned by the backend workflow contract.",
         displayLabel: "Demo business PostgreSQL / approved_vendor_spend",
+        governanceBindings: [],
         sourceFamily: "postgresql",
         sourceFlavor: "warehouse",
         sourceId: "demo-business-postgres"

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -4,6 +4,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { HealthStatusCard } from "./health-status-card";
 import type { HealthSnapshot } from "../lib/health";
 import type {
+  GovernanceBindingStatus,
   OperatorWorkflowAuditEvent,
   OperatorWorkflowExecutedEvidence,
   OperatorHistoryItem,
@@ -419,6 +420,45 @@ function findSourceOption(
   return sourceOptions.find((source) => source.sourceId === sourceId);
 }
 
+function governanceBindingStateLabel(binding: GovernanceBindingStatus): string {
+  return `${binding.role.replace("_", " ")}: ${binding.state}`;
+}
+
+function hasEntitlementAffectingGovernanceDrift(source?: SourceOption): boolean {
+  return (
+    source?.governanceBindings.some(
+      (binding) => binding.affectsEntitlement && binding.state !== "valid"
+    ) ?? false
+  );
+}
+
+function renderGovernanceBindingStatuses(source?: SourceOption) {
+  if (!source || source.governanceBindings.length === 0) {
+    return null;
+  }
+
+  const hasDrift = hasEntitlementAffectingGovernanceDrift(source);
+  return (
+    <div
+      aria-label="Governance binding status"
+      className={`state-callout state-callout-${hasDrift ? "danger" : "empty"}`}
+    >
+      <p className="state-callout-title">
+        {hasDrift ? "Governance binding review required" : "Governance bindings current"}
+      </p>
+      <div className="guard-list">
+        {source.governanceBindings.map((binding) => (
+          <div className="guard-item" key={`${source.sourceId}:${binding.role}`}>
+            <span className="meta-label">{governanceBindingStateLabel(binding)}</span>
+            <strong>{binding.summary}</strong>
+            <span>{binding.recovery}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -779,6 +819,15 @@ function resolveSourceBinding(
       };
     }
 
+    if (hasEntitlementAffectingGovernanceDrift(source)) {
+      return {
+        blockedReason:
+          "Resolve entitlement-affecting governance binding status before preview can be requested.",
+        source,
+        state: "query"
+      };
+    }
+
     return {
       source,
       state
@@ -795,6 +844,15 @@ function resolveSourceBinding(
   if (source.activationPosture !== "active") {
     return {
       blockedReason: "The selected source is not executable for preview submission.",
+      state: "query"
+    };
+  }
+
+  if (hasEntitlementAffectingGovernanceDrift(source)) {
+    return {
+      blockedReason:
+        "Resolve entitlement-affecting governance binding status before preview can be requested.",
+      source,
       state: "query"
     };
   }
@@ -1746,6 +1804,16 @@ export function QueryWorkflowShell({
       return;
     }
 
+    if (hasEntitlementAffectingGovernanceDrift(selectedSource)) {
+      setPreviewSubmission({
+        code: "preview_governance_binding_review_required",
+        message:
+          "Resolve entitlement-affecting governance binding status before preview can be requested.",
+        status: "failed"
+      });
+      return;
+    }
+
     setPreviewSubmission({ status: "submitting" });
 
     const headers: Record<string, string> = {
@@ -2151,6 +2219,7 @@ export function QueryWorkflowShell({
                     Choose one explicit source before preview submission. SafeQuery does not infer or
                     auto-route the initial source binding.
                   </p>
+                  {renderGovernanceBindingStatuses(sourceBinding.source)}
                   {sourceBinding.blockedReason ? (
                     <div className="state-callout state-callout-danger">
                       <p className="state-callout-title">Preview submission blocked</p>

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -276,10 +276,9 @@ function parseSourceOption(value: unknown): SourceOption | null {
   const sourceId = readOptionalString(value.sourceId);
   const displayLabel = readOptionalString(value.displayLabel);
   const description = readOptionalString(value.description);
-  const governanceBindings = parseArray(
-    value.governanceBindings,
-    parseGovernanceBindingStatus
-  );
+  const governanceBindings = Array.isArray(value.governanceBindings)
+    ? parseArray(value.governanceBindings, parseGovernanceBindingStatus)
+    : null;
 
   if (
     !sourceId ||

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -1,9 +1,20 @@
 export type SourceActivationPosture = "active" | "paused" | "blocked" | "retired";
+export type GovernanceBindingState = "valid" | "missing" | "ambiguous" | "stale" | "drifted";
+export type GovernanceBindingRole = "owner" | "security_review" | "exception_policy";
+
+export type GovernanceBindingStatus = {
+  affectsEntitlement: boolean;
+  recovery: string;
+  role: GovernanceBindingRole;
+  state: GovernanceBindingState;
+  summary: string;
+};
 
 export type SourceOption = {
   activationPosture: SourceActivationPosture;
   description: string;
   displayLabel: string;
+  governanceBindings: GovernanceBindingStatus[];
   sourceFamily?: string;
   sourceFlavor?: string | null;
   sourceId: string;
@@ -91,6 +102,20 @@ function isObject(value: unknown): value is RawObject {
 
 function isActivationPosture(value: unknown): value is SourceActivationPosture {
   return value === "active" || value === "paused" || value === "blocked" || value === "retired";
+}
+
+function isGovernanceBindingState(value: unknown): value is GovernanceBindingState {
+  return (
+    value === "valid" ||
+    value === "missing" ||
+    value === "ambiguous" ||
+    value === "stale" ||
+    value === "drifted"
+  );
+}
+
+function isGovernanceBindingRole(value: unknown): value is GovernanceBindingRole {
+  return value === "owner" || value === "security_review" || value === "exception_policy";
 }
 
 function readOptionalString(value: unknown): string | undefined {
@@ -217,6 +242,32 @@ function parseRetrievedCitation(value: unknown): OperatorWorkflowRetrievedCitati
   };
 }
 
+function parseGovernanceBindingStatus(value: unknown): GovernanceBindingStatus | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const summary = readOptionalString(value.summary);
+  const recovery = readOptionalString(value.recovery);
+  if (
+    !isGovernanceBindingRole(value.role) ||
+    !isGovernanceBindingState(value.state) ||
+    typeof value.affectsEntitlement !== "boolean" ||
+    !summary ||
+    !recovery
+  ) {
+    return null;
+  }
+
+  return {
+    affectsEntitlement: value.affectsEntitlement,
+    recovery,
+    role: value.role,
+    state: value.state,
+    summary
+  };
+}
+
 function parseSourceOption(value: unknown): SourceOption | null {
   if (!isObject(value)) {
     return null;
@@ -225,8 +276,18 @@ function parseSourceOption(value: unknown): SourceOption | null {
   const sourceId = readOptionalString(value.sourceId);
   const displayLabel = readOptionalString(value.displayLabel);
   const description = readOptionalString(value.description);
+  const governanceBindings = parseArray(
+    value.governanceBindings,
+    parseGovernanceBindingStatus
+  );
 
-  if (!sourceId || !displayLabel || !description || !isActivationPosture(value.activationPosture)) {
+  if (
+    !sourceId ||
+    !displayLabel ||
+    !description ||
+    !isActivationPosture(value.activationPosture) ||
+    governanceBindings === null
+  ) {
     return null;
   }
 
@@ -234,6 +295,7 @@ function parseSourceOption(value: unknown): SourceOption | null {
     activationPosture: value.activationPosture,
     description,
     displayLabel,
+    governanceBindings,
     sourceFamily: readOptionalString(value.sourceFamily),
     sourceFlavor: readOptionalString(value.sourceFlavor) ?? null,
     sourceId


### PR DESCRIPTION
## Summary
- expose sanitized governance binding states on operator workflow source options and support bundle active sources
- render stale/drifted governance binding guidance in the operator shell without raw binding values
- fail closed when a source is linked to a stale governance contract

## Verification
- cd backend && python3 -m pytest tests/test_support_bundle.py tests/test_preview_source_governance_resolution.py tests/test_operator_workflow_history.py tests/test_source_entitlements.py tests/test_enterprise_auth_bridge_contract.py
- cd frontend && npm test -- --run app/page.test.tsx
- cd frontend && npm run build
- git diff --check

Closes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governance binding status reporting added to operator workflows and support bundles (role, state: valid/missing/ambiguous/stale/drifted, affects entitlement, summary, recovery).
  * Workflow preview/submission is blocked when entitlement-affecting bindings require review; UI shows binding breakdown and recovery guidance.

* **Tests**
  * End-to-end and unit tests updated/added to cover governance binding states, payload shape, and fail-closed behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->