### PR TITLE
Probe active source family runtimes in first-run doctor

### DIFF
--- a/backend/app/services/first_run_doctor.py
+++ b/backend/app/services/first_run_doctor.py
@@ -42,6 +42,7 @@ from app.services.source_entitlements import (
     ensure_subject_is_entitled_for_source,
 )
 from app.services.source_family_profiles import (
+    ACTIVE_SOURCE_FAMILIES,
     get_active_source_runtime_posture_requirements,
 )
 
@@ -520,6 +521,89 @@ def _check_execution_connector(
     )
 
 
+def _active_source_family_runtime_check(source_family: str) -> FirstRunDoctorCheck:
+    normalized_source_family = source_family.strip().lower()
+    runtime_posture = get_active_source_runtime_posture_requirements(
+        normalized_source_family
+    )
+    detail: dict[str, object] = {
+        "source_family": normalized_source_family,
+        "runtime_scope": "local_driver_prerequisites",
+        "live_source_connectivity": "not_required",
+    }
+    if runtime_posture is not None:
+        detail["runtime_posture"] = runtime_posture.model_dump(mode="json")
+
+    runtime_dependency = None
+    try:
+        if normalized_source_family == "mssql":
+            runtime_dependency = "pyodbc/odbc-driver-18"
+            runtime_detail = check_mssql_execution_runtime_readiness()
+            family_name = "MSSQL"
+        elif normalized_source_family == "postgresql":
+            runtime_dependency = "psycopg"
+            runtime_detail = check_postgresql_execution_runtime_readiness()
+            family_name = "PostgreSQL"
+        else:
+            return FirstRunDoctorCheck(
+                name=f"source_family_runtime:{normalized_source_family}",
+                status="fail",
+                message=(
+                    "Active source family has no first-run runtime diagnostic."
+                ),
+                detail=detail,
+            )
+    except (
+        MSSQLExecutionRuntimeUnavailable,
+        PostgreSQLExecutionRuntimeUnavailable,
+    ) as exc:
+        if normalized_source_family == "mssql":
+            family_name = "MSSQL"
+        elif normalized_source_family == "postgresql":
+            family_name = "PostgreSQL"
+        else:
+            family_name = normalized_source_family
+        detail.update(
+            {
+                "runtime_status": "unavailable",
+                "error": exc.__class__.__name__,
+            }
+        )
+        if runtime_dependency is not None:
+            detail["runtime_dependency"] = runtime_dependency
+        return FirstRunDoctorCheck(
+            name=f"source_family_runtime:{normalized_source_family}",
+            status="fail",
+            message=(
+                f"{family_name} driver runtime is unavailable for the active "
+                "source family."
+            ),
+            detail=detail,
+        )
+
+    detail.update(
+        {
+            "runtime_status": "available",
+            "runtime": runtime_detail,
+        }
+    )
+    if runtime_dependency is not None:
+        detail["runtime_dependency"] = runtime_dependency
+    return FirstRunDoctorCheck(
+        name=f"source_family_runtime:{normalized_source_family}",
+        status="pass",
+        message=f"{family_name} driver runtime is ready for the active source family.",
+        detail=detail,
+    )
+
+
+def _active_source_family_runtime_checks() -> list[FirstRunDoctorCheck]:
+    return [
+        _active_source_family_runtime_check(source_family)
+        for source_family in ACTIVE_SOURCE_FAMILIES
+    ]
+
+
 def _source_governance_checks_for_source(
     session: Session,
     source: RegisteredSource,
@@ -802,6 +886,8 @@ def run_first_run_doctor(
     except SQLAlchemyError as exc:
         logger.exception("First-run doctor could not read source governance data.")
         checks.extend(_source_governance_unavailable_checks(exc))
+
+    checks.extend(_active_source_family_runtime_checks())
 
     if backend_probe_mode == "served_route":
         checks.append(_check_backend_served_route(resolved_backend_base_url))

--- a/backend/tests/test_first_run_doctor.py
+++ b/backend/tests/test_first_run_doctor.py
@@ -91,6 +91,20 @@ def _expected_runtime_posture(source_family: str) -> dict[str, object]:
     }
 
 
+@pytest.fixture(autouse=True)
+def _available_source_family_runtimes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        first_run_doctor_service,
+        "check_mssql_execution_runtime_readiness",
+        lambda: {"odbc_driver_18": "available", "pyodbc": "available"},
+    )
+    monkeypatch.setattr(
+        first_run_doctor_service,
+        "check_postgresql_execution_runtime_readiness",
+        lambda: {"dict_row": "available", "psycopg": "available"},
+    )
+
+
 def test_http_probe_rejects_non_http_schemes_before_urlopen(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -547,6 +561,108 @@ def test_first_run_doctor_fails_closed_when_mssql_driver_runtime_is_missing(
             "runtime_dependency": "pyodbc/odbc-driver-18",
         },
     }
+
+
+def test_first_run_doctor_checks_active_mssql_runtime_without_mssql_demo_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable_mssql_runtime() -> dict[str, object]:
+        raise first_run_doctor_service.MSSQLExecutionRuntimeUnavailable(
+            "ODBC Driver 18 for SQL Server must be installed before the MSSQL "
+            "execution connector can run."
+        )
+
+    monkeypatch.setattr(
+        first_run_doctor_service,
+        "check_mssql_execution_runtime_readiness",
+        unavailable_mssql_runtime,
+    )
+
+    with _session_scope() as session:
+        seed_demo_source_governance(session)
+
+        result = run_first_run_doctor(
+            session,
+            database_probe=lambda: None,
+            **_ready_surface_probes(),
+        )
+
+    payload = result.model_dump(mode="json")
+    mssql_runtime_checks = [
+        check
+        for check in payload["checks"]
+        if check["name"] == "source_family_runtime:mssql"
+    ]
+    assert result.status == "fail"
+    assert mssql_runtime_checks == [
+        {
+            "name": "source_family_runtime:mssql",
+            "status": "fail",
+            "message": (
+                "MSSQL driver runtime is unavailable for the active source family."
+            ),
+            "detail": {
+                "source_family": "mssql",
+                "runtime_scope": "local_driver_prerequisites",
+                "live_source_connectivity": "not_required",
+                "runtime_posture": _expected_runtime_posture("mssql"),
+                "runtime_status": "unavailable",
+                "error": "MSSQLExecutionRuntimeUnavailable",
+                "runtime_dependency": "pyodbc/odbc-driver-18",
+            },
+        }
+    ]
+
+
+def test_first_run_doctor_checks_active_postgresql_runtime_without_source_seed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable_postgresql_runtime() -> dict[str, object]:
+        raise first_run_doctor_service.PostgreSQLExecutionRuntimeUnavailable(
+            "psycopg must be installed and importable before the PostgreSQL "
+            "execution connector can run."
+        )
+
+    monkeypatch.setattr(
+        first_run_doctor_service,
+        "check_postgresql_execution_runtime_readiness",
+        unavailable_postgresql_runtime,
+        raising=False,
+    )
+
+    with _session_scope() as session:
+        result = run_first_run_doctor(
+            session,
+            database_probe=lambda: None,
+            **_ready_surface_probes(),
+        )
+
+    payload = result.model_dump(mode="json")
+    postgresql_runtime_checks = [
+        check
+        for check in payload["checks"]
+        if check["name"] == "source_family_runtime:postgresql"
+    ]
+    assert result.status == "fail"
+    assert postgresql_runtime_checks == [
+        {
+            "name": "source_family_runtime:postgresql",
+            "status": "fail",
+            "message": (
+                "PostgreSQL driver runtime is unavailable for the active source "
+                "family."
+            ),
+            "detail": {
+                "source_family": "postgresql",
+                "runtime_scope": "local_driver_prerequisites",
+                "live_source_connectivity": "not_required",
+                "runtime_posture": _expected_runtime_posture("postgresql"),
+                "runtime_status": "unavailable",
+                "error": "PostgreSQLExecutionRuntimeUnavailable",
+                "runtime_dependency": "psycopg",
+            },
+        }
+    ]
 
 
 def test_first_run_doctor_fails_closed_when_source_seed_is_missing() -> None:


### PR DESCRIPTION
## Summary
- add first-run doctor runtime checks for every active source family declared by the profile set
- report MSSQL and PostgreSQL local driver prerequisite readiness separately from source registry governance checks
- keep runtime details scoped to family/prerequisite status without connection references

## Verification
- cd backend && python3 -m pytest tests/test_first_run_doctor.py tests/test_source_family_profiles.py tests/test_postgresql_execution_connector.py

Closes #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime availability diagnostics for MSSQL and PostgreSQL database sources, including detailed error reporting for unavailable runtimes.

* **Tests**
  * Added test coverage for database source runtime readiness checks and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->