### PR TITLE
Define pilot deployment environment contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ For limited pilot operations after first-run setup, use
 classify normal, degraded, maintenance, incident, and recovery posture. Keep
 SafeQuery control-plane records authoritative over UI summaries, LLM output,
 adapter output, MLflow, Search, Analyst, and external evidence.
+Use [docs/pilot-deployment-profile.md](./docs/pilot-deployment-profile.md) to
+classify required, optional, and forbidden environment values before treating a
+local first-run stack as pilot evidence.
 
 Known product-readiness gaps remain for later Epic K/O/P work:
 
@@ -184,6 +187,9 @@ connector binding are missing. The CLI doctor also probes
 `SAFEQUERY_BACKEND_BASE_URL` `/health` and `SAFEQUERY_FRONTEND_BASE_URL`;
 unreachable or unhealthy surfaces are reported as failures instead of
 first-run-ready passes.
+For the required, optional, and forbidden environment-value contract that frames
+these checks, see
+[docs/pilot-deployment-profile.md](./docs/pilot-deployment-profile.md).
 
 6. Confirm the live operator workflow contract exposes an active source selector
    option:
@@ -287,8 +293,8 @@ hostname:
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="<reachable-app-postgres-url>" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="<reachable-app-postgres-url>" alembic current
 ```
 
 Source-foundation smoke verification:

--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -69,31 +69,33 @@ This reading order is intended to help new contributors understand SafeQuery fro
     Use this to understand how NL2SQL quality should be measured safely in the current source-aware baseline.
 27. [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md)
     Use this as the 2-source core path pilot-readiness checklist after the source-aware implementation slices are complete.
-28. [pilot-operations-runbook.md](./pilot-operations-runbook.md)
+28. [pilot-deployment-profile.md](./pilot-deployment-profile.md)
+    Use this to classify local/pilot environment values as required, optional, or forbidden before startup, doctor checks, exports, or support bundles.
+29. [pilot-operations-runbook.md](./pilot-operations-runbook.md)
     Use this to classify normal, degraded, maintenance, incident, and recovery posture during limited pilot operation without treating UI, LLM, adapter, MLflow, Search, Analyst, or external evidence as authoritative.
 
 ### 5. Approved Follow-on Direction
 
-29. [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md)
+30. [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md)
     Read first in this section to understand how SafeQuery expands beyond one hard-coded business source while keeping request, candidate, and execution paths single-source.
-30. [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md)
+31. [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md)
     Review how source families, flavors, connector profiles, and guard profiles are separated so future onboarding does not redesign the control plane.
-31. [design/target-source-registry.md](./design/target-source-registry.md)
+32. [design/target-source-registry.md](./design/target-source-registry.md)
     Use this to understand the concrete registry model, source lifecycle expectations, and application PostgreSQL separation guardrails.
-32. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
+33. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
     Review the family and flavor rollout matrix before planning connector, guard, or evaluation work for additional sources.
-33. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
+34. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
     Read this to understand why the product shell is workflow-first and why the Epic A shell remains a developer state demo.
-34. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
+35. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
     Review how SafeQuery may borrow OSS ergonomics without turning the product into a generic chat shell or moving trust boundaries.
-35. [implementation-roadmap.md](./implementation-roadmap.md)
+36. [implementation-roadmap.md](./implementation-roadmap.md)
     Finish this section with the current implementation sequence so roadmap work stays aligned with the reviewed docs direction.
 
 ### 6. Local Setup and Threat Review
 
-36. [local-development.md](./local-development.md)
+37. [local-development.md](./local-development.md)
     Use this once the document set is clear so local startup follows the reviewed topology and role split.
-37. [security/threat-model.md](./security/threat-model.md)
+38. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks for the current source-aware and UX-foundation baseline before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [01_READING_ORDER.md](./01_READING_ORDER.md): recommended reading sequence for engineers and reviewers
 - [README.md](../README.md): repository-level startup and baseline orientation that points contributors back to the reviewed docs set
 - [local-development.md](./local-development.md): contributor startup path for env setup, compose startup, migrations, and baseline troubleshooting
+- [pilot-deployment-profile.md](./pilot-deployment-profile.md): local/pilot profile and environment contract for required, optional, and forbidden values
 
 ### Normative Baseline
 
@@ -70,6 +71,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md): governed semantic retrieval and analyst-style orchestration in the current source-aware baseline
 - [design/evaluation-harness.md](./design/evaluation-harness.md): evaluation goals, datasets, and scoring for the current baseline
 - [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md): pilot-readiness verification checklist for the completed 2-source core path
+- [pilot-deployment-profile.md](./pilot-deployment-profile.md): pilot deployment assumptions and environment contract for safe local/pilot operation
 - [pilot-operations-runbook.md](./pilot-operations-runbook.md): operator runbook and incident state taxonomy for normal, degraded, maintenance, incident, and recovery pilot states
 - [security/threat-model.md](./security/threat-model.md): threat model and residual risk summary for the current source-aware and UX-foundation baseline
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -32,6 +32,9 @@ For limited pilot operations after first-run setup, use
 degraded, maintenance, incident, and recovery posture. The runbook keeps
 SafeQuery control-plane records authoritative over UI summaries, LLM output,
 adapter output, MLflow, Search, Analyst, and external evidence.
+Use [pilot-deployment-profile.md](./pilot-deployment-profile.md) to classify
+required, optional, and forbidden environment values before promoting a local
+first-run stack into a pilot window.
 
 ## Current Baseline
 
@@ -119,6 +122,11 @@ The full stack expects a repository-level `.env` file:
 ```bash
 cp .env.example .env
 ```
+
+For the pilot environment contract, including required, optional, and forbidden
+values, use [pilot-deployment-profile.md](./pilot-deployment-profile.md).
+Missing required values should fail closed, and raw secrets must not be placed
+in frontend/public values, audit exports, or support bundles.
 
 That file provides the baseline values for:
 
@@ -345,8 +353,8 @@ Example host-shell path:
 ```bash
 python3 -m pip install -e backend
 cd backend
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic upgrade head
-SAFEQUERY_APP_POSTGRES_URL="postgresql://safequery:change-me-for-shared-environments@127.0.0.1:5432/safequery" alembic current
+SAFEQUERY_APP_POSTGRES_URL="<reachable-app-postgres-url>" alembic upgrade head
+SAFEQUERY_APP_POSTGRES_URL="<reachable-app-postgres-url>" alembic current
 ```
 
 ## 6. Optional Host-Shell Component Checks

--- a/docs/pilot-deployment-profile.md
+++ b/docs/pilot-deployment-profile.md
@@ -7,7 +7,7 @@ sharing evidence from a pilot stack. It complements
 [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md),
 and [pilot-operations-runbook.md](./pilot-operations-runbook.md).
 
-The profile is intentionally local/pilot scoped. It does not define production
+The profile is intentionally local/pilot-scoped. It does not define production
 release, cloud tenancy, secret rotation, or enterprise identity deployment.
 Those remain later deployment and security tracks.
 

--- a/docs/pilot-deployment-profile.md
+++ b/docs/pilot-deployment-profile.md
@@ -1,0 +1,196 @@
+# Pilot Deployment Profile and Environment Contract
+
+This document defines the limited SafeQuery pilot deployment profile and the
+environment-value contract operators should use before starting, validating, or
+sharing evidence from a pilot stack. It complements
+[local-development.md](./local-development.md),
+[pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md),
+and [pilot-operations-runbook.md](./pilot-operations-runbook.md).
+
+The profile is intentionally local/pilot scoped. It does not define production
+release, cloud tenancy, secret rotation, or enterprise identity deployment.
+Those remain later deployment and security tracks.
+
+## Pilot Profile Assumptions
+
+The pilot profile assumes:
+
+- operators start from the repo-root `.env.example` contract and create a local
+  `.env` before running Compose
+- the backend owns source registry, entitlement, request, candidate, guard,
+  execution, audit, doctor, and support-bundle decisions
+- application PostgreSQL stores SafeQuery control-plane state only
+- business-source credentials are separate from application database credentials
+- browser-visible values are configuration endpoints, not secrets
+- optional extension surfaces such as Search, Analyst, and MLflow are evidence
+  helpers only when explicitly enabled for the pilot window
+
+Do not infer pilot readiness from hostnames, service names, local file paths,
+comments, or nearby metadata. Missing, blank, placeholder, mixed, or forbidden
+environment values must fail closed before pilot traffic continues.
+
+## Environment Categories
+
+Classify every environment value in one of three categories:
+
+| Category | Meaning | Pilot behavior |
+| --- | --- | --- |
+| Required | The stack, doctor, or pilot workflow cannot be evaluated safely without this value. | Missing or blank values fail closed. |
+| Optional | The value has a reviewed default, is needed only for a specific extension, or is activated by a later pilot lane. | Leave unset unless the related lane is explicitly enabled and verified. |
+| Forbidden | The value would expose credentials, confuse the trust boundary, or leak source data into untrusted surfaces. | Reject the configuration or stop sharing the artifact. |
+
+When an optional lane is enabled for a deployment, its related governance,
+audit, evaluation, and authorization requirements become mandatory for that
+deployment.
+
+## Required Values
+
+The local/pilot Compose baseline requires these values:
+
+| Value | Role |
+| --- | --- |
+| `SAFEQUERY_APP_POSTGRES_URL` | Backend connection to application PostgreSQL for SafeQuery-owned control-plane records. |
+| `APP_POSTGRES_DB` | Compose startup value for the application PostgreSQL database. |
+| `APP_POSTGRES_USER` | Compose startup value for the application PostgreSQL user. |
+| `APP_POSTGRES_PASSWORD` | Compose startup value for the application PostgreSQL password. |
+| `API_INTERNAL_BASE_URL` | Frontend server-side route to the backend inside the deployment boundary. |
+| `NEXT_PUBLIC_API_BASE_URL` | Browser-facing backend URL. This must be an endpoint only, never a secret-bearing URL. |
+| `SAFEQUERY_BACKEND_BASE_URL` | First-run doctor backend probe base URL. |
+| `SAFEQUERY_FRONTEND_BASE_URL` | First-run doctor frontend probe base URL. |
+
+The application database values are required because the backend must have an
+authoritative place to persist migrations, source registry records, contracts,
+schema snapshots, requests, candidates, execution state, and audit records.
+They do not create a business query source.
+
+## Optional Values
+
+These values are optional for the baseline local/pilot profile unless a specific
+pilot lane says otherwise:
+
+| Value | Role |
+| --- | --- |
+| `SAFEQUERY_APP_NAME` | Operator-facing application name with a reviewed default. |
+| `SAFEQUERY_ENVIRONMENT` | Environment label used for diagnostics and support context. |
+| `SAFEQUERY_DEV_AUTH_ENABLED` | Dev/local authentication fixture toggle. It must stay off unless the local pilot path explicitly uses the dev entitlement fixture. |
+| `SAFEQUERY_CORS_ORIGINS` | Allowed frontend origins for the backend. Narrow to the expected frontend URL for the pilot. |
+| `BUSINESS_POSTGRES_SOURCE_DB` | Compose startup value for the local business PostgreSQL source container. |
+| `BUSINESS_POSTGRES_SOURCE_USER` | Compose startup value for the local business PostgreSQL source user. |
+| `BUSINESS_POSTGRES_SOURCE_PASSWORD` | Compose startup value for the local business PostgreSQL source password. |
+| `BUSINESS_MSSQL_SOURCE_SA_PASSWORD` | Compose startup value for the local business MSSQL source container. |
+| `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` | Backend-only connection setting for an explicitly registered business PostgreSQL source. |
+| `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` | Backend-only connection setting for an explicitly registered business MSSQL source. |
+
+Optional business-source connection values must stay backend-only and
+source-scoped. They are valid only when the backend-owned source registry,
+connector profile, entitlement, guard, and pilot verification evidence agree.
+
+## Forbidden Values
+
+The pilot profile forbids:
+
+- raw secrets in frontend or public payloads, including `NEXT_PUBLIC_*`
+  variables, browser responses, UI state, static assets, telemetry, issue text,
+  and screenshots
+- source credentials in audit exports or support bundles
+- source connection URLs, connection strings, passwords, tokens, cookies, CSRF
+  secrets, session secrets, private keys, or identity-provider internals in
+  artifacts shared outside the backend trust boundary
+- application database credentials reused for business-source access
+- application PostgreSQL treated as an active business source
+- business-source credentials inferred from application database names,
+  service names, driver names, or comments
+- client-supplied identity, tenant, source, host, proto, or forwarded-header
+  values treated as trusted environment binding
+- workstation-local absolute paths in publishable docs, validation plans,
+  support bundles, audit exports, or operator-facing evidence
+
+If a forbidden value appears, stop the affected pilot path, rotate or replace
+the exposed credential if needed, and preserve only bounded identifiers such as
+request ids, candidate ids, run ids, audit ids, source ids, and command names.
+
+## Application Database
+
+Application PostgreSQL is SafeQuery-owned persistence. It stores application
+records such as:
+
+- migrations and schema posture
+- source registry records and source readiness state
+- dataset contracts and schema snapshots
+- request, candidate, guard, approval, execution, and audit records
+- operator workflow history and readiness evidence
+
+`SAFEQUERY_APP_POSTGRES_URL` must point to this application database. In this
+contract, application PostgreSQL is not a business source, not a query target,
+and not a fallback source credential pool.
+
+## Business Sources
+
+Business sources are separate from application PostgreSQL and become usable only
+through explicit backend records:
+
+- `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL` belongs to an explicitly registered
+  business PostgreSQL source such as the local demo source.
+- `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` belongs to an explicitly
+  registered business MSSQL source.
+
+For each active source, the pilot must be able to prove source id, source
+family, optional flavor, connector profile, dataset contract, schema snapshot,
+entitlement binding, guard profile, and readiness evidence from authoritative
+backend records. Do not activate a source from environment naming alone.
+
+## Auth, CSRF, and Session
+
+Auth, CSRF, and session values remain trusted-backend concerns:
+
+- `SAFEQUERY_DEV_AUTH_ENABLED` is a local fixture toggle, not production auth.
+- Session cookies, CSRF secrets, bridge tokens, identity-provider assertions,
+  and authorization internals must never be placed in frontend/public
+  environment values or support artifacts.
+- The backend must establish and validate application-owned session and
+  authorization context before state-changing or execute-bound paths.
+
+If auth context is missing, placeholder, unsigned, forwarded without a trusted
+proxy, or otherwise untrusted, keep the pilot path blocked.
+
+## Audit Export and Support Bundle
+
+Audit exports and support bundles are bounded diagnostic artifacts. They may
+include application version, environment label, source ids, source posture,
+health summaries, migration posture, workflow state summaries, lifecycle
+metrics, and audit completeness counts.
+
+They must not include:
+
+- raw operator prompts, raw SQL, or raw result rows
+- database URLs, connection strings, passwords, tokens, cookies, session
+  secrets, CSRF secrets, private keys, or source connection references
+- source credentials in audit exports or support bundles
+- workstation-local absolute paths
+
+Before sharing an artifact, inspect it as text and stop if a forbidden value is
+present. An export or bundle that contains forbidden values is an incident or
+recovery input, not a shareable pilot artifact.
+
+## Validation and Doctor Guidance
+
+Use the first-run doctor after env setup, migrations, and demo source seeding:
+
+```bash
+docker-compose --env-file .env -f infra/docker-compose.yml run --rm backend python -m app.cli.first_run_doctor
+```
+
+The doctor should fail closed when required backend-owned prerequisites are
+missing, including application database connectivity, migrations, source
+registry records, dataset contract linkage, approved schema snapshots,
+entitlement seed data, execution connector binding, backend reachability, and
+frontend reachability.
+
+The doctor is not a secret scanner. Operators must still manually inspect
+changed docs, validation plans, audit exports, support bundles, and public
+payloads for forbidden values before sharing them.
+
+When a doctor, smoke, export, or support-bundle result depends on a missing
+prerequisite signal, reject the pilot posture instead of substituting guessed
+context. Use repo-relative command forms and documented environment variables
+in durable notes.

--- a/tests/smoke/test-pilot-safety-checklist.sh
+++ b/tests/smoke/test-pilot-safety-checklist.sh
@@ -7,6 +7,7 @@ cd "$repo_root"
 
 checklist="docs/pilot-safety-verification-checklist.md"
 runbook="docs/pilot-operations-runbook.md"
+deployment_profile="docs/pilot-deployment-profile.md"
 
 if [[ ! -f "$checklist" ]]; then
   echo "missing pilot-safety checklist: $checklist" >&2
@@ -15,6 +16,11 @@ fi
 
 if [[ ! -f "$runbook" ]]; then
   echo "missing pilot operations runbook: $runbook" >&2
+  exit 1
+fi
+
+if [[ ! -f "$deployment_profile" ]]; then
+  echo "missing pilot deployment profile: $deployment_profile" >&2
   exit 1
 fi
 
@@ -135,6 +141,43 @@ for pattern in "${runbook_required_patterns[@]}"; do
   fi
 done
 
+deployment_required_patterns=(
+  "^# Pilot Deployment Profile and Environment Contract$"
+  "^## Pilot Profile Assumptions$"
+  "^## Environment Categories$"
+  "^## Required Values$"
+  "^## Optional Values$"
+  "^## Forbidden Values$"
+  "^## Application Database$"
+  "^## Business Sources$"
+  "^## Auth, CSRF, and Session$"
+  "^## Audit Export and Support Bundle$"
+  "^## Validation and Doctor Guidance$"
+  "SAFEQUERY_APP_POSTGRES_URL"
+  "APP_POSTGRES_DB"
+  "APP_POSTGRES_USER"
+  "APP_POSTGRES_PASSWORD"
+  "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL"
+  "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING"
+  "SAFEQUERY_DEV_AUTH_ENABLED"
+  "SAFEQUERY_CORS_ORIGINS"
+  "API_INTERNAL_BASE_URL"
+  "NEXT_PUBLIC_API_BASE_URL"
+  "SAFEQUERY_BACKEND_BASE_URL"
+  "SAFEQUERY_FRONTEND_BASE_URL"
+  "raw secrets in frontend or public payloads"
+  "source credentials in audit exports or support bundles"
+  "application PostgreSQL is not a business source"
+  "fail closed"
+)
+
+for pattern in "${deployment_required_patterns[@]}"; do
+  if ! grep -Eq "$pattern" "$deployment_profile"; then
+    echo "$deployment_profile missing required deployment profile pattern: $pattern" >&2
+    exit 1
+  fi
+done
+
 if grep -Eqi "(postgresql.*approved[[:space:]]+follow-on|approved[[:space:]]+follow-on.*postgresql)" "$checklist"; then
   echo "$checklist must not describe PostgreSQL as follow-on for the 2-source core path" >&2
   exit 1
@@ -153,6 +196,10 @@ for entrypoint in docs/README.md docs/01_READING_ORDER.md; do
   fi
   if ! grep -Fq "pilot-operations-runbook.md" "$entrypoint"; then
     echo "$entrypoint missing pilot operations runbook link" >&2
+    exit 1
+  fi
+  if ! grep -Fq "pilot-deployment-profile.md" "$entrypoint"; then
+    echo "$entrypoint missing pilot deployment profile link" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary
- Add a pilot deployment profile and environment contract for required, optional, and forbidden values.
- Link the contract from README, docs README, reading order, and local first-run guidance.
- Tighten the pilot safety docs smoke check to require the contract and entrypoint links.

## Verification
- bash tests/smoke/test-pilot-safety-checklist.sh
- bash tests/smoke/test-local-startup-docs.sh
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- cd backend && python3 -m pytest tests/test_first_run_doctor.py tests/test_support_bundle.py
- targeted rg scan for workstation-local paths, inline credential URLs, and secret env literals across changed docs

Closes #333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a pilot deployment profile defining environment configuration contract (required, optional, forbidden), fail-closed rules, and prohibited public secrets; updated docs navigation and reading order to reference it.
  * Replaced hard-coded Postgres examples with a generic reachable-URL placeholder.
* **Tests**
  * Extended smoke tests to require and validate the new deployment profile and its governance statements, and to verify updated cross-links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->