### PR TITLE
Expand fail-closed auth route coverage

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -513,8 +513,12 @@ def create_app() -> FastAPI:
 
     @app.get("/support/bundle", response_model=SupportBundle)
     def read_support_bundle(
+        authenticated_subject: AuthenticatedSubject = Depends(
+            require_authenticated_subject
+        ),
         session: Session = Depends(require_preview_submission_session),
     ) -> SupportBundle:
+        authenticated_subject.normalized_subject_id()
         database = check_database_health(str(settings.app_postgres_url))
         sql_generation = check_sql_generation_runtime_health(settings.sql_generation)
         return build_support_bundle(
@@ -824,8 +828,12 @@ def create_app() -> FastAPI:
 
     @app.get("/operator/workflow", response_model=OperatorWorkflowSnapshot)
     def read_operator_workflow(
+        authenticated_subject: AuthenticatedSubject = Depends(
+            require_authenticated_subject
+        ),
         session: Session = Depends(require_preview_submission_session),
     ) -> OperatorWorkflowSnapshot:
+        authenticated_subject.normalized_subject_id()
         return get_operator_workflow_snapshot(session)
 
     return app

--- a/backend/tests/test_dev_auth_preview_api.py
+++ b/backend/tests/test_dev_auth_preview_api.py
@@ -236,6 +236,53 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
+    def test_missing_csrf_blocks_preview_http_request_with_valid_session(self) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+
+        response = self._client().post(
+            "/requests/preview",
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": DEMO_SOURCE_ID,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "csrf_failed",
+                    "message": "Refresh the page before submitting preview requests.",
+                }
+            },
+        )
+
+    def test_missing_csrf_blocks_execute_http_request_with_valid_session(self) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+
+        response = self._client().post(
+            "/candidates/candidate-not-reached/execute",
+            cookies=app_session.cookies,
+            json={},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "csrf_failed",
+                    "message": "Refresh the page before submitting preview requests.",
+                }
+            },
+        )
+
     def test_mismatched_session_subject_blocks_preview_http_request(self) -> None:
         os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
         os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
@@ -359,6 +406,40 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
                 "source_id": DEMO_SOURCE_ID,
             },
         )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "unauthenticated",
+                    "message": "Sign in before submitting preview requests.",
+                }
+            },
+        )
+
+    def test_production_default_dev_auth_blocks_operator_workflow_http_request(
+        self,
+    ) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "production"
+
+        response = self._client().get("/operator/workflow")
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "unauthenticated",
+                    "message": "Sign in before submitting preview requests.",
+                }
+            },
+        )
+
+    def test_production_default_dev_auth_blocks_support_bundle_http_request(self) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "production"
+
+        response = self._client().get("/support/bundle")
 
         self.assertEqual(response.status_code, 401)
         self.assertEqual(

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -701,6 +701,8 @@ def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:
         "SAFEQUERY_APP_POSTGRES_URL",
         "postgresql://safequery:app-secret@db:5432/safequery",
     )
+    monkeypatch.setenv("SAFEQUERY_ENVIRONMENT", "development")
+    monkeypatch.setenv("SAFEQUERY_DEV_AUTH_ENABLED", "true")
     monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
     get_settings.cache_clear()
     main_module = importlib.import_module("app.main")


### PR DESCRIPTION
## Summary
- require authenticated subjects for operator workflow and support bundle read routes
- add focused production fail-closed regressions for unauthenticated workflow/support reads
- add valid-session CSRF-missing regressions for preview and execute POST routes

## Verification
- python3 -m pytest tests/test_dev_auth_preview_api.py tests/test_support_bundle.py tests/test_api_errors.py
- npm test -- page.test.tsx

Closes #319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Administrative endpoints now validate authentication credentials during request processing.

* **Tests**
  * Added test cases validating CSRF token enforcement for authenticated users.
  * Added test coverage for authorization checks on restricted endpoints across different deployment environments.
  * Updated test configuration to support validation of environment-specific authentication behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->