### PR TITLE
Share release gate scenario metadata

### DIFF
--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -127,6 +127,7 @@ class SourceAwareAuditEvent(BaseModel):
     retrieved_asset_ids: Optional[list[NonEmptyTrimmedString]] = None
     retrieved_citations: Optional[list[RetrievalCitationAuditPayload]] = None
     executed_evidence: Optional[list[ExecutedEvidenceAuditPayload]] = None
+    release_gate_scenario: Optional[dict[str, object]] = None
     analyst_mode_version: Optional[NonEmptyTrimmedString] = None
 
     source_id: SourceIdentifier

--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -96,6 +96,18 @@ class ExecutedEvidenceAuditPayload(BaseModel):
     can_authorize_execution: Literal[False] = False
 
 
+class ReleaseGateScenarioAuditPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: NonEmptyTrimmedString
+    source_id: SourceIdentifier
+    candidate_id: NonEmptyTrimmedString
+    guard_decision: Literal["allow", "reject"]
+    guard_audit_event_id: UUID
+    execution_run_id: Optional[UUID] = None
+    execution_audit_event_id: Optional[UUID] = None
+
+
 class SourceAwareAuditEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -127,7 +139,7 @@ class SourceAwareAuditEvent(BaseModel):
     retrieved_asset_ids: Optional[list[NonEmptyTrimmedString]] = None
     retrieved_citations: Optional[list[RetrievalCitationAuditPayload]] = None
     executed_evidence: Optional[list[ExecutedEvidenceAuditPayload]] = None
-    release_gate_scenario: Optional[dict[str, object]] = None
+    release_gate_scenario: Optional[ReleaseGateScenarioAuditPayload] = None
     analyst_mode_version: Optional[NonEmptyTrimmedString] = None
 
     source_id: SourceIdentifier

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -55,24 +55,37 @@ class ReleaseGateAuditArtifact(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _hydrate_scenario_id_from_event_metadata(cls, value: Any) -> Any:
-        if not isinstance(value, Mapping) or value.get("scenario_id") is not None:
+        if not isinstance(value, Mapping):
             return value
 
+        top_level_scenario_id = value.get("scenario_id")
         event = value.get("event")
-        release_gate_scenario = None
+        release_gate_scenario: Any = None
         if isinstance(event, SourceAwareAuditEvent):
             release_gate_scenario = event.release_gate_scenario
         elif isinstance(event, Mapping):
             release_gate_scenario = event.get("release_gate_scenario")
 
-        if not isinstance(release_gate_scenario, Mapping):
+        if isinstance(release_gate_scenario, Mapping):
+            embedded_scenario_id = release_gate_scenario.get("scenario_id")
+        else:
+            embedded_scenario_id = getattr(
+                release_gate_scenario,
+                "scenario_id",
+                None,
+            )
+
+        if not isinstance(embedded_scenario_id, str) or not embedded_scenario_id.strip():
             return value
 
-        scenario_id = release_gate_scenario.get("scenario_id")
-        if not isinstance(scenario_id, str) or not scenario_id.strip():
+        if isinstance(top_level_scenario_id, str) and top_level_scenario_id.strip():
+            if top_level_scenario_id != embedded_scenario_id:
+                return value
+            return value
+        if top_level_scenario_id is not None and not isinstance(top_level_scenario_id, str):
             return value
 
-        return {**value, "scenario_id": scenario_id}
+        return {**value, "scenario_id": embedded_scenario_id}
 
 
 class ReleaseGateDecision(BaseModel):

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any, Iterable as TypingIterable, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 
 from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.evaluation.comparison import (
@@ -51,6 +51,28 @@ class ReleaseGateAuditArtifact(BaseModel):
 
     scenario_id: str
     event: SourceAwareAuditEvent
+
+    @model_validator(mode="before")
+    @classmethod
+    def _hydrate_scenario_id_from_event_metadata(cls, value: Any) -> Any:
+        if not isinstance(value, Mapping) or value.get("scenario_id") is not None:
+            return value
+
+        event = value.get("event")
+        release_gate_scenario = None
+        if isinstance(event, SourceAwareAuditEvent):
+            release_gate_scenario = event.release_gate_scenario
+        elif isinstance(event, Mapping):
+            release_gate_scenario = event.get("release_gate_scenario")
+
+        if not isinstance(release_gate_scenario, Mapping):
+            return value
+
+        scenario_id = release_gate_scenario.get("scenario_id")
+        if not isinstance(scenario_id, str) or not scenario_id.strip():
+            return value
+
+        return {**value, "scenario_id": scenario_id}
 
 
 class ReleaseGateDecision(BaseModel):

--- a/backend/app/features/evaluation/scenario_metadata.py
+++ b/backend/app/features/evaluation/scenario_metadata.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Literal, Optional, Union
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from app.features.evaluation.harness import (
+    MSSQLEvaluationScenario,
+    PostgreSQLEvaluationScenario,
+    list_mssql_evaluation_scenarios,
+    list_postgresql_evaluation_scenarios,
+)
+
+
+ScenarioArtifact = Union[MSSQLEvaluationScenario, PostgreSQLEvaluationScenario]
+
+
+class ReleaseGateScenarioMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: str
+    source_id: str
+    candidate_id: str
+    guard_decision: Literal["allow", "reject"]
+    guard_audit_event_id: UUID
+    execution_run_id: Optional[UUID] = None
+    execution_audit_event_id: Optional[UUID] = None
+
+
+def build_release_gate_scenario_metadata(
+    *,
+    source_id: str,
+    source_family: str,
+    source_flavor: str | None,
+    dataset_contract_version: int | None,
+    schema_snapshot_version: int | None,
+    execution_policy_version: int | None,
+    connector_profile_version: int | None,
+    canonical_sql: str,
+    candidate_id: str | None,
+    guard_decision: Literal["allow", "reject"] | None,
+    guard_audit_event_id: UUID | None,
+    execution_run_id: UUID | None = None,
+    execution_audit_event_id: UUID | None = None,
+) -> ReleaseGateScenarioMetadata | None:
+    if candidate_id is None or guard_decision is None or guard_audit_event_id is None:
+        return None
+
+    scenario = _find_authoritative_scenario(
+        source_id=source_id,
+        source_family=source_family,
+        source_flavor=source_flavor,
+        dataset_contract_version=dataset_contract_version,
+        schema_snapshot_version=schema_snapshot_version,
+        execution_policy_version=execution_policy_version,
+        connector_profile_version=connector_profile_version,
+        canonical_sql=canonical_sql,
+        guard_decision=guard_decision,
+    )
+    if scenario is None:
+        return None
+
+    return ReleaseGateScenarioMetadata(
+        scenario_id=scenario.scenario_id,
+        source_id=scenario.source.source_id,
+        candidate_id=candidate_id,
+        guard_decision=guard_decision,
+        guard_audit_event_id=guard_audit_event_id,
+        execution_run_id=execution_run_id,
+        execution_audit_event_id=execution_audit_event_id,
+    )
+
+
+def _find_authoritative_scenario(
+    *,
+    source_id: str,
+    source_family: str,
+    source_flavor: str | None,
+    dataset_contract_version: int | None,
+    schema_snapshot_version: int | None,
+    execution_policy_version: int | None,
+    connector_profile_version: int | None,
+    canonical_sql: str,
+    guard_decision: Literal["allow", "reject"],
+) -> ScenarioArtifact | None:
+    normalized_sql = " ".join(canonical_sql.split())
+    for scenario in (
+        list_mssql_evaluation_scenarios() + list_postgresql_evaluation_scenarios()
+    ):
+        source = scenario.source
+        if (
+            source.source_id == source_id
+            and source.source_family == source_family
+            and source.source_flavor == source_flavor
+            and source.dataset_contract_version == dataset_contract_version
+            and source.schema_snapshot_version == schema_snapshot_version
+            and source.execution_policy_version == execution_policy_version
+            and (
+                connector_profile_version is None
+                or source.connector_profile_version == connector_profile_version
+            )
+            and " ".join(scenario.canonical_sql.split()) == normalized_sql
+            and scenario.expected.decision == guard_decision
+        ):
+            return scenario
+    return None

--- a/backend/app/features/evaluation/scenario_metadata.py
+++ b/backend/app/features/evaluation/scenario_metadata.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
-
+from app.features.audit.event_model import ReleaseGateScenarioAuditPayload
 from app.features.evaluation.harness import (
     MSSQLEvaluationScenario,
     PostgreSQLEvaluationScenario,
@@ -14,18 +13,6 @@ from app.features.evaluation.harness import (
 
 
 ScenarioArtifact = Union[MSSQLEvaluationScenario, PostgreSQLEvaluationScenario]
-
-
-class ReleaseGateScenarioMetadata(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    scenario_id: str
-    source_id: str
-    candidate_id: str
-    guard_decision: Literal["allow", "reject"]
-    guard_audit_event_id: UUID
-    execution_run_id: Optional[UUID] = None
-    execution_audit_event_id: Optional[UUID] = None
 
 
 def build_release_gate_scenario_metadata(
@@ -43,7 +30,7 @@ def build_release_gate_scenario_metadata(
     guard_audit_event_id: UUID | None,
     execution_run_id: UUID | None = None,
     execution_audit_event_id: UUID | None = None,
-) -> ReleaseGateScenarioMetadata | None:
+) -> ReleaseGateScenarioAuditPayload | None:
     if candidate_id is None or guard_decision is None or guard_audit_event_id is None:
         return None
 
@@ -61,7 +48,7 @@ def build_release_gate_scenario_metadata(
     if scenario is None:
         return None
 
-    return ReleaseGateScenarioMetadata(
+    return ReleaseGateScenarioAuditPayload(
         scenario_id=scenario.scenario_id,
         source_id=scenario.source.source_id,
         candidate_id=candidate_id,
@@ -96,10 +83,8 @@ def _find_authoritative_scenario(
             and source.dataset_contract_version == dataset_contract_version
             and source.schema_snapshot_version == schema_snapshot_version
             and source.execution_policy_version == execution_policy_version
-            and (
-                connector_profile_version is None
-                or source.connector_profile_version == connector_profile_version
-            )
+            and connector_profile_version is not None
+            and source.connector_profile_version == connector_profile_version
             and " ".join(scenario.canonical_sql.split()) == normalized_sql
             and scenario.expected.decision == guard_decision
         ):

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -396,10 +396,7 @@ def _build_execution_audit_event(
             execution_audit_event_id=event.event_id,
         )
         if metadata is not None:
-            event.release_gate_scenario = metadata.model_dump(
-                mode="json",
-                exclude_none=True,
-            )
+            event.release_gate_scenario = metadata
     return event
 
 

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -17,6 +17,9 @@ from app.features.audit.event_model import (
     ExecutedEvidenceAuditPayload,
     SourceAwareAuditEvent,
 )
+from app.features.evaluation.scenario_metadata import (
+    build_release_gate_scenario_metadata,
+)
 from app.features.execution.connector_selection import (
     ExecutionConnectorSelection,
     ExecutionConnectorSelectionError,
@@ -172,6 +175,7 @@ class ExecutionAuditContext(BaseModel):
     session_id: str
     query_candidate_id: Optional[str] = None
     candidate_owner_subject: Optional[str] = None
+    guard_audit_event_id: Optional[UUID] = None
     execution_policy_version: Optional[int] = None
     connector_profile_version: Optional[int] = None
 
@@ -315,6 +319,7 @@ def _build_execution_audit_event(
     event_type: str,
     candidate_source: SourceBoundCandidateMetadata,
     audit_context: ExecutionAuditContext | None,
+    canonical_sql: str | None = None,
     primary_deny_code: str | None = None,
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
@@ -323,7 +328,7 @@ def _build_execution_audit_event(
     if audit_context is None:
         return None
 
-    return SourceAwareAuditEvent(
+    event = SourceAwareAuditEvent(
         event_id=(
             audit_context.event_id
             if event_type in {"execution_completed", "execution_denied"}
@@ -364,6 +369,38 @@ def _build_execution_audit_event(
         execution_row_count=execution_row_count,
         result_truncated=result_truncated,
     )
+    if canonical_sql is not None and event_type in {
+        "execution_completed",
+        "execution_denied",
+    }:
+        guard_decision = "allow" if primary_deny_code is None else "reject"
+        metadata = build_release_gate_scenario_metadata(
+            source_id=candidate_source.source_id,
+            source_family=candidate_source.source_family,
+            source_flavor=candidate_source.source_flavor,
+            dataset_contract_version=candidate_source.dataset_contract_version,
+            schema_snapshot_version=candidate_source.schema_snapshot_version,
+            execution_policy_version=(
+                audit_context.execution_policy_version
+                or candidate_source.execution_policy_version
+            ),
+            connector_profile_version=(
+                audit_context.connector_profile_version
+                or candidate_source.connector_profile_version
+            ),
+            canonical_sql=canonical_sql,
+            candidate_id=audit_context.query_candidate_id,
+            guard_decision=guard_decision,
+            guard_audit_event_id=audit_context.guard_audit_event_id,
+            execution_run_id=event.event_id,
+            execution_audit_event_id=event.event_id,
+        )
+        if metadata is not None:
+            event.release_gate_scenario = metadata.model_dump(
+                mode="json",
+                exclude_none=True,
+            )
+    return event
 
 
 def _build_execution_audit_events(
@@ -371,6 +408,7 @@ def _build_execution_audit_events(
     event_types: list[str],
     candidate_source: SourceBoundCandidateMetadata,
     audit_context: ExecutionAuditContext | None,
+    canonical_sql: str | None = None,
     primary_deny_code: str | None = None,
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
@@ -386,6 +424,7 @@ def _build_execution_audit_events(
             event_type=event_type,
             candidate_source=candidate_source,
             audit_context=audit_context,
+            canonical_sql=canonical_sql,
             primary_deny_code=(
                 primary_deny_code
                 if event_type
@@ -427,6 +466,7 @@ def _attach_execution_denial_audit_event(
             event_types=["execution_requested", "execution_denied"],
             candidate_source=candidate_source,
             audit_context=audit_context,
+            canonical_sql=None,
             primary_deny_code=error.deny_code,
         ),
     )
@@ -446,6 +486,7 @@ def _attach_cancellation_audit_event(
             event_types=["execution_requested", "execution_failed"],
             candidate_source=candidate_source,
             audit_context=audit_context,
+            canonical_sql=None,
             candidate_state="canceled",
         ),
     )
@@ -469,6 +510,7 @@ def _attach_runtime_failure_audit_event(
             ],
             candidate_source=candidate_source,
             audit_context=audit_context,
+            canonical_sql=None,
             candidate_state="failed",
         ),
     )
@@ -994,6 +1036,7 @@ def execute_candidate_sql(
         event_types=["execution_requested", "execution_started", "execution_completed"],
         candidate_source=candidate.source,
         audit_context=audit_context,
+        canonical_sql=candidate.canonical_sql,
         execution_row_count=metadata.row_count,
         result_truncated=metadata.result_truncated,
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from time import perf_counter
 from typing import Any, Callable, Optional
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -24,7 +24,7 @@ from app.core.errors import (
 )
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
-from app.db.models.preview import PreviewCandidate
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate
 from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
 from app.features.audit import SourceAwareAuditEvent
@@ -296,6 +296,22 @@ def _build_execution_source_binding_denial_audit_event(
         primary_deny_code=DENY_SOURCE_BINDING_MISMATCH,
         denial_cause="source_binding_mismatch",
         candidate_state="denied",
+    )
+
+
+def _latest_guard_audit_event_id(
+    session: Session,
+    *,
+    candidate_id: str,
+) -> UUID | None:
+    return session.scalar(
+        select(PreviewAuditEvent.event_id)
+        .where(
+            PreviewAuditEvent.candidate_id == candidate_id,
+            PreviewAuditEvent.event_type == "guard_evaluated",
+        )
+        .order_by(PreviewAuditEvent.lifecycle_order.desc())
+        .limit(1)
     )
 
 
@@ -631,6 +647,10 @@ def create_app() -> FastAPI:
             query_candidate_id=candidate_id,
             candidate_owner_subject=user_subject,
         )
+        guard_audit_event_id = _latest_guard_audit_event_id(
+            session,
+            candidate_id=candidate_id,
+        )
         try:
             candidate: ExecutableCandidateRecord | None = None
             selection: ExecutionConnectorSelection | None = None
@@ -675,6 +695,7 @@ def create_app() -> FastAPI:
                     session_id=application_session.audit_session_id,
                     query_candidate_id=candidate_id,
                     candidate_owner_subject=user_subject,
+                    guard_audit_event_id=guard_audit_event_id,
                     execution_policy_version=(
                         prepared_candidate.source.execution_policy_version
                     ),
@@ -724,6 +745,7 @@ def create_app() -> FastAPI:
                 session_id=application_session.audit_session_id,
                 query_candidate_id=candidate_id,
                 candidate_owner_subject=user_subject,
+                guard_audit_event_id=guard_audit_event_id,
                 execution_policy_version=candidate.source.execution_policy_version,
                 connector_profile_version=candidate.source.connector_profile_version,
             )

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -38,6 +38,11 @@ CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY = {
     "postgresql": 3,
 }
 
+CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY = {
+    "mssql": 1,
+    "postgresql": 1,
+}
+
 
 class SourceBoundCandidateMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -394,6 +399,13 @@ def _raise_authoritative_approval_error(
             execution_policy_version=(
                 approval.execution_policy_version if approval is not None else None
             ),
+            connector_profile_version=(
+                CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY.get(
+                    approval.source_family
+                )
+                if approval is not None
+                else None
+            ),
         ),
     )
     _raise_revalidation_error(
@@ -423,6 +435,11 @@ def _candidate_lifecycle_from_approval(
             dataset_contract_version=approval.dataset_contract_version,
             schema_snapshot_version=approval.schema_snapshot_version,
             execution_policy_version=approval.execution_policy_version,
+            connector_profile_version=(
+                CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY.get(
+                    approval.source_family
+                )
+            ),
         ),
     )
 

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -14,6 +14,9 @@ from app.features.audit.event_model import (
     SourceFamily,
 )
 from app.features.auth.context import AuthenticatedSubject
+from app.features.evaluation.scenario_metadata import (
+    build_release_gate_scenario_metadata,
+)
 from app.features.execution import execute_candidate_sql, select_execution_connector
 from app.features.execution.runtime import (
     CancellationProbe,
@@ -133,12 +136,14 @@ def _audit_base(
     event_type: AuditEventType,
     causation_event_id: UUID | None,
     primary_deny_code: str | None = None,
+    canonical_sql: str | None = None,
+    guard_decision: str | None = None,
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
 ) -> SourceAwareAuditEvent:
-    return SourceAwareAuditEvent(
+    event = SourceAwareAuditEvent(
         event_id=uuid4(),
         event_type=event_type,
         occurred_at=audit_context.occurred_at,
@@ -176,6 +181,7 @@ def _audit_base(
         guard_version=(
             audit_context.guard_version if event_type == "guard_evaluated" else None
         ),
+        guard_decision=guard_decision if event_type == "guard_evaluated" else None,
         adapter_provider=(
             adapter_metadata.adapter_provider if adapter_metadata is not None else None
         ),
@@ -209,6 +215,30 @@ def _audit_base(
         execution_row_count=execution_row_count,
         result_truncated=result_truncated,
     )
+    if (
+        event_type == "guard_evaluated"
+        and canonical_sql is not None
+        and guard_decision in {"allow", "reject"}
+    ):
+        metadata = build_release_gate_scenario_metadata(
+            source_id=candidate_source.source_id,
+            source_family=candidate_source.source_family,
+            source_flavor=candidate_source.source_flavor,
+            dataset_contract_version=candidate_source.dataset_contract_version,
+            schema_snapshot_version=candidate_source.schema_snapshot_version,
+            execution_policy_version=candidate_source.execution_policy_version,
+            connector_profile_version=candidate_source.connector_profile_version,
+            canonical_sql=canonical_sql,
+            candidate_id=audit_context.query_candidate_id,
+            guard_decision=guard_decision,
+            guard_audit_event_id=event.event_id,
+        )
+        if metadata is not None:
+            event.release_gate_scenario = metadata.model_dump(
+                mode="json",
+                exclude_none=True,
+            )
+    return event
 
 
 def _append_audit_event(
@@ -218,6 +248,8 @@ def _append_audit_event(
     candidate_source: SourceBoundCandidateMetadata,
     event_type: AuditEventType,
     primary_deny_code: str | None = None,
+    canonical_sql: str | None = None,
+    guard_decision: str | None = None,
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
@@ -230,6 +262,8 @@ def _append_audit_event(
             event_type=event_type,
             causation_event_id=events[-1].event_id if events else None,
             primary_deny_code=primary_deny_code,
+            canonical_sql=canonical_sql,
+            guard_decision=guard_decision,
             candidate_state=candidate_state,
             execution_row_count=execution_row_count,
             result_truncated=result_truncated,
@@ -253,6 +287,7 @@ def _build_execution_audit_context(
         session_id=audit_context.session_id,
         query_candidate_id=audit_context.query_candidate_id,
         candidate_owner_subject=audit_context.candidate_owner_subject,
+        guard_audit_event_id=previous_event_id,
         execution_policy_version=MSSQL_EXECUTION_POLICY_VERSION,
         connector_profile_version=MSSQL_CONNECTOR_PROFILE_VERSION,
     )
@@ -398,6 +433,8 @@ def run_mssql_core_vertical_slice(
             candidate_source=candidate_source,
             event_type="guard_evaluated",
             primary_deny_code=primary_deny_code,
+            canonical_sql=canonical_sql,
+            guard_decision="reject",
             candidate_state="denied",
             adapter_metadata=adapter_metadata,
         )
@@ -424,6 +461,8 @@ def run_mssql_core_vertical_slice(
         audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="guard_evaluated",
+        canonical_sql=canonical_sql,
+        guard_decision="allow",
         candidate_state="preview_ready",
         adapter_metadata=adapter_metadata,
     )

--- a/backend/app/services/mssql_vertical_slice.py
+++ b/backend/app/services/mssql_vertical_slice.py
@@ -234,10 +234,7 @@ def _audit_base(
             guard_audit_event_id=event.event_id,
         )
         if metadata is not None:
-            event.release_gate_scenario = metadata.model_dump(
-                mode="json",
-                exclude_none=True,
-            )
+            event.release_gate_scenario = metadata
     return event
 
 

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -247,10 +247,7 @@ def _audit_base(
             guard_audit_event_id=event.event_id,
         )
         if metadata is not None:
-            event.release_gate_scenario = metadata.model_dump(
-                mode="json",
-                exclude_none=True,
-            )
+            event.release_gate_scenario = metadata
     return event
 
 

--- a/backend/app/services/postgresql_vertical_slice.py
+++ b/backend/app/services/postgresql_vertical_slice.py
@@ -14,6 +14,9 @@ from app.features.audit.event_model import (
     SourceFamily,
 )
 from app.features.auth.context import AuthenticatedSubject
+from app.features.evaluation.scenario_metadata import (
+    build_release_gate_scenario_metadata,
+)
 from app.features.execution import execute_candidate_sql, select_execution_connector
 from app.features.execution.runtime import (
     CancellationProbe,
@@ -146,12 +149,14 @@ def _audit_base(
     event_type: AuditEventType,
     causation_event_id: UUID | None,
     primary_deny_code: str | None = None,
+    canonical_sql: str | None = None,
+    guard_decision: str | None = None,
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
 ) -> SourceAwareAuditEvent:
-    return SourceAwareAuditEvent(
+    event = SourceAwareAuditEvent(
         event_id=uuid4(),
         event_type=event_type,
         occurred_at=audit_context.occurred_at,
@@ -189,6 +194,7 @@ def _audit_base(
         guard_version=(
             audit_context.guard_version if event_type == "guard_evaluated" else None
         ),
+        guard_decision=guard_decision if event_type == "guard_evaluated" else None,
         adapter_provider=(
             adapter_metadata.adapter_provider if adapter_metadata is not None else None
         ),
@@ -222,6 +228,30 @@ def _audit_base(
         execution_row_count=execution_row_count,
         result_truncated=result_truncated,
     )
+    if (
+        event_type == "guard_evaluated"
+        and canonical_sql is not None
+        and guard_decision in {"allow", "reject"}
+    ):
+        metadata = build_release_gate_scenario_metadata(
+            source_id=candidate_source.source_id,
+            source_family=candidate_source.source_family,
+            source_flavor=candidate_source.source_flavor,
+            dataset_contract_version=candidate_source.dataset_contract_version,
+            schema_snapshot_version=candidate_source.schema_snapshot_version,
+            execution_policy_version=candidate_source.execution_policy_version,
+            connector_profile_version=candidate_source.connector_profile_version,
+            canonical_sql=canonical_sql,
+            candidate_id=audit_context.query_candidate_id,
+            guard_decision=guard_decision,
+            guard_audit_event_id=event.event_id,
+        )
+        if metadata is not None:
+            event.release_gate_scenario = metadata.model_dump(
+                mode="json",
+                exclude_none=True,
+            )
+    return event
 
 
 def _append_audit_event(
@@ -231,6 +261,8 @@ def _append_audit_event(
     candidate_source: SourceBoundCandidateMetadata,
     event_type: AuditEventType,
     primary_deny_code: str | None = None,
+    canonical_sql: str | None = None,
+    guard_decision: str | None = None,
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
@@ -243,6 +275,8 @@ def _append_audit_event(
             event_type=event_type,
             causation_event_id=events[-1].event_id if events else None,
             primary_deny_code=primary_deny_code,
+            canonical_sql=canonical_sql,
+            guard_decision=guard_decision,
             candidate_state=candidate_state,
             execution_row_count=execution_row_count,
             result_truncated=result_truncated,
@@ -266,6 +300,7 @@ def _build_execution_audit_context(
         session_id=audit_context.session_id,
         query_candidate_id=audit_context.query_candidate_id,
         candidate_owner_subject=audit_context.candidate_owner_subject,
+        guard_audit_event_id=previous_event_id,
         execution_policy_version=POSTGRESQL_EXECUTION_POLICY_VERSION,
         connector_profile_version=POSTGRESQL_CONNECTOR_PROFILE_VERSION,
     )
@@ -417,6 +452,8 @@ def run_postgresql_core_vertical_slice(
             candidate_source=candidate_source,
             event_type="guard_evaluated",
             primary_deny_code=primary_deny_code,
+            canonical_sql=canonical_sql,
+            guard_decision="reject",
             candidate_state="denied",
             adapter_metadata=adapter_metadata,
         )
@@ -443,6 +480,8 @@ def run_postgresql_core_vertical_slice(
         audit_context=candidate_audit_context,
         candidate_source=candidate_source,
         event_type="guard_evaluated",
+        canonical_sql=canonical_sql,
+        guard_decision="allow",
         candidate_state="preview_ready",
         adapter_metadata=adapter_metadata,
     )

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -32,6 +32,7 @@ from app.features.guard import (
 )
 from app.features.operator_history.payloads import GuardStatus
 from app.services.candidate_lifecycle import (
+    CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY,
     CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY,
 )
 from app.services.source_entitlements import (
@@ -250,6 +251,7 @@ def _build_preview_lifecycle_audit_events(
     audit_context: PreviewAuditContext | None,
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
     guard_evaluation: SQLGuardEvaluation | None = None,
+    candidate_sql: str | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
         return []
@@ -262,6 +264,20 @@ def _build_preview_lifecycle_audit_events(
         "generation_completed",
         "guard_evaluated",
     ):
+        execution_policy_version = (
+            CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY.get(
+                resolved_source.source_family
+            )
+            if event_type == "guard_evaluated" and guard_evaluation is not None
+            else None
+        )
+        connector_profile_version = (
+            CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY.get(
+                resolved_source.source_family
+            )
+            if event_type == "guard_evaluated" and guard_evaluation is not None
+            else None
+        )
         event = SourceAwareAuditEvent(
             event_id=uuid4(),
             event_type=event_type,
@@ -343,6 +359,8 @@ def _build_preview_lifecycle_audit_events(
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
+            execution_policy_version=execution_policy_version,
+            connector_profile_version=connector_profile_version,
             candidate_state=(
                 "generated"
                 if adapter_metadata is not None and event_type == "generation_completed"
@@ -372,12 +390,11 @@ def _build_preview_lifecycle_audit_events(
                 else None
             ),
         )
-        if event_type == "guard_evaluated" and guard_evaluation is not None:
-            execution_policy_version = (
-                CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY.get(
-                    resolved_source.source_family
-                )
-            )
+        if (
+            event_type == "guard_evaluated"
+            and guard_evaluation is not None
+            and candidate_sql is not None
+        ):
             metadata = build_release_gate_scenario_metadata(
                 source_id=resolved_source.source_id,
                 source_family=resolved_source.source_family,
@@ -385,17 +402,14 @@ def _build_preview_lifecycle_audit_events(
                 dataset_contract_version=dataset_contract.contract_version,
                 schema_snapshot_version=schema_snapshot.snapshot_version,
                 execution_policy_version=execution_policy_version,
-                connector_profile_version=None,
-                canonical_sql=guard_evaluation.canonical_sql,
+                connector_profile_version=connector_profile_version,
+                canonical_sql=candidate_sql,
                 candidate_id=audit_context.query_candidate_id,
                 guard_decision=guard_evaluation.decision,
                 guard_audit_event_id=event.event_id,
             )
             if metadata is not None:
-                event.release_gate_scenario = metadata.model_dump(
-                    mode="json",
-                    exclude_none=True,
-                )
+                event.release_gate_scenario = metadata
         causation_event_id = event.event_id
         events.append(event)
 
@@ -1334,6 +1348,7 @@ def submit_preview_request(
             audit_context=audit_context,
             adapter_metadata=adapter_metadata,
             guard_evaluation=guard_evaluation,
+            candidate_sql=candidate_sql,
         ),
     )
     request_id, candidate_id = _persist_preview_submission_records(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -22,6 +22,9 @@ from app.db.models.source_registry import RegisteredSource
 from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.auth.context import AuthenticatedSubject
 from app.features.auth.governance_bindings import normalize_governance_binding
+from app.features.evaluation.scenario_metadata import (
+    build_release_gate_scenario_metadata,
+)
 from app.features.guard import (
     SQLGuardEvaluation,
     evaluate_mssql_sql_guard,
@@ -369,6 +372,30 @@ def _build_preview_lifecycle_audit_events(
                 else None
             ),
         )
+        if event_type == "guard_evaluated" and guard_evaluation is not None:
+            execution_policy_version = (
+                CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY.get(
+                    resolved_source.source_family
+                )
+            )
+            metadata = build_release_gate_scenario_metadata(
+                source_id=resolved_source.source_id,
+                source_family=resolved_source.source_family,
+                source_flavor=resolved_source.source_flavor,
+                dataset_contract_version=dataset_contract.contract_version,
+                schema_snapshot_version=schema_snapshot.snapshot_version,
+                execution_policy_version=execution_policy_version,
+                connector_profile_version=None,
+                canonical_sql=guard_evaluation.canonical_sql,
+                candidate_id=audit_context.query_candidate_id,
+                guard_decision=guard_evaluation.decision,
+                guard_audit_event_id=event.event_id,
+            )
+            if metadata is not None:
+                event.release_gate_scenario = metadata.model_dump(
+                    mode="json",
+                    exclude_none=True,
+                )
         causation_event_id = event.event_id
         events.append(event)
 

--- a/backend/tests/test_audit_event_model.py
+++ b/backend/tests/test_audit_event_model.py
@@ -285,3 +285,22 @@ def test_executed_evidence_rejects_retrieval_citation_shape() -> None:
 
     with pytest.raises(ValidationError):
         SourceAwareAuditEvent(**payload)
+
+
+def test_release_gate_scenario_audit_payload_rejects_extra_metadata() -> None:
+    payload = _source_aware_payload()
+    payload.update(
+        {
+            "release_gate_scenario": {
+                "scenario_id": "postgresql-positive-approved-vendor-spend-top-vendors",
+                "source_id": "sap-approved-spend",
+                "candidate_id": "candidate-123",
+                "guard_decision": "allow",
+                "guard_audit_event_id": uuid4(),
+                "connection_string": "postgresql://user:secret@example.test/db",
+            },
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        SourceAwareAuditEvent(**payload)

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -29,6 +29,7 @@ from app.db.models.source_registry import RegisteredSource, SourceActivationPost
 from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 from app.features.auth.session import create_test_application_session
+from app.features.evaluation.harness import list_postgresql_evaluation_scenarios
 from app.features.guard import SQLGuardEvaluation, SQLGuardRejection
 from app.services import request_preview as request_preview_service
 from app.services.request_preview import (
@@ -50,15 +51,18 @@ from app.services.sql_generation_adapter import (
 def _seed_authoritative_source_governance(
     session: Session,
     *,
+    source_id: str = "sap-approved-spend",
     include_datasets: bool = True,
     source_posture: SourceActivationPosture = SourceActivationPosture.ACTIVE,
     connection_reference: str = "vault:sap-approved-spend",
     source_family: str = "postgresql",
     source_flavor: str = "warehouse",
+    dataset_contract_version: int = 1,
+    schema_snapshot_version: int = 1,
 ) -> None:
     source = RegisteredSource(
         id=uuid4(),
-        source_id="sap-approved-spend",
+        source_id=source_id,
         display_label="SAP spend cube / approved_vendor_spend",
         source_family=source_family,
         source_flavor=source_flavor,
@@ -76,7 +80,7 @@ def _seed_authoritative_source_governance(
     snapshot = SchemaSnapshot(
         id=uuid4(),
         registered_source_id=source.id,
-        snapshot_version=1,
+        snapshot_version=schema_snapshot_version,
         review_status=SchemaSnapshotReviewStatus.APPROVED,
         reviewed_at=datetime.now(timezone.utc),
     )
@@ -87,7 +91,7 @@ def _seed_authoritative_source_governance(
         id=uuid4(),
         registered_source_id=source.id,
         schema_snapshot_id=snapshot.id,
-        contract_version=1,
+        contract_version=dataset_contract_version,
         display_name="SAP spend cube contract",
         owner_binding="group:finance-analysts",
         security_review_binding=None,
@@ -424,6 +428,143 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
             "prompt_version": "sql_generation_adapter_request.v1",
             "prompt_fingerprint": persisted_candidate.prompt_fingerprint,
         }.items() <= persisted_generation_event.audit_payload.items()
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+def test_http_preview_to_execute_emits_release_gate_scenario_metadata(
+    monkeypatch,
+) -> None:
+    scenario = next(
+        scenario
+        for scenario in list_postgresql_evaluation_scenarios()
+        if scenario.scenario_id
+        == "postgresql-positive-approved-vendor-spend-top-vendors"
+    )
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    monkeypatch.setenv(
+        "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        "postgresql://safequery_exec:secret@business-postgres-source:5432/business",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    adapter = _RecordingHTTPPreviewAdapter(scenario.canonical_sql)
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: adapter,
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(
+            session,
+            source_id=scenario.source.source_id,
+            source_family=scenario.source.source_family,
+            source_flavor=scenario.source.source_flavor,
+            dataset_contract_version=scenario.source.dataset_contract_version,
+            schema_snapshot_version=scenario.source.schema_snapshot_version,
+            connection_reference="env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        )
+        app_session = create_test_application_session(subject)
+
+        preview_response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": scenario.prompt,
+                "source_id": scenario.source.source_id,
+            },
+        )
+
+        assert preview_response.status_code == 200
+        persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_guard_event = (
+            session.execute(
+                select(PreviewAuditEvent).where(
+                    PreviewAuditEvent.event_type == "guard_evaluated"
+                )
+            )
+            .scalars()
+            .one()
+        )
+
+        app.state.execution_query_runner = lambda **_: [
+            {"vendor_name": "Acme", "approved_amount": 1000}
+        ]
+        execute_response = client.post(
+            f"/candidates/{persisted_candidate.candidate_id}/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": scenario.source.source_id},
+        )
+
+        assert execute_response.status_code == 200
+        persisted_execution_event = (
+            session.execute(
+                select(PreviewAuditEvent).where(
+                    PreviewAuditEvent.event_type == "execution_completed"
+                )
+            )
+            .scalars()
+            .one()
+        )
+
+        # These release-gate inputs let Epic T fixtures correlate generated SQL,
+        # the guard decision, execution run, and authoritative audit evidence.
+        expected_guard_metadata = {
+            "scenario_id": scenario.scenario_id,
+            "source_id": scenario.source.source_id,
+            "candidate_id": persisted_candidate.candidate_id,
+            "guard_decision": "allow",
+            "guard_audit_event_id": str(persisted_guard_event.event_id),
+        }
+        assert (
+            persisted_guard_event.audit_payload["release_gate_scenario"]
+            == expected_guard_metadata
+        )
+        assert persisted_execution_event.audit_payload["release_gate_scenario"] == {
+            **expected_guard_metadata,
+            "execution_run_id": str(persisted_execution_event.event_id),
+            "execution_audit_event_id": str(persisted_execution_event.event_id),
+        }
+        serialized_metadata = str(
+            [
+                persisted_guard_event.audit_payload["release_gate_scenario"],
+                persisted_execution_event.audit_payload["release_gate_scenario"],
+            ]
+        )
+        assert "safequery_exec:secret" not in serialized_metadata
+        assert "business-postgres-source:5432" not in serialized_metadata
     finally:
         session.close()
         engine.dispose()

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -98,6 +98,54 @@ def test_release_gate_passes_when_authoritative_records_match_harness() -> None:
     assert decision.failures == ()
 
 
+def test_release_gate_accepts_scenario_id_from_shared_audit_metadata() -> None:
+    scenario = list_postgresql_evaluation_scenarios()[0]
+    event_id = uuid4()
+    audit_artifact = {
+        "event": {
+            "event_id": event_id,
+            "event_type": "execution_completed",
+            "occurred_at": datetime.now(timezone.utc),
+            "request_id": f"request-{scenario.scenario_id}",
+            "correlation_id": f"correlation-{scenario.scenario_id}",
+            "user_subject": "user:release-gate",
+            "session_id": "session-release-gate",
+            "source_id": scenario.source.source_id,
+            "source_family": scenario.source.source_family,
+            "source_flavor": scenario.source.source_flavor,
+            "dialect_profile_version": scenario.source.dialect_profile_version,
+            "dataset_contract_version": scenario.source.dataset_contract_version,
+            "schema_snapshot_version": scenario.source.schema_snapshot_version,
+            "execution_policy_version": scenario.source.execution_policy_version,
+            "connector_profile_version": scenario.source.connector_profile_version,
+            "release_gate_scenario": {
+                "scenario_id": scenario.scenario_id,
+                "source_id": scenario.source.source_id,
+                "candidate_id": "candidate-release-gate",
+                "guard_decision": "allow",
+                "guard_audit_event_id": str(uuid4()),
+                "execution_run_id": str(event_id),
+                "execution_audit_event_id": str(event_id),
+            },
+        },
+    }
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=_observed_records_from_harness(),
+        audit_artifacts=(
+            audit_artifact,
+            *(
+                artifact
+                for artifact in _audit_artifacts_from_harness()
+                if artifact["scenario_id"] != scenario.scenario_id
+            ),
+        ),
+    )
+
+    assert decision.status == "pass"
+    assert decision.failure_count == 0
+
+
 def test_release_gate_fails_closed_when_evaluations_have_no_audit_artifacts() -> None:
     decision = reconstruct_release_gate(observed_artifacts=_observed_records_from_harness())
 

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -15,6 +15,9 @@ from app.features.evaluation.harness import (
     list_mssql_evaluation_scenarios,
     list_postgresql_evaluation_scenarios,
 )
+from app.features.evaluation.scenario_metadata import (
+    build_release_gate_scenario_metadata,
+)
 from app.features.mlflow_export import build_mlflow_export_from_evaluation_scenario
 
 
@@ -99,7 +102,16 @@ def test_release_gate_passes_when_authoritative_records_match_harness() -> None:
 
 
 def test_release_gate_accepts_scenario_id_from_shared_audit_metadata() -> None:
-    scenario = list_postgresql_evaluation_scenarios()[0]
+    scenario = next(
+        (
+            scenario
+            for scenario in list_postgresql_evaluation_scenarios()
+            if scenario.evaluation_boundary != "guard"
+            and scenario.expected.decision == "allow"
+        ),
+        None,
+    )
+    assert scenario is not None
     event_id = uuid4()
     audit_artifact = {
         "event": {
@@ -144,6 +156,90 @@ def test_release_gate_accepts_scenario_id_from_shared_audit_metadata() -> None:
 
     assert decision.status == "pass"
     assert decision.failure_count == 0
+
+
+def test_release_gate_fails_closed_for_scenario_id_metadata_mismatch() -> None:
+    scenario = next(
+        scenario
+        for scenario in list_postgresql_evaluation_scenarios()
+        if scenario.evaluation_boundary != "guard"
+        and scenario.expected.decision == "allow"
+    )
+    event_id = uuid4()
+    audit_artifact = {
+        "scenario_id": "postgresql-safety-stale-policy-denied",
+        "event": {
+            "event_id": event_id,
+            "event_type": "execution_completed",
+            "occurred_at": datetime.now(timezone.utc),
+            "request_id": f"request-{scenario.scenario_id}",
+            "correlation_id": f"correlation-{scenario.scenario_id}",
+            "user_subject": "user:release-gate",
+            "session_id": "session-release-gate",
+            "source_id": scenario.source.source_id,
+            "source_family": scenario.source.source_family,
+            "source_flavor": scenario.source.source_flavor,
+            "dialect_profile_version": scenario.source.dialect_profile_version,
+            "dataset_contract_version": scenario.source.dataset_contract_version,
+            "schema_snapshot_version": scenario.source.schema_snapshot_version,
+            "execution_policy_version": scenario.source.execution_policy_version,
+            "connector_profile_version": scenario.source.connector_profile_version,
+            "release_gate_scenario": {
+                "scenario_id": scenario.scenario_id,
+                "source_id": scenario.source.source_id,
+                "candidate_id": "candidate-release-gate",
+                "guard_decision": "allow",
+                "guard_audit_event_id": str(uuid4()),
+                "execution_run_id": str(event_id),
+                "execution_audit_event_id": str(event_id),
+            },
+        },
+    }
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=_observed_records_from_harness(),
+        audit_artifacts=(
+            audit_artifact,
+            *(
+                artifact
+                for artifact in _audit_artifacts_from_harness()
+                if artifact["scenario_id"]
+                not in {scenario.scenario_id, "postgresql-safety-stale-policy-denied"}
+            ),
+        ),
+    )
+
+    assert decision.status == "fail"
+    assert {
+        failure.deny_code
+        for failure in decision.failures
+        if failure.scenario_id
+        in {scenario.scenario_id, "postgresql-safety-stale-policy-denied"}
+    } == {"DENY_MISSING_AUDIT_COVERAGE", "DENY_STALE_AUDIT_COVERAGE"}
+
+
+def test_release_gate_scenario_metadata_requires_connector_profile_version() -> None:
+    scenario = next(
+        scenario
+        for scenario in list_postgresql_evaluation_scenarios()
+        if scenario.source.connector_profile_version is not None
+    )
+
+    metadata = build_release_gate_scenario_metadata(
+        source_id=scenario.source.source_id,
+        source_family=scenario.source.source_family,
+        source_flavor=scenario.source.source_flavor,
+        dataset_contract_version=scenario.source.dataset_contract_version,
+        schema_snapshot_version=scenario.source.schema_snapshot_version,
+        execution_policy_version=scenario.source.execution_policy_version,
+        connector_profile_version=None,
+        canonical_sql=scenario.canonical_sql,
+        candidate_id="candidate-release-gate",
+        guard_decision=scenario.expected.decision,
+        guard_audit_event_id=uuid4(),
+    )
+
+    assert metadata is None
 
 
 def test_release_gate_fails_closed_when_evaluations_have_no_audit_artifacts() -> None:


### PR DESCRIPTION
## Summary
- add shared release-gate scenario metadata derived from authoritative evaluation harness records
- persist compatible metadata on HTTP guard/execute audit payloads and vertical-slice audit events
- allow release-gate audit artifacts to hydrate scenario_id from embedded event metadata

## Verification
- cd backend && .venv/bin/python -m pytest tests/test_preview_persistence.py tests/test_candidate_execute_api.py
- cd backend && .venv/bin/python -m pytest tests/test_evaluation_harness.py tests/test_release_gate.py

Closes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit events now include release-gate scenario metadata (scenario identifiers, source/profile versions, guard decision and linked guard/execution event IDs) and are propagated from preview/guard evaluation to execution.
  * Execution and preview flows are enriched to compute and attach connector/profile version and canonical-SQL–based scenario linkage when available.

* **Tests**
  * Added tests verifying scenario-metadata validation and persistence across preview → guard → execution, and rejection of unexpected metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->