### PR TITLE
[codex] Harden source credential loading

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -242,7 +242,12 @@ class Settings(BaseSettings):
             return value
 
         parts = _mssql_connection_string_parts(normalized)
-        password = parts.get("pwd") or parts.get("password")
+        if "pwd" in parts:
+            password = parts["pwd"]
+        elif "password" in parts:
+            password = parts["password"]
+        else:
+            password = None
         if password is None:
             return value
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from typing import Annotated, Literal, Optional
+from urllib.parse import unquote, urlsplit
 
 from pydantic import (
     AnyHttpUrl,
@@ -37,6 +38,32 @@ class ProductionIdentityBridgeSettings(BaseModel):
 
 
 SQLGenerationProvider = Literal["disabled", "local_llm", "vanna"]
+
+_PLACEHOLDER_CREDENTIAL_VALUES = frozenset(
+    {
+        "change-me",
+        "changeme",
+        "todo",
+        "placeholder",
+        "example",
+    }
+)
+
+
+def _is_placeholder_credential(value: str) -> bool:
+    return value.strip().lower() in _PLACEHOLDER_CREDENTIAL_VALUES
+
+
+def _mssql_connection_string_parts(connection_string: str) -> dict[str, str]:
+    parts: dict[str, str] = {}
+    for segment in connection_string.split(";"):
+        key, separator, value = segment.partition("=")
+        if not separator:
+            continue
+        normalized_key = key.strip().lower()
+        if normalized_key:
+            parts[normalized_key] = value.strip()
+    return parts
 
 
 class SQLGenerationSettings(BaseModel):
@@ -100,6 +127,7 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
+        hide_input_in_errors=True,
     )
 
     @field_validator("cors_origins", mode="before")
@@ -148,13 +176,7 @@ class Settings(BaseSettings):
             )
 
         normalized_lower = normalized.lower()
-        if normalized_lower in {
-            "change-me",
-            "changeme",
-            "todo",
-            "placeholder",
-            "example",
-        }:
+        if _is_placeholder_credential(normalized_lower):
             raise ValueError(
                 "SAFEQUERY_SQL_GENERATION_VANNA_API_KEY must come from a trusted "
                 "credential source, not a placeholder value."
@@ -179,16 +201,61 @@ class Settings(BaseSettings):
             )
 
         normalized_lower = normalized.lower()
-        if normalized_lower in {
-            "change-me",
-            "changeme",
-            "todo",
-            "placeholder",
-            "example",
-        }:
+        if _is_placeholder_credential(normalized_lower):
             raise ValueError(
                 "SAFEQUERY_PRODUCTION_IDENTITY_BRIDGE_SHARED_SECRET must come from "
                 "a trusted credential source, not a placeholder value."
+            )
+
+        return value
+
+    @field_validator("business_postgres_source_url")
+    @classmethod
+    def _reject_placeholder_business_postgres_source_url(
+        cls,
+        value: Optional[PostgresDsn],
+    ) -> Optional[PostgresDsn]:
+        if value is None:
+            return value
+
+        parsed = urlsplit(str(value))
+        password = unquote(parsed.password or "").strip()
+        if password and _is_placeholder_credential(password):
+            raise ValueError(
+                "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must come from a trusted "
+                "credential source, not a placeholder value."
+            )
+
+        return value
+
+    @field_validator("business_mssql_source_connection_string")
+    @classmethod
+    def _reject_placeholder_business_mssql_source_connection_string(
+        cls,
+        value: Optional[str],
+    ) -> Optional[str]:
+        if value is None:
+            return value
+
+        normalized = value.strip()
+        if not normalized:
+            return value
+
+        parts = _mssql_connection_string_parts(normalized)
+        password = parts.get("pwd") or parts.get("password")
+        if password is None:
+            return value
+
+        if not password.strip():
+            raise ValueError(
+                "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must include a "
+                "non-empty password from a trusted credential source."
+            )
+
+        if _is_placeholder_credential(password):
+            raise ValueError(
+                "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must come from a "
+                "trusted credential source, not a placeholder value."
             )
 
         return value

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -36,7 +36,7 @@ class SettingsTestCase(unittest.TestCase):
                     "Server=tcp:mssql-source,1433;"
                     "Database=business;"
                     "Uid=safequery_reader;"
-                    "Pwd=change-me;"
+                    "Pwd=safequery-test-credential-001;"
                     "Encrypt=yes;"
                     "TrustServerCertificate=no\n"
                 )
@@ -215,6 +215,46 @@ class SettingsTestCase(unittest.TestCase):
             settings.require_business_mssql_source().connection_string,
             "Driver={ODBC Driver 18 for SQL Server};Server=tcp:mssql,1433",
         )
+
+    def test_business_postgres_source_rejects_placeholder_password(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must come from a trusted "
+            "credential source",
+        ) as exc_info:
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                business_postgres_source_url=(
+                    "postgresql://source_reader:change-me@pg-source:5432/business"
+                ),
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
+
+        self.assertNotIn("source_reader:change-me", str(exc_info.exception))
+
+    def test_business_mssql_source_rejects_placeholder_password(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must come from a "
+            "trusted credential source",
+        ) as exc_info:
+            Settings(
+                app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+                business_mssql_source_connection_string=(
+                    "Driver={ODBC Driver 18 for SQL Server};"
+                    "Server=tcp:mssql-source,1433;"
+                    "Database=business;"
+                    "Uid=safequery_reader;"
+                    "Pwd=change-me;"
+                    "Encrypt=yes;"
+                    "TrustServerCertificate=no"
+                ),
+                _env_file=None,
+                _env_prefix="SAFEQUERY_",
+            )
+
+        self.assertNotIn("Pwd=change-me", str(exc_info.exception))
 
     def test_dev_auth_is_disabled_by_default_and_can_enable_for_development(self) -> None:
         default_settings = Settings(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -256,6 +256,33 @@ class SettingsTestCase(unittest.TestCase):
 
         self.assertNotIn("Pwd=change-me", str(exc_info.exception))
 
+    def test_business_mssql_source_rejects_empty_password_values(self) -> None:
+        for password_kv in ("Pwd=", "Pwd=   ", "Password=", "Password=   "):
+            with self.subTest(password_kv=password_kv):
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING must "
+                    "include a non-empty password",
+                ) as exc_info:
+                    Settings(
+                        app_postgres_url=(
+                            "postgresql://safequery:safequery@db:5432/safequery"
+                        ),
+                        business_mssql_source_connection_string=(
+                            "Driver={ODBC Driver 18 for SQL Server};"
+                            "Server=tcp:mssql-source,1433;"
+                            "Database=business;"
+                            "Uid=safequery_reader;"
+                            f"{password_kv};"
+                            "Encrypt=yes;"
+                            "TrustServerCertificate=no"
+                        ),
+                        _env_file=None,
+                        _env_prefix="SAFEQUERY_",
+                    )
+
+                self.assertNotIn(f"{password_kv};", str(exc_info.exception))
+
     def test_dev_auth_is_disabled_by_default_and_can_enable_for_development(self) -> None:
         default_settings = Settings(
             app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",


### PR DESCRIPTION
## Summary
- reject placeholder PostgreSQL and MSSQL business-source credential values at settings load time
- hide Pydantic validation inputs so credential-loading errors do not echo raw connector values
- add focused regression coverage for sanitized placeholder rejection

## Verification
- cd backend && python3 -m pytest tests/test_config.py -q
- cd backend && python3 -m pytest tests/test_config.py tests/test_postgresql_execution_connector.py tests/test_mssql_execution_connector.py tests/test_candidate_execute_api.py tests/test_api_errors.py tests/test_audit_event_model.py tests/test_support_bundle.py -q
- cd backend && python3 -m pytest -q

Closes #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for business data source credentials to reject placeholder or empty passwords.
  * Centralized placeholder detection and configured config errors to hide sensitive input values.

* **Tests**
  * Added/updated tests to cover credential validation and ensure placeholder tokens are not exposed in error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->