### PR TITLE
Add adapter failure evaluation cases

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -10,6 +10,7 @@ from app.features.evaluation.comparison import (
 )
 from app.features.evaluation.harness import (
     EvaluationExpectedOutcome,
+    EvaluationOutcomeCategory,
     EvaluationScenarioKind,
     EvaluationSourceProfile,
     MSSQLEvaluationScenario,
@@ -31,6 +32,7 @@ __all__ = [
     "EvaluationComparisonRow",
     "EvaluationExpectedOutcome",
     "EvaluationObservedOutcome",
+    "EvaluationOutcomeCategory",
     "EvaluationScenarioKind",
     "EvaluationOutcomeRecord",
     "EvaluationOutcomeSnapshot",

--- a/backend/app/features/evaluation/comparison.py
+++ b/backend/app/features/evaluation/comparison.py
@@ -4,7 +4,11 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, PositiveInt, model_validator
 
-from app.features.evaluation.harness import EvaluationScenarioKind, EvaluationSourceProfile
+from app.features.evaluation.harness import (
+    EvaluationOutcomeCategory,
+    EvaluationScenarioKind,
+    EvaluationSourceProfile,
+)
 
 
 ComparisonStatus = Literal["pass", "fail", "regression"]
@@ -18,6 +22,7 @@ class EvaluationObservedOutcome(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     decision: Literal["allow", "reject"]
+    outcome_category: EvaluationOutcomeCategory
     primary_code: Optional[str] = None
 
     @model_validator(mode="after")
@@ -172,6 +177,8 @@ def _collect_regressions(
             regressions.append(field_name)
     if baseline.outcome.decision != candidate.outcome.decision:
         regressions.append("decision")
+    if baseline.outcome.outcome_category != candidate.outcome.outcome_category:
+        regressions.append("outcome_category")
     if baseline.outcome.primary_code != candidate.outcome.primary_code:
         regressions.append("primary_code")
 

--- a/backend/app/features/evaluation/harness.py
+++ b/backend/app/features/evaluation/harness.py
@@ -7,7 +7,24 @@ from pydantic import BaseModel, ConfigDict, PositiveInt, model_validator
 
 
 EvaluationScenarioKind = Literal["positive", "safety", "regression"]
-EvaluationBoundary = Literal["guard", "connector_selection", "lifecycle", "execution"]
+EvaluationBoundary = Literal[
+    "generation",
+    "guard",
+    "connector_selection",
+    "lifecycle",
+    "execution",
+    "runtime",
+]
+EvaluationOutcomeCategory = Literal[
+    "bounded_success",
+    "connector_selection_denial",
+    "guard_denial",
+    "lifecycle_denial",
+    "malformed_generation",
+    "runtime_timeout",
+    "runtime_unavailable",
+    "source_binding_denial",
+]
 RegressionValidationSurface = Literal["generation", "guard", "execute", "audit"]
 RegressionRolloutStatus = Literal["active_baseline", "planned", "planned_flavor"]
 
@@ -40,6 +57,7 @@ class EvaluationExpectedOutcome(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     decision: Literal["allow", "reject"]
+    outcome_category: EvaluationOutcomeCategory
     primary_code: Optional[str] = None
     canonical_sql: Optional[str] = None
     execution_evidence: Optional[EvaluationExecutionEvidence] = None
@@ -98,6 +116,7 @@ class SourceRegressionMatrixEntry(BaseModel):
     executable: bool
     validates: tuple[RegressionValidationSurface, ...]
     expected_decision: Optional[Literal["allow", "reject"]] = None
+    expected_outcome_category: Optional[EvaluationOutcomeCategory] = None
     primary_code: Optional[str] = None
 
 
@@ -174,6 +193,7 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         ),
         expected=EvaluationExpectedOutcome(
             decision="allow",
+            outcome_category="bounded_success",
             canonical_sql=(
                 "SELECT TOP 10 vendor_name, approved_amount "
                 "FROM dbo.approved_vendor_spend "
@@ -200,6 +220,7 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         ),
         expected=EvaluationExpectedOutcome(
             decision="allow",
+            outcome_category="bounded_success",
             canonical_sql=(
                 "SELECT region, COUNT(*) AS vendor_count "
                 "FROM dbo.approved_vendor_spend "
@@ -225,7 +246,21 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         ),
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="guard_denial",
             primary_code="DENY_RESOURCE_ABUSE",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-safety-guard-denies-write-operation",
+        kind="safety",
+        evaluation_boundary="guard",
+        source=_MSSQL_SOURCE,
+        prompt="Delete old approved vendor spend records.",
+        canonical_sql="DELETE FROM dbo.approved_vendor_spend WHERE approved_amount = 0",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            outcome_category="guard_denial",
+            primary_code="DENY_WRITE_OPERATION",
         ),
     ),
     MSSQLEvaluationScenario(
@@ -237,6 +272,7 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="source_binding_denial",
             primary_code="DENY_SOURCE_BINDING_MISMATCH",
         ),
     ),
@@ -249,6 +285,7 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="connector_selection_denial",
             primary_code="DENY_UNSUPPORTED_SOURCE_BINDING",
         ),
     ),
@@ -261,6 +298,7 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="lifecycle_denial",
             primary_code="DENY_POLICY_VERSION_STALE",
         ),
     ),
@@ -273,6 +311,7 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="lifecycle_denial",
             primary_code="DENY_APPROVAL_EXPIRED",
         ),
     ),
@@ -285,7 +324,34 @@ MSSQL_EVALUATION_SCENARIOS: tuple[MSSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT vendor_name FROM [remote].[sales].[dbo].[vendors]",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="guard_denial",
             primary_code="DENY_LINKED_SERVER",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-regression-malformed-adapter-output-denied",
+        kind="regression",
+        evaluation_boundary="generation",
+        source=_MSSQL_SOURCE,
+        prompt="Return approved vendor spend with malformed adapter output.",
+        canonical_sql="",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            outcome_category="malformed_generation",
+            primary_code="DENY_SQL_GENERATION_FAILED",
+        ),
+    ),
+    MSSQLEvaluationScenario(
+        scenario_id="mssql-regression-runtime-timeout-denied",
+        kind="regression",
+        evaluation_boundary="runtime",
+        source=_MSSQL_SOURCE,
+        prompt="Run approved vendor spend query when the runtime times out.",
+        canonical_sql="SELECT TOP 10 vendor_name FROM dbo.approved_vendor_spend",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            outcome_category="runtime_timeout",
+            primary_code="DENY_RUNTIME_TIMEOUT",
         ),
     ),
 )
@@ -304,6 +370,7 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         ),
         expected=EvaluationExpectedOutcome(
             decision="allow",
+            outcome_category="bounded_success",
             canonical_sql=(
                 "SELECT vendor_name, approved_spend "
                 "FROM finance.approved_vendor_spend "
@@ -330,6 +397,7 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         ),
         expected=EvaluationExpectedOutcome(
             decision="allow",
+            outcome_category="bounded_success",
             canonical_sql=(
                 "SELECT region, COUNT(*) AS vendor_count "
                 "FROM finance.approved_vendor_spend "
@@ -352,7 +420,21 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT schemaname FROM pg_catalog.pg_tables",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="guard_denial",
             primary_code="DENY_SYSTEM_CATALOG_ACCESS",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-safety-guard-denies-write-operation",
+        kind="safety",
+        evaluation_boundary="guard",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Update approved vendor spend amounts.",
+        canonical_sql="UPDATE finance.approved_vendor_spend SET approved_spend = 0",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            outcome_category="guard_denial",
+            primary_code="DENY_WRITE_OPERATION",
         ),
     ),
     PostgreSQLEvaluationScenario(
@@ -364,6 +446,7 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="source_binding_denial",
             primary_code="DENY_SOURCE_BINDING_MISMATCH",
         ),
     ),
@@ -376,6 +459,7 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="connector_selection_denial",
             primary_code="DENY_UNSUPPORTED_SOURCE_BINDING",
         ),
     ),
@@ -388,6 +472,7 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="lifecycle_denial",
             primary_code="DENY_POLICY_VERSION_STALE",
         ),
     ),
@@ -400,6 +485,7 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="lifecycle_denial",
             primary_code="DENY_APPROVAL_EXPIRED",
         ),
     ),
@@ -412,6 +498,7 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT id FROM public.query_candidates LIMIT 10",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="connector_selection_denial",
             primary_code="DENY_UNSUPPORTED_SOURCE_BINDING",
         ),
     ),
@@ -424,7 +511,60 @@ POSTGRESQL_EVALUATION_SCENARIOS: tuple[PostgreSQLEvaluationScenario, ...] = (
         canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
         expected=EvaluationExpectedOutcome(
             decision="reject",
+            outcome_category="source_binding_denial",
             primary_code="DENY_APPLICATION_POSTGRES_REUSE",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-regression-malformed-adapter-output-denied",
+        kind="regression",
+        evaluation_boundary="generation",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Return approved vendor spend with malformed adapter output.",
+        canonical_sql="",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            outcome_category="malformed_generation",
+            primary_code="DENY_SQL_GENERATION_FAILED",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-regression-runtime-unavailable-denied",
+        kind="regression",
+        evaluation_boundary="runtime",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Run approved vendor spend query when the PostgreSQL runtime is unavailable.",
+        canonical_sql="SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 10",
+        expected=EvaluationExpectedOutcome(
+            decision="reject",
+            outcome_category="runtime_unavailable",
+            primary_code="DENY_RUNTIME_UNAVAILABLE",
+        ),
+    ),
+    PostgreSQLEvaluationScenario(
+        scenario_id="postgresql-positive-payload-bounded-approved-vendor-spend",
+        kind="positive",
+        evaluation_boundary="execution",
+        source=_POSTGRESQL_SOURCE,
+        prompt="Show approved vendor spend notes within bounded result payload limits.",
+        canonical_sql=(
+            "SELECT vendor_name, vendor_notes "
+            "FROM finance.approved_vendor_spend "
+            "ORDER BY vendor_name LIMIT 500"
+        ),
+        expected=EvaluationExpectedOutcome(
+            decision="allow",
+            outcome_category="bounded_success",
+            canonical_sql=(
+                "SELECT vendor_name, vendor_notes "
+                "FROM finance.approved_vendor_spend "
+                "ORDER BY vendor_name LIMIT 500"
+            ),
+            execution_evidence={
+                "connector_id": "postgresql_readonly",
+                "ownership": "backend",
+                "row_shape": ("vendor_name", "vendor_notes"),
+            },
         ),
     ),
 )
@@ -496,6 +636,7 @@ def _matrix_entry_from_scenario(
         executable=True,
         validates=_validated_surfaces_for(scenario),
         expected_decision=scenario.expected.decision,
+        expected_outcome_category=scenario.expected.outcome_category,
         primary_code=scenario.expected.primary_code,
     )
 
@@ -503,8 +644,10 @@ def _matrix_entry_from_scenario(
 def _validated_surfaces_for(
     scenario: ScenarioArtifact,
 ) -> tuple[RegressionValidationSurface, ...]:
+    if scenario.evaluation_boundary == "generation":
+        return ("generation", "audit")
     if scenario.evaluation_boundary == "guard":
         return ("generation", "guard", "audit")
-    if scenario.evaluation_boundary == "execution":
+    if scenario.evaluation_boundary in {"execution", "runtime"}:
         return ("generation", "guard", "execute", "audit")
     return ("execute", "audit")

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -49,7 +49,7 @@ class ReleaseGateFailure(BaseModel):
 class ReleaseGateAuditArtifact(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    scenario_id: str
+    scenario_id: Optional[str] = None
     event: SourceAwareAuditEvent
 
     @model_validator(mode="before")
@@ -86,6 +86,22 @@ class ReleaseGateAuditArtifact(BaseModel):
             return value
 
         return {**value, "scenario_id": embedded_scenario_id}
+
+    @model_validator(mode="after")
+    def _require_scenario_id_except_raw_generation_failure(
+        self,
+    ) -> "ReleaseGateAuditArtifact":
+        if self.scenario_id is not None:
+            return self
+        if (
+            self.event.event_type == "generation_failed"
+            and self.event.release_gate_scenario is None
+        ):
+            return self
+        raise ValueError(
+            "scenario_id is required unless a raw generation_failed audit event "
+            "omits release_gate_scenario by design."
+        )
 
 
 class ReleaseGateDecision(BaseModel):
@@ -246,7 +262,7 @@ def _audit_failures_for_scenario(
     candidates = [
         artifact.event
         for artifact in audit_artifacts
-        if artifact.scenario_id == scenario.scenario_id
+        if _audit_artifact_can_cover_scenario(artifact=artifact, scenario=scenario)
     ]
     if not candidates:
         return ReleaseGateFailure(
@@ -312,10 +328,15 @@ def _audit_mismatches_for_scenario(
     if release_gate_scenario is None and release_gate_scenario_required:
         mismatches.append("release_gate_scenario")
     elif release_gate_scenario is not None:
+        expected_guard_decision = (
+            scenario.expected.decision
+            if scenario.evaluation_boundary == "guard"
+            else "allow"
+        )
         scenario_expected_values = {
             "release_gate_scenario.scenario_id": scenario.scenario_id,
             "release_gate_scenario.source_id": scenario.source.source_id,
-            "release_gate_scenario.guard_decision": scenario.expected.decision,
+            "release_gate_scenario.guard_decision": expected_guard_decision,
         }
         mismatches.extend(
             field
@@ -357,6 +378,26 @@ def _audit_mismatches_for_scenario(
         if getattr(event, field) != expected
     )
     return tuple(mismatches)
+
+
+def _audit_artifact_can_cover_scenario(
+    *,
+    artifact: ReleaseGateAuditArtifact,
+    scenario: ScenarioArtifact,
+) -> bool:
+    if artifact.scenario_id == scenario.scenario_id:
+        return True
+    if artifact.scenario_id is not None:
+        return False
+    event = artifact.event
+    return (
+        scenario.evaluation_boundary == "generation"
+        and event.event_type == "generation_failed"
+        and event.release_gate_scenario is None
+        and event.source_id == scenario.source.source_id
+        and event.source_family == scenario.source.source_family
+        and event.primary_deny_code == scenario.expected.primary_code
+    )
 
 
 def _failures_for_row(row: EvaluationComparisonRow) -> tuple[ReleaseGateFailure, ...]:
@@ -417,6 +458,21 @@ def _regression_detail(row: EvaluationComparisonRow) -> str:
             "Observed decision does not match the authoritative scenario expectation: "
             f"expected decision={expected_decision!r}, observed decision={observed_decision!r}, "
             f"expected deny code={expected_code!r}, observed deny code={observed_code!r}."
+        )
+    if set(row.regressions) == {"outcome_category"}:
+        baseline_outcome = row.baseline.outcome if row.baseline is not None else None
+        candidate_outcome = row.candidate.outcome if row.candidate is not None else None
+        expected_category = (
+            baseline_outcome.outcome_category if baseline_outcome is not None else None
+        )
+        observed_category = (
+            candidate_outcome.outcome_category if candidate_outcome is not None else None
+        )
+        return (
+            "Observed outcome category does not match the authoritative scenario "
+            "expectation while decision and deny code remained stable: "
+            f"expected outcome category={expected_category!r}, "
+            f"observed outcome category={observed_category!r}."
         )
 
     return (

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -174,6 +174,7 @@ def _record_from_scenario(scenario: ScenarioArtifact) -> EvaluationOutcomeRecord
         source=EvaluationOutcomeSnapshot.model_validate(scenario.source.model_dump()),
         outcome=EvaluationObservedOutcome(
             decision=scenario.expected.decision,
+            outcome_category=scenario.expected.outcome_category,
             primary_code=scenario.expected.primary_code,
         ),
     )
@@ -283,8 +284,12 @@ def _audit_failures_for_scenario(
 
 
 def _expected_audit_event_type_for(scenario: ScenarioArtifact) -> str:
+    if scenario.evaluation_boundary == "generation":
+        return "generation_failed"
     if scenario.evaluation_boundary == "guard":
         return "guard_evaluated"
+    if scenario.evaluation_boundary == "runtime":
+        return "execution_failed"
     if scenario.expected.decision == "allow":
         return "execution_completed"
     return "execution_denied"
@@ -299,9 +304,14 @@ def _audit_mismatches_for_scenario(
 ) -> tuple[str, ...]:
     mismatches: list[str] = []
     release_gate_scenario = event.release_gate_scenario
-    if release_gate_scenario is None:
-        mismatches.append("release_gate_scenario")
+    if expected_event_type == "generation_failed":
+        release_gate_scenario_required = False
     else:
+        release_gate_scenario_required = True
+
+    if release_gate_scenario is None and release_gate_scenario_required:
+        mismatches.append("release_gate_scenario")
+    elif release_gate_scenario is not None:
         scenario_expected_values = {
             "release_gate_scenario.scenario_id": scenario.scenario_id,
             "release_gate_scenario.source_id": scenario.source.source_id,

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -394,10 +394,33 @@ def _audit_artifact_can_cover_scenario(
         scenario.evaluation_boundary == "generation"
         and event.event_type == "generation_failed"
         and event.release_gate_scenario is None
+        and _raw_generation_audit_identity_is_unique(scenario)
         and event.source_id == scenario.source.source_id
         and event.source_family == scenario.source.source_family
         and event.primary_deny_code == scenario.expected.primary_code
     )
+
+
+def _raw_generation_audit_identity_is_unique(scenario: ScenarioArtifact) -> bool:
+    identity = (
+        scenario.source.source_id,
+        scenario.source.source_family,
+        scenario.expected.primary_code,
+    )
+    matching_scenario_count = sum(
+        1
+        for candidate in (
+            list_mssql_evaluation_scenarios() + list_postgresql_evaluation_scenarios()
+        )
+        if candidate.evaluation_boundary == "generation"
+        and (
+            candidate.source.source_id,
+            candidate.source.source_family,
+            candidate.expected.primary_code,
+        )
+        == identity
+    )
+    return matching_scenario_count == 1
 
 
 def _failures_for_row(row: EvaluationComparisonRow) -> tuple[ReleaseGateFailure, ...]:

--- a/backend/tests/test_evaluation_harness.py
+++ b/backend/tests/test_evaluation_harness.py
@@ -17,7 +17,12 @@ from app.db.models.dataset_contract import (
     DatasetContractDatasetKind,
 )
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
-from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
+from app.db.models.preview import (
+    PreviewAuditEvent,
+    PreviewCandidate,
+    PreviewCandidateApproval,
+    PreviewRequest,
+)
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
 from app.features.evaluation import (
@@ -288,6 +293,7 @@ def test_mssql_evaluation_fixtures_are_source_bound_and_reconstructable() -> Non
         assert scenario.source.schema_snapshot_version > 0
         assert scenario.source.execution_policy_version > 0
         assert scenario.expected.decision in {"allow", "reject"}
+        assert scenario.expected.outcome_category
         if scenario.expected.decision == "reject":
             assert scenario.expected.primary_code
 
@@ -330,6 +336,7 @@ def test_postgresql_evaluation_fixtures_are_source_bound_and_reconstructable() -
         assert scenario.source.schema_snapshot_version > 0
         assert scenario.source.execution_policy_version > 0
         assert scenario.expected.decision in {"allow", "reject"}
+        assert scenario.expected.outcome_category
         if scenario.expected.decision == "reject":
             assert scenario.expected.primary_code
 
@@ -388,6 +395,104 @@ def test_source_regression_matrix_covers_active_families_and_keeps_planned_non_e
             entry.expected_decision == "reject" and entry.primary_code
             for entry in family_entries
         )
+        assert {
+            "malformed_generation",
+            "guard_denial",
+            "bounded_success",
+        } <= {entry.expected_outcome_category for entry in family_entries}
+
+
+def test_evaluation_harness_covers_issue_365_failure_and_bound_cases() -> None:
+    scenarios = list_mssql_evaluation_scenarios() + list_postgresql_evaluation_scenarios()
+    categories = {scenario.expected.outcome_category for scenario in scenarios}
+    scenario_ids = {scenario.scenario_id for scenario in scenarios}
+    serialized = " ".join(scenario.model_dump_json() for scenario in scenarios)
+
+    assert {
+        "malformed_generation",
+        "guard_denial",
+        "runtime_timeout",
+        "runtime_unavailable",
+        "bounded_success",
+    } <= categories
+    assert {
+        "mssql-safety-guard-denies-write-operation",
+        "postgresql-safety-guard-denies-write-operation",
+        "mssql-regression-malformed-adapter-output-denied",
+        "postgresql-regression-malformed-adapter-output-denied",
+        "mssql-regression-runtime-timeout-denied",
+        "postgresql-regression-runtime-unavailable-denied",
+        "postgresql-positive-payload-bounded-approved-vendor-spend",
+    } <= scenario_ids
+    assert "password" not in serialized.lower()
+    assert "connection_string" not in serialized.lower()
+    assert "/Users/" not in serialized
+    assert "C:\\Users\\" not in serialized
+
+
+def test_malformed_adapter_output_scenario_fails_before_candidate_approval() -> None:
+    from app.services.request_preview import (
+        PreviewAuditContext,
+        PreviewSubmissionContractError,
+        PreviewSubmissionRequest,
+        submit_preview_request,
+    )
+
+    scenario = _postgresql_scenarios_by_id()[
+        "postgresql-regression-malformed-adapter-output-denied"
+    ]
+
+    class MalformedAdapter:
+        def generate_sql(self, request):
+            del request
+            return type("MalformedAdapterResponse", (), {"candidate_sql": "   "})()
+
+    with _session_scope() as session:
+        _seed_postgresql_source(session, scenario=scenario)
+
+        with pytest.raises(PreviewSubmissionContractError) as exc_info:
+            submit_preview_request(
+                payload=PreviewSubmissionRequest(
+                    question=scenario.prompt,
+                    source_id=scenario.source.source_id,
+                ),
+                authenticated_subject=AuthenticatedSubject(
+                    subject_id="user:alice",
+                    governance_bindings=frozenset({"group:finance-analysts"}),
+                ),
+                session=session,
+                sql_generation_adapter=MalformedAdapter(),
+                audit_context=PreviewAuditContext(
+                    occurred_at=datetime.now(timezone.utc),
+                    request_id="request-365-malformed-generation",
+                    correlation_id="correlation-365-malformed-generation",
+                    user_subject="user:alice",
+                    session_id="session-365-malformed-generation",
+                    query_candidate_id="candidate-365-malformed-generation",
+                    candidate_owner_subject="user:alice",
+                    application_version="safequery-test",
+                ),
+            )
+
+        persisted_events = (
+            session.query(PreviewAuditEvent)
+            .order_by(PreviewAuditEvent.lifecycle_order)
+            .all()
+        )
+        persisted_candidates = session.query(PreviewCandidate).all()
+        persisted_approvals = session.query(PreviewCandidateApproval).all()
+
+    assert exc_info.value.public_code == "preview_generation_failed"
+    assert persisted_candidates == []
+    assert persisted_approvals == []
+    assert [event.event_type for event in persisted_events] == ["generation_failed"]
+    assert persisted_events[0].audit_payload["denial_cause"] == (
+        "sql_generation_response_invalid"
+    )
+    serialized_events = str([event.audit_payload for event in persisted_events])
+    assert "password" not in serialized_events.lower()
+    assert "connection_string" not in serialized_events.lower()
+    assert "/Users/" not in serialized_events
 
 
 @pytest.mark.parametrize(
@@ -1348,6 +1453,7 @@ def test_postgresql_core_vertical_slice_cancellation_probe_blocks_before_executi
     "scenario_id",
     (
         "mssql-safety-guard-denies-waitfor-delay",
+        "mssql-safety-guard-denies-write-operation",
         "mssql-regression-linked-server-denied",
     ),
 )
@@ -1458,6 +1564,7 @@ def test_mssql_safety_approval_expiry_denies_at_lifecycle_boundary() -> None:
     "scenario_id",
     (
         "postgresql-safety-guard-denies-system-catalog-access",
+        "postgresql-safety-guard-denies-write-operation",
     ),
 )
 def test_postgresql_guard_safety_scenarios_deny_with_expected_codes(
@@ -1620,7 +1727,7 @@ def test_evaluation_comparison_keeps_same_family_different_sources_separate() ->
                 schema_snapshot_version=9,
                 execution_policy_version=3,
             ),
-            outcome={"decision": "allow"},
+            outcome={"decision": "allow", "outcome_category": "bounded_success"},
         ),
     )
     candidate = (
@@ -1638,7 +1745,7 @@ def test_evaluation_comparison_keeps_same_family_different_sources_separate() ->
                 schema_snapshot_version=9,
                 execution_policy_version=3,
             ),
-            outcome={"decision": "allow"},
+            outcome={"decision": "allow", "outcome_category": "bounded_success"},
         ),
     )
 
@@ -1668,7 +1775,7 @@ def test_evaluation_comparison_marks_profile_version_drift_as_regression() -> No
             schema_snapshot_version=7,
             execution_policy_version=2,
         ),
-        outcome={"decision": "allow"},
+        outcome={"decision": "allow", "outcome_category": "bounded_success"},
     )
     candidate = EvaluationOutcomeRecord(
         scenario_id="mssql-positive-approved-vendor-spend-top-vendors",
@@ -1684,7 +1791,7 @@ def test_evaluation_comparison_marks_profile_version_drift_as_regression() -> No
             schema_snapshot_version=7,
             execution_policy_version=2,
         ),
-        outcome={"decision": "allow"},
+        outcome={"decision": "allow", "outcome_category": "bounded_success"},
     )
 
     comparison = compare_evaluation_outcomes(
@@ -1715,7 +1822,11 @@ def test_evaluation_observed_outcome_reject_requires_non_blank_primary_code(
         ValueError,
         match="Reject outcomes must include a machine-readable primary code.",
     ):
-        EvaluationObservedOutcome(decision="reject", primary_code=primary_code)
+        EvaluationObservedOutcome(
+            decision="reject",
+            outcome_category="guard_denial",
+            primary_code=primary_code,
+        )
 
 
 @pytest.mark.parametrize("duplicate_side", ("baseline", "candidate"))
@@ -1736,7 +1847,7 @@ def test_evaluation_comparison_rejects_duplicate_comparison_identity(
             schema_snapshot_version=9,
             execution_policy_version=3,
         ),
-        outcome={"decision": "allow"},
+        outcome={"decision": "allow", "outcome_category": "bounded_success"},
     )
     baseline = (record, record) if duplicate_side == "baseline" else (record,)
     candidate = (record, record) if duplicate_side == "candidate" else (record,)

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -72,11 +72,12 @@ def _audit_artifacts_from_harness() -> tuple[dict[str, object], ...]:
         event_id = uuid4()
         guard_audit_event_id = event_id if event_type == "guard_evaluated" else uuid4()
         candidate_id = f"candidate-{scenario.scenario_id}"
+        guard_decision = "reject" if scenario.evaluation_boundary == "guard" else "allow"
         release_gate_scenario = {
             "scenario_id": scenario.scenario_id,
             "source_id": scenario.source.source_id,
             "candidate_id": candidate_id,
-            "guard_decision": scenario.expected.decision,
+            "guard_decision": guard_decision,
             "guard_audit_event_id": guard_audit_event_id,
         }
         if event_type in {"execution_completed", "execution_denied"}:
@@ -360,6 +361,58 @@ def test_release_gate_fails_closed_when_audit_event_lacks_scenario_metadata() ->
     assert "release_gate_scenario" in decision.failures[0].detail
 
 
+def test_release_gate_accepts_raw_generation_failed_audit_event_without_scenario_id() -> None:
+    scenario = next(
+        scenario
+        for scenario in list_postgresql_evaluation_scenarios()
+        if scenario.evaluation_boundary == "generation"
+    )
+    audit_artifacts = list(_audit_artifacts_from_harness())
+    target_index = next(
+        index
+        for index, artifact in enumerate(audit_artifacts)
+        if artifact["scenario_id"] == scenario.scenario_id
+    )
+    event = dict(audit_artifacts[target_index]["event"])
+    event.pop("release_gate_scenario", None)
+    audit_artifacts[target_index] = {"event": event}
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=_observed_records_from_harness(),
+        audit_artifacts=tuple(audit_artifacts),
+    )
+
+    assert decision.status == "pass"
+    assert decision.failure_count == 0
+
+
+def test_release_gate_accepts_runtime_audit_guard_decision_that_allowed_execution() -> None:
+    scenario = next(
+        scenario
+        for scenario in list_mssql_evaluation_scenarios()
+        if scenario.evaluation_boundary == "runtime"
+    )
+    audit_artifacts = list(_audit_artifacts_from_harness())
+    target_artifact = next(
+        artifact
+        for artifact in audit_artifacts
+        if artifact["scenario_id"] == scenario.scenario_id
+    )
+    event = target_artifact["event"]
+    assert isinstance(event, dict)
+    release_gate_scenario = event["release_gate_scenario"]
+    assert isinstance(release_gate_scenario, dict)
+    assert release_gate_scenario["guard_decision"] == "allow"
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=_observed_records_from_harness(),
+        audit_artifacts=tuple(audit_artifacts),
+    )
+
+    assert decision.status == "pass"
+    assert decision.failure_count == 0
+
+
 def test_release_gate_fails_closed_when_execute_audit_linkage_is_missing() -> None:
     audit_artifacts = list(_audit_artifacts_from_harness())
     target_index = next(
@@ -474,6 +527,34 @@ def test_release_gate_fails_closed_for_safety_regression() -> None:
     assert decision.failures[0].source_id == "business-mssql-source"
     assert decision.failures[0].source_family == "mssql"
     assert decision.failures[0].scenario_category == "safety"
+
+
+def test_release_gate_reports_outcome_category_regression_detail() -> None:
+    mutated_records = list(_observed_records_from_harness())
+    target_index = next(
+        index
+        for index, record in enumerate(mutated_records)
+        if record.scenario_id == "mssql-safety-guard-denies-write-operation"
+    )
+    target = mutated_records[target_index]
+    mutated_records[target_index] = target.model_copy(
+        update={
+            "outcome": target.outcome.model_copy(
+                update={"outcome_category": "runtime_timeout"}
+            )
+        }
+    )
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=tuple(mutated_records),
+        audit_artifacts=_audit_artifacts_from_harness(),
+    )
+
+    assert decision.status == "fail"
+    assert decision.failure_count == 1
+    assert decision.failures[0].deny_code == "DENY_SAFETY_SCENARIO_REGRESSION"
+    assert "outcome category" in decision.failures[0].detail
+    assert "source profile" not in decision.failures[0].detail
 
 
 def test_release_gate_fails_closed_for_missing_evaluation_coverage() -> None:

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -47,6 +47,7 @@ def _observed_records_from_harness() -> tuple[EvaluationOutcomeRecord, ...]:
             source=scenario.source.model_dump(),
             outcome={
                 "decision": scenario.expected.decision,
+                "outcome_category": scenario.expected.outcome_category,
                 "primary_code": scenario.expected.primary_code,
             },
         )
@@ -57,8 +58,12 @@ def _observed_records_from_harness() -> tuple[EvaluationOutcomeRecord, ...]:
 def _audit_artifacts_from_harness() -> tuple[dict[str, object], ...]:
     artifacts: list[dict[str, object]] = []
     for scenario in _all_scenarios():
-        if scenario.evaluation_boundary == "guard":
+        if scenario.evaluation_boundary == "generation":
+            event_type = "generation_failed"
+        elif scenario.evaluation_boundary == "guard":
             event_type = "guard_evaluated"
+        elif scenario.evaluation_boundary == "runtime":
+            event_type = "execution_failed"
         elif scenario.expected.decision == "allow":
             event_type = "execution_completed"
         else:
@@ -103,7 +108,11 @@ def _audit_artifacts_from_harness() -> tuple[dict[str, object], ...]:
                     "execution_policy_version": scenario.source.execution_policy_version,
                     "connector_profile_version": scenario.source.connector_profile_version,
                     "primary_deny_code": scenario.expected.primary_code,
-                    "release_gate_scenario": release_gate_scenario,
+                    "release_gate_scenario": (
+                        None
+                        if event_type == "generation_failed"
+                        else release_gate_scenario
+                    ),
                 },
             }
         )
@@ -445,7 +454,11 @@ def test_release_gate_fails_closed_for_safety_regression() -> None:
     mutated_records[target_index] = target.model_copy(
         update={
             "outcome": target.outcome.model_copy(
-                update={"decision": "allow", "primary_code": None}
+                update={
+                    "decision": "allow",
+                    "outcome_category": "bounded_success",
+                    "primary_code": None,
+                }
             )
         }
     )

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Union
 from uuid import uuid4
 
+import app.features.evaluation.release_gate as release_gate_module
 from app.features.evaluation import (
     EvaluationOutcomeRecord,
     reconstruct_release_gate,
@@ -384,6 +385,70 @@ def test_release_gate_accepts_raw_generation_failed_audit_event_without_scenario
 
     assert decision.status == "pass"
     assert decision.failure_count == 0
+
+
+def test_release_gate_rejects_ambiguous_raw_generation_failed_audit_event(
+    monkeypatch,
+) -> None:
+    scenario = next(
+        scenario
+        for scenario in list_postgresql_evaluation_scenarios()
+        if scenario.evaluation_boundary == "generation"
+    )
+    duplicate_scenario = scenario.model_copy(
+        update={
+            "scenario_id": f"{scenario.scenario_id}-duplicate",
+        }
+    )
+    patched_postgresql_scenarios = (
+        list_postgresql_evaluation_scenarios() + (duplicate_scenario,)
+    )
+    patched_all_scenarios = (
+        list_mssql_evaluation_scenarios() + patched_postgresql_scenarios
+    )
+    monkeypatch.setattr(
+        release_gate_module,
+        "list_postgresql_evaluation_scenarios",
+        lambda: patched_postgresql_scenarios,
+    )
+
+    observed_artifacts = tuple(
+        EvaluationOutcomeRecord(
+            scenario_id=scenario.scenario_id,
+            kind=scenario.kind,
+            source=scenario.source.model_dump(),
+            outcome={
+                "decision": scenario.expected.decision,
+                "outcome_category": scenario.expected.outcome_category,
+                "primary_code": scenario.expected.primary_code,
+            },
+        )
+        for scenario in patched_all_scenarios
+    )
+    audit_artifacts = list(_audit_artifacts_from_harness())
+    target_index = next(
+        index
+        for index, artifact in enumerate(audit_artifacts)
+        if artifact["scenario_id"] == scenario.scenario_id
+    )
+    event = dict(audit_artifacts[target_index]["event"])
+    event.pop("release_gate_scenario", None)
+    audit_artifacts[target_index] = {"event": event}
+
+    decision = reconstruct_release_gate(
+        observed_artifacts=observed_artifacts,
+        audit_artifacts=tuple(audit_artifacts),
+    )
+
+    missing_generation_failures = [
+        failure
+        for failure in decision.failures
+        if failure.deny_code == "DENY_MISSING_AUDIT_COVERAGE"
+        and failure.scenario_id
+        in {scenario.scenario_id, duplicate_scenario.scenario_id}
+    ]
+    assert decision.status == "fail"
+    assert len(missing_generation_failures) == 2
 
 
 def test_release_gate_accepts_runtime_audit_guard_decision_that_allowed_execution() -> None:

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -73,7 +73,11 @@ def _audit_artifacts_from_harness() -> tuple[dict[str, object], ...]:
         event_id = uuid4()
         guard_audit_event_id = event_id if event_type == "guard_evaluated" else uuid4()
         candidate_id = f"candidate-{scenario.scenario_id}"
-        guard_decision = "reject" if scenario.evaluation_boundary == "guard" else "allow"
+        guard_decision = (
+            scenario.expected.decision
+            if scenario.evaluation_boundary == "guard"
+            else "allow"
+        )
         release_gate_scenario = {
             "scenario_id": scenario.scenario_id,
             "source_id": scenario.source.source_id,
@@ -401,10 +405,12 @@ def test_release_gate_rejects_ambiguous_raw_generation_failed_audit_event(
         }
     )
     patched_postgresql_scenarios = (
-        list_postgresql_evaluation_scenarios() + (duplicate_scenario,)
+        *list_postgresql_evaluation_scenarios(),
+        duplicate_scenario,
     )
     patched_all_scenarios = (
-        list_mssql_evaluation_scenarios() + patched_postgresql_scenarios
+        *list_mssql_evaluation_scenarios(),
+        *patched_postgresql_scenarios,
     )
     monkeypatch.setattr(
         release_gate_module,


### PR DESCRIPTION
## Summary
- add evaluation outcome categories so release records distinguish bounded success, malformed generation, guard denial, and runtime failures
- add MSSQL/PostgreSQL malformed adapter, unsafe SQL, runtime timeout/unavailable, and payload-bound scenarios
- add regression coverage that malformed adapter output leaves no approved candidate and emits safe generation-failed audit metadata

## Verification
- cd backend && python3 -m pytest tests/test_evaluation_harness.py -q
- cd backend && python3 -m pytest tests/test_release_gate.py -q
- cd backend && python3 -m pytest tests/test_generation_context_preparation.py tests/test_adapter_credential_isolation.py tests/test_preview_persistence.py tests/test_execution_runtime_controls.py

## Notes
- Full backend suite currently has two pending-evaluation response shape failures unrelated to this harness checkpoint: tests/test_request_source_selection.py::RequestSourceSelectionTestCase::test_preview_submission_accepts_registered_executable_source_id and tests/test_source_bound_records.py::test_preview_submission_binds_all_records_to_authoritative_source_id expect null evaluation fields to be omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit outcome categories and new evaluation boundaries for generation and runtime; introduced scenarios for guard write denials, malformed generation, runtime failures, and a bounded-payload success case.

* **Bug Fixes**
  * Regression detection and reporting now include outcome-category differences and show a dedicated message when that is the sole regression; audit matching relaxed for partially-identified generation-failure events.

* **Tests**
  * Expanded tests and fixtures to cover outcome categories, new scenarios, audit behaviors, and regression messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->