### PR TITLE
[T-7] Document dedicated governance review export contract

### DIFF
--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -48,7 +48,8 @@ This reading order is intended to help new contributors understand SafeQuery fro
 19. [design/audit-event-model.md](./design/audit-event-model.md)
     Read this before implementing persistence, replay, or operational diagnostics.
 20. [design/audit-governance-export-bundle.md](./design/audit-governance-export-bundle.md)
-    Read this before generating or reviewing source-aware governance export bundles.
+    Read this before designing, generating, or reviewing dedicated governance
+    review exports separate from support bundles.
 
 ### 3. UX Foundation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [design/sql-guard-deny-catalog.md](./design/sql-guard-deny-catalog.md): machine-readable deny code catalog for SQL Guard
 - [design/sql-guard-deny-corpus.md](./design/sql-guard-deny-corpus.md): representative deny scenarios required for guard testing
 - [design/audit-event-model.md](./design/audit-event-model.md): audit event taxonomy and required fields
-- [design/audit-governance-export-bundle.md](./design/audit-governance-export-bundle.md): reviewer expectations and limitations for source-aware governance export bundles
+- [design/audit-governance-export-bundle.md](./design/audit-governance-export-bundle.md): dedicated reviewer-scoped governance export contract separate from support bundles
 
 ### UX Foundation
 

--- a/docs/design/audit-governance-export-bundle.md
+++ b/docs/design/audit-governance-export-bundle.md
@@ -1,9 +1,71 @@
-# Audit Governance Export Bundle
+# Dedicated Governance Review Export Contract
 
-The support bundle includes a `governanceReview` section for read-only lifecycle
-review. It is generated from persisted SafeQuery control-plane records and can
-be produced from local fixture data without live source, adapter, search,
-analyst, MLflow, or LLM services.
+SafeQuery governance review evidence must be available as a dedicated export
+contract separate from the support bundle. The support bundle remains a bounded
+operator diagnostic artifact; it must not become the reviewer-scoped evidence
+artifact for source governance, audit reconstruction, release posture, or
+execution-bound review.
+
+The dedicated export is generated from persisted SafeQuery control-plane
+records and can be produced from local fixture data without live source,
+adapter, search, analyst, MLflow, or LLM services. It is review evidence only:
+it does not authorize execution, approve candidates, refresh stale approvals,
+or substitute for entitlement checks, SQL Guard, source activation posture, or
+execution policy revalidation.
+
+## Contract Shape
+
+The export shape should be a JSON artifact or a future read-only endpoint with
+the same payload contract:
+
+```json
+{
+  "contract": "safequery.governance_review_export.v1",
+  "generatedAt": "<iso-8601-timestamp>",
+  "generatedBy": {
+    "authority": "safequery_control_plane",
+    "reviewerScope": "reviewer-only",
+    "actorId": "<redacted-reviewer-id>"
+  },
+  "filters": {
+    "sourceIds": ["<source-id>"],
+    "sourceFamilies": ["postgresql", "mssql"],
+    "timeWindow": {
+      "from": "<iso-8601-timestamp>",
+      "to": "<iso-8601-timestamp>"
+    },
+    "requestIds": ["<request-id>"],
+    "candidateIds": ["<candidate-id>"]
+  },
+  "authority": {
+    "recordStore": "safequery_control_plane",
+    "snapshotId": "<committed-snapshot-id>",
+    "snapshotConsistency": "single_committed_snapshot"
+  },
+  "evidence": []
+}
+```
+
+The initial CLI artifact can use repo-local fixture or backend records. A future
+endpoint may expose the same contract at a reviewer-only route such as
+`GET /governance/review-export`, but that endpoint must be a separate
+implementation follow-up and must not reuse unrestricted support-bundle
+posture as authorization.
+
+## Filters and Scope
+
+The export request must define an explicit source filter, time window, and
+reviewer scope before evidence is assembled:
+
+- `sourceIds` or `sourceFamilies` restrict the export to approved source
+  records that the reviewer is allowed to inspect.
+- `timeWindow.from` and `timeWindow.to` bound the lifecycle, audit, release-gate,
+  and governance records included in the artifact.
+- Optional `requestIds` and `candidateIds` narrow the export to direct
+  authoritative records only. They must not pull sibling requests, same-parent
+  candidates, or adjacent evidence by naming convention.
+- Empty, malformed, unauthorized, or mixed-scope filters fail closed instead of
+  producing a broad export.
 
 ## Reviewer Expectations
 
@@ -19,33 +81,75 @@ Reviewers should treat `governanceReview.authority` and each evidence
   subordinate unless a future control-plane record explicitly promotes a field
   into an authoritative SafeQuery record.
 
-Each evidence item is scoped to one request and, when present, one candidate. The
-bundle carries source identity, source family and flavor, dataset contract
+Each evidence item is scoped to one request and, when present, one candidate.
+The export carries source identity, source family and flavor, dataset contract
 version, schema snapshot version, lifecycle event order, actor metadata,
-candidate guard state, review approval metadata, and execution result metadata.
+candidate guard state, review approval metadata, release-gate status, and
+execution result metadata. Evidence must be read from one committed control-plane
+snapshot or rejected as mixed-snapshot state.
+
+## Redaction and Forbidden Values
+
+The dedicated export uses explicit redaction. It may include durable record ids,
+timestamps, source ids, source family and flavor, dataset contract versions,
+schema snapshot versions, lifecycle state, deny codes, approval metadata,
+release-gate status, audit completeness status, and bounded result metadata.
+
+It must include no raw credentials, no connection strings, no database URLs, no
+passwords, no tokens, no cookies, no CSRF secrets, no private keys, no raw
+identity payloads, no raw SQL, no raw result rows, no source connection
+references, and no workstation-local absolute paths.
+
+Redacted fields should be omitted or replaced with stable redaction markers such
+as `<redacted>`. A missing field means unavailable or intentionally redacted; it
+is not proof that the omitted action was safe.
+
+## Authority Requirements
+
+The export is reviewer-only. The caller must already have a trusted SafeQuery
+reviewer authorization context bound to the requested source and time filters.
+Forwarded headers, unsigned identity fields, placeholder credentials, sample
+tokens, or TODO values are not valid reviewer authority.
+
+When provenance, auth context, source binding, snapshot consistency, or filter
+authority is missing or only partially trusted, generation must fail closed. The
+exporter must not infer tenant, repository, account, issue, source, or candidate
+linkage from path shape, comments, display names, or nearby metadata.
+
+## Support Bundle Relationship
+
+The support bundle may keep a compact `governanceReview` summary for bounded
+operator triage, but that summary is not the dedicated governance review export.
+Support-bundle posture does not grant reviewer access, does not broaden export
+filters, and does not replace the dedicated redaction and authority checks
+above.
+
+Use the support bundle for operational diagnosis. Use the dedicated governance
+review export when a reviewer needs source- and time-bounded governance evidence
+that can be evaluated without raw secrets, local paths, unrestricted support
+context, or execution authority.
 
 ## Export Limitations
 
-The bundle is review evidence only. It does not approve, re-approve, or authorize
-execution. Reviewers must not use it as a bypass for candidate approval,
-entitlement checks, SQL Guard, source activation posture, or execution policy
-revalidation.
-
-The export intentionally excludes raw SQL, raw result rows, connection strings,
-raw credentials, tokens, raw identity payloads, source connection references,
-and workstation-local paths. A missing field should be interpreted as
-unavailable or intentionally redacted, not as proof that an action was safe.
-
-The bundle summarizes a committed database snapshot at generation time. It does
+The export summarizes a committed database snapshot at generation time. It does
 not prove that external services were reachable later, that a subordinate
 adapter's own logs are complete, or that an external system retained matching
 evidence.
+
+Implementation of a served endpoint, download flow, or signed artifact is
+explicitly deferred until a separate implementation follow-up defines the exact
+authorization middleware, snapshot read boundary, redaction tests, and reviewer
+UX. Reopen this design if implementation work cannot preserve reviewer-only
+scope, source/time filtering, redaction, and fail-closed behavior without
+changing the contract.
 
 ## Local Verification
 
 Focused verification should use local persisted records or fixture-backed tests:
 
 ```bash
+bash tests/smoke/test-pilot-safety-checklist.sh
+
 cd backend
 python3 -m pytest tests/test_support_bundle.py
 ```
@@ -55,5 +159,6 @@ Generated exports should be inspected for:
 - lifecycle completeness across request, candidate, review, and execution
   records
 - clear authority labels on control-plane and subordinate evidence
-- absence of raw SQL, result rows, credentials, tokens, raw identity payloads,
-  connection references, and workstation-local paths
+- reviewer-only scope and explicit source filter and time window values
+- absence of raw SQL, result rows, credentials, tokens, connection strings, raw
+  identity payloads, connection references, and workstation-local absolute paths

--- a/docs/pilot-deployment-profile.md
+++ b/docs/pilot-deployment-profile.md
@@ -160,6 +160,12 @@ include application version, environment label, source ids, source posture,
 health summaries, migration posture, workflow state summaries, lifecycle
 metrics, and audit completeness counts.
 
+Dedicated governance review exports are separate reviewer-scoped artifacts, not
+support bundles with a broader audience. Use
+`docs/design/audit-governance-export-bundle.md` for the required source/time
+filters, reviewer-only authority, redaction rules, and fail-closed behavior.
+Support-bundle posture must not substitute for that contract.
+
 They must not include:
 
 - raw operator prompts, raw SQL, or raw result rows

--- a/docs/pilot-operations-runbook.md
+++ b/docs/pilot-operations-runbook.md
@@ -417,6 +417,12 @@ for normal, degraded, maintenance, or recovery triage and the operator does not
 need to share raw logs, direct database credentials, query result rows, or local
 machine paths.
 
+Do not use the support bundle as the dedicated governance review export. When a
+reviewer needs source- and time-bounded governance evidence, follow
+`docs/design/audit-governance-export-bundle.md` instead. The dedicated export
+requires reviewer-only authority, explicit source/time filters, redaction, and
+fail-closed handling for missing provenance or mixed-snapshot evidence.
+
 Generate the bundle from the backend environment that is already configured for
 SafeQuery:
 

--- a/docs/pilot-safety-verification-checklist.md
+++ b/docs/pilot-safety-verification-checklist.md
@@ -447,6 +447,8 @@ Manual sign-off should record:
 - inspected positive and negative scenario ids
 - release gate status and failure list, if any
 - any skipped check with the explicit prerequisite that prevented it
+- dedicated governance review export filters and redaction status when a
+  reviewer-scoped export is part of the evidence package
 
 Do not sign off pilot readiness by inferring success from naming conventions,
 client-supplied source hints, optional extension traces, or operator-facing

--- a/tests/smoke/test-pilot-safety-checklist.sh
+++ b/tests/smoke/test-pilot-safety-checklist.sh
@@ -8,6 +8,7 @@ cd "$repo_root"
 checklist="docs/pilot-safety-verification-checklist.md"
 runbook="docs/pilot-operations-runbook.md"
 deployment_profile="docs/pilot-deployment-profile.md"
+governance_export_contract="docs/design/audit-governance-export-bundle.md"
 
 if [[ ! -f "$checklist" ]]; then
   echo "missing pilot-safety checklist: $checklist" >&2
@@ -21,6 +22,11 @@ fi
 
 if [[ ! -f "$deployment_profile" ]]; then
   echo "missing pilot deployment profile: $deployment_profile" >&2
+  exit 1
+fi
+
+if [[ ! -f "$governance_export_contract" ]]; then
+  echo "missing governance review export contract: $governance_export_contract" >&2
   exit 1
 fi
 
@@ -195,6 +201,28 @@ deployment_required_patterns=(
 for pattern in "${deployment_required_patterns[@]}"; do
   if ! grep -Eq "$pattern" "$deployment_profile"; then
     echo "$deployment_profile missing required deployment profile pattern: $pattern" >&2
+    exit 1
+  fi
+done
+
+governance_export_required_patterns=(
+  "^# Dedicated Governance Review Export Contract$"
+  "separate from the support bundle"
+  "reviewer-only"
+  "source filter"
+  "time window"
+  "redaction"
+  "no raw credentials"
+  "no connection strings"
+  "no workstation-local absolute paths"
+  "does not authorize execution"
+  "fail closed"
+  "separate implementation follow-up"
+)
+
+for pattern in "${governance_export_required_patterns[@]}"; do
+  if ! grep -Eq "$pattern" "$governance_export_contract"; then
+    echo "$governance_export_contract missing required governance export pattern: $pattern" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary
- document a dedicated reviewer-scoped governance review export contract separate from support bundles
- require explicit source/time filters, reviewer-only authority, redaction, and fail-closed handling
- tighten the pilot safety smoke to keep the contract present and linked from pilot docs

## Verification
- bash tests/smoke/test-pilot-safety-checklist.sh
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- bash tests/smoke/test-design-contract.sh
- cd backend && python3 -m pytest tests/test_support_bundle.py

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified governance review export requirements and contracts, including filtering, authority scope, and redaction guidelines
  * Enhanced deployment profiles, operations runbooks, and safety checklists with explicit governance export specifications distinguishing them from general support bundles

* **Tests**
  * Strengthened validation to ensure governance export documentation requirements are comprehensively documented

<!-- end of auto-generated comment: release notes by coderabbit.ai -->