### PR TITLE
[R-5] Add audit export redaction regressions

### DIFF
--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -30,12 +30,49 @@ from app.services.operator_workflow import (
 
 _APP_VERSION = "0.1.0"
 _WINDOWS_USER_PROFILE_SEGMENT = "Users"
-_FORBIDDEN_VALUE_PATTERNS = (
-    re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\\s\"']+"),
-    re.compile(r"(?i)\b(driver|server|database|uid|pwd)\s*="),
-    re.compile(r"(?i)\b(sk|pk|ghp|github_pat)-[a-z0-9][a-z0-9_-]{8,}"),
-    re.compile(r"(?i)(^|[\\/])Users[\\/][^\\/\"]+"),
-    re.compile(rf"(?i)[a-z]:\\{_WINDOWS_USER_PROFILE_SEGMENT}\\[^\\\"]+"),
+_FORBIDDEN_EXPORT_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "connection-string-like values",
+        re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
+    ),
+    (
+        "connection-string-like values",
+        re.compile(r"(?i)\b(driver|server|database|uid|pwd)\s*="),
+    ),
+    (
+        "token-like values",
+        re.compile(
+            r"(?i)\b(?:sk|pk|ghp|github_pat)[_-][a-z0-9][a-z0-9_-]{8,}"
+        ),
+    ),
+    (
+        "token-like values",
+        re.compile(
+            r"(?i)\b(?:access[_-]?token|refresh[_-]?token|id[_-]?token|token)\s*[:=]"
+        ),
+    ),
+    (
+        "raw credential names",
+        re.compile(
+            r"(?i)(^|[^a-z0-9])"
+            r"(?:password|passwd|pwd|credential|client[_-]?secret|"
+            r"api[_-]?key|private[_-]?key)\b"
+        ),
+    ),
+    (
+        "workstation-local paths",
+        re.compile(r"(?i)(^|[\\/])Users[\\/][^\\/\"]+"),
+    ),
+    (
+        "workstation-local paths",
+        re.compile(rf"(?i)[a-z]:\\{_WINDOWS_USER_PROFILE_SEGMENT}\\[^\\\"]+"),
+    ),
+)
+_IDENTITY_EXPORT_FIELD_NAMES = frozenset(
+    {
+        "authenticatedSubjectId",
+        "ownerSubjectId",
+    }
 )
 
 
@@ -388,6 +425,7 @@ def _redaction_policy() -> SupportBundleRedaction:
             "tokens",
             "raw_result_rows",
             "candidate_sql",
+            "raw_identity_payloads",
             "workstation_local_paths",
             "source_connection_references",
         ]
@@ -591,29 +629,43 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
     )
 
 
-def _iter_strings(value: object) -> list[str]:
+def _iter_string_values(
+    value: object,
+    path: tuple[str, ...] = (),
+) -> list[tuple[tuple[str, ...], str]]:
     if isinstance(value, str):
-        return [value]
+        return [(path, value)]
     if isinstance(value, dict):
-        strings: list[str] = []
-        for item in value.values():
-            strings.extend(_iter_strings(item))
+        strings: list[tuple[tuple[str, ...], str]] = []
+        for key, item in value.items():
+            strings.extend(_iter_string_values(item, (*path, str(key))))
         return strings
     if isinstance(value, list):
         strings = []
-        for item in value:
-            strings.extend(_iter_strings(item))
+        for index, item in enumerate(value):
+            strings.extend(_iter_string_values(item, (*path, str(index))))
         return strings
     return []
 
 
+def _is_raw_identity_payload(path: tuple[str, ...], value: str) -> bool:
+    if not path or path[-1] not in _IDENTITY_EXPORT_FIELD_NAMES:
+        return False
+    normalized = value.lstrip()
+    return normalized.startswith("{") or normalized.startswith("[")
+
+
 def _assert_bundle_is_shareable(bundle: SupportBundle) -> None:
     payload = bundle.model_dump(mode="json", by_alias=True, exclude_none=True)
-    for value in _iter_strings(payload):
-        for pattern in _FORBIDDEN_VALUE_PATTERNS:
+    for path, value in _iter_string_values(payload):
+        if _is_raw_identity_payload(path, value):
+            raise ValueError(
+                "Support bundle contains non-shareable raw identity payloads."
+            )
+        for category, pattern in _FORBIDDEN_EXPORT_VALUE_PATTERNS:
             if pattern.search(value):
                 raise ValueError(
-                    "Support bundle contains a non-shareable diagnostic value."
+                    f"Support bundle contains non-shareable {category}."
                 )
 
 

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -463,6 +463,7 @@ def test_support_bundle_service_includes_bounded_diagnostics_without_secrets(
                 "tokens",
                 "raw_result_rows",
                 "candidate_sql",
+                "raw_identity_payloads",
                 "workstation_local_paths",
                 "source_connection_references",
             ]
@@ -609,6 +610,92 @@ def test_governance_review_execute_result_rejects_boolean_row_count(
     assert execute_result["resultTruncated"] is False
 
 
+def test_governance_review_export_rejects_unsafe_export_values_by_category(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    unsafe_cases = (
+        (
+            "ghp_unsafeTokenShouldNotEcho123456789",
+            "token-like values",
+            lambda session: setattr(
+                session.query(PreviewCandidate).one(),
+                "adapter_run_id",
+                "ghp_unsafeTokenShouldNotEcho123456789",
+            ),
+        ),
+        (
+            "postgresql://reader:secret-value@db:5432/business",
+            "connection-string-like values",
+            lambda session: setattr(
+                session.query(PreviewRequest).one(),
+                "auth_source",
+                "postgresql://reader:secret-value@db:5432/business",
+            ),
+        ),
+        (
+            "database_password",
+            "raw credential names",
+            lambda session: setattr(
+                session.query(PreviewCandidate).one(),
+                "adapter_provider",
+                "database_password",
+            ),
+        ),
+        (
+            "operator@example.test",
+            "raw identity payloads",
+            lambda session: setattr(
+                session.query(PreviewRequest).one(),
+                "authenticated_subject_id",
+                '{"sub":"user:demo","email":"operator@example.test"}',
+            ),
+        ),
+        (
+            "/".join(["", "Users", "example", ".safequery", "private.log"]),
+            "workstation-local paths",
+            lambda session: setattr(
+                session.query(PreviewCandidate).one(),
+                "prompt_fingerprint",
+                "/".join(["", "Users", "example", ".safequery", "private.log"]),
+            ),
+        ),
+    )
+
+    for unsafe_value, expected_category, mutate in unsafe_cases:
+        with _session_scope() as session:
+            _add_governance_review_workflow_records(session)
+            mutate(session)
+            session.commit()
+
+            try:
+                build_support_bundle(
+                    session,
+                    settings=get_settings(),
+                    database={"status": "ok", "detail": "ready"},
+                    sql_generation={
+                        "status": "disabled",
+                        "detail": "provider_disabled",
+                    },
+                    generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+                )
+            except ValueError as exc:
+                message = str(exc)
+            else:
+                raise AssertionError(
+                    f"Expected support bundle export to reject {expected_category}."
+                )
+
+        assert expected_category in message
+        assert unsafe_value not in message
+
+
 def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:
     monkeypatch.setenv(
         "SAFEQUERY_APP_POSTGRES_URL",
@@ -641,6 +728,7 @@ def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:
         "tokens",
         "raw_result_rows",
         "candidate_sql",
+        "raw_identity_payloads",
         "workstation_local_paths",
         "source_connection_references",
     ]

--- a/docs/design/audit-governance-export-bundle.md
+++ b/docs/design/audit-governance-export-bundle.md
@@ -32,9 +32,9 @@ entitlement checks, SQL Guard, source activation posture, or execution policy
 revalidation.
 
 The export intentionally excludes raw SQL, raw result rows, connection strings,
-raw credentials, tokens, source connection references, and workstation-local
-paths. A missing field should be interpreted as unavailable or intentionally
-redacted, not as proof that an action was safe.
+raw credentials, tokens, raw identity payloads, source connection references,
+and workstation-local paths. A missing field should be interpreted as
+unavailable or intentionally redacted, not as proof that an action was safe.
 
 The bundle summarizes a committed database snapshot at generation time. It does
 not prove that external services were reachable later, that a subordinate
@@ -55,5 +55,5 @@ Generated exports should be inspected for:
 - lifecycle completeness across request, candidate, review, and execution
   records
 - clear authority labels on control-plane and subordinate evidence
-- absence of raw SQL, result rows, credentials, tokens, connection references,
-  and workstation-local paths
+- absence of raw SQL, result rows, credentials, tokens, raw identity payloads,
+  connection references, and workstation-local paths


### PR DESCRIPTION
## Summary
- add category-aware governance/support bundle export rejection for unsafe secret-bearing values
- cover token-like values, connection strings, raw credential names, raw identity payloads, and workstation-local paths
- document raw identity payload exclusion in the governance export bundle design note

## Verification
- cd backend && python3 -m pytest tests/test_support_bundle.py -q
- cd backend && python3 -m pytest -q
- rg path-hygiene checks over touched export/test/design surfaces for raw /Users/... and Windows user-profile literals

Closes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support bundle shareability validation with improved error detection and reporting. Raw identity payloads are now excluded from exported support bundles.

* **Documentation**
  * Updated audit governance export bundle documentation to reflect changes to redaction policies and clarify excluded content categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->