### PR TITLE
[codex] Update preview evaluation contract tests

### DIFF
--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -365,6 +365,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             {
                 "source_id": "sap-approved-spend",
                 "state": "pending",
+                "primary_deny_code": None,
+                "denial_reason": None,
             },
         )
 

--- a/backend/tests/test_source_bound_records.py
+++ b/backend/tests/test_source_bound_records.py
@@ -124,5 +124,7 @@ def test_preview_submission_binds_all_records_to_authoritative_source_id() -> No
         "evaluation": {
             "source_id": "sap-approved-spend",
             "state": "pending",
+            "primary_deny_code": None,
+            "denial_reason": None,
         },
     }


### PR DESCRIPTION
## Summary
- update source-selection preview evaluation success assertion for nullable denial metadata
- update the adjacent source-bound records exact-match contract for the same evaluation payload shape
- keep source binding, request state, candidate state, and pending guard status coverage intact

## Root Cause
Epic T-0 expanded `EvaluationRecord` with nullable `primary_deny_code` and `denial_reason`, but success-path exact-match tests still expected the older `{source_id, state}` shape.

## Verification
- `cd backend && python3 -m pytest tests/test_request_source_selection.py::RequestSourceSelectionTestCase::test_preview_submission_accepts_registered_executable_source_id -q`
- `cd backend && python3 -m pytest tests/test_source_bound_records.py::test_preview_submission_binds_all_records_to_authoritative_source_id -q`
- `cd backend && python3 -m pytest -q`

Closes #375
Part of #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for evaluation responses to include `primary_deny_code` and `denial_reason` fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->