### PR TITLE
Clarify HTTP preview execute regression coverage

### DIFF
--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -32,6 +32,8 @@ from app.services.candidate_lifecycle import (
 
 
 class CandidateExecuteApiTestCase(unittest.TestCase):
+    """Lower-level execute revalidation tests seed approved candidates directly."""
+
     def setUp(self) -> None:
         self._previous_env = {
             name: os.environ.get(name)

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -281,7 +281,7 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         get_settings.cache_clear()
 
 
-def test_http_preview_submission_persists_adapter_generated_candidate(
+def test_http_preview_allow_path_creates_approved_candidate_and_executes(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv(
@@ -495,7 +495,7 @@ def test_guard_denial_reason_sanitizer_keeps_truncation_within_cap() -> None:
     assert sanitized.endswith("...")
 
 
-def test_http_preview_submission_blocks_guard_rejected_adapter_sql(
+def test_http_preview_guard_denied_candidate_remains_non_executable(
     monkeypatch,
 ) -> None:
     monkeypatch.setenv(
@@ -634,7 +634,17 @@ def test_http_preview_submission_blocks_guard_rejected_adapter_sql(
         )
 
         assert execute_response.status_code == 403
-        assert execute_response.json()["error"]["code"] == "execution_denied"
+        execute_payload = execute_response.json()
+        assert execute_payload["error"] == {
+            "code": "execution_denied",
+            "message": "Candidate execution was denied.",
+        }
+        assert len(execute_payload["audit"]["events"]) == 1
+        denial_event = execute_payload["audit"]["events"][0]
+        assert denial_event["event_type"] == "execution_denied"
+        assert denial_event["primary_deny_code"] == "DENY_CANDIDATE_NOT_APPROVED"
+        assert denial_event["denial_cause"] == "candidate_not_approved"
+        assert "DELETE FROM" not in str(execute_payload)
         assert calls == []
     finally:
         session.close()


### PR DESCRIPTION
## Summary
- rename HTTP preview allow and deny regression tests around the intended lifecycle states
- assert preview guard allow creates an approved candidate that executes through the HTTP path
- assert guard-denied preview candidates remain non-executable with bounded denial audit evidence
- mark direct-seeded execute API tests as lower-level revalidation coverage

Part of #349
Closes #353

## Verification
- cd backend && .venv/bin/python -m pytest tests/test_preview_persistence.py tests/test_candidate_execute_api.py
- cd backend && .venv/bin/python -m pytest tests/test_source_bound_execute_path.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage to validate complete execution denial response structures, including error messages and audit event details
  * Added descriptive documentation to test fixtures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->