### PR TITLE
Add operator revise preview flow

### DIFF
--- a/backend/alembic/versions/0010_preview_revision_context.py
+++ b/backend/alembic/versions/0010_preview_revision_context.py
@@ -1,0 +1,32 @@
+"""Persist preview revision context."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0010_preview_revision_context"
+down_revision: str | None = "0009_candidate_approval_records"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+_REVISION_COLUMNS = (
+    ("revised_from_request_id", sa.String(length=255)),
+    ("revised_from_candidate_id", sa.String(length=255)),
+    ("revised_from_run_id", sa.String(length=255)),
+    ("revised_from_source_id", sa.String(length=255)),
+)
+
+
+def upgrade() -> None:
+    for table_name in ("preview_requests", "preview_candidates"):
+        for column_name, column_type in _REVISION_COLUMNS:
+            op.add_column(table_name, sa.Column(column_name, column_type, nullable=True))
+
+
+def downgrade() -> None:
+    for table_name in ("preview_candidates", "preview_requests"):
+        for column_name, _ in reversed(_REVISION_COLUMNS):
+            op.drop_column(table_name, column_name)

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -56,6 +56,22 @@ class PreviewRequest(Base):
     session_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     governance_bindings: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     entitlement_decision: Mapped[str] = mapped_column(String(32), nullable=False)
+    revised_from_request_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    revised_from_candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    revised_from_run_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    revised_from_source_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
     request_text: Mapped[str] = mapped_column(Text, nullable=False)
     request_state: Mapped[str] = mapped_column(String(64), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -119,6 +135,22 @@ class PreviewCandidate(Base):
     )
     schema_snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
     authenticated_subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    revised_from_request_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    revised_from_candidate_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    revised_from_run_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    revised_from_source_id: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
     candidate_sql: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     adapter_provider: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     adapter_model: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -88,6 +88,19 @@ class OperatorWorkflowHistoryItem(BaseModel):
         default_factory=list,
         serialization_alias="retrievedCitations",
     )
+    revision_context: Optional["OperatorWorkflowRevisionContext"] = Field(
+        default=None,
+        serialization_alias="revisionContext",
+    )
+
+
+class OperatorWorkflowRevisionContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: Optional[str] = Field(default=None, serialization_alias="requestId")
+    candidate_id: Optional[str] = Field(default=None, serialization_alias="candidateId")
+    run_id: Optional[str] = Field(default=None, serialization_alias="runId")
+    source_id: str = Field(serialization_alias="sourceId")
 
 
 class OperatorWorkflowAuditEventSummary(BaseModel):
@@ -533,6 +546,25 @@ def _history_occurred_at(
     return _as_utc_datetime(event.occurred_at if event is not None else fallback)
 
 
+def _revision_context_for_record(
+    *,
+    request_id: str | None,
+    candidate_id: str | None,
+    run_id: str | None,
+    source_id: str | None,
+) -> OperatorWorkflowRevisionContext | None:
+    if source_id is None or (
+        request_id is None and candidate_id is None and run_id is None
+    ):
+        return None
+    return OperatorWorkflowRevisionContext(
+        request_id=request_id,
+        candidate_id=candidate_id,
+        run_id=run_id,
+        source_id=source_id,
+    )
+
+
 def _build_operator_history(
     session: Session,
     *,
@@ -608,6 +640,12 @@ def _build_operator_history(
                 retrieved_citations=(
                     _retrieved_citations_for_event(candidate_event) if candidate_event else []
                 ),
+                revision_context=_revision_context_for_record(
+                    request_id=candidate.revised_from_request_id,
+                    candidate_id=candidate.revised_from_candidate_id,
+                    run_id=candidate.revised_from_run_id,
+                    source_id=candidate.revised_from_source_id,
+                ),
             )
         )
 
@@ -633,6 +671,12 @@ def _build_operator_history(
                 ),
                 retrieved_citations=(
                     _retrieved_citations_for_event(request_event) if request_event else []
+                ),
+                revision_context=_revision_context_for_record(
+                    request_id=request.revised_from_request_id,
+                    candidate_id=request.revised_from_candidate_id,
+                    run_id=request.revised_from_run_id,
+                    source_id=request.revised_from_source_id,
                 ),
             )
         )

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -610,6 +610,10 @@ def _resolve_revision_record(
             raise PreviewSubmissionContractError(
                 "Revision context for a request requires an authoritative request id."
             )
+        if revision.candidate_id is not None or revision.run_id is not None:
+            raise PreviewSubmissionContractError(
+                "Revision context for a request cannot include candidate_id or run_id."
+            )
         request = session.scalar(
             select(PreviewRequest).where(
                 PreviewRequest.request_id == revision.request_id
@@ -618,6 +622,13 @@ def _resolve_revision_record(
         if request is None:
             raise PreviewSubmissionContractError(
                 "Revision context references an unknown preview request."
+            )
+        if (
+            revision.lifecycle_state is not None
+            and revision.lifecycle_state != request.request_state
+        ):
+            raise PreviewSubmissionContractError(
+                "Revision context lifecycle_state does not match request_state."
             )
         if request.request_state not in {
             "blocked",
@@ -640,6 +651,10 @@ def _resolve_revision_record(
             raise PreviewSubmissionContractError(
                 "Revision context for a candidate requires an authoritative candidate id."
             )
+        if revision.run_id is not None:
+            raise PreviewSubmissionContractError(
+                "Revision context for a candidate cannot include run_id."
+            )
         candidate = session.scalar(
             select(PreviewCandidate).where(
                 PreviewCandidate.candidate_id == revision.candidate_id
@@ -648,6 +663,13 @@ def _resolve_revision_record(
         if candidate is None:
             raise PreviewSubmissionContractError(
                 "Revision context references an unknown preview candidate."
+            )
+        if (
+            revision.lifecycle_state is not None
+            and revision.lifecycle_state != candidate.candidate_state
+        ):
+            raise PreviewSubmissionContractError(
+                "Revision context lifecycle_state does not match candidate_state."
             )
         if candidate.candidate_state not in {"blocked", "preview_ready"}:
             raise PreviewSubmissionContractError(
@@ -687,6 +709,10 @@ def _resolve_revision_record(
     if run_state not in {"completed", "empty", "failed", "execution_denied"}:
         raise PreviewSubmissionContractError(
             "Execution run state is not eligible for revision."
+        )
+    if revision.lifecycle_state is not None and revision.lifecycle_state != run_state:
+        raise PreviewSubmissionContractError(
+            "Revision context lifecycle_state does not match run_state."
         )
     if revision.candidate_id is not None and revision.candidate_id != run_event.candidate_id:
         raise PreviewSubmissionContractError(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -634,6 +634,7 @@ def _resolve_revision_record(
             "blocked",
             "preview_denied",
             "preview_generation_failed",
+            "preview_malformed",
             "preview_unavailable",
         }:
             raise PreviewSubmissionContractError(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints, Validation
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from typing import Any, NoReturn, Optional
+from typing import Any, Literal, NoReturn, Optional
 from typing_extensions import Annotated
 from uuid import UUID, uuid4
 
@@ -138,6 +138,17 @@ class PreviewSubmissionRequest(BaseModel):
 
     question: NonEmptyTrimmedString
     source_id: NonEmptyTrimmedString
+    revise_from: Optional["PreviewRevisionContext"] = None
+
+
+class PreviewRevisionContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    item_type: Literal["request", "candidate", "run"]
+    request_id: Optional[NonEmptyTrimmedString] = None
+    candidate_id: Optional[NonEmptyTrimmedString] = None
+    run_id: Optional[NonEmptyTrimmedString] = None
+    lifecycle_state: Optional[NonEmptyTrimmedString] = None
 
 
 class RequestRecord(BaseModel):
@@ -145,6 +156,7 @@ class RequestRecord(BaseModel):
     request_id: str
     source_id: str
     state: str
+    revision_context: Optional["RevisionRecord"] = None
 
 
 class CandidateRecord(BaseModel):
@@ -159,6 +171,16 @@ class CandidateRecord(BaseModel):
     state: str
     primary_deny_code: Optional[str] = None
     denial_reason: Optional[str] = None
+    revision_context: Optional["RevisionRecord"] = None
+
+
+class RevisionRecord(BaseModel):
+    item_type: Literal["request", "candidate", "run"]
+    request_id: Optional[str] = None
+    candidate_id: Optional[str] = None
+    run_id: Optional[str] = None
+    source_id: str
+    lifecycle_state: Optional[str] = None
 
 
 class AuditRecord(BaseModel):
@@ -565,6 +587,125 @@ def _joined_governance_bindings(bindings: list[str]) -> str | None:
     return ",".join(sorted(bindings)) if bindings else None
 
 
+def _terminal_run_state(event: PreviewAuditEvent) -> str | None:
+    if event.event_type == "execution_completed":
+        row_count = event.audit_payload.get("execution_row_count")
+        return "empty" if row_count == 0 else "completed"
+    if event.event_type == "execution_denied":
+        return "execution_denied"
+    if event.event_type == "execution_failed":
+        return "canceled" if event.candidate_state == "canceled" else "failed"
+    return None
+
+
+def _resolve_revision_record(
+    session: Session,
+    revision: PreviewRevisionContext | None,
+) -> RevisionRecord | None:
+    if revision is None:
+        return None
+
+    if revision.item_type == "request":
+        if revision.request_id is None:
+            raise PreviewSubmissionContractError(
+                "Revision context for a request requires an authoritative request id."
+            )
+        request = session.scalar(
+            select(PreviewRequest).where(
+                PreviewRequest.request_id == revision.request_id
+            )
+        )
+        if request is None:
+            raise PreviewSubmissionContractError(
+                "Revision context references an unknown preview request."
+            )
+        if request.request_state not in {
+            "blocked",
+            "preview_denied",
+            "preview_generation_failed",
+            "preview_unavailable",
+        }:
+            raise PreviewSubmissionContractError(
+                "Preview request state is not eligible for revision."
+            )
+        return RevisionRecord(
+            item_type="request",
+            request_id=request.request_id,
+            source_id=request.source_id,
+            lifecycle_state=request.request_state,
+        )
+
+    if revision.item_type == "candidate":
+        if revision.candidate_id is None:
+            raise PreviewSubmissionContractError(
+                "Revision context for a candidate requires an authoritative candidate id."
+            )
+        candidate = session.scalar(
+            select(PreviewCandidate).where(
+                PreviewCandidate.candidate_id == revision.candidate_id
+            )
+        )
+        if candidate is None:
+            raise PreviewSubmissionContractError(
+                "Revision context references an unknown preview candidate."
+            )
+        if candidate.candidate_state not in {"blocked", "preview_ready"}:
+            raise PreviewSubmissionContractError(
+                "Preview candidate state is not eligible for revision."
+            )
+        if revision.request_id is not None and revision.request_id != candidate.request_id:
+            raise PreviewSubmissionContractError(
+                "Revision context candidate does not belong to the supplied request."
+            )
+        return RevisionRecord(
+            item_type="candidate",
+            request_id=candidate.request_id,
+            candidate_id=candidate.candidate_id,
+            source_id=candidate.source_id,
+            lifecycle_state=candidate.candidate_state,
+        )
+
+    if revision.run_id is None:
+        raise PreviewSubmissionContractError(
+            "Revision context for a run requires an authoritative run id."
+        )
+    try:
+        run_event_id = UUID(revision.run_id)
+    except ValueError as exc:
+        raise PreviewSubmissionContractError(
+            "Revision context run id is malformed."
+        ) from exc
+
+    run_event = session.scalar(
+        select(PreviewAuditEvent).where(PreviewAuditEvent.event_id == run_event_id)
+    )
+    if run_event is None:
+        raise PreviewSubmissionContractError(
+            "Revision context references an unknown execution run."
+        )
+    run_state = _terminal_run_state(run_event)
+    if run_state not in {"completed", "empty", "failed", "execution_denied"}:
+        raise PreviewSubmissionContractError(
+            "Execution run state is not eligible for revision."
+        )
+    if revision.candidate_id is not None and revision.candidate_id != run_event.candidate_id:
+        raise PreviewSubmissionContractError(
+            "Revision context run does not belong to the supplied candidate."
+        )
+    if revision.request_id is not None and revision.request_id != run_event.request_id:
+        raise PreviewSubmissionContractError(
+            "Revision context run does not belong to the supplied request."
+        )
+    return RevisionRecord(
+        item_type="run",
+        request_id=run_event.request_id,
+        candidate_id=run_event.candidate_id,
+        run_id=str(run_event.event_id),
+        source_id=run_event.source_id,
+        lifecycle_state=run_state,
+    )
+
+
 def _persist_preview_audit_events(
     session: Session,
     *,
@@ -822,6 +963,7 @@ def _persist_preview_submission_records(
     candidate_state: str = "preview_ready",
     guard_status: GuardStatus = PREVIEW_PENDING_GUARD_STATUS,
 ) -> tuple[str, str]:
+    revision_record = _resolve_revision_record(session, payload.revise_from)
     request_id = (
         audit_context.request_id
         if audit_context is not None and audit_context.request_id.strip()
@@ -840,6 +982,14 @@ def _persist_preview_submission_records(
     governance_bindings = _joined_governance_bindings(
         sorted(authenticated_subject.normalized_governance_bindings())
     )
+    if revision_record is not None and (
+        request_id == revision_record.request_id
+        or candidate_id == revision_record.candidate_id
+    ):
+        _raise_preview_persistence_contract_error(
+            session,
+            "Revised preview attempts must use new request and candidate identities.",
+        )
 
     for attempt in range(2):
         try:
@@ -849,6 +999,11 @@ def _persist_preview_submission_records(
             if preview_request is None:
                 preview_request = PreviewRequest(request_id=request_id)
                 session.add(preview_request)
+            elif revision_record is not None:
+                _raise_preview_persistence_contract_error(
+                    session,
+                    "Revised preview attempts cannot overwrite an existing request.",
+                )
             elif preview_request.registered_source_id != resolved_source.id:
                 _raise_preview_persistence_contract_error(
                     session,
@@ -872,6 +1027,18 @@ def _persist_preview_submission_records(
             )
             preview_request.governance_bindings = governance_bindings
             preview_request.entitlement_decision = "allow"
+            preview_request.revised_from_request_id = (
+                revision_record.request_id if revision_record is not None else None
+            )
+            preview_request.revised_from_candidate_id = (
+                revision_record.candidate_id if revision_record is not None else None
+            )
+            preview_request.revised_from_run_id = (
+                revision_record.run_id if revision_record is not None else None
+            )
+            preview_request.revised_from_source_id = (
+                revision_record.source_id if revision_record is not None else None
+            )
             preview_request.request_text = payload.question
             preview_request.request_state = request_state
             session.flush()
@@ -882,12 +1049,22 @@ def _persist_preview_submission_records(
                     PreviewCandidate.source_id == resolved_source.source_id,
                 )
             ).scalar_one_or_none()
+            if preview_candidate is not None and revision_record is not None:
+                _raise_preview_persistence_contract_error(
+                    session,
+                    "Revised preview attempts cannot overwrite an existing candidate.",
+                )
             if preview_candidate is None:
                 preview_candidate = session.execute(
                     select(PreviewCandidate).where(
                         PreviewCandidate.candidate_id == candidate_id
                     )
                 ).scalar_one_or_none()
+                if preview_candidate is not None and revision_record is not None:
+                    _raise_preview_persistence_contract_error(
+                        session,
+                        "Revised preview attempts cannot overwrite an existing candidate.",
+                    )
                 if preview_candidate is None:
                     preview_candidate = PreviewCandidate(candidate_id=candidate_id)
                     session.add(preview_candidate)
@@ -928,6 +1105,18 @@ def _persist_preview_submission_records(
             preview_candidate.schema_snapshot_id = schema_snapshot.id
             preview_candidate.schema_snapshot_version = schema_snapshot.snapshot_version
             preview_candidate.authenticated_subject_id = subject_id
+            preview_candidate.revised_from_request_id = (
+                revision_record.request_id if revision_record is not None else None
+            )
+            preview_candidate.revised_from_candidate_id = (
+                revision_record.candidate_id if revision_record is not None else None
+            )
+            preview_candidate.revised_from_run_id = (
+                revision_record.run_id if revision_record is not None else None
+            )
+            preview_candidate.revised_from_source_id = (
+                revision_record.source_id if revision_record is not None else None
+            )
             preview_candidate.candidate_sql = candidate_sql
             preview_candidate.adapter_provider = (
                 adapter_metadata.adapter_provider if adapter_metadata is not None else None
@@ -1063,6 +1252,7 @@ def _persist_preview_denial_records(
     request_state: str = "preview_denied",
     entitlement_decision: str = "deny",
 ) -> None:
+    revision_record = _resolve_revision_record(session, payload.revise_from)
     request_id = (
         audit_context.request_id
         if audit_context is not None and audit_context.request_id.strip()
@@ -1072,6 +1262,11 @@ def _persist_preview_denial_records(
     governance_bindings = _joined_governance_bindings(
         sorted(authenticated_subject.normalized_governance_bindings())
     )
+    if revision_record is not None and request_id == revision_record.request_id:
+        _raise_preview_persistence_contract_error(
+            session,
+            "Revised preview attempts must use a new request identity.",
+        )
 
     try:
         preview_request = session.execute(
@@ -1080,6 +1275,11 @@ def _persist_preview_denial_records(
         if preview_request is None:
             preview_request = PreviewRequest(request_id=request_id)
             session.add(preview_request)
+        elif revision_record is not None:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Revised preview attempts cannot overwrite an existing request.",
+            )
         elif preview_request.registered_source_id != resolved_source.id:
             _raise_preview_persistence_contract_error(
                 session,
@@ -1103,6 +1303,18 @@ def _persist_preview_denial_records(
         )
         preview_request.governance_bindings = governance_bindings
         preview_request.entitlement_decision = entitlement_decision
+        preview_request.revised_from_request_id = (
+            revision_record.request_id if revision_record is not None else None
+        )
+        preview_request.revised_from_candidate_id = (
+            revision_record.candidate_id if revision_record is not None else None
+        )
+        preview_request.revised_from_run_id = (
+            revision_record.run_id if revision_record is not None else None
+        )
+        preview_request.revised_from_source_id = (
+            revision_record.source_id if revision_record is not None else None
+        )
         preview_request.request_text = payload.question
         preview_request.request_state = request_state
         session.flush()
@@ -1265,6 +1477,7 @@ def submit_preview_request(
         dataset_contract=dataset_contract,
         entitlement_decision="allow",
     )
+    revision_record = _resolve_revision_record(session, payload.revise_from)
 
     candidate_sql: str | None = None
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None
@@ -1375,6 +1588,7 @@ def submit_preview_request(
             request_id=request_id,
             source_id=resolved_source.source_id,
             state="submitted",
+            revision_context=revision_record,
         ),
         candidate=CandidateRecord(
             candidate_id=candidate_id,
@@ -1388,6 +1602,7 @@ def submit_preview_request(
             state=candidate_state,
             primary_deny_code=primary_deny_code,
             denial_reason=denial_reason,
+            revision_context=revision_record,
         ),
         audit=audit,
         evaluation=EvaluationRecord(

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -358,6 +358,60 @@ def test_operator_workflow_history_is_built_from_preview_request_and_candidate_r
     assert history[1]["auditEvents"][0]["eventType"] == "guard_evaluated"
 
 
+def test_operator_workflow_history_marks_revised_attempt_context() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-original",
+                candidate_id="preview-candidate-original",
+            ),
+        )
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by yearly spend",
+                source_id="sap-approved-spend",
+                revise_from={
+                    "item_type": "candidate",
+                    "request_id": "preview-request-original",
+                    "candidate_id": "preview-candidate-original",
+                },
+            ),
+            subject,
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-revised",
+                candidate_id="preview-candidate-revised",
+            ),
+        )
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    history = [
+        item.model_dump(mode="json", by_alias=True, exclude_none=True)
+        for item in snapshot.history
+    ]
+    revised_candidate = next(
+        item for item in history if item["recordId"] == "preview-candidate-revised"
+    )
+    assert revised_candidate["revisionContext"] == {
+        "requestId": "preview-request-original",
+        "candidateId": "preview-candidate-original",
+        "sourceId": "sap-approved-spend",
+    }
+
+
 def test_operator_workflow_history_includes_execution_run_records() -> None:
     with _session_scope() as session:
         _seed_authoritative_source_governance(session)

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -30,6 +30,7 @@ from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewSt
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
+from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.auth.session import create_test_application_session
 from app.features.evaluation.harness import list_postgresql_evaluation_scenarios
 from app.features.guard import SQLGuardEvaluation, SQLGuardRejection
@@ -1381,6 +1382,226 @@ def test_preview_submission_updates_existing_request_and_candidate_records() -> 
     assert persisted_candidates[0].candidate_id == "preview-candidate-231"
     assert persisted_candidates[0].request_id == "preview-request-231"
     assert persisted_candidates[0].source_id == "sap-approved-spend"
+
+
+def test_preview_revision_from_completed_run_creates_new_authoritative_attempt() -> None:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    completed_run_id = uuid4()
+
+    with Session(engine) as session:
+        _seed_authoritative_source_governance(session)
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-original",
+                correlation_id="preview-correlation-original",
+                user_subject="user:alice",
+                session_id="session-original",
+                query_candidate_id="preview-candidate-original",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+        )
+        request_before = session.scalar(
+            select(PreviewRequest).where(
+                PreviewRequest.request_id == "preview-request-original"
+            )
+        )
+        candidate_before = session.scalar(
+            select(PreviewCandidate).where(
+                PreviewCandidate.candidate_id == "preview-candidate-original"
+            )
+        )
+        assert request_before is not None
+        assert candidate_before is not None
+        original_request_db_id = request_before.id
+        original_candidate_db_id = candidate_before.id
+
+        request_preview_service.persist_execution_audit_events(
+            session,
+            candidate_id="preview-candidate-original",
+            audit_events=[
+                SourceAwareAuditEvent(
+                    event_id=completed_run_id,
+                    event_type="execution_completed",
+                    occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+                    request_id="preview-request-original",
+                    correlation_id="preview-correlation-original",
+                    user_subject="user:alice",
+                    session_id="session-original",
+                    query_candidate_id="preview-candidate-original",
+                    candidate_owner_subject="user:alice",
+                    source_id="sap-approved-spend",
+                    source_family="postgresql",
+                    source_flavor="warehouse",
+                    dataset_contract_version=1,
+                    schema_snapshot_version=1,
+                    execution_row_count=3,
+                    result_truncated=False,
+                )
+            ],
+        )
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by yearly spend",
+                source_id="sap-approved-spend",
+                revise_from={
+                    "item_type": "run",
+                    "request_id": "preview-request-original",
+                    "candidate_id": "preview-candidate-original",
+                    "run_id": str(completed_run_id),
+                },
+            ),
+            subject,
+            session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 6, 0, tzinfo=timezone.utc),
+                request_id="preview-request-revised",
+                correlation_id="preview-correlation-revised",
+                user_subject="user:alice",
+                session_id="session-revised",
+                query_candidate_id="preview-candidate-revised",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+        )
+
+        persisted_requests = (
+            session.execute(select(PreviewRequest).order_by(PreviewRequest.request_id))
+            .scalars()
+            .all()
+        )
+        persisted_candidates = (
+            session.execute(
+                select(PreviewCandidate).order_by(PreviewCandidate.candidate_id)
+            )
+            .scalars()
+            .all()
+        )
+        original_request = next(
+            request
+            for request in persisted_requests
+            if request.request_id == "preview-request-original"
+        )
+        revised_request = next(
+            request
+            for request in persisted_requests
+            if request.request_id == "preview-request-revised"
+        )
+        original_candidate = next(
+            candidate
+            for candidate in persisted_candidates
+            if candidate.candidate_id == "preview-candidate-original"
+        )
+        revised_candidate = next(
+            candidate
+            for candidate in persisted_candidates
+            if candidate.candidate_id == "preview-candidate-revised"
+        )
+
+    assert response.request.revision_context is not None
+    assert response.request.revision_context.run_id == str(completed_run_id)
+    assert len(persisted_requests) == 2
+    assert len(persisted_candidates) == 2
+    assert original_request.id == original_request_db_id
+    assert original_request.request_text == "Show approved vendors by quarterly spend"
+    assert original_request.revised_from_run_id is None
+    assert original_candidate.id == original_candidate_db_id
+    assert original_candidate.request_id == "preview-request-original"
+    assert original_candidate.revised_from_run_id is None
+    assert revised_request.request_text == "Show approved vendors by yearly spend"
+    assert revised_request.revised_from_request_id == "preview-request-original"
+    assert revised_request.revised_from_candidate_id == "preview-candidate-original"
+    assert revised_request.revised_from_run_id == str(completed_run_id)
+    assert revised_request.revised_from_source_id == "sap-approved-spend"
+    assert revised_candidate.request_id == "preview-request-revised"
+    assert revised_candidate.revised_from_request_id == "preview-request-original"
+    assert revised_candidate.revised_from_candidate_id == "preview-candidate-original"
+    assert revised_candidate.revised_from_run_id == str(completed_run_id)
+    assert revised_candidate.revised_from_source_id == "sap-approved-spend"
+
+
+def test_preview_revision_rejects_reused_authoritative_attempt_ids() -> None:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    with Session(engine) as session:
+        _seed_authoritative_source_governance(session)
+        audit_context = PreviewAuditContext(
+            occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+            request_id="preview-request-original",
+            correlation_id="preview-correlation-original",
+            user_subject="user:alice",
+            session_id="session-original",
+            query_candidate_id="preview-candidate-original",
+            candidate_owner_subject="user:alice",
+            auth_source="test-helper",
+        )
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=audit_context.model_copy(deep=True),
+        )
+
+        with pytest.raises(PreviewSubmissionContractError) as exc_info:
+            submit_preview_request(
+                PreviewSubmissionRequest(
+                    question="Show approved vendors by yearly spend",
+                    source_id="sap-approved-spend",
+                    revise_from={
+                        "item_type": "candidate",
+                        "request_id": "preview-request-original",
+                        "candidate_id": "preview-candidate-original",
+                    },
+                ),
+                subject,
+                session,
+                audit_context=audit_context.model_copy(deep=True),
+            )
+
+        persisted_request = session.scalar(
+            select(PreviewRequest).where(
+                PreviewRequest.request_id == "preview-request-original"
+            )
+        )
+        persisted_candidates = session.execute(select(PreviewCandidate)).scalars().all()
+
+    assert str(exc_info.value) == (
+        "Revised preview attempts must use new request and candidate identities."
+    )
+    assert persisted_request is not None
+    assert persisted_request.request_text == "Show approved vendors by quarterly spend"
+    assert len(persisted_candidates) == 1
+    assert persisted_candidates[0].candidate_id == "preview-candidate-original"
 
 
 def test_preview_candidate_reapproval_clears_invalidation_and_refreshes_expiry() -> None:

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -1538,6 +1538,106 @@ def test_preview_revision_from_completed_run_creates_new_authoritative_attempt()
     assert revised_candidate.revised_from_source_id == "sap-approved-spend"
 
 
+def test_preview_revision_from_malformed_request_creates_new_authoritative_attempt() -> None:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    with Session(engine) as session:
+        _seed_authoritative_source_governance(session)
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-original",
+                correlation_id="preview-correlation-original",
+                user_subject="user:alice",
+                session_id="session-original",
+                query_candidate_id="preview-candidate-original",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+        )
+        original_request = session.scalar(
+            select(PreviewRequest).where(
+                PreviewRequest.request_id == "preview-request-original"
+            )
+        )
+        assert original_request is not None
+        original_request_db_id = original_request.id
+        original_request.request_state = "preview_malformed"
+        session.flush()
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by yearly spend",
+                source_id="sap-approved-spend",
+                revise_from={
+                    "item_type": "request",
+                    "request_id": "preview-request-original",
+                    "lifecycle_state": "preview_malformed",
+                },
+            ),
+            subject,
+            session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 6, 0, tzinfo=timezone.utc),
+                request_id="preview-request-revised",
+                correlation_id="preview-correlation-revised",
+                user_subject="user:alice",
+                session_id="session-revised",
+                query_candidate_id="preview-candidate-revised",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+        )
+
+        persisted_requests = (
+            session.execute(select(PreviewRequest).order_by(PreviewRequest.request_id))
+            .scalars()
+            .all()
+        )
+        revised_request = next(
+            request
+            for request in persisted_requests
+            if request.request_id == "preview-request-revised"
+        )
+        original_request_after_revision = next(
+            request
+            for request in persisted_requests
+            if request.request_id == "preview-request-original"
+        )
+
+    assert response.request.revision_context is not None
+    assert response.request.revision_context.item_type == "request"
+    assert response.request.revision_context.request_id == "preview-request-original"
+    assert response.request.revision_context.lifecycle_state == "preview_malformed"
+    assert len(persisted_requests) == 2
+    assert original_request_after_revision.id == original_request_db_id
+    assert original_request_after_revision.request_text == (
+        "Show approved vendors by quarterly spend"
+    )
+    assert original_request_after_revision.request_state == "preview_malformed"
+    assert revised_request.request_text == "Show approved vendors by yearly spend"
+    assert revised_request.revised_from_request_id == "preview-request-original"
+    assert revised_request.revised_from_candidate_id is None
+    assert revised_request.revised_from_run_id is None
+    assert revised_request.revised_from_source_id == "sap-approved-spend"
+
+
 def test_preview_revision_rejects_inconsistent_lineage_contract_fields() -> None:
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -1538,6 +1538,133 @@ def test_preview_revision_from_completed_run_creates_new_authoritative_attempt()
     assert revised_candidate.revised_from_source_id == "sap-approved-spend"
 
 
+def test_preview_revision_rejects_inconsistent_lineage_contract_fields() -> None:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    completed_run_id = uuid4()
+
+    with Session(engine) as session:
+        _seed_authoritative_source_governance(session)
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-original",
+                correlation_id="preview-correlation-original",
+                user_subject="user:alice",
+                session_id="session-original",
+                query_candidate_id="preview-candidate-original",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+        )
+        request_preview_service.persist_execution_audit_events(
+            session,
+            candidate_id="preview-candidate-original",
+            audit_events=[
+                SourceAwareAuditEvent(
+                    event_id=completed_run_id,
+                    event_type="execution_completed",
+                    occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+                    request_id="preview-request-original",
+                    correlation_id="preview-correlation-original",
+                    user_subject="user:alice",
+                    session_id="session-original",
+                    query_candidate_id="preview-candidate-original",
+                    candidate_owner_subject="user:alice",
+                    source_id="sap-approved-spend",
+                    source_family="postgresql",
+                    source_flavor="warehouse",
+                    dataset_contract_version=1,
+                    schema_snapshot_version=1,
+                    execution_row_count=3,
+                    result_truncated=False,
+                )
+            ],
+        )
+
+        cases = [
+            (
+                {
+                    "item_type": "request",
+                    "request_id": "preview-request-original",
+                    "candidate_id": "preview-candidate-original",
+                },
+                "candidate_id or run_id",
+            ),
+            (
+                {
+                    "item_type": "request",
+                    "request_id": "preview-request-original",
+                    "lifecycle_state": "blocked",
+                },
+                "lifecycle_state does not match request_state",
+            ),
+            (
+                {
+                    "item_type": "candidate",
+                    "candidate_id": "preview-candidate-original",
+                    "run_id": str(completed_run_id),
+                },
+                "candidate cannot include run_id",
+            ),
+            (
+                {
+                    "item_type": "candidate",
+                    "candidate_id": "preview-candidate-original",
+                    "lifecycle_state": "blocked",
+                },
+                "lifecycle_state does not match candidate_state",
+            ),
+            (
+                {
+                    "item_type": "run",
+                    "run_id": str(completed_run_id),
+                    "lifecycle_state": "failed",
+                },
+                "lifecycle_state does not match run_state",
+            ),
+        ]
+
+        for revision_context, expected_message in cases:
+            with pytest.raises(PreviewSubmissionContractError) as exc_info:
+                submit_preview_request(
+                    PreviewSubmissionRequest(
+                        question="Show approved vendors by yearly spend",
+                        source_id="sap-approved-spend",
+                        revise_from=revision_context,
+                    ),
+                    subject,
+                    session,
+                    audit_context=PreviewAuditContext(
+                        occurred_at=datetime(2026, 1, 2, 3, 6, 0, tzinfo=timezone.utc),
+                        request_id="preview-request-revised",
+                        correlation_id="preview-correlation-revised",
+                        user_subject="user:alice",
+                        session_id="session-revised",
+                        query_candidate_id="preview-candidate-revised",
+                        candidate_owner_subject="user:alice",
+                        auth_source="test-helper",
+                    ),
+                )
+
+            assert expected_message in str(exc_info.value)
+
+
 def test_preview_revision_rejects_reused_authoritative_attempt_ids() -> None:
     engine = create_engine(
         "sqlite+pysqlite:///:memory:",

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -363,6 +363,8 @@ button {
   border: 1px solid var(--border-soft);
   background: rgba(255, 255, 255, 0.03);
   color: var(--text-secondary);
+  box-shadow: none;
+  cursor: pointer;
 }
 
 .inline-link,

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -358,7 +358,8 @@ button {
   cursor: pointer;
 }
 
-.ghost-link {
+.ghost-link,
+.ghost-button {
   border: 1px solid var(--border-soft);
   background: rgba(255, 255, 255, 0.03);
   color: var(--text-secondary);

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -476,77 +476,88 @@ describe("pilot safety UI smoke", () => {
     });
   });
 
-  it("submits a revised preview attempt from request-backed failure history", async () => {
-    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = input.toString();
+  it.each([
+    ["preview_unavailable", "unavailable"],
+    ["preview_malformed", "malformed"]
+  ])(
+    "submits a revised preview attempt from %s request-backed failure history",
+    async (lifecycleState, failureLabel) => {
+      const requestId = `request-pilot-${failureLabel}-001`;
+      const question = `Pilot ${failureLabel} preview`;
+      const revisedQuestion = `Pilot ${failureLabel} preview with revised source context`;
+      const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
 
-      if (url.endsWith("/operator/workflow")) {
-        const payload = pilotWorkflowPayload();
-        return Promise.resolve({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              ...payload,
-              history: [
-                {
-                  auditEvents: [],
-                  executedEvidence: [],
-                  itemType: "request",
-                  label: "Pilot unavailable preview",
-                  lifecycleState: "preview_unavailable",
-                  occurredAt: "2026-04-21T14:42:00Z",
-                  recordId: "request-pilot-unavailable-001",
-                  retrievedCitations: [],
-                  sourceId: "demo-business-postgres",
-                  sourceLabel: "Demo business PostgreSQL / approved_vendor_spend"
-                },
-                ...payload.history
-              ]
-            })
-        });
-      }
-
-      if (url.endsWith("/requests/preview")) {
-        return new Promise(() => {});
-      }
-
-      return new Promise(() => {});
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    render(
-      await HomePage({
-        searchParams: {
-          history_item_type: "request",
-          history_record_id: "request-pilot-unavailable-001",
-          question: "Pilot unavailable preview",
-          source_id: "demo-business-postgres",
-          state: "review_denied"
+        if (url.endsWith("/operator/workflow")) {
+          const payload = pilotWorkflowPayload();
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                ...payload,
+                history: [
+                  {
+                    auditEvents: [],
+                    executedEvidence: [],
+                    itemType: "request",
+                    label: question,
+                    lifecycleState,
+                    occurredAt: "2026-04-21T14:42:00Z",
+                    recordId: requestId,
+                    retrievedCitations: [],
+                    sourceId: "demo-business-postgres",
+                    sourceLabel: "Demo business PostgreSQL / approved_vendor_spend"
+                  },
+                  ...payload.history
+                ]
+              })
+          });
         }
-      })
-    );
 
-    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
-    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
-      target: { value: "Pilot unavailable preview with revised source context" }
-    });
-    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+        if (url.endsWith("/requests/preview")) {
+          return new Promise(() => {});
+        }
 
-    await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        "http://127.0.0.1:8000/requests/preview",
-        expect.objectContaining({
-          body: JSON.stringify({
-            question: "Pilot unavailable preview with revised source context",
+        return new Promise(() => {});
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      render(
+        await HomePage({
+          searchParams: {
+            history_item_type: "request",
+            history_record_id: requestId,
+            question,
             source_id: "demo-business-postgres",
-            revise_from: {
-              item_type: "request",
-              request_id: "request-pilot-unavailable-001"
-            }
-          }),
-          method: "POST"
+            state: "review_denied"
+          }
         })
       );
-    });
-  });
+
+      fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+      fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+        target: { value: revisedQuestion }
+      });
+      fireEvent.submit(
+        screen.getByRole("button", { name: /submit for preview/i }).closest("form")!
+      );
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "http://127.0.0.1:8000/requests/preview",
+          expect.objectContaining({
+            body: JSON.stringify({
+              question: revisedQuestion,
+              source_id: "demo-business-postgres",
+              revise_from: {
+                item_type: "request",
+                request_id: requestId
+              }
+            }),
+            method: "POST"
+          })
+        );
+      });
+    }
+  );
 });

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -332,7 +332,11 @@ describe("pilot safety UI smoke", () => {
                 question: "Pilot source preview with revised filter",
                 request_id: "request-revised-001",
                 revision_context: {
+                  item_type: "run",
+                  request_id: "request-pilot-001",
+                  candidate_id: "candidate-pilot-001",
                   run_id: "run-pilot-001",
+                  lifecycle_state: "completed",
                   source_id: "demo-business-postgres"
                 },
                 source_id: "demo-business-postgres",

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -384,4 +384,169 @@ describe("pilot safety UI smoke", () => {
       );
     });
   });
+
+  it("submits a revised preview attempt from execution-denied run context", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        const payload = pilotWorkflowPayload();
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...payload,
+              history: [
+                ...payload.history,
+                {
+                  auditEvents: [
+                    {
+                      candidateId: "candidate-pilot-001",
+                      candidateState: "preview_ready",
+                      eventId: "run-pilot-denied-001",
+                      eventType: "execution_denied",
+                      occurredAt: "2026-04-21T14:40:00Z",
+                      primaryDenyCode: "DENY_EXECUTION_POLICY",
+                      requestId: "request-pilot-001",
+                      resultTruncated: null,
+                      rowCount: null,
+                      sourceId: "demo-business-postgres"
+                    }
+                  ],
+                  executedEvidence: [],
+                  itemType: "run",
+                  label: "Pilot denied run",
+                  lifecycleState: "execution_denied",
+                  occurredAt: "2026-04-21T14:40:00Z",
+                  recordId: "run-pilot-denied-001",
+                  requestId: "request-pilot-001",
+                  retrievedCitations: [],
+                  runState: "execution_denied",
+                  sourceId: "demo-business-postgres",
+                  sourceLabel: "Demo business PostgreSQL / approved_vendor_spend"
+                }
+              ]
+            })
+        });
+      }
+
+      if (url.endsWith("/requests/preview")) {
+        return new Promise(() => {});
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "run",
+          history_record_id: "run-pilot-denied-001",
+          question: "Pilot denied run",
+          source_id: "demo-business-postgres",
+          state: "execution_denied"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Pilot denied run with revised filter" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/requests/preview",
+        expect.objectContaining({
+          body: JSON.stringify({
+            question: "Pilot denied run with revised filter",
+            source_id: "demo-business-postgres",
+            revise_from: {
+              item_type: "run",
+              request_id: "request-pilot-001",
+              candidate_id: "candidate-pilot-001",
+              run_id: "run-pilot-denied-001"
+            }
+          }),
+          method: "POST"
+        })
+      );
+    });
+  });
+
+  it("submits a revised preview attempt from request-backed failure history", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        const payload = pilotWorkflowPayload();
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              ...payload,
+              history: [
+                {
+                  auditEvents: [],
+                  executedEvidence: [],
+                  itemType: "request",
+                  label: "Pilot unavailable preview",
+                  lifecycleState: "preview_unavailable",
+                  occurredAt: "2026-04-21T14:42:00Z",
+                  recordId: "request-pilot-unavailable-001",
+                  retrievedCitations: [],
+                  sourceId: "demo-business-postgres",
+                  sourceLabel: "Demo business PostgreSQL / approved_vendor_spend"
+                },
+                ...payload.history
+              ]
+            })
+        });
+      }
+
+      if (url.endsWith("/requests/preview")) {
+        return new Promise(() => {});
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "request",
+          history_record_id: "request-pilot-unavailable-001",
+          question: "Pilot unavailable preview",
+          source_id: "demo-business-postgres",
+          state: "review_denied"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Pilot unavailable preview with revised source context" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/requests/preview",
+        expect.objectContaining({
+          body: JSON.stringify({
+            question: "Pilot unavailable preview with revised source context",
+            source_id: "demo-business-postgres",
+            revise_from: {
+              item_type: "request",
+              request_id: "request-pilot-unavailable-001"
+            }
+          }),
+          method: "POST"
+        })
+      );
+    });
+  });
 });

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -294,4 +294,94 @@ describe("pilot safety UI smoke", () => {
     expect(screen.queryByText(/execution completed/i)).not.toBeInTheDocument();
     expect(within(screen.getByLabelText(/operator history/i)).getByText("Pilot completed run")).toBeInTheDocument();
   });
+
+  it("submits a revised preview attempt with prior run context", async () => {
+    const csrfToken = document.createElement("meta");
+    csrfToken.name = "safequery-csrf-token";
+    csrfToken.content = "csrf-from-session-bootstrap";
+    document.head.appendChild(csrfToken);
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(pilotWorkflowPayload())
+        });
+      }
+
+      if (url.endsWith("/requests/preview")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [],
+                source_id: "demo-business-postgres",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-revised-001",
+                candidate_sql: null,
+                guard_status: "pending",
+                source_id: "demo-business-postgres",
+                state: "preview_ready"
+              },
+              request: {
+                question: "Pilot source preview with revised filter",
+                request_id: "request-revised-001",
+                revision_context: {
+                  run_id: "run-pilot-001",
+                  source_id: "demo-business-postgres"
+                },
+                source_id: "demo-business-postgres",
+                state: "submitted"
+              }
+            })
+        });
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "run",
+          history_record_id: "run-pilot-001",
+          question: "Pilot source preview",
+          source_id: "demo-business-postgres",
+          state: "completed"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+    expect(screen.getByText(/revised attempt draft/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Pilot source preview with revised filter" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/requests/preview",
+        expect.objectContaining({
+          body: JSON.stringify({
+            question: "Pilot source preview with revised filter",
+            source_id: "demo-business-postgres",
+            revise_from: {
+              item_type: "run",
+              request_id: "request-pilot-001",
+              candidate_id: "candidate-pilot-001",
+              run_id: "run-pilot-001"
+            }
+          }),
+          method: "POST"
+        })
+      );
+    });
+  });
 });

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -944,6 +944,7 @@ function historyItemToState(item: OperatorHistoryItem): CanonicalWorkflowState {
       lifecycleState === "blocked" ||
       lifecycleState === "preview_denied" ||
       lifecycleState === "preview_generation_failed" ||
+      lifecycleState === "preview_malformed" ||
       lifecycleState === "preview_unavailable" ||
       lifecycleState === "invalidated" ||
       guardStatus === "blocked" ||
@@ -1160,6 +1161,7 @@ function isRevisableRequestLifecycleState(lifecycleState: string): boolean {
     normalizedLifecycleState === "blocked" ||
     normalizedLifecycleState === "preview_denied" ||
     normalizedLifecycleState === "preview_generation_failed" ||
+    normalizedLifecycleState === "preview_malformed" ||
     normalizedLifecycleState === "preview_unavailable"
   );
 }

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -149,6 +149,7 @@ type PreviewSubmissionResult = {
   guardStatus: string;
   requestId: string;
   requestState: string;
+  revisionContext: RevisionDraftContext | null;
   sourceId: string;
 };
 
@@ -710,7 +711,36 @@ function parsePreviewSubmissionResult(
     guardStatus,
     requestId,
     requestState,
+    revisionContext:
+      parsePreviewRevisionContext(value.request.revision_context, expectedSourceId) ??
+      parsePreviewRevisionContext(value.candidate.revision_context, expectedSourceId),
     sourceId: expectedSourceId
+  };
+}
+
+function parsePreviewRevisionContext(
+  value: unknown,
+  expectedSourceId: string
+): RevisionDraftContext | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const itemType = value.item_type;
+  const sourceId = readOptionalString(value.source_id);
+  if (
+    (itemType !== "request" && itemType !== "candidate" && itemType !== "run") ||
+    sourceId !== expectedSourceId
+  ) {
+    return null;
+  }
+
+  return {
+    candidateId: readOptionalString(value.candidate_id) ?? undefined,
+    itemType,
+    requestId: readOptionalString(value.request_id) ?? undefined,
+    runId: readOptionalString(value.run_id) ?? undefined,
+    sourceId
   };
 }
 
@@ -912,6 +942,9 @@ function historyItemToState(item: OperatorHistoryItem): CanonicalWorkflowState {
     if (
       lifecycleState === "review_denied" ||
       lifecycleState === "blocked" ||
+      lifecycleState === "preview_denied" ||
+      lifecycleState === "preview_generation_failed" ||
+      lifecycleState === "preview_unavailable" ||
       lifecycleState === "invalidated" ||
       guardStatus === "blocked" ||
       guardStatus === "invalidated"
@@ -1073,6 +1106,7 @@ function revisionDraftFromSelectedContext(
   state: CanonicalWorkflowState,
   candidatePreview: AuthoritativeCandidatePreview | null,
   runContext: AuthoritativeRunContext | null,
+  selectedHistoryItem?: OperatorHistoryItem,
   sourceId?: string
 ): RevisionDraftContext | null {
   if (state === "review_denied" && candidatePreview) {
@@ -1087,7 +1121,10 @@ function revisionDraftFromSelectedContext(
   if (
     runContext &&
     sourceId &&
-    (state === "completed" || state === "empty" || state === "failed")
+    (state === "completed" ||
+      state === "empty" ||
+      state === "failed" ||
+      state === "execution_denied")
   ) {
     const auditEvent = runContext.auditEvents.find(
       (event) => event.eventId === runContext.runIdentity
@@ -1101,7 +1138,30 @@ function revisionDraftFromSelectedContext(
     };
   }
 
+  if (
+    state === "review_denied" &&
+    selectedHistoryItem?.itemType === "request" &&
+    selectedHistoryItem.sourceId === sourceId &&
+    isRevisableRequestLifecycleState(selectedHistoryItem.lifecycleState)
+  ) {
+    return {
+      itemType: "request",
+      requestId: selectedHistoryItem.recordId,
+      sourceId: selectedHistoryItem.sourceId
+    };
+  }
+
   return null;
+}
+
+function isRevisableRequestLifecycleState(lifecycleState: string): boolean {
+  const normalizedLifecycleState = lifecycleState.toLowerCase();
+  return (
+    normalizedLifecycleState === "blocked" ||
+    normalizedLifecycleState === "preview_denied" ||
+    normalizedLifecycleState === "preview_generation_failed" ||
+    normalizedLifecycleState === "preview_unavailable"
+  );
 }
 
 function revisionDraftFromHistoryContext(
@@ -1728,6 +1788,11 @@ function renderStatePanel(
           run-backed outcome that was rejected after preview.
         </p>
         <div className="action-row">
+          {onStartRevision ? (
+            <button className="ghost-button" onClick={onStartRevision} type="button">
+              Revise attempt
+            </button>
+          ) : null}
           <a className="action-link" href={buildStateHref("preview", question, sourceId)}>
             Back to SQL preview
           </a>
@@ -1892,15 +1957,18 @@ export function QueryWorkflowShell({
     normalizedState,
     operatorWorkflow
   );
+  const selectedHistoryItem = historyRecordId
+    ? operatorWorkflow.history.find((item) => item.recordId === historyRecordId)
+    : undefined;
   const selectedRevisionDraft = revisionDraftFromSelectedContext(
     normalizedState,
     candidatePreview,
     historyRunContext,
+    selectedHistoryItem,
     submittedSourceId
   );
-  const selectedHistoryItem = historyRecordId
-    ? operatorWorkflow.history.find((item) => item.recordId === historyRecordId)
-    : undefined;
+  const selectedRevisionContext =
+    revisionDraftFromHistoryContext(selectedHistoryItem?.revisionContext) ?? revisionDraft;
 
   function startRevision() {
     const nextRevisionDraft = selectedRevisionDraft;
@@ -2008,7 +2076,7 @@ export function QueryWorkflowShell({
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
         setSubmittedState("review_denied");
-        setRevisionDraft(null);
+        setRevisionDraft(result.revisionContext ?? revisionDraft);
         setSubmittedCandidatePreview({
           auditEvents: [],
           candidateId: result.candidateId,
@@ -2033,6 +2101,7 @@ export function QueryWorkflowShell({
       if (isPendingPreviewState(result) && !isReadyPreviewState(result)) {
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
+        setRevisionDraft(result.revisionContext ?? revisionDraft);
         setSubmittedCandidatePreview({
           auditEvents: [],
           candidateId: result.candidateId,
@@ -2066,7 +2135,7 @@ export function QueryWorkflowShell({
       setSubmittedQuestion(submittedQuestionText);
       setSubmittedSourceId(result.sourceId);
       setSubmittedState("preview");
-      setRevisionDraft(null);
+      setRevisionDraft(result.revisionContext ?? revisionDraft);
       setSubmittedCandidatePreview({
         auditEvents: [],
         candidateId: result.candidateId,
@@ -2586,13 +2655,13 @@ export function QueryWorkflowShell({
                 </span>
                 <strong>{workflowContext.candidateIdentity ?? "Draft only"}</strong>
               </div>
-              {selectedHistoryItem?.revisionContext ? (
+              {selectedRevisionContext ? (
                 <div className="guard-item">
                   <span className="meta-label">Revised from</span>
                   <strong>
-                    {selectedHistoryItem.revisionContext.runId ??
-                      selectedHistoryItem.revisionContext.candidateId ??
-                      selectedHistoryItem.revisionContext.requestId}
+                    {selectedRevisionContext.runId ??
+                      selectedRevisionContext.candidateId ??
+                      selectedRevisionContext.requestId}
                   </strong>
                 </div>
               ) : null}

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -8,6 +8,7 @@ import type {
   OperatorWorkflowAuditEvent,
   OperatorWorkflowExecutedEvidence,
   OperatorHistoryItem,
+  OperatorWorkflowRevisionContext,
   OperatorWorkflowRetrievedCitation,
   OperatorWorkflowSnapshot,
   SourceOption
@@ -72,6 +73,14 @@ type ResolvedSourceBinding = {
 type WorkflowHrefContext = {
   historyItemType?: OperatorHistoryItem["itemType"];
   historyRecordId?: string;
+};
+
+type RevisionDraftContext = {
+  candidateId?: string;
+  itemType: "request" | "candidate" | "run";
+  requestId?: string;
+  runId?: string;
+  sourceId: string;
 };
 
 type FirstRunGuidance = {
@@ -1060,6 +1069,91 @@ function findAuthoritativeRunContext(
   };
 }
 
+function revisionDraftFromSelectedContext(
+  state: CanonicalWorkflowState,
+  candidatePreview: AuthoritativeCandidatePreview | null,
+  runContext: AuthoritativeRunContext | null,
+  sourceId?: string
+): RevisionDraftContext | null {
+  if (state === "review_denied" && candidatePreview) {
+    return {
+      candidateId: candidatePreview.candidateId,
+      itemType: "candidate",
+      requestId: candidatePreview.requestId,
+      sourceId: candidatePreview.sourceId
+    };
+  }
+
+  if (
+    runContext &&
+    sourceId &&
+    (state === "completed" || state === "empty" || state === "failed")
+  ) {
+    const auditEvent = runContext.auditEvents.find(
+      (event) => event.eventId === runContext.runIdentity
+    );
+    return {
+      candidateId: auditEvent?.candidateId ?? undefined,
+      itemType: "run",
+      requestId: auditEvent?.requestId,
+      runId: runContext.runIdentity,
+      sourceId
+    };
+  }
+
+  return null;
+}
+
+function revisionDraftFromHistoryContext(
+  revisionContext?: OperatorWorkflowRevisionContext | null
+): RevisionDraftContext | null {
+  if (!revisionContext) {
+    return null;
+  }
+
+  if (revisionContext.runId) {
+    return {
+      candidateId: revisionContext.candidateId ?? undefined,
+      itemType: "run",
+      requestId: revisionContext.requestId ?? undefined,
+      runId: revisionContext.runId,
+      sourceId: revisionContext.sourceId
+    };
+  }
+
+  if (revisionContext.candidateId) {
+    return {
+      candidateId: revisionContext.candidateId,
+      itemType: "candidate",
+      requestId: revisionContext.requestId ?? undefined,
+      sourceId: revisionContext.sourceId
+    };
+  }
+
+  if (revisionContext.requestId) {
+    return {
+      itemType: "request",
+      requestId: revisionContext.requestId,
+      sourceId: revisionContext.sourceId
+    };
+  }
+
+  return null;
+}
+
+function serializeRevisionDraft(revision: RevisionDraftContext | null) {
+  if (!revision) {
+    return undefined;
+  }
+
+  return {
+    item_type: revision.itemType,
+    request_id: revision.requestId,
+    candidate_id: revision.candidateId,
+    run_id: revision.runId
+  };
+}
+
 function renderCandidateSqlPreview(preview: AuthoritativeCandidatePreview | null) {
   if (!preview) {
     return (
@@ -1507,7 +1601,8 @@ function renderStatePanel(
   question: string,
   sourceId?: string,
   canOpenCompleted = false,
-  context?: WorkflowHrefContext
+  context?: WorkflowHrefContext,
+  onStartRevision?: () => void
 ) {
   if (state === "signin") {
     return (
@@ -1567,9 +1662,11 @@ function renderStatePanel(
           <a className="action-link" href={buildStateHref("empty", question, sourceId)}>
             Open empty state
           </a>
-          <a className="ghost-link" href={buildStateHref("failed", question, sourceId)}>
-            Open failed state
-          </a>
+          {onStartRevision ? (
+            <button className="ghost-button" onClick={onStartRevision} type="button">
+              Revise attempt
+            </button>
+          ) : null}
         </div>
       </div>
     );
@@ -1585,9 +1682,11 @@ function renderStatePanel(
           denial, auth failure, or transport issues.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("query", question, sourceId)}>
-            Revise question
-          </a>
+          {onStartRevision ? (
+            <button className="action-button" onClick={onStartRevision} type="button">
+              Revise attempt
+            </button>
+          ) : null}
           <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
             Back to SQL preview
           </a>
@@ -1606,9 +1705,11 @@ function renderStatePanel(
           sees a blocked candidate, not a synthetic run outcome.
         </p>
         <div className="action-row">
-          <a className="action-link" href={buildStateHref("query", question, sourceId)}>
-            Return to query input
-          </a>
+          {onStartRevision ? (
+            <button className="action-button" onClick={onStartRevision} type="button">
+              Revise attempt
+            </button>
+          ) : null}
           <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
             Back to SQL preview
           </a>
@@ -1630,9 +1731,6 @@ function renderStatePanel(
           <a className="action-link" href={buildStateHref("preview", question, sourceId)}>
             Back to SQL preview
           </a>
-          <a className="ghost-link" href={buildStateHref("query", question, sourceId)}>
-            Revise question
-          </a>
         </div>
       </div>
     );
@@ -1651,9 +1749,11 @@ function renderStatePanel(
           <a className="action-link" href={buildStateHref("completed", question, sourceId)}>
             Open completed state
           </a>
-          <a className="ghost-link" href={buildStateHref("query", question, sourceId)}>
-            Revise question
-          </a>
+          {onStartRevision ? (
+            <button className="ghost-button" onClick={onStartRevision} type="button">
+              Revise attempt
+            </button>
+          ) : null}
         </div>
       </div>
     );
@@ -1716,6 +1816,7 @@ export function QueryWorkflowShell({
   const [submittedQuestion, setSubmittedQuestion] = useState(question);
   const [submittedSourceId, setSubmittedSourceId] = useState(sourceId);
   const [submittedState, setSubmittedState] = useState(requestedState);
+  const [revisionDraft, setRevisionDraft] = useState<RevisionDraftContext | null>(null);
 
   useEffect(() => {
     setSubmittedQuestion(question);
@@ -1725,6 +1826,7 @@ export function QueryWorkflowShell({
     setExecuteSubmission({ status: "idle" });
     setSubmittedCandidatePreview(null);
     setSubmittedRunContext(null);
+    setRevisionDraft(null);
   }, [question, requestedState, sourceId]);
 
   const sourceBinding = resolveSourceBinding(
@@ -1790,6 +1892,28 @@ export function QueryWorkflowShell({
     normalizedState,
     operatorWorkflow
   );
+  const selectedRevisionDraft = revisionDraftFromSelectedContext(
+    normalizedState,
+    candidatePreview,
+    historyRunContext,
+    submittedSourceId
+  );
+  const selectedHistoryItem = historyRecordId
+    ? operatorWorkflow.history.find((item) => item.recordId === historyRecordId)
+    : undefined;
+
+  function startRevision() {
+    const nextRevisionDraft = selectedRevisionDraft;
+    if (!nextRevisionDraft) {
+      return;
+    }
+    setRevisionDraft(nextRevisionDraft);
+    setSubmittedQuestion(submittedQuestion);
+    setSubmittedSourceId(submittedSourceId ?? nextRevisionDraft.sourceId);
+    setSubmittedState("query");
+    setPreviewSubmission({ status: "idle" });
+    setExecuteSubmission({ status: "idle" });
+  }
 
   async function submitPreview(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -1845,7 +1969,8 @@ export function QueryWorkflowShell({
       const response = await fetch(`${apiUrl}/requests/preview`, {
         body: JSON.stringify({
           question: submittedQuestionText,
-          source_id: selectedSourceId
+          source_id: selectedSourceId,
+          revise_from: serializeRevisionDraft(revisionDraft)
         }),
         credentials: "same-origin",
         headers,
@@ -1883,6 +2008,7 @@ export function QueryWorkflowShell({
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
         setSubmittedState("review_denied");
+        setRevisionDraft(null);
         setSubmittedCandidatePreview({
           auditEvents: [],
           candidateId: result.candidateId,
@@ -1940,6 +2066,7 @@ export function QueryWorkflowShell({
       setSubmittedQuestion(submittedQuestionText);
       setSubmittedSourceId(result.sourceId);
       setSubmittedState("preview");
+      setRevisionDraft(null);
       setSubmittedCandidatePreview({
         auditEvents: [],
         candidateId: result.candidateId,
@@ -2192,7 +2319,8 @@ export function QueryWorkflowShell({
               question,
               candidateSourceId,
               canOpenCompletedFromPreview,
-              historyHrefContext
+              historyHrefContext,
+              selectedRevisionDraft ? startRevision : undefined
             )}
           </section>
 
@@ -2210,6 +2338,15 @@ export function QueryWorkflowShell({
             <form className="query-form" onSubmit={submitPreview}>
               {sourceSelectVisible ? (
                 <>
+                  {revisionDraft ? (
+                    <div className="state-callout state-callout-warning">
+                      <p className="state-callout-title">Revised attempt draft</p>
+                      <p>
+                        New preview will keep prior context from {revisionDraft.itemType}{" "}
+                        {revisionDraft.runId ?? revisionDraft.candidateId ?? revisionDraft.requestId}.
+                      </p>
+                    </div>
+                  ) : null}
                   <label className="field-label" htmlFor="source_id">
                     Source
                   </label>
@@ -2449,6 +2586,16 @@ export function QueryWorkflowShell({
                 </span>
                 <strong>{workflowContext.candidateIdentity ?? "Draft only"}</strong>
               </div>
+              {selectedHistoryItem?.revisionContext ? (
+                <div className="guard-item">
+                  <span className="meta-label">Revised from</span>
+                  <strong>
+                    {selectedHistoryItem.revisionContext.runId ??
+                      selectedHistoryItem.revisionContext.candidateId ??
+                      selectedHistoryItem.revisionContext.requestId}
+                  </strong>
+                </div>
+              ) : null}
               <div className="guard-item">
                 <span className="meta-label">
                   {workflowContext.candidateState ? "Candidate state" : "Lifecycle state"}

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -57,6 +57,13 @@ export type OperatorWorkflowRetrievedCitation = {
   sourceFlavor: string | null;
 };
 
+export type OperatorWorkflowRevisionContext = {
+  candidateId?: string | null;
+  requestId?: string | null;
+  runId?: string | null;
+  sourceId: string;
+};
+
 export type OperatorHistoryItem = {
   auditEvents: OperatorWorkflowAuditEvent[];
   candidateSql?: string | null;
@@ -75,6 +82,7 @@ export type OperatorHistoryItem = {
   sourceId: string;
   sourceLabel: string;
   retrievedCitations: OperatorWorkflowRetrievedCitation[];
+  revisionContext?: OperatorWorkflowRevisionContext | null;
 };
 
 export type OperatorWorkflowSnapshot = {
@@ -243,6 +251,27 @@ function parseRetrievedCitation(value: unknown): OperatorWorkflowRetrievedCitati
   };
 }
 
+function parseRevisionContext(value: unknown): OperatorWorkflowRevisionContext | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const sourceId = readOptionalString(value.sourceId);
+  if (!sourceId) {
+    return null;
+  }
+
+  return {
+    candidateId: readOptionalString(value.candidateId) ?? null,
+    requestId: readOptionalString(value.requestId) ?? null,
+    runId: readOptionalString(value.runId) ?? null,
+    sourceId
+  };
+}
+
 function parseGovernanceBindingStatus(value: unknown): GovernanceBindingStatus | null {
   if (!isObject(value)) {
     return null;
@@ -317,6 +346,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   const auditEvents = parseArray(value.auditEvents, parseAuditEvent);
   const executedEvidence = parseArray(value.executedEvidence, parseExecutedEvidence);
   const retrievedCitations = parseArray(value.retrievedCitations, parseRetrievedCitation);
+  const revisionContext = parseRevisionContext(value.revisionContext);
 
   if (
     (itemType !== "request" && itemType !== "candidate" && itemType !== "run") ||
@@ -351,7 +381,8 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     runState: readOptionalString(value.runState) ?? null,
     sourceId,
     sourceLabel,
-    retrievedCitations
+    retrievedCitations,
+    revisionContext
   };
 }
 


### PR DESCRIPTION
## Summary
- add validated revise_from context for request, candidate, and run anchored preview attempts
- persist revision lineage on preview requests and candidates and surface it in operator workflow history
- add UI revise draft flow that submits a new preview attempt without treating prior output as authority

## Verification
- cd backend && python3 -m pytest tests/test_preview_persistence.py tests/test_operator_workflow_history.py -q
- cd frontend && npm test -- --run app/pilot-safety-smoke.test.tsx
- cd frontend && npm test

Closes #379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submit revised preview attempts with persisted lineage to their original request/candidate/run/source; DB schema updated to store revision context.
  * Revision context surfaced in operator workflow history and UI (shows "Revised from", preserves revision drafts, and enables "Revise attempt" flow).

* **Tests**
  * New unit, integration, and smoke tests covering revise flows, persistence rules, contract validation, and history serialization.

* **Style**
  * Ghost button styling aligned with ghost links for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->