### PR TITLE
Preserve operator read forbidden frontend state

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -484,6 +484,44 @@ describe("HomePage", () => {
     expect(screen.queryByRole("option", { name: /sap spend cube/i })).not.toBeInTheDocument();
   });
 
+  it("renders operator read forbidden guidance without implying backend outage", async () => {
+    const secretDetail = "support-token-should-not-render";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: false,
+            json: () =>
+              Promise.resolve({
+                error: {
+                  code: "operator_read_forbidden",
+                  message: "Reviewer or support authority is required to read the operator workflow.",
+                  raw: secretDetail
+                }
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(await HomePage({}));
+
+    expect(screen.getByRole("heading", { name: /operator workflow authority required/i })).toBeInTheDocument();
+    expect(screen.getByText(/reviewer or support authority is required before reading/i)).toBeInTheDocument();
+    expect(screen.getByText(/use a signed-in operator with reviewer, support, or admin authority/i)).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /backend workflow unavailable/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/backend workflow payload is unavailable/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(secretDetail)).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /sap spend cube/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/no live history rows/i)).toBeInTheDocument();
+  });
+
   it("renders normalized auth and entitlement workflow failures without leaking sensitive details", async () => {
     const secretDetail = "idp-token-should-not-render";
     const failureCases = [
@@ -506,6 +544,11 @@ describe("HomePage", () => {
         code: "entitlement_denied",
         message: "The signed-in operator is not entitled to use that source.",
         statusCopy: /this source or workflow context/i
+      },
+      {
+        code: "operator_read_forbidden",
+        message: "Reviewer or support authority is required to read the operator workflow.",
+        statusCopy: /before reading the operator workflow/i
       }
     ] as const;
 
@@ -537,7 +580,7 @@ describe("HomePage", () => {
       render(await HomePage({}));
 
       expect(screen.getByLabelText(/operator history/i)).toHaveTextContent(failureCase.code);
-      expect(screen.getByText(failureCase.statusCopy)).toBeInTheDocument();
+      expect(screen.getAllByText(failureCase.statusCopy).length).toBeGreaterThan(0);
       expect(screen.getByText(failureCase.message)).toBeInTheDocument();
       expect(screen.queryByText(secretDetail)).not.toBeInTheDocument();
     }

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -289,6 +289,14 @@ function getFirstRunGuidance(snapshot: OperatorWorkflowSnapshot): FirstRunGuidan
     };
   }
 
+  if (snapshot.status === "operator_read_forbidden") {
+    return {
+      body:
+        "Confirm the signed-in operator has reviewer, support, or admin authority before reading the operator workflow.",
+      title: "Operator workflow authority required"
+    };
+  }
+
   if (snapshot.status === "live" && snapshot.sources.length === 0) {
     return {
       body:
@@ -331,13 +339,18 @@ function getOperatorRecoveryGuidance(
     snapshot.status === "unauthenticated" ||
     snapshot.status === "session_invalid" ||
     snapshot.status === "csrf_failed" ||
+    snapshot.status === "operator_read_forbidden" ||
     snapshot.status === "entitlement_denied"
   ) {
     return {
       action:
-        "Revise the session, request freshness, or entitlement binding before retrying.",
+        snapshot.status === "operator_read_forbidden"
+          ? "Use a signed-in operator with reviewer, support, or admin authority before retrying."
+          : "Revise the session, request freshness, or entitlement binding before retrying.",
       anchor:
-        "Use SafeQuery auth and entitlement records as the prerequisite; do not infer access from UI text or external evidence.",
+        snapshot.status === "operator_read_forbidden"
+          ? "Use SafeQuery authority records as the prerequisite; do not infer reviewer or support authority from UI text or external evidence."
+          : "Use SafeQuery auth and entitlement records as the prerequisite; do not infer access from UI text or external evidence.",
       title: "Workflow access blocked"
     };
   }
@@ -942,6 +955,10 @@ function getWorkflowDataStatusCopy(status: OperatorWorkflowSnapshot["status"]): 
 
   if (status === "entitlement_denied") {
     return "The signed-in operator is not entitled to this source or workflow context.";
+  }
+
+  if (status === "operator_read_forbidden") {
+    return "Reviewer or support authority is required before reading the operator workflow.";
   }
 
   if (status === "malformed") {

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -91,6 +91,7 @@ export type OperatorWorkflowSnapshot = {
     | "unauthenticated"
     | "session_invalid"
     | "csrf_failed"
+    | "operator_read_forbidden"
     | "entitlement_denied";
 };
 
@@ -382,6 +383,7 @@ function unavailableSnapshotForApiError(payload: unknown): OperatorWorkflowSnaps
     error?.code === "unauthenticated" ||
     error?.code === "session_invalid" ||
     error?.code === "csrf_failed" ||
+    error?.code === "operator_read_forbidden" ||
     error?.code === "entitlement_denied"
   ) {
     return {


### PR DESCRIPTION
## Summary
- preserve operator_read_forbidden as a frontend operator workflow status
- render reviewer/support authority guidance instead of backend-unavailable copy
- add focused frontend coverage for denied-read guidance, sanitized message preservation, and hidden source/history evidence

## Verification
- cd frontend && npm test -- --run app/page.test.tsx
- cd frontend && npm test -- --run app/page.test.tsx app/pilot-safety-smoke.test.tsx
- cd frontend && npm test -- --run

Closes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added handling for authorization-related read permission restrictions with improved user guidance, status messaging, and operator authority requirement notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->