### PR TITLE
Add source-aware regression matrix

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -14,8 +14,10 @@ from app.features.evaluation.harness import (
     EvaluationSourceProfile,
     MSSQLEvaluationScenario,
     PostgreSQLEvaluationScenario,
+    SourceRegressionMatrixEntry,
     list_mssql_evaluation_scenarios,
     list_postgresql_evaluation_scenarios,
+    list_source_regression_matrix,
 )
 from app.features.evaluation.release_gate import (
     ReleaseGateAuditArtifact,
@@ -38,8 +40,10 @@ __all__ = [
     "ReleaseGateAuditArtifact",
     "ReleaseGateDecision",
     "ReleaseGateFailure",
+    "SourceRegressionMatrixEntry",
     "compare_evaluation_outcomes",
     "list_mssql_evaluation_scenarios",
     "list_postgresql_evaluation_scenarios",
+    "list_source_regression_matrix",
     "reconstruct_release_gate",
 ]

--- a/backend/app/features/evaluation/harness.py
+++ b/backend/app/features/evaluation/harness.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import copy
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, PositiveInt, model_validator
 
 
 EvaluationScenarioKind = Literal["positive", "safety", "regression"]
 EvaluationBoundary = Literal["guard", "connector_selection", "lifecycle", "execution"]
+RegressionValidationSurface = Literal["generation", "guard", "execute", "audit"]
+RegressionRolloutStatus = Literal["active_baseline", "planned", "planned_flavor"]
+
+ScenarioArtifact = Union["MSSQLEvaluationScenario", "PostgreSQLEvaluationScenario"]
 
 
 class EvaluationSourceProfile(BaseModel):
@@ -79,6 +83,22 @@ class PostgreSQLEvaluationScenario(BaseModel):
     @property
     def identity(self) -> tuple[str, str]:
         return (self.source.source_id, self.scenario_id)
+
+
+class SourceRegressionMatrixEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: Optional[str] = None
+    scenario_kind: Optional[EvaluationScenarioKind] = None
+    evaluation_boundary: Optional[EvaluationBoundary] = None
+    source_id: Optional[str] = None
+    source_family: str
+    source_flavor: Optional[str] = None
+    rollout_status: RegressionRolloutStatus
+    executable: bool
+    validates: tuple[RegressionValidationSurface, ...]
+    expected_decision: Optional[Literal["allow", "reject"]] = None
+    primary_code: Optional[str] = None
 
 
 _MSSQL_SOURCE = EvaluationSourceProfile(
@@ -416,3 +436,75 @@ def list_mssql_evaluation_scenarios() -> tuple[MSSQLEvaluationScenario, ...]:
 
 def list_postgresql_evaluation_scenarios() -> tuple[PostgreSQLEvaluationScenario, ...]:
     return tuple(copy.deepcopy(scenario) for scenario in POSTGRESQL_EVALUATION_SCENARIOS)
+
+
+def list_source_regression_matrix() -> tuple[SourceRegressionMatrixEntry, ...]:
+    active_entries = tuple(
+        _matrix_entry_from_scenario(scenario)
+        for scenario in (
+            list_mssql_evaluation_scenarios() + list_postgresql_evaluation_scenarios()
+        )
+    )
+    planned_entries = (
+        SourceRegressionMatrixEntry(
+            source_family="mysql",
+            rollout_status="planned",
+            executable=False,
+            validates=(),
+        ),
+        SourceRegressionMatrixEntry(
+            source_family="mariadb",
+            rollout_status="planned",
+            executable=False,
+            validates=(),
+        ),
+        SourceRegressionMatrixEntry(
+            source_family="postgresql",
+            source_flavor="aurora-postgresql",
+            rollout_status="planned_flavor",
+            executable=False,
+            validates=(),
+        ),
+        SourceRegressionMatrixEntry(
+            source_family="mysql",
+            source_flavor="aurora-mysql",
+            rollout_status="planned_flavor",
+            executable=False,
+            validates=(),
+        ),
+        SourceRegressionMatrixEntry(
+            source_family="oracle",
+            rollout_status="planned",
+            executable=False,
+            validates=(),
+        ),
+    )
+    return active_entries + planned_entries
+
+
+def _matrix_entry_from_scenario(
+    scenario: ScenarioArtifact,
+) -> SourceRegressionMatrixEntry:
+    return SourceRegressionMatrixEntry(
+        scenario_id=scenario.scenario_id,
+        scenario_kind=scenario.kind,
+        evaluation_boundary=scenario.evaluation_boundary,
+        source_id=scenario.source.source_id,
+        source_family=scenario.source.source_family,
+        source_flavor=scenario.source.source_flavor,
+        rollout_status="active_baseline",
+        executable=True,
+        validates=_validated_surfaces_for(scenario),
+        expected_decision=scenario.expected.decision,
+        primary_code=scenario.expected.primary_code,
+    )
+
+
+def _validated_surfaces_for(
+    scenario: ScenarioArtifact,
+) -> tuple[RegressionValidationSurface, ...]:
+    if scenario.evaluation_boundary == "guard":
+        return ("generation", "guard", "audit")
+    if scenario.evaluation_boundary == "execution":
+        return ("generation", "guard", "execute", "audit")
+    return ("execute", "audit")

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -30,6 +30,7 @@ from app.features.evaluation import (
     compare_evaluation_outcomes,
     list_mssql_evaluation_scenarios,
     list_postgresql_evaluation_scenarios,
+    list_source_regression_matrix,
 )
 from app.features.execution import (
     ExecutionConnectorExecutionError,
@@ -350,6 +351,43 @@ def test_postgresql_evaluation_fixture_listing_returns_defensive_copies() -> Non
     assert fresh_scenario.source is not mutated_scenario.source
     assert fresh_scenario.scenario_id == original_scenario_id
     assert fresh_scenario.source.source_id == original_source_id
+
+
+def test_source_regression_matrix_covers_active_families_and_keeps_planned_non_executable() -> None:
+    matrix = list_source_regression_matrix()
+    active_entries = [entry for entry in matrix if entry.rollout_status == "active_baseline"]
+    planned_entries = [entry for entry in matrix if entry.rollout_status != "active_baseline"]
+
+    assert {entry.source_family for entry in active_entries} == {"mssql", "postgresql"}
+    assert planned_entries
+    assert all(entry.executable is False for entry in planned_entries)
+    assert all(entry.scenario_id is None for entry in planned_entries)
+
+    for entry in active_entries:
+        assert entry.scenario_id
+        assert entry.source_id
+        assert entry.source_family in {"mssql", "postgresql"}
+        assert entry.source_flavor
+        assert entry.validates
+        assert set(entry.validates) <= {"generation", "guard", "execute", "audit"}
+        assert "audit" in entry.validates
+
+    for source_family in ("mssql", "postgresql"):
+        family_entries = [
+            entry for entry in active_entries if entry.source_family == source_family
+        ]
+        decisions = {entry.expected_decision for entry in family_entries}
+        validated_surfaces = {
+            surface for entry in family_entries for surface in entry.validates
+        }
+
+        assert {"allow", "reject"} <= decisions
+        assert {"generation", "guard", "execute", "audit"} <= validated_surfaces
+        assert any(entry.scenario_kind == "positive" for entry in family_entries)
+        assert any(
+            entry.expected_decision == "reject" and entry.primary_code
+            for entry in family_entries
+        )
 
 
 @pytest.mark.parametrize(

--- a/docs/design/dialect-capability-matrix.md
+++ b/docs/design/dialect-capability-matrix.md
@@ -62,3 +62,51 @@ It is a planning and review aid for connector, guard, and evaluation work.
 - Oracle execution must not be inferred from adapter hints, client-supplied
   metadata, analyst artifacts, MLflow traces, driver names, connection
   descriptors, hostnames, labels, or generated SQL text.
+
+## Active Regression Matrix
+
+The evaluation harness exposes this same active-source matrix through
+`list_source_regression_matrix()`. Active entries are executable regression
+coverage; planned entries are metadata-only and must not be run as execution
+coverage until their source family or flavor is explicitly activated.
+
+| Scenario ID | Source family | Source flavor | Decision | Validates |
+| --- | --- | --- | --- | --- |
+| `mssql-positive-approved-vendor-spend-top-vendors` | `mssql` | `sqlserver` | allow | generation, guard, execute, audit |
+| `mssql-positive-approved-vendor-count-by-region` | `mssql` | `sqlserver` | allow | generation, guard, execute, audit |
+| `mssql-safety-guard-denies-waitfor-delay` | `mssql` | `sqlserver` | reject | generation, guard, audit |
+| `mssql-safety-wrong-source-binding-denied` | `mssql` | `sqlserver` | reject | generation, guard, execute, audit |
+| `mssql-safety-unsupported-source-binding-denied` | `mssql` | `legacy-sqlserver` | reject | execute, audit |
+| `mssql-safety-stale-policy-denied` | `mssql` | `sqlserver` | reject | execute, audit |
+| `mssql-safety-approval-expiry-denied` | `mssql` | `sqlserver` | reject | execute, audit |
+| `mssql-regression-linked-server-denied` | `mssql` | `sqlserver` | reject | generation, guard, audit |
+| `postgresql-positive-approved-vendor-spend-top-vendors` | `postgresql` | `warehouse` | allow | generation, guard, execute, audit |
+| `postgresql-positive-approved-vendor-count-by-region` | `postgresql` | `warehouse` | allow | generation, guard, execute, audit |
+| `postgresql-safety-guard-denies-system-catalog-access` | `postgresql` | `warehouse` | reject | generation, guard, audit |
+| `postgresql-safety-wrong-source-binding-denied` | `postgresql` | `warehouse` | reject | generation, guard, execute, audit |
+| `postgresql-safety-unsupported-source-binding-denied` | `postgresql` | `legacy-warehouse` | reject | execute, audit |
+| `postgresql-safety-stale-policy-denied` | `postgresql` | `warehouse` | reject | execute, audit |
+| `postgresql-safety-approval-expiry-denied` | `postgresql` | `warehouse` | reject | execute, audit |
+| `postgresql-safety-application-postgres-exposure-denied` | `postgresql` | `persistence` | reject | execute, audit |
+| `postgresql-safety-application-postgres-execution-reuse-denied` | `postgresql` | `warehouse` | reject | generation, guard, execute, audit |
+
+## Planned Non-Executable Entries
+
+| Family or Flavor | Rollout status | Execution coverage |
+| --- | --- | --- |
+| `mysql` | planned metadata only | non-executable |
+| `mariadb` | planned metadata only | non-executable |
+| `postgresql` / `aurora-postgresql` | planned flavor | non-executable |
+| `mysql` / `aurora-mysql` | planned flavor | non-executable |
+| `oracle` | long-range planned metadata only | non-executable |
+
+## Follow-Up Candidates
+
+- The MSSQL core vertical-slice test still overlaps the active matrix for
+  `mssql-positive-approved-vendor-spend-top-vendors`. Keep it while it proves
+  persistence and audit ordering, but avoid adding new vertical-slice-only
+  cases without a matching scenario ID in the matrix.
+- Runtime timeout, cancellation, and source-unavailable classifications are
+  documented rollout requirements but remain outside this issue's active
+  matrix; they should become explicit scenario IDs before source activation
+  gates depend on them.


### PR DESCRIPTION
## Summary
- add an exported source regression matrix for active MSSQL and PostgreSQL evaluation scenarios
- keep planned source families and flavors represented as non-executable matrix entries
- document active scenario coverage and follow-up candidates in the dialect capability matrix

## Verification
- cd backend && python3 -m pytest tests/test_evaluation_harness.py tests/test_sql_guard_deny_corpus.py tests/test_source_bound_execute_path.py -q
- cd backend && python3 -m pytest tests/test_release_gate.py -q

Closes #362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced regression source matrix to track evaluation scenarios across databases, including active executable entries and planned non-executable entries for systematic coverage mapping.

* **Tests**
  * Added comprehensive tests validating matrix structure, scenario coverage across database types, and expected validation stages.

* **Documentation**
  * Updated dialect capability documentation with active regression matrix details and planned source database entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->