### PR TITLE
[codex] Fail doctor on app postgres source reference

### DIFF
--- a/backend/app/services/first_run_doctor.py
+++ b/backend/app/services/first_run_doctor.py
@@ -22,6 +22,7 @@ from app.db.models.dataset_contract import DatasetContract, DatasetContractDatas
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
+from app.features.guard.deny_taxonomy import DENY_SOURCE_BINDING_MISMATCH
 from app.features.execution import (
     ExecutionConnectorSelectionError,
     MSSQLExecutionRuntimeUnavailable,
@@ -417,6 +418,40 @@ def _check_execution_connector(
                 "source_family": source.source_family,
                 "source_flavor": source.source_flavor,
                 "deny_code": exc.deny_code,
+            },
+        )
+
+    expected_connection_reference_by_connector = {
+        "postgresql_readonly": "env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        "mssql_readonly": "env:SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING",
+    }
+    expected_connection_reference = expected_connection_reference_by_connector.get(
+        selection.connector_id
+    )
+    actual_connection_reference = getattr(source, "connection_reference", None)
+    normalized_connection_reference = (
+        actual_connection_reference.strip()
+        if isinstance(actual_connection_reference, str)
+        else None
+    )
+    if (
+        expected_connection_reference is None
+        or normalized_connection_reference != expected_connection_reference
+    ):
+        return FirstRunDoctorCheck(
+            name="execution_connector",
+            status="fail",
+            message=(
+                "Active demo source is not bound to the backend-owned execution "
+                "connection reference."
+            ),
+            detail={
+                "source_id": selection.source_id,
+                "source_family": selection.source_family,
+                "source_flavor": selection.source_flavor,
+                "connector_id": selection.connector_id,
+                "ownership": selection.ownership,
+                "deny_code": DENY_SOURCE_BINDING_MISMATCH,
             },
         )
 

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -422,6 +422,41 @@ def test_first_run_doctor_fails_closed_when_demo_source_connector_binding_drifts
     }
 
 
+def test_first_run_doctor_fails_closed_when_demo_source_reuses_app_postgres_reference() -> None:
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+        source = session.get(RegisteredSource, DEMO_SOURCE_UUID)
+        assert source is not None
+        source.connection_reference = "env:SAFEQUERY_APP_POSTGRES_URL"
+        session.commit()
+
+        result = run_first_run_doctor(
+            session,
+            database_probe=lambda: None,
+            **_ready_surface_probes(),
+        )
+
+    sections = _doctor_sections(result.model_dump(mode="json"))
+    assert result.status == "fail"
+    assert sections["source_registry"]["status"] == "pass"
+    assert sections["dataset_contract"]["status"] == "pass"
+    assert sections["schema_snapshot"]["status"] == "pass"
+    assert sections["entitlement_seed"]["status"] == "pass"
+    assert sections["execution_connector"]["status"] == "fail"
+    assert sections["execution_connector"]["message"] == (
+        "Active demo source is not bound to the backend-owned execution "
+        "connection reference."
+    )
+    assert sections["execution_connector"]["detail"] == {
+        "source_id": "demo-business-postgres",
+        "source_family": "postgresql",
+        "source_flavor": "warehouse",
+        "connector_id": "postgresql_readonly",
+        "ownership": "backend",
+        "deny_code": "DENY_SOURCE_BINDING_MISMATCH",
+    }
+
+
 def test_first_run_doctor_fails_closed_when_postgresql_driver_runtime_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -487,6 +522,7 @@ def test_first_run_doctor_fails_closed_when_mssql_driver_runtime_is_missing(
             source_id="business-mssql-source",
             source_family="mssql",
             source_flavor="sqlserver",
+            connection_reference="env:SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING",
         ),
         SimpleNamespace(contract_version=3),
         SimpleNamespace(snapshot_version=7),


### PR DESCRIPTION
## Summary

- Add a focused regression test proving the first-run doctor fails closed when a demo PostgreSQL source points at `env:SAFEQUERY_APP_POSTGRES_URL`.
- Require the doctor execution connector readiness check to verify the connector-specific business-source connection reference before reporting runtime readiness.
- Keep legitimate business PostgreSQL and MSSQL readiness paths source-aware by preserving the expected business connection references in tests.

## Root Cause

The execute API already rejected an application PostgreSQL connection reference, but the first-run doctor only checked source metadata, connector selection, and driver runtime. That allowed readiness evidence to report `pass` for a source registry record whose `connection_reference` pointed at the app database env var.

## Verification

- `python3 -m pytest tests/test_first_run_doctor.py::test_first_run_doctor_fails_closed_when_demo_source_reuses_app_postgres_reference -q` reproduced the failure before the fix.
- `python3 -m pytest tests/test_first_run_doctor.py::test_first_run_doctor_fails_closed_when_demo_source_reuses_app_postgres_reference tests/test_first_run_doctor.py::test_first_run_doctor_fails_closed_when_mssql_driver_runtime_is_missing -q`
- `python3 -m pytest tests/test_first_run_doctor.py tests/test_candidate_execute_api.py tests/test_postgresql_execution_connector.py tests/test_execution_connector_selection.py tests/test_support_bundle.py -q`
- `python3 -m pytest -q`