### PR TITLE
Persist guard denial evidence fail closed

### DIFF
--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -121,6 +121,7 @@ class SourceAwareAuditEvent(BaseModel):
     prompt_version: Optional[NonEmptyTrimmedString] = None
     prompt_fingerprint: Optional[NonEmptyTrimmedString] = None
     guard_version: Optional[NonEmptyTrimmedString] = None
+    guard_decision: Optional[Literal["allow", "reject"]] = None
     application_version: Optional[NonEmptyTrimmedString] = None
     retrieval_corpus_version: Optional[NonEmptyTrimmedString] = None
     retrieved_asset_ids: Optional[list[NonEmptyTrimmedString]] = None
@@ -138,6 +139,7 @@ class SourceAwareAuditEvent(BaseModel):
     connector_profile_version: Optional[PositiveInt] = None
     primary_deny_code: Optional[NonEmptyTrimmedString] = None
     denial_cause: Optional[NonEmptyTrimmedString] = None
+    denial_reason: Optional[NonEmptyTrimmedString] = None
     candidate_state: Optional[NonEmptyTrimmedString] = None
     execution_row_count: Optional[int] = None
     result_truncated: Optional[bool] = None

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -101,6 +101,8 @@ class OperatorWorkflowAuditEventSummary(BaseModel):
     source_id: str = Field(serialization_alias="sourceId")
     candidate_state: Optional[str] = Field(default=None, serialization_alias="candidateState")
     primary_deny_code: Optional[str] = Field(default=None, serialization_alias="primaryDenyCode")
+    guard_decision: Optional[str] = Field(default=None, serialization_alias="guardDecision")
+    denial_reason: Optional[str] = Field(default=None, serialization_alias="denialReason")
     row_count: Optional[int] = Field(default=None, serialization_alias="rowCount")
     result_truncated: Optional[bool] = Field(default=None, serialization_alias="resultTruncated")
 
@@ -400,6 +402,8 @@ def _audit_event_summary(event: PreviewAuditEvent) -> OperatorWorkflowAuditEvent
         source_id=event.source_id,
         candidate_state=event.candidate_state,
         primary_deny_code=event.primary_deny_code,
+        guard_decision=_read_text(event.audit_payload.get("guard_decision")),
+        denial_reason=_read_text(event.audit_payload.get("denial_reason")),
         row_count=_read_non_negative_int(event.audit_payload.get("execution_row_count")),
         result_truncated=_read_bool(event.audit_payload.get("result_truncated")),
     )
@@ -592,6 +596,9 @@ def _build_operator_history(
                 candidate_sql=candidate.candidate_sql,
                 request_id=candidate.request_id,
                 guard_status=candidate.guard_status,
+                primary_deny_code=(
+                    candidate_event.primary_deny_code if candidate_event else None
+                ),
                 audit_events=(
                     [_audit_event_summary(candidate_event)] if candidate_event else []
                 ),

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -59,18 +59,18 @@ PREVIEW_PENDING_GUARD_STATUS: GuardStatus = "pending"
 _MAX_DENIAL_REASON_LENGTH = 240
 _RAW_WORKSTATION_PATH_PATTERN = re.compile(
     r"(?i)(?:"
-    r"(?<!:)/(?:[^/\s:;,'\")]+/)+[^\s:;,'\")]*"
+    r"(?:^|(?<=[\s'\"(=]))/(?:[^/\s:;,'\")]+/)+[^\s:;,'\")]*"
     r"|[a-z]:[\\/](?:[^\\/\s:;,'\")]+[\\/])*[^\\/\s:;,'\")]+"
     r"|\\\\[^\\\s/:;,'\")]+\\[^\\\s:;,'\")]+(?:\\[^\\\s:;,'\")]+)*"
     r"|(?<!\S)~[\\/][^\s:;,'\")]+"
     r")"
 )
 _CREDENTIAL_MARKER_PATTERN = re.compile(
-    r"(?i)("
+    r"(?i)(?<![A-Za-z0-9_])("
     r"password|passwd|pwd|secret|token|credential|bearer"
     r"|api[_ -]?key|access[_ -]?key|private[_ -]?key"
     r"|client[_ -]?secret|connection[_ -]?string"
-    r")"
+    r")(?![A-Za-z0-9_])"
 )
 _GUARD_VERSION_BY_SOURCE_FAMILY = {
     "mssql": "mssql-guard-v1",

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -58,10 +58,19 @@ NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, 
 PREVIEW_PENDING_GUARD_STATUS: GuardStatus = "pending"
 _MAX_DENIAL_REASON_LENGTH = 240
 _RAW_WORKSTATION_PATH_PATTERN = re.compile(
-    r"(?i)(?:/users/[^\s:;,'\")]+|[a-z]:\\users\\[^\s:;,'\")]+)"
+    r"(?i)(?:"
+    r"(?<!:)/(?:[^/\s:;,'\")]+/)+[^\s:;,'\")]*"
+    r"|[a-z]:[\\/](?:[^\\/\s:;,'\")]+[\\/])*[^\\/\s:;,'\")]+"
+    r"|\\\\[^\\\s/:;,'\")]+\\[^\\\s:;,'\")]+(?:\\[^\\\s:;,'\")]+)*"
+    r"|(?<!\S)~[\\/][^\s:;,'\")]+"
+    r")"
 )
 _CREDENTIAL_MARKER_PATTERN = re.compile(
-    r"(?i)(password|passwd|pwd|secret|token|credential|connection[_ -]?string)"
+    r"(?i)("
+    r"password|passwd|pwd|secret|token|credential|bearer"
+    r"|api[_ -]?key|access[_ -]?key|private[_ -]?key"
+    r"|client[_ -]?secret|connection[_ -]?string"
+    r")"
 )
 _GUARD_VERSION_BY_SOURCE_FAMILY = {
     "mssql": "mssql-guard-v1",
@@ -102,7 +111,9 @@ def _sanitized_guard_denial_reason(
         return "SQL guard rejected the generated candidate."
 
     if len(detail) > _MAX_DENIAL_REASON_LENGTH:
-        return f"{detail[:_MAX_DENIAL_REASON_LENGTH].rstrip()}..."
+        suffix = "..."
+        max_prefix = max(1, _MAX_DENIAL_REASON_LENGTH - len(suffix))
+        return f"{detail[:max_prefix].rstrip()}{suffix}"
     return detail
 
 

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import re
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -55,6 +56,13 @@ from app.services.sql_generation_adapter import (
 
 NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 PREVIEW_PENDING_GUARD_STATUS: GuardStatus = "pending"
+_MAX_DENIAL_REASON_LENGTH = 240
+_RAW_WORKSTATION_PATH_PATTERN = re.compile(
+    r"(?i)(?:/users/[^\s:;,'\")]+|[a-z]:\\users\\[^\s:;,'\")]+)"
+)
+_CREDENTIAL_MARKER_PATTERN = re.compile(
+    r"(?i)(password|passwd|pwd|secret|token|credential|connection[_ -]?string)"
+)
 _GUARD_VERSION_BY_SOURCE_FAMILY = {
     "mssql": "mssql-guard-v1",
     "postgresql": "postgresql-guard-v1",
@@ -73,6 +81,41 @@ def _resolve_sql_guard_controls(source_family: str) -> tuple[str, Any]:
             f"Unsupported source family '{source_family}' cannot be guarded."
         )
     return guard_version, evaluator
+
+
+def _sanitized_guard_denial_reason(
+    guard_evaluation: SQLGuardEvaluation | None,
+) -> str | None:
+    if (
+        guard_evaluation is None
+        or guard_evaluation.decision == "allow"
+        or not guard_evaluation.rejections
+    ):
+        return None
+
+    detail = guard_evaluation.rejections[0].detail.strip()
+    if (
+        not detail
+        or _RAW_WORKSTATION_PATH_PATTERN.search(detail)
+        or _CREDENTIAL_MARKER_PATTERN.search(detail)
+    ):
+        return "SQL guard rejected the generated candidate."
+
+    if len(detail) > _MAX_DENIAL_REASON_LENGTH:
+        return f"{detail[:_MAX_DENIAL_REASON_LENGTH].rstrip()}..."
+    return detail
+
+
+def _primary_guard_deny_code(
+    guard_evaluation: SQLGuardEvaluation | None,
+) -> str | None:
+    if (
+        guard_evaluation is None
+        or guard_evaluation.decision == "allow"
+        or not guard_evaluation.rejections
+    ):
+        return None
+    return guard_evaluation.rejections[0].code
 
 
 class PreviewSubmissionRequest(BaseModel):
@@ -99,6 +142,8 @@ class CandidateRecord(BaseModel):
     dataset_contract_version: int
     schema_snapshot_version: int
     state: str
+    primary_deny_code: Optional[str] = None
+    denial_reason: Optional[str] = None
 
 
 class AuditRecord(BaseModel):
@@ -110,6 +155,8 @@ class AuditRecord(BaseModel):
 class EvaluationRecord(BaseModel):
     source_id: str
     state: str
+    primary_deny_code: Optional[str] = None
+    denial_reason: Optional[str] = None
 
 
 class PreviewSubmissionResponse(BaseModel):
@@ -234,6 +281,12 @@ def _build_preview_lifecycle_audit_events(
                 if event_type == "guard_evaluated"
                 else None
             ),
+            guard_decision=(
+                guard_evaluation.decision
+                if event_type == "guard_evaluated"
+                and guard_evaluation is not None
+                else None
+            ),
             application_version=audit_context.application_version,
             adapter_provider=(
                 adapter_metadata.adapter_provider
@@ -288,11 +341,8 @@ def _build_preview_lifecycle_audit_events(
                 else None
             ),
             primary_deny_code=(
-                guard_evaluation.rejections[0].code
+                _primary_guard_deny_code(guard_evaluation)
                 if event_type == "guard_evaluated"
-                and guard_evaluation is not None
-                and guard_evaluation.decision != "allow"
-                and guard_evaluation.rejections
                 else None
             ),
             denial_cause=(
@@ -300,6 +350,11 @@ def _build_preview_lifecycle_audit_events(
                 if event_type == "guard_evaluated"
                 and guard_evaluation is not None
                 and guard_evaluation.decision != "allow"
+                else None
+            ),
+            denial_reason=(
+                _sanitized_guard_denial_reason(guard_evaluation)
+                if event_type == "guard_evaluated"
                 else None
             ),
         )
@@ -1258,6 +1313,8 @@ def submit_preview_request(
         candidate_state=candidate_state,
         guard_status=guard_status,
     )
+    primary_deny_code = _primary_guard_deny_code(guard_evaluation)
+    denial_reason = _sanitized_guard_denial_reason(guard_evaluation)
 
     return PreviewSubmissionResponse(
         request=RequestRecord(
@@ -1276,6 +1333,8 @@ def submit_preview_request(
             dataset_contract_version=dataset_contract.contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
             state=candidate_state,
+            primary_deny_code=primary_deny_code,
+            denial_reason=denial_reason,
         ),
         audit=audit,
         evaluation=EvaluationRecord(
@@ -1287,5 +1346,7 @@ def submit_preview_request(
                 if guard_evaluation.decision == "allow"
                 else "blocked"
             ),
+            primary_deny_code=primary_deny_code,
+            denial_reason=denial_reason,
         ),
     )

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -458,6 +458,7 @@ def _rejected_guard_evaluation(detail: str) -> SQLGuardEvaluation:
         + "\\" * 2
         + "\\".join(("fileserver", "share", "safequery.sql")),
         "guard detail referenced ~" + "/" + "safequery/query.sql",
+        "guard detail referenced path=" + "/" + "/".join(("tmp", "safequery.sql")),
         "guard detail referenced bearer token in adapter output",
     ],
 )
@@ -468,6 +469,20 @@ def test_guard_denial_reason_sanitizer_blocks_paths_and_credentials(
         _sanitized_guard_denial_reason(_rejected_guard_evaluation(detail))
         == "SQL guard rejected the generated candidate."
     )
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "Guard rejected external reference https://docs.example.test/guard/reason",
+        "Guard rejected tokenized input from the parser stage",
+        "Guard rejected message from the secretariat review queue",
+    ],
+)
+def test_guard_denial_reason_sanitizer_keeps_benign_reason_terms(
+    detail: str,
+) -> None:
+    assert _sanitized_guard_denial_reason(_rejected_guard_evaluation(detail)) == detail
 
 
 def test_guard_denial_reason_sanitizer_keeps_truncation_within_cap() -> None:

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -29,7 +29,7 @@ from app.db.models.source_registry import RegisteredSource, SourceActivationPost
 from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 from app.features.auth.session import create_test_application_session
-from app.features.guard import SQLGuardEvaluation
+from app.features.guard import SQLGuardEvaluation, SQLGuardRejection
 from app.services import request_preview as request_preview_service
 from app.services.request_preview import (
     PreviewAuditContext,
@@ -37,6 +37,7 @@ from app.services.request_preview import (
     PreviewSubmissionRequest,
     _build_preview_lifecycle_audit_events,
     _persist_candidate_approval_record,
+    _sanitized_guard_denial_reason,
     submit_preview_request,
 )
 from app.services.operator_workflow import get_operator_workflow_snapshot
@@ -428,6 +429,55 @@ def test_http_preview_submission_persists_adapter_generated_candidate(
         engine.dispose()
         app.dependency_overrides.clear()
         get_settings.cache_clear()
+
+
+def _rejected_guard_evaluation(detail: str) -> SQLGuardEvaluation:
+    return SQLGuardEvaluation(
+        decision="reject",
+        profile="postgresql",
+        canonical_sql="SELECT 1",
+        source=None,
+        rejections=[
+            SQLGuardRejection(
+                code="DENY_TEST",
+                detail=detail,
+                path="canonical_sql",
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "guard detail referenced " + "/" + "/".join(("home", "alice", "query.sql")),
+        "guard detail referenced " + "/" + "/".join(("tmp", "safequery.sql")),
+        "guard detail referenced " + "/" + "/".join(("var", "log", "safequery")),
+        "guard detail referenced C:" + "\\" + "\\".join(("temp", "safequery.sql")),
+        "guard detail referenced "
+        + "\\" * 2
+        + "\\".join(("fileserver", "share", "safequery.sql")),
+        "guard detail referenced ~" + "/" + "safequery/query.sql",
+        "guard detail referenced bearer token in adapter output",
+    ],
+)
+def test_guard_denial_reason_sanitizer_blocks_paths_and_credentials(
+    detail: str,
+) -> None:
+    assert (
+        _sanitized_guard_denial_reason(_rejected_guard_evaluation(detail))
+        == "SQL guard rejected the generated candidate."
+    )
+
+
+def test_guard_denial_reason_sanitizer_keeps_truncation_within_cap() -> None:
+    detail = "Guard rejection detail " + ("x" * 260)
+
+    sanitized = _sanitized_guard_denial_reason(_rejected_guard_evaluation(detail))
+
+    assert sanitized is not None
+    assert len(sanitized) == request_preview_service._MAX_DENIAL_REASON_LENGTH
+    assert sanitized.endswith("...")
 
 
 def test_http_preview_submission_blocks_guard_rejected_adapter_sql(

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -39,6 +39,7 @@ from app.services.request_preview import (
     _persist_candidate_approval_record,
     submit_preview_request,
 )
+from app.services.operator_workflow import get_operator_workflow_snapshot
 from app.services.sql_generation_adapter import (
     SQLGenerationAdapterConfigurationError,
     SQLGenerationAdapterResponse,
@@ -489,7 +490,19 @@ def test_http_preview_submission_blocks_guard_rejected_adapter_sql(
         response_payload = response.json()
         assert response_payload["candidate"]["guard_status"] == "blocked"
         assert response_payload["candidate"]["state"] == "blocked"
+        assert response_payload["candidate"]["primary_deny_code"] == (
+            "DENY_MULTI_STATEMENT"
+        )
+        assert response_payload["candidate"]["denial_reason"] == (
+            "Canonical SQL must contain exactly one SELECT statement."
+        )
         assert response_payload["evaluation"]["state"] == "blocked"
+        assert response_payload["evaluation"]["primary_deny_code"] == (
+            "DENY_MULTI_STATEMENT"
+        )
+        assert response_payload["evaluation"]["denial_reason"] == (
+            "Canonical SQL must contain exactly one SELECT statement."
+        )
 
         persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
@@ -514,9 +527,37 @@ def test_http_preview_submission_blocks_guard_rejected_adapter_sql(
         assert persisted_approval.executed_at is None
         assert persisted_guard_event.primary_deny_code == "DENY_MULTI_STATEMENT"
         assert persisted_guard_event.denial_cause == "guard_rejected"
+        assert persisted_guard_event.audit_payload["source_id"] == "sap-approved-spend"
+        assert persisted_guard_event.audit_payload["query_candidate_id"] == (
+            persisted_candidate.candidate_id
+        )
+        assert persisted_guard_event.audit_payload["guard_decision"] == "reject"
+        assert persisted_guard_event.audit_payload["denial_reason"] == (
+            "Canonical SQL must contain exactly one SELECT statement."
+        )
         assert persisted_guard_event.audit_payload["guard_version"] == (
             "postgresql-guard-v1"
         )
+        assert "DELETE FROM" not in str(persisted_guard_event.audit_payload)
+
+        workflow_payload = get_operator_workflow_snapshot(session).model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
+        )
+        candidate_item = next(
+            item
+            for item in workflow_payload["history"]
+            if item["itemType"] == "candidate"
+        )
+        assert candidate_item["guardStatus"] == "blocked"
+        assert candidate_item["primaryDenyCode"] == "DENY_MULTI_STATEMENT"
+        assert candidate_item["auditEvents"][0]["guardDecision"] == "reject"
+        assert candidate_item["auditEvents"][0]["denialReason"] == (
+            "Canonical SQL must contain exactly one SELECT statement."
+        )
+        serialized_workflow = str(workflow_payload)
+        assert "credential" not in serialized_workflow.lower()
 
         calls: list[str] = []
         app.state.execution_query_runner = lambda **_: calls.append("called")


### PR DESCRIPTION
## Summary
- Persist guard-denied preview candidates as blocked with invalidated approval records and bounded denial metadata.
- Add guard decision and sanitized denial reason to preview audit payloads and operator workflow audit summaries.
- Keep execution against denied candidates on the existing fail-closed execution_denied contract.

## Verification
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_candidate_execute_api.py tests/test_api_errors.py
- cd backend && python3 -m pytest tests/test_operator_workflow_history.py -q
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_candidate_execute_api.py tests/test_api_errors.py tests/test_operator_workflow_history.py -q

Closes #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit trail now records guard evaluation outcomes (allow/reject) and includes a sanitized, truncated denial reason plus a primary denial code in API responses and workflow summaries.

* **Tests**
  * Expanded and strengthened tests for guard rejection flows, denial-reason sanitization/truncation, payload persistence, and workflow snapshot assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->