### PR TITLE
Preserve dev-auth operator workflow access

### DIFF
--- a/backend/app/features/auth/operator_access.py
+++ b/backend/app/features/auth/operator_access.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from app.core.config import Settings
 from app.core.errors import api_error
 from app.features.auth.context import AuthenticatedSubject
+from app.services.demo_source_seed import (
+    DEMO_DEV_GOVERNANCE_BINDING,
+    DEMO_DEV_SUBJECT_ID,
+)
 
 
 OPERATOR_EVIDENCE_READ_AUTHORITY_BINDINGS = frozenset(
@@ -17,11 +22,50 @@ OPERATOR_EVIDENCE_READ_AUTHORITY_BINDINGS = frozenset(
 )
 
 
+def _has_operator_evidence_read_authority(
+    authenticated_subject: AuthenticatedSubject,
+) -> bool:
+    subject_bindings = authenticated_subject.normalized_governance_bindings()
+    return bool(subject_bindings & OPERATOR_EVIDENCE_READ_AUTHORITY_BINDINGS)
+
+
+def _has_local_dev_operator_workflow_authority(
+    authenticated_subject: AuthenticatedSubject,
+    settings: Settings,
+) -> bool:
+    if (
+        not settings.dev_auth_enabled
+        or settings.environment not in {"development", "test"}
+    ):
+        return False
+
+    return (
+        authenticated_subject.normalized_subject_id() == DEMO_DEV_SUBJECT_ID
+        and DEMO_DEV_GOVERNANCE_BINDING
+        in authenticated_subject.normalized_governance_bindings()
+    )
+
+
 def ensure_operator_evidence_read_authority(
     authenticated_subject: AuthenticatedSubject,
 ) -> None:
-    subject_bindings = authenticated_subject.normalized_governance_bindings()
-    if subject_bindings & OPERATOR_EVIDENCE_READ_AUTHORITY_BINDINGS:
+    if _has_operator_evidence_read_authority(authenticated_subject):
+        return
+
+    raise api_error(
+        403,
+        "operator_read_forbidden",
+        "Operator evidence requires reviewer or support authority.",
+    )
+
+
+def ensure_operator_workflow_read_authority(
+    authenticated_subject: AuthenticatedSubject,
+    settings: Settings,
+) -> None:
+    if _has_operator_evidence_read_authority(
+        authenticated_subject
+    ) or _has_local_dev_operator_workflow_authority(authenticated_subject, settings):
         return
 
     raise api_error(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,7 +33,10 @@ from app.features.auth.context import (
     AuthenticatedSubject,
     require_authenticated_subject,
 )
-from app.features.auth.operator_access import ensure_operator_evidence_read_authority
+from app.features.auth.operator_access import (
+    ensure_operator_evidence_read_authority,
+    ensure_operator_workflow_read_authority,
+)
 from app.features.auth.session import (
     ApplicationSessionContext,
     require_application_session,
@@ -836,7 +839,7 @@ def create_app() -> FastAPI:
         session: Session = Depends(require_preview_submission_session),
     ) -> OperatorWorkflowSnapshot:
         authenticated_subject.normalized_subject_id()
-        ensure_operator_evidence_read_authority(authenticated_subject)
+        ensure_operator_workflow_read_authority(authenticated_subject, settings)
         return get_operator_workflow_snapshot(session)
 
     return app

--- a/backend/tests/test_dev_auth_preview_api.py
+++ b/backend/tests/test_dev_auth_preview_api.py
@@ -448,6 +448,17 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
             },
         )
 
+    def test_enabled_development_dev_auth_allows_operator_workflow_http_request(
+        self,
+    ) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+
+        response = self._client().get("/operator/workflow")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["sources"][0]["sourceId"], DEMO_SOURCE_ID)
+
     def test_production_default_dev_auth_blocks_support_bundle_http_request(self) -> None:
         os.environ["SAFEQUERY_ENVIRONMENT"] = "production"
 
@@ -463,6 +474,27 @@ class DevAuthPreviewApiTestCase(unittest.TestCase):
                 }
             },
         )
+
+    def test_enabled_development_dev_auth_does_not_allow_support_bundle_http_request(
+        self,
+    ) -> None:
+        os.environ["SAFEQUERY_ENVIRONMENT"] = "development"
+        os.environ["SAFEQUERY_DEV_AUTH_ENABLED"] = "true"
+
+        response = self._client().get("/support/bundle")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "operator_read_forbidden",
+                    "message": "Operator evidence requires reviewer or support authority.",
+                }
+            },
+        )
+        self.assertNotIn("activeSources", response.text)
+        self.assertNotIn(DEMO_SOURCE_ID, response.text)
 
     def test_authenticated_unentitled_subject_cannot_read_operator_workflow(
         self,


### PR DESCRIPTION
## Summary
- preserve default development dev-auth access to /operator/workflow for the demo local operator
- keep /support/bundle on the stricter reviewer/support evidence-read authority gate
- add regression coverage for dev-auth workflow allow and support bundle denial

## Verification
- cd backend && python3 -m pytest tests/test_dev_auth_preview_api.py::DevAuthPreviewApiTestCase::test_enabled_development_dev_auth_allows_operator_workflow_http_request
- cd backend && python3 -m pytest tests/test_dev_auth_preview_api.py::DevAuthPreviewApiTestCase::test_enabled_development_dev_auth_allows_operator_workflow_http_request tests/test_dev_auth_preview_api.py::DevAuthPreviewApiTestCase::test_enabled_development_dev_auth_does_not_allow_support_bundle_http_request tests/test_dev_auth_preview_api.py::DevAuthPreviewApiTestCase::test_authenticated_unentitled_subject_cannot_read_operator_workflow tests/test_dev_auth_preview_api.py::DevAuthPreviewApiTestCase::test_authenticated_unentitled_subject_cannot_read_support_bundle
- cd backend && python3 -m pytest tests/test_dev_auth_preview_api.py tests/test_support_bundle.py
- cd backend && python3 -m pytest

Closes #328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operator workflow read access authorization with environment-gated development mode overrides.

* **Tests**
  * Added test cases validating operator workflow authorization behavior and development mode access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->