### PR TITLE
Fail closed on malformed preview guard decisions

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -22,6 +22,7 @@ _SAFE_API_ERROR_CODES = frozenset(
         "execution_denied",
         "execution_unavailable",
         "operator_read_forbidden",
+        "preview_guard_malformed",
         "preview_generation_failed",
         "preview_source_malformed",
         "preview_source_unavailable",

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from typing import Any, Optional
+from typing import Any, NoReturn, Optional
 from typing_extensions import Annotated
 from uuid import UUID, uuid4
 
@@ -1018,6 +1018,13 @@ def _evaluate_preview_sql_guard(
     candidate_sql: str,
     resolved_source: RegisteredSource,
 ) -> SQLGuardEvaluation:
+    def raise_malformed_guard_decision() -> NoReturn:
+        raise PreviewSubmissionContractError(
+            "SQL Guard returned malformed decision data.",
+            public_code="preview_guard_malformed",
+            public_message="SQL Guard returned malformed decision data.",
+        )
+
     guard_payload = {
         "canonical_sql": candidate_sql,
         "source": {
@@ -1027,7 +1034,25 @@ def _evaluate_preview_sql_guard(
         },
     }
     _, evaluator = _resolve_sql_guard_controls(resolved_source.source_family)
-    return evaluator(guard_payload)
+    try:
+        guard_evaluation = SQLGuardEvaluation.model_validate(evaluator(guard_payload))
+    except ValidationError:
+        raise_malformed_guard_decision()
+
+    if guard_evaluation.decision == "allow":
+        if (
+            not isinstance(guard_evaluation.canonical_sql, str)
+            or guard_evaluation.canonical_sql != candidate_sql
+        ):
+            raise_malformed_guard_decision()
+        if (
+            guard_evaluation.source is None
+            or guard_evaluation.source.source_id != resolved_source.source_id
+            or guard_evaluation.source.source_family != resolved_source.source_family
+            or guard_evaluation.source.source_flavor != resolved_source.source_flavor
+        ):
+            raise_malformed_guard_decision()
+    return guard_evaluation
 
 
 def submit_preview_request(

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -537,6 +537,79 @@ def test_http_preview_submission_blocks_guard_rejected_adapter_sql(
         get_settings.cache_clear()
 
 
+def test_http_preview_submission_rejects_malformed_guard_decision_without_approval(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: _RecordingHTTPPreviewAdapter(),
+    )
+    monkeypatch.setitem(
+        request_preview_service._SQL_GUARD_EVALUATOR_BY_SOURCE_FAMILY,
+        "postgresql",
+        lambda _: {"decision": "allow"},
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "error": {
+                "code": "preview_guard_malformed",
+                "message": "SQL Guard returned malformed decision data.",
+            }
+        }
+        assert session.execute(select(PreviewCandidate)).scalars().all() == []
+        assert session.execute(select(PreviewCandidateApproval)).scalars().all() == []
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
 def test_http_preview_submission_uses_mssql_guard_profile(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- validate SQL Guard evaluator output before candidate lifecycle persistence
- require allow decisions to match the preview candidate SQL and source binding
- return a safe preview_guard_malformed API error without creating candidate approval rows

## Tests
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_candidate_execute_api.py

Note: backend/.venv/bin/python is absent in this worktree, so verification used the available python3 interpreter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for SQL preview submissions to detect and reject malformed guard responses, preventing invalid data from persisting.
  * Improved error handling with stricter validation of SQL guard decisions to ensure consistency between submitted and approved SQL statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->