### PR TITLE
Wire SQL Guard into HTTP preview submission

### DIFF
--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -21,6 +21,11 @@ from app.db.models.source_registry import RegisteredSource
 from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.auth.context import AuthenticatedSubject
 from app.features.auth.governance_bindings import normalize_governance_binding
+from app.features.guard import (
+    SQLGuardEvaluation,
+    evaluate_mssql_sql_guard,
+    evaluate_postgresql_sql_guard,
+)
 from app.features.operator_history.payloads import GuardStatus
 from app.services.candidate_lifecycle import (
     CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY,
@@ -50,6 +55,10 @@ from app.services.sql_generation_adapter import (
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 PREVIEW_PENDING_GUARD_STATUS: GuardStatus = "pending"
+_GUARD_VERSION_BY_SOURCE_FAMILY = {
+    "mssql": "mssql-guard-v1",
+    "postgresql": "postgresql-guard-v1",
+}
 
 
 class PreviewSubmissionRequest(BaseModel):
@@ -165,6 +174,7 @@ def _build_preview_lifecycle_audit_events(
     schema_snapshot: SchemaSnapshot,
     audit_context: PreviewAuditContext | None,
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
+    guard_evaluation: SQLGuardEvaluation | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
         return []
@@ -203,7 +213,12 @@ def _build_preview_lifecycle_audit_events(
                 audit_context.entitlement_source_bindings or None
             ),
             guard_version=(
-                audit_context.guard_version if event_type == "guard_evaluated" else None
+                _GUARD_VERSION_BY_SOURCE_FAMILY[resolved_source.source_family]
+                if event_type == "guard_evaluated"
+                and guard_evaluation is not None
+                else audit_context.guard_version
+                if event_type == "guard_evaluated"
+                else None
             ),
             application_version=audit_context.application_version,
             adapter_provider=(
@@ -250,7 +265,28 @@ def _build_preview_lifecycle_audit_events(
             candidate_state=(
                 "generated"
                 if adapter_metadata is not None and event_type == "generation_completed"
-                else "preview_ready" if event_type == "guard_evaluated" else None
+                else (
+                    "preview_ready"
+                    if guard_evaluation is None or guard_evaluation.decision == "allow"
+                    else "blocked"
+                )
+                if event_type == "guard_evaluated"
+                else None
+            ),
+            primary_deny_code=(
+                guard_evaluation.rejections[0].code
+                if event_type == "guard_evaluated"
+                and guard_evaluation is not None
+                and guard_evaluation.decision != "allow"
+                and guard_evaluation.rejections
+                else None
+            ),
+            denial_cause=(
+                "guard_rejected"
+                if event_type == "guard_evaluated"
+                and guard_evaluation is not None
+                and guard_evaluation.decision != "allow"
+                else None
             ),
         )
         causation_event_id = event.event_id
@@ -663,6 +699,7 @@ def _persist_preview_submission_records(
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
     request_state: str = "previewed",
     candidate_state: str = "preview_ready",
+    guard_status: GuardStatus = PREVIEW_PENDING_GUARD_STATUS,
 ) -> tuple[str, str]:
     request_id = (
         audit_context.request_id
@@ -789,7 +826,7 @@ def _persist_preview_submission_records(
             preview_candidate.prompt_fingerprint = (
                 adapter_metadata.prompt_fingerprint if adapter_metadata is not None else None
             )
-            preview_candidate.guard_status = PREVIEW_PENDING_GUARD_STATUS
+            preview_candidate.guard_status = guard_status
             preview_candidate.candidate_state = candidate_state
             session.flush()
             _persist_candidate_approval_record(
@@ -962,6 +999,29 @@ def _persist_preview_denial_records(
         ) from exc
 
 
+def _evaluate_preview_sql_guard(
+    *,
+    candidate_sql: str,
+    resolved_source: RegisteredSource,
+) -> SQLGuardEvaluation:
+    guard_payload = {
+        "canonical_sql": candidate_sql,
+        "source": {
+            "source_id": resolved_source.source_id,
+            "source_family": resolved_source.source_family,
+            "source_flavor": resolved_source.source_flavor,
+        },
+    }
+    if resolved_source.source_family == "mssql":
+        return evaluate_mssql_sql_guard(guard_payload)
+    if resolved_source.source_family == "postgresql":
+        return evaluate_postgresql_sql_guard(guard_payload)
+
+    raise PreviewSubmissionContractError(
+        f"Unsupported source family '{resolved_source.source_family}' cannot be guarded."
+    )
+
+
 def submit_preview_request(
     payload: PreviewSubmissionRequest,
     authenticated_subject: AuthenticatedSubject,
@@ -1068,6 +1128,10 @@ def submit_preview_request(
 
     candidate_sql: str | None = None
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None
+    guard_evaluation: SQLGuardEvaluation | None = None
+    guard_status: GuardStatus = PREVIEW_PENDING_GUARD_STATUS
+    candidate_state = "preview_ready"
+    request_state = "previewed"
     if sql_generation_adapter is not None:
         if audit_context is None:
             raise PreviewSubmissionContractError(
@@ -1091,6 +1155,16 @@ def submit_preview_request(
                 adapter_response=adapter_response,
                 adapter_run_id=audit_context.correlation_id,
             )
+            guard_evaluation = _evaluate_preview_sql_guard(
+                candidate_sql=candidate_sql,
+                resolved_source=resolved_source,
+            )
+            if guard_evaluation.decision == "allow":
+                guard_status = "allow"
+            else:
+                guard_status = "blocked"
+                candidate_state = "blocked"
+                request_state = "blocked"
         except (
             GenerationContextPreparationError,
             SQLGenerationAdapterConfigurationError,
@@ -1133,6 +1207,7 @@ def submit_preview_request(
             schema_snapshot=schema_snapshot,
             audit_context=audit_context,
             adapter_metadata=adapter_metadata,
+            guard_evaluation=guard_evaluation,
         ),
     )
     request_id, candidate_id = _persist_preview_submission_records(
@@ -1146,6 +1221,9 @@ def submit_preview_request(
         audit_events=audit.events,
         candidate_sql=candidate_sql,
         adapter_metadata=adapter_metadata,
+        request_state=request_state,
+        candidate_state=candidate_state,
+        guard_status=guard_status,
     )
 
     return PreviewSubmissionResponse(
@@ -1158,17 +1236,23 @@ def submit_preview_request(
         candidate=CandidateRecord(
             candidate_id=candidate_id,
             candidate_sql=candidate_sql,
-            guard_status=PREVIEW_PENDING_GUARD_STATUS,
+            guard_status=guard_status,
             source_id=resolved_source.source_id,
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
-            state="preview_ready",
+            state=candidate_state,
         ),
         audit=audit,
         evaluation=EvaluationRecord(
             source_id=resolved_source.source_id,
-            state="pending",
+            state=(
+                "pending"
+                if guard_evaluation is None
+                else "allowed"
+                if guard_evaluation.decision == "allow"
+                else "blocked"
+            ),
         ),
     )

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from typing import Optional
+from typing import Any, Optional
 from typing_extensions import Annotated
 from uuid import UUID, uuid4
 
@@ -59,6 +59,20 @@ _GUARD_VERSION_BY_SOURCE_FAMILY = {
     "mssql": "mssql-guard-v1",
     "postgresql": "postgresql-guard-v1",
 }
+_SQL_GUARD_EVALUATOR_BY_SOURCE_FAMILY = {
+    "mssql": evaluate_mssql_sql_guard,
+    "postgresql": evaluate_postgresql_sql_guard,
+}
+
+
+def _resolve_sql_guard_controls(source_family: str) -> tuple[str, Any]:
+    guard_version = _GUARD_VERSION_BY_SOURCE_FAMILY.get(source_family)
+    evaluator = _SQL_GUARD_EVALUATOR_BY_SOURCE_FAMILY.get(source_family)
+    if guard_version is None or evaluator is None:
+        raise PreviewSubmissionContractError(
+            f"Unsupported source family '{source_family}' cannot be guarded."
+        )
+    return guard_version, evaluator
 
 
 class PreviewSubmissionRequest(BaseModel):
@@ -213,7 +227,7 @@ def _build_preview_lifecycle_audit_events(
                 audit_context.entitlement_source_bindings or None
             ),
             guard_version=(
-                _GUARD_VERSION_BY_SOURCE_FAMILY[resolved_source.source_family]
+                _resolve_sql_guard_controls(resolved_source.source_family)[0]
                 if event_type == "guard_evaluated"
                 and guard_evaluation is not None
                 else audit_context.guard_version
@@ -1012,14 +1026,8 @@ def _evaluate_preview_sql_guard(
             "source_flavor": resolved_source.source_flavor,
         },
     }
-    if resolved_source.source_family == "mssql":
-        return evaluate_mssql_sql_guard(guard_payload)
-    if resolved_source.source_family == "postgresql":
-        return evaluate_postgresql_sql_guard(guard_payload)
-
-    raise PreviewSubmissionContractError(
-        f"Unsupported source family '{resolved_source.source_family}' cannot be guarded."
-    )
+    _, evaluator = _resolve_sql_guard_controls(resolved_source.source_family)
+    return evaluator(guard_payload)
 
 
 def submit_preview_request(

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -5,6 +5,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
@@ -28,10 +29,13 @@ from app.db.models.source_registry import RegisteredSource, SourceActivationPost
 from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 from app.features.auth.session import create_test_application_session
+from app.features.guard import SQLGuardEvaluation
+from app.services import request_preview as request_preview_service
 from app.services.request_preview import (
     PreviewAuditContext,
     PreviewSubmissionContractError,
     PreviewSubmissionRequest,
+    _build_preview_lifecycle_audit_events,
     _persist_candidate_approval_record,
     submit_preview_request,
 )
@@ -616,6 +620,60 @@ def test_http_preview_submission_uses_mssql_guard_profile(
         engine.dispose()
         app.dependency_overrides.clear()
         get_settings.cache_clear()
+
+
+def test_preview_lifecycle_audit_guard_version_fails_closed_when_mapping_missing(
+    monkeypatch,
+) -> None:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        _seed_authoritative_source_governance(
+            session,
+            source_family="mssql",
+            source_flavor="analytics",
+        )
+        resolved_source = session.execute(select(RegisteredSource)).scalar_one()
+        dataset_contract = session.execute(select(DatasetContract)).scalar_one()
+        schema_snapshot = session.execute(select(SchemaSnapshot)).scalar_one()
+
+        monkeypatch.delitem(
+            request_preview_service._GUARD_VERSION_BY_SOURCE_FAMILY,
+            "mssql",
+        )
+
+        with pytest.raises(PreviewSubmissionContractError) as exc_info:
+            _build_preview_lifecycle_audit_events(
+                resolved_source=resolved_source,
+                dataset_contract=dataset_contract,
+                schema_snapshot=schema_snapshot,
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="preview-request-unmapped-guard",
+                    correlation_id="preview-correlation-unmapped-guard",
+                    user_subject="user:alice",
+                    session_id="session-unmapped-guard",
+                    query_candidate_id="preview-candidate-unmapped-guard",
+                    candidate_owner_subject="user:alice",
+                    auth_source="test-helper",
+                ),
+                guard_evaluation=SQLGuardEvaluation(
+                    decision="allow",
+                    profile="common",
+                    canonical_sql="SELECT 1",
+                    source=None,
+                    rejections=[],
+                ),
+            )
+
+        assert "Unsupported source family 'mssql' cannot be guarded." == str(
+            exc_info.value
+        )
 
 
 def test_http_preview_adapter_failure_persists_authoritative_failure(

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -47,13 +47,15 @@ def _seed_authoritative_source_governance(
     include_datasets: bool = True,
     source_posture: SourceActivationPosture = SourceActivationPosture.ACTIVE,
     connection_reference: str = "vault:sap-approved-spend",
+    source_family: str = "postgresql",
+    source_flavor: str = "warehouse",
 ) -> None:
     source = RegisteredSource(
         id=uuid4(),
         source_id="sap-approved-spend",
         display_label="SAP spend cube / approved_vendor_spend",
-        source_family="postgresql",
-        source_flavor="warehouse",
+        source_family=source_family,
+        source_flavor=source_flavor,
         activation_posture=source_posture,
         connector_profile_id=None,
         dialect_profile_id=None,
@@ -105,15 +107,17 @@ def _seed_authoritative_source_governance(
 
 
 class _RecordingHTTPPreviewAdapter:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        candidate_sql: str = " SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50; ",
+    ) -> None:
         self.adapter_request = None
+        self.candidate_sql = candidate_sql
 
     def generate_sql(self, request):
         self.adapter_request = request
         return SQLGenerationAdapterResponse(
-            candidate_sql=(
-                " SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50; "
-            ),
+            candidate_sql=self.candidate_sql,
             provider="local_llm",
             adapter_version="test.local_llm.v1",
             model="safequery-test-sql",
@@ -338,7 +342,7 @@ def test_http_preview_submission_persists_adapter_generated_candidate(
 
         assert response_payload["request"]["request_id"] == request_id
         assert response_payload["candidate"]["candidate_sql"] == candidate_sql
-        assert response_payload["candidate"]["guard_status"] == "pending"
+        assert response_payload["candidate"]["guard_status"] == "allow"
         assert response_payload["candidate"]["state"] == "preview_ready"
 
         adapter_payload = adapter.adapter_request.model_dump(mode="json")
@@ -372,15 +376,21 @@ def test_http_preview_submission_persists_adapter_generated_candidate(
         )
 
         assert persisted_candidate.candidate_sql == candidate_sql
+        assert persisted_candidate.guard_status == "allow"
         persisted_approval = session.execute(
             select(PreviewCandidateApproval)
         ).scalar_one()
-        assert persisted_approval.approved_sql is None
-        assert persisted_approval.approval_state == "pending_guard"
+        assert persisted_approval.approved_sql == candidate_sql
+        assert persisted_approval.approval_state == "approved"
         assert persisted_approval.executed_at is None
 
         calls: list[str] = []
-        app.state.execution_query_runner = lambda **_: calls.append("called")
+
+        def query_runner(**_):
+            calls.append("called")
+            return []
+
+        app.state.execution_query_runner = query_runner
         execute_response = client.post(
             f"/candidates/{persisted_candidate.candidate_id}/execute",
             headers=app_session.headers,
@@ -388,12 +398,11 @@ def test_http_preview_submission_persists_adapter_generated_candidate(
             json={"selected_source_id": "sap-approved-spend"},
         )
 
-        assert execute_response.status_code == 403
-        assert execute_response.json()["error"]["code"] == "execution_denied"
-        assert calls == []
+        assert execute_response.status_code == 200
+        assert calls == ["called"]
         session.refresh(persisted_approval)
-        assert persisted_approval.approval_state == "pending_guard"
-        assert persisted_approval.executed_at is None
+        assert persisted_approval.approval_state == "executed"
+        assert persisted_approval.executed_at is not None
         assert persisted_candidate.adapter_provider == "local_llm"
         assert persisted_candidate.adapter_model == "safequery-test-sql"
         assert persisted_candidate.adapter_version == "test.local_llm.v1"
@@ -409,6 +418,199 @@ def test_http_preview_submission_persists_adapter_generated_candidate(
             "prompt_version": "sql_generation_adapter_request.v1",
             "prompt_fingerprint": persisted_candidate.prompt_fingerprint,
         }.items() <= persisted_generation_event.audit_payload.items()
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+def test_http_preview_submission_blocks_guard_rejected_adapter_sql(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    adapter = _RecordingHTTPPreviewAdapter(
+        "SELECT vendor_id FROM finance.approved_vendor_spend; "
+        "DELETE FROM finance.approved_vendor_spend;"
+    )
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: adapter,
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 200
+        response_payload = response.json()
+        assert response_payload["candidate"]["guard_status"] == "blocked"
+        assert response_payload["candidate"]["state"] == "blocked"
+        assert response_payload["evaluation"]["state"] == "blocked"
+
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
+        persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_approval = session.execute(
+            select(PreviewCandidateApproval)
+        ).scalar_one()
+        persisted_guard_event = (
+            session.execute(
+                select(PreviewAuditEvent).where(
+                    PreviewAuditEvent.event_type == "guard_evaluated"
+                )
+            )
+            .scalars()
+            .one()
+        )
+
+        assert persisted_request.request_state == "blocked"
+        assert persisted_candidate.guard_status == "blocked"
+        assert persisted_candidate.candidate_state == "blocked"
+        assert persisted_approval.approval_state == "invalidated"
+        assert persisted_approval.approved_sql is None
+        assert persisted_approval.executed_at is None
+        assert persisted_guard_event.primary_deny_code == "DENY_MULTI_STATEMENT"
+        assert persisted_guard_event.denial_cause == "guard_rejected"
+        assert persisted_guard_event.audit_payload["guard_version"] == (
+            "postgresql-guard-v1"
+        )
+
+        calls: list[str] = []
+        app.state.execution_query_runner = lambda **_: calls.append("called")
+        execute_response = client.post(
+            f"/candidates/{persisted_candidate.candidate_id}/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "sap-approved-spend"},
+        )
+
+        assert execute_response.status_code == 403
+        assert execute_response.json()["error"]["code"] == "execution_denied"
+        assert calls == []
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+def test_http_preview_submission_uses_mssql_guard_profile(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    adapter = _RecordingHTTPPreviewAdapter(
+        " SELECT TOP 50 vendor_id FROM finance.approved_vendor_spend; "
+    )
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: adapter,
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(
+            session,
+            source_family="mssql",
+            source_flavor="analytics",
+        )
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 200
+        response_payload = response.json()
+        assert response_payload["candidate"]["guard_status"] == "allow"
+        assert response_payload["candidate"]["source_family"] == "mssql"
+
+        persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_guard_event = (
+            session.execute(
+                select(PreviewAuditEvent).where(
+                    PreviewAuditEvent.event_type == "guard_evaluated"
+                )
+            )
+            .scalars()
+            .one()
+        )
+
+        assert persisted_candidate.guard_status == "allow"
+        assert persisted_candidate.source_family == "mssql"
+        assert persisted_guard_event.audit_payload["guard_version"] == "mssql-guard-v1"
     finally:
         session.close()
         engine.dispose()


### PR DESCRIPTION
## Summary
- invoke source-family SQL Guard during HTTP preview submission after adapter SQL normalization
- persist allow/blocked guard status, guard version, and deny metadata into preview records/events
- cover PostgreSQL allow/reject and MSSQL profile selection in HTTP preview persistence tests

## Verification
- cd backend && python3 -m pytest tests/test_preview_persistence.py -q
- cd backend && python3 -m pytest tests/test_sql_guard_mssql_profile.py tests/test_sql_guard_postgresql_profile.py -q
- cd backend && python3 -m pytest tests/test_candidate_execute_api.py -q

Note: backend/.venv/bin/python was not present in this worktree, so local verification used python3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL preview submissions are evaluated by source-specific guards; previews are allowed or blocked and candidate state reflects the decision.
  * Guard outcomes are persisted and surfaced in preview responses and lifecycle audit events, including denial codes and guard version when applicable.

* **Tests**
  * Added integration and unit tests covering guard allow/reject paths, database-specific guard profiles, and a fails-closed guard mapping scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->