### PR TITLE
Reject blank business Postgres source passwords

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -218,13 +218,25 @@ class Settings(BaseSettings):
         if value is None:
             return value
 
-        parsed = urlsplit(str(value))
-        password = unquote(parsed.password or "").strip()
-        if password and _is_placeholder_credential(password):
-            raise ValueError(
-                "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must come from a trusted "
-                "credential source, not a placeholder value."
-            )
+        source_hosts = value.hosts()
+        passwords = [host.get("password") for host in source_hosts]
+        if not passwords:
+            parsed = urlsplit(str(value))
+            passwords = [parsed.password]
+
+        for password_value in passwords:
+            password = unquote(password_value or "").strip()
+            if not password:
+                raise ValueError(
+                    "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must include a "
+                    "non-empty password from a trusted credential source."
+                )
+
+            if _is_placeholder_credential(password):
+                raise ValueError(
+                    "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must come from a trusted "
+                    "credential source, not a placeholder value."
+                )
 
         return value
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -233,6 +233,32 @@ class SettingsTestCase(unittest.TestCase):
 
         self.assertNotIn("source_reader:change-me", str(exc_info.exception))
 
+    def test_business_postgres_source_rejects_blank_or_absent_password(self) -> None:
+        for source_url in (
+            "postgresql://source_reader:@pg-source:5432/business",
+            "postgresql://source_reader@pg-source:5432/business",
+        ):
+            with self.subTest(source_url=source_url):
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL must include a "
+                    "non-empty password",
+                ) as exc_info:
+                    Settings(
+                        app_postgres_url=(
+                            "postgresql://safequery:safequery@db:5432/safequery"
+                        ),
+                        business_postgres_source_url=source_url,
+                        _env_file=None,
+                        _env_prefix="SAFEQUERY_",
+                    )
+
+                error_text = str(exc_info.exception)
+                self.assertIn("SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL", error_text)
+                self.assertNotIn(source_url, error_text)
+                self.assertNotIn("source_reader:", error_text)
+                self.assertNotIn("pg-source", error_text)
+
     def test_business_mssql_source_rejects_placeholder_password(self) -> None:
         with self.assertRaisesRegex(
             ValidationError,


### PR DESCRIPTION
## Summary
- Require configured business PostgreSQL source URLs to include a non-empty password
- Keep placeholder password rejection intact
- Add focused regression coverage for blank and absent source passwords with sanitized validation errors

## Verification
- cd backend && python3 -m pytest tests/test_config.py -k blank_or_absent -q
- cd backend && python3 -m pytest tests/test_config.py -k "business_postgres_source_rejects_blank_or_absent_password or business_postgres_source_rejects_placeholder_password or env_file_loads_database_url" -q
- cd backend && python3 -m pytest tests/test_config.py
- cd backend && python3 -m pytest tests/test_application_postgres_guard.py -q

Closes #345