### PR TITLE
Restrict operator evidence reads by authority

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -21,6 +21,7 @@ _SAFE_API_ERROR_CODES = frozenset(
         "entitlement_denied",
         "execution_denied",
         "execution_unavailable",
+        "operator_read_forbidden",
         "preview_generation_failed",
         "preview_source_malformed",
         "preview_source_unavailable",

--- a/backend/app/features/auth/operator_access.py
+++ b/backend/app/features/auth/operator_access.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from app.core.errors import api_error
+from app.features.auth.context import AuthenticatedSubject
+
+
+OPERATOR_EVIDENCE_READ_AUTHORITY_BINDINGS = frozenset(
+    {
+        "entitlement:safequery-admin",
+        "entitlement:safequery-operator-evidence-read",
+        "entitlement:safequery-support",
+        "group:security-reviewers",
+        "role:safequery-admin",
+        "role:safequery-support",
+        "role:sql-reviewer",
+    }
+)
+
+
+def ensure_operator_evidence_read_authority(
+    authenticated_subject: AuthenticatedSubject,
+) -> None:
+    subject_bindings = authenticated_subject.normalized_governance_bindings()
+    if subject_bindings & OPERATOR_EVIDENCE_READ_AUTHORITY_BINDINGS:
+        return
+
+    raise api_error(
+        403,
+        "operator_read_forbidden",
+        "Operator evidence requires reviewer or support authority.",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.features.auth.context import (
     AuthenticatedSubject,
     require_authenticated_subject,
 )
+from app.features.auth.operator_access import ensure_operator_evidence_read_authority
 from app.features.auth.session import (
     ApplicationSessionContext,
     require_application_session,
@@ -519,6 +520,7 @@ def create_app() -> FastAPI:
         session: Session = Depends(require_preview_submission_session),
     ) -> SupportBundle:
         authenticated_subject.normalized_subject_id()
+        ensure_operator_evidence_read_authority(authenticated_subject)
         database = check_database_health(str(settings.app_postgres_url))
         sql_generation = check_sql_generation_runtime_health(settings.sql_generation)
         return build_support_bundle(
@@ -834,6 +836,7 @@ def create_app() -> FastAPI:
         session: Session = Depends(require_preview_submission_session),
     ) -> OperatorWorkflowSnapshot:
         authenticated_subject.normalized_subject_id()
+        ensure_operator_evidence_read_authority(authenticated_subject)
         return get_operator_workflow_snapshot(session)
 
     return app

--- a/backend/tests/test_dev_auth_preview_api.py
+++ b/backend/tests/test_dev_auth_preview_api.py
@@ -76,6 +76,18 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
         )
         return TestClient(app)
 
+    def _client_with_subject(self, subject: AuthenticatedSubject) -> TestClient:
+        get_settings.cache_clear()
+        main_module = importlib.import_module("app.main")
+        app = main_module.create_app()
+        app.dependency_overrides[main_module.require_authenticated_subject] = (
+            lambda: subject
+        )
+        app.dependency_overrides[require_preview_submission_session] = (
+            lambda: self.session
+        )
+        return TestClient(app)
+
     def _seed_restricted_source(self, source_id: str) -> None:
         source = RegisteredSource(
             id=uuid4(),
@@ -451,6 +463,75 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
                 }
             },
         )
+
+    def test_authenticated_unentitled_subject_cannot_read_operator_workflow(
+        self,
+    ) -> None:
+        response = self._client_with_subject(
+            AuthenticatedSubject(
+                subject_id="user:authenticated-without-operator-authority",
+                governance_bindings=frozenset({"group:unrelated-analysts"}),
+            )
+        ).get("/operator/workflow")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "operator_read_forbidden",
+                    "message": "Operator evidence requires reviewer or support authority.",
+                }
+            },
+        )
+        self.assertNotIn("sources", response.text)
+        self.assertNotIn(DEMO_SOURCE_ID, response.text)
+
+    def test_authenticated_unentitled_subject_cannot_read_support_bundle(
+        self,
+    ) -> None:
+        response = self._client_with_subject(
+            AuthenticatedSubject(
+                subject_id="user:authenticated-without-support-authority",
+                governance_bindings=frozenset({"group:unrelated-analysts"}),
+            )
+        ).get("/support/bundle")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "operator_read_forbidden",
+                    "message": "Operator evidence requires reviewer or support authority.",
+                }
+            },
+        )
+        self.assertNotIn("activeSources", response.text)
+        self.assertNotIn("audit", response.text)
+        self.assertNotIn(DEMO_SOURCE_ID, response.text)
+
+    def test_reviewer_subject_can_read_operator_workflow(self) -> None:
+        response = self._client_with_subject(
+            AuthenticatedSubject(
+                subject_id="user:source-reviewer",
+                governance_bindings=frozenset({"group:security-reviewers"}),
+            )
+        ).get("/operator/workflow")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["sources"][0]["sourceId"], DEMO_SOURCE_ID)
+
+    def test_support_subject_can_read_support_bundle(self) -> None:
+        response = self._client_with_subject(
+            AuthenticatedSubject(
+                subject_id="user:support-engineer",
+                governance_bindings=frozenset({"entitlement:safequery-support"}),
+            )
+        ).get("/support/bundle")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["activeSources"][0]["sourceId"], DEMO_SOURCE_ID)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -48,7 +48,9 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         self.app = main_module.create_app()
         self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(
             subject_id="user:alice",
-            governance_bindings=frozenset({"group:finance-analysts"}),
+            governance_bindings=frozenset(
+                {"group:finance-analysts", "group:security-reviewers"}
+            ),
         )
         self.app.dependency_overrides[require_preview_submission_session] = (
             lambda: self.session

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -23,6 +23,7 @@ from app.db.models.preview import (
 )
 from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
+from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 from app.services.demo_source_seed import seed_demo_source_governance
 from app.services.support_bundle import build_support_bundle
 
@@ -45,6 +46,10 @@ def _client(session: Session) -> TestClient:
     get_settings.cache_clear()
     main_module = importlib.import_module("app.main")
     app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(
+        subject_id="user:support-reviewer",
+        governance_bindings=frozenset({"group:security-reviewers"}),
+    )
     app.dependency_overrides[require_preview_submission_session] = lambda: session
     return TestClient(app)
 


### PR DESCRIPTION
## Summary
- require explicit reviewer/support/admin-style governance authority before returning /operator/workflow or /support/bundle
- add sanitized 403 coverage for authenticated-but-unentitled subjects
- keep authorized reviewer/support and existing redaction/support bundle paths covered

## Tests
- cd backend && python3 -m pytest tests/test_dev_auth_preview_api.py -k 'authenticated_unentitled_subject_cannot_read'
- cd backend && python3 -m pytest tests/test_dev_auth_preview_api.py -k 'authenticated_unentitled_subject_cannot_read or reviewer_subject_can_read_operator_workflow or support_subject_can_read_support_bundle'
- cd backend && python3 -m pytest tests/test_dev_auth_preview_api.py tests/test_support_bundle.py tests/test_operator_workflow_history.py
- cd backend && python3 -m pytest tests/test_request_source_selection.py
- cd backend && python3 -m pytest

Closes #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced authorization enforcement for operator evidence and workflow data access based on user governance bindings; users lacking required permissions receive a 403 Forbidden response

* **Tests**
  * Added authorization tests verifying access denial for unauthorized users and proper data access for users with required governance roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->