### PR TITLE
Add candidate attempt history comparison

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -8,7 +8,12 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.models.dataset_contract import DatasetContract
-from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
+from app.db.models.preview import (
+    PreviewAuditEvent,
+    PreviewCandidate,
+    PreviewCandidateApproval,
+    PreviewRequest,
+)
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource
 from app.features.auth.governance_bindings import normalize_governance_binding
@@ -92,6 +97,30 @@ class OperatorWorkflowHistoryItem(BaseModel):
         default=None,
         serialization_alias="revisionContext",
     )
+    candidate_attempts: list["OperatorWorkflowCandidateAttemptSummary"] = Field(
+        default_factory=list,
+        serialization_alias="candidateAttempts",
+    )
+
+
+class OperatorWorkflowCandidateAttemptSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_id: str = Field(serialization_alias="candidateId")
+    request_id: str = Field(serialization_alias="requestId")
+    source_id: str = Field(serialization_alias="sourceId")
+    source_family: str = Field(serialization_alias="sourceFamily")
+    source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+    candidate_state: str = Field(serialization_alias="candidateState")
+    guard_status: str = Field(serialization_alias="guardStatus")
+    guard_decision: Optional[str] = Field(default=None, serialization_alias="guardDecision")
+    primary_deny_code: Optional[str] = Field(default=None, serialization_alias="primaryDenyCode")
+    denial_reason: Optional[str] = Field(default=None, serialization_alias="denialReason")
+    occurred_at: datetime = Field(serialization_alias="occurredAt")
+    dataset_contract_version: int = Field(serialization_alias="datasetContractVersion")
+    schema_snapshot_version: int = Field(serialization_alias="schemaSnapshotVersion")
+    approved: bool
+    executed: bool
 
 
 class OperatorWorkflowRevisionContext(BaseModel):
@@ -539,6 +568,103 @@ def _terminal_run_events(
     return terminal_events
 
 
+def _candidate_attempts_by_candidate_id(
+    *,
+    candidates: list[PreviewCandidate],
+    candidate_events: dict[str, PreviewAuditEvent],
+    audit_events: list[PreviewAuditEvent],
+    approvals: list[PreviewCandidateApproval],
+) -> dict[str, list[OperatorWorkflowCandidateAttemptSummary]]:
+    candidate_ids = {candidate.candidate_id for candidate in candidates}
+    parents: dict[str, str] = {candidate_id: candidate_id for candidate_id in candidate_ids}
+    candidates_by_request_id = {candidate.request_id: candidate for candidate in candidates}
+
+    def find(candidate_id: str) -> str:
+        parent = parents[candidate_id]
+        if parent != candidate_id:
+            parents[candidate_id] = find(parent)
+        return parents[candidate_id]
+
+    def union(left: str, right: str) -> None:
+        if left not in parents or right not in parents:
+            return
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parents[right_root] = left_root
+
+    for candidate in candidates:
+        if candidate.revised_from_candidate_id:
+            union(candidate.candidate_id, candidate.revised_from_candidate_id)
+        if candidate.revised_from_request_id:
+            revised_from_candidate = candidates_by_request_id.get(
+                candidate.revised_from_request_id
+            )
+            if revised_from_candidate is not None:
+                union(candidate.candidate_id, revised_from_candidate.candidate_id)
+
+    approved_candidate_ids = {
+        approval.candidate_id
+        for approval in approvals
+        if approval.approval_state in {"approved", "executed"}
+        and approval.invalidated_at is None
+    }
+    executed_candidate_ids = {
+        event.candidate_id
+        for event in audit_events
+        if event.candidate_id is not None and event.event_type == "execution_completed"
+    }
+    attempts_by_root: dict[str, list[OperatorWorkflowCandidateAttemptSummary]] = {}
+    for candidate in candidates:
+        candidate_event = candidate_events.get(candidate.candidate_id)
+        attempts_by_root.setdefault(find(candidate.candidate_id), []).append(
+            OperatorWorkflowCandidateAttemptSummary(
+                candidate_id=candidate.candidate_id,
+                request_id=candidate.request_id,
+                source_id=candidate.source_id,
+                source_family=candidate.source_family,
+                source_flavor=candidate.source_flavor,
+                candidate_state=candidate.candidate_state,
+                guard_status=candidate.guard_status,
+                guard_decision=(
+                    _read_text(candidate_event.audit_payload.get("guard_decision"))
+                    if candidate_event
+                    else None
+                ),
+                primary_deny_code=(
+                    candidate_event.primary_deny_code if candidate_event else None
+                ),
+                denial_reason=(
+                    _read_text(candidate_event.audit_payload.get("denial_reason"))
+                    if candidate_event
+                    else None
+                ),
+                occurred_at=_history_occurred_at(
+                    candidate_event,
+                    candidate.updated_at or candidate.created_at,
+                ),
+                dataset_contract_version=candidate.dataset_contract_version,
+                schema_snapshot_version=candidate.schema_snapshot_version,
+                approved=candidate.candidate_id in approved_candidate_ids,
+                executed=candidate.candidate_id in executed_candidate_ids,
+            )
+        )
+
+    attempts_by_candidate_id: dict[str, list[OperatorWorkflowCandidateAttemptSummary]] = {}
+    for attempts in attempts_by_root.values():
+        if len(attempts) < 2:
+            continue
+        ordered_attempts = sorted(
+            attempts,
+            key=lambda attempt: (attempt.occurred_at, attempt.candidate_id),
+            reverse=True,
+        )
+        for attempt in ordered_attempts:
+            attempts_by_candidate_id[attempt.candidate_id] = ordered_attempts
+
+    return attempts_by_candidate_id
+
+
 def _history_occurred_at(
     event: PreviewAuditEvent | None,
     fallback: datetime,
@@ -572,6 +698,7 @@ def _build_operator_history(
 ) -> list[OperatorWorkflowHistoryItem]:
     requests = session.execute(select(PreviewRequest)).scalars().all()
     candidates = session.execute(select(PreviewCandidate)).scalars().all()
+    approvals = session.execute(select(PreviewCandidateApproval)).scalars().all()
     audit_events = (
         session.execute(
             select(PreviewAuditEvent).order_by(
@@ -588,6 +715,17 @@ def _build_operator_history(
     request_labels = _request_labels_by_id(requests)
     request_events = _latest_request_events(audit_events)
     candidate_events = _latest_candidate_events(audit_events)
+    candidate_attempts = _candidate_attempts_by_candidate_id(
+        candidates=candidates,
+        candidate_events=candidate_events,
+        audit_events=audit_events,
+        approvals=approvals,
+    )
+    request_candidate_attempts = {
+        candidate.request_id: candidate_attempts[candidate.candidate_id]
+        for candidate in candidates
+        if candidate.candidate_id in candidate_attempts
+    }
 
     history: list[OperatorWorkflowHistoryItem] = []
     for event, run_state in _terminal_run_events(audit_events):
@@ -608,6 +746,11 @@ def _build_operator_history(
                 audit_events=[_audit_event_summary(event)],
                 executed_evidence=_executed_evidence_for_event(event),
                 retrieved_citations=_retrieved_citations_for_event(event),
+                candidate_attempts=(
+                    candidate_attempts.get(event.candidate_id, [])
+                    if event.candidate_id is not None
+                    else []
+                ),
             )
         )
 
@@ -646,6 +789,7 @@ def _build_operator_history(
                     run_id=candidate.revised_from_run_id,
                     source_id=candidate.revised_from_source_id,
                 ),
+                candidate_attempts=candidate_attempts.get(candidate.candidate_id, []),
             )
         )
 
@@ -678,6 +822,7 @@ def _build_operator_history(
                     run_id=request.revised_from_run_id,
                     source_id=request.revised_from_source_id,
                 ),
+                candidate_attempts=request_candidate_attempts.get(request.request_id, []),
             )
         )
 

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
 from app.db.models.dataset_contract import DatasetContract
-from app.db.models.preview import PreviewAuditEvent
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewCandidateApproval
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.context import AuthenticatedSubject
@@ -198,6 +198,9 @@ def _audit_event(
     event_type: str,
     request_id: str = "preview-request-234",
     candidate_id: str | None = None,
+    primary_deny_code: str | None = None,
+    candidate_state: str | None = None,
+    audit_payload: dict[str, object] | None = None,
 ) -> PreviewAuditEvent:
     return PreviewAuditEvent(
         event_id=event_id,
@@ -214,7 +217,9 @@ def _audit_event(
         source_id="sap-approved-spend",
         source_family="postgresql",
         source_flavor="warehouse",
-        audit_payload={"event_type": event_type},
+        primary_deny_code=primary_deny_code,
+        candidate_state=candidate_state,
+        audit_payload=audit_payload or {"event_type": event_type},
     )
 
 
@@ -410,6 +415,170 @@ def test_operator_workflow_history_marks_revised_attempt_context() -> None:
         "candidateId": "preview-candidate-original",
         "sourceId": "sap-approved-spend",
     }
+
+
+def test_operator_workflow_history_compares_candidate_attempt_guard_outcomes() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            subject,
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-original",
+                candidate_id="preview-candidate-original",
+            ),
+        )
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by yearly spend",
+                source_id="sap-approved-spend",
+                revise_from={
+                    "item_type": "candidate",
+                    "request_id": "preview-request-original",
+                    "candidate_id": "preview-candidate-original",
+                },
+            ),
+            subject,
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-revised",
+                candidate_id="preview-candidate-revised",
+            ),
+        )
+
+        original = session.execute(
+            select(PreviewCandidate).where(
+                PreviewCandidate.candidate_id == "preview-candidate-original"
+            )
+        ).scalar_one()
+        revised = session.execute(
+            select(PreviewCandidate).where(
+                PreviewCandidate.candidate_id == "preview-candidate-revised"
+            )
+        ).scalar_one()
+        original.candidate_state = "blocked"
+        original.guard_status = "blocked"
+        revised.candidate_state = "approved_for_execution"
+        revised.guard_status = "allow"
+        session.add_all(
+            [
+                _audit_event(
+                    event_id=UUID("00000000-0000-4000-8000-000000000021"),
+                    lifecycle_order=9,
+                    event_type="guard_evaluated",
+                    request_id="preview-request-original",
+                    candidate_id="preview-candidate-original",
+                    primary_deny_code="DENY_WRITE_OPERATION",
+                    candidate_state="blocked",
+                    audit_payload={
+                        "event_type": "guard_evaluated",
+                        "guard_decision": "reject",
+                        "denial_reason": "SQL guard rejected a write operation.",
+                    },
+                ),
+                _audit_event(
+                    event_id=UUID("00000000-0000-4000-8000-000000000022"),
+                    lifecycle_order=9,
+                    event_type="guard_evaluated",
+                    request_id="preview-request-revised",
+                    candidate_id="preview-candidate-revised",
+                    candidate_state="approved_for_execution",
+                    audit_payload={
+                        "event_type": "guard_evaluated",
+                        "guard_decision": "allow",
+                    },
+                ),
+                _audit_event(
+                    event_id=UUID("00000000-0000-4000-8000-000000000023"),
+                    lifecycle_order=10,
+                    event_type="execution_completed",
+                    request_id="preview-request-revised",
+                    candidate_id="preview-candidate-revised",
+                    candidate_state="approved_for_execution",
+                    audit_payload={
+                        "event_type": "execution_completed",
+                        "execution_row_count": 3,
+                        "result_truncated": False,
+                    },
+                ),
+            ]
+        )
+        approval = session.execute(
+            select(PreviewCandidateApproval).where(
+                PreviewCandidateApproval.candidate_id == revised.candidate_id
+            )
+        ).scalar_one()
+        original_approval = session.execute(
+            select(PreviewCandidateApproval).where(
+                PreviewCandidateApproval.candidate_id == original.candidate_id
+            )
+        ).scalar_one()
+        original_approval.invalidated_at = datetime(
+            2026, 1, 2, 3, 4, 30, tzinfo=timezone.utc
+        )
+        original_approval.approval_state = "invalidated"
+        approval.approved_at = datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc)
+        approval.approval_expires_at = approval.approved_at + timedelta(minutes=10)
+        approval.executed_at = datetime(2026, 1, 2, 3, 6, 0, tzinfo=timezone.utc)
+        approval.approval_state = "executed"
+        session.commit()
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    history = [
+        item.model_dump(mode="json", by_alias=True, exclude_none=True)
+        for item in snapshot.history
+    ]
+    revised_candidate = next(
+        item for item in history if item["recordId"] == "preview-candidate-revised"
+    )
+    assert revised_candidate["candidateAttempts"] == [
+        {
+            "candidateId": "preview-candidate-revised",
+            "requestId": "preview-request-revised",
+            "sourceId": "sap-approved-spend",
+            "sourceFamily": "postgresql",
+            "sourceFlavor": "warehouse",
+            "candidateState": "approved_for_execution",
+            "guardStatus": "allow",
+            "guardDecision": "allow",
+            "occurredAt": "2026-01-02T03:04:05Z",
+            "datasetContractVersion": 1,
+            "schemaSnapshotVersion": 1,
+            "approved": True,
+            "executed": True,
+        },
+        {
+            "candidateId": "preview-candidate-original",
+            "requestId": "preview-request-original",
+            "sourceId": "sap-approved-spend",
+            "sourceFamily": "postgresql",
+            "sourceFlavor": "warehouse",
+            "candidateState": "blocked",
+            "guardStatus": "blocked",
+            "guardDecision": "reject",
+            "primaryDenyCode": "DENY_WRITE_OPERATION",
+            "denialReason": "SQL guard rejected a write operation.",
+            "occurredAt": "2026-01-02T03:04:05Z",
+            "datasetContractVersion": 1,
+            "schemaSnapshotVersion": 1,
+            "approved": False,
+            "executed": False,
+        },
+    ]
+    serialized_attempts = str(revised_candidate["candidateAttempts"]).lower()
+    assert "select" not in serialized_attempts
+    assert "secret" not in serialized_attempts
+    assert "token" not in serialized_attempts
 
 
 def test_operator_workflow_history_includes_execution_run_records() -> None:

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -295,6 +295,7 @@ button:focus-visible {
 .action-row,
 .guard-list,
 .evidence-list,
+.attempt-list,
 .history-list,
 .placeholder-block,
 .first-run-panel {
@@ -456,6 +457,44 @@ button:disabled {
   border: 1px solid var(--border-soft);
   border-radius: 14px;
   background: rgba(7, 11, 20, 0.38);
+}
+
+.attempt-list {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.attempt-item {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: rgba(7, 11, 20, 0.38);
+  color: var(--text-secondary);
+}
+
+.attempt-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.attempt-heading strong {
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.attempt-item-success {
+  border-color: rgba(79, 209, 139, 0.38);
+}
+
+.attempt-item-danger {
+  border-color: rgba(255, 107, 122, 0.38);
+}
+
+.attempt-item-warning {
+  border-color: rgba(240, 193, 91, 0.35);
 }
 
 .evidence-item {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -698,6 +698,98 @@ describe("HomePage", () => {
     );
   });
 
+  it("renders candidate attempt guard comparisons as read-only history evidence", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateAttempts: [
+                      {
+                        approved: true,
+                        candidateId: "candidate-approved",
+                        candidateState: "approved_for_execution",
+                        datasetContractVersion: 1,
+                        executed: true,
+                        guardDecision: "allow",
+                        guardStatus: "allow",
+                        occurredAt: "2026-04-21T14:26:00Z",
+                        requestId: "request-approved",
+                        schemaSnapshotVersion: 1,
+                        sourceFamily: "postgresql",
+                        sourceFlavor: "warehouse",
+                        sourceId: "sap-approved-spend"
+                      },
+                      {
+                        approved: false,
+                        candidateId: "candidate-denied",
+                        candidateState: "blocked",
+                        datasetContractVersion: 1,
+                        denialReason: "SQL guard rejected a write operation.",
+                        executed: false,
+                        guardDecision: "reject",
+                        guardStatus: "blocked",
+                        occurredAt: "2026-04-21T14:20:00Z",
+                        primaryDenyCode: "DENY_WRITE_OPERATION",
+                        requestId: "request-denied",
+                        schemaSnapshotVersion: 1,
+                        sourceFamily: "postgresql",
+                        sourceFlavor: "warehouse",
+                        sourceId: "sap-approved-spend"
+                      }
+                    ],
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "allow",
+                    itemType: "candidate",
+                    label: "Approved revised candidate",
+                    lifecycleState: "approved_for_execution",
+                    occurredAt: "2026-04-21T14:26:00Z",
+                    recordId: "candidate-approved",
+                    requestId: "request-approved",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-approved",
+          question: "Approved revised candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    const comparison = screen.getByLabelText(/candidate attempt guard comparison/i);
+    expect(comparison).toHaveTextContent("candidate-approved");
+    expect(comparison).toHaveTextContent("Executed");
+    expect(comparison).toHaveTextContent("candidate-denied");
+    expect(comparison).toHaveTextContent("DENY_WRITE_OPERATION");
+    expect(comparison).toHaveTextContent("SQL guard rejected a write operation.");
+    expect(comparison).toHaveTextContent("Contract v1; schema v1");
+    expect(screen.getByRole("button", { name: /execute reviewed candidate/i })).toBeDisabled();
+    expect(comparison).not.toHaveTextContent(/select vendor_name/i);
+    expect(comparison).not.toHaveTextContent(/secret|token/i);
+  });
+
   it("keeps reopened history source separate from a mismatched draft source", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -6,6 +6,7 @@ import type { HealthSnapshot } from "../lib/health";
 import type {
   GovernanceBindingStatus,
   OperatorWorkflowAuditEvent,
+  OperatorWorkflowCandidateAttempt,
   OperatorWorkflowExecutedEvidence,
   OperatorHistoryItem,
   OperatorWorkflowRevisionContext,
@@ -547,8 +548,10 @@ function parseExecuteAuditEvent(value: unknown): OperatorWorkflowAuditEvent | nu
   return {
     candidateId: readOptionalString(value.query_candidate_id),
     candidateState: readOptionalString(value.candidate_state),
+    denialReason: readOptionalString(value.denial_reason),
     eventId,
     eventType,
+    guardDecision: readOptionalString(value.guard_decision),
     occurredAt,
     primaryDenyCode: readOptionalString(value.primary_deny_code),
     requestId,
@@ -1658,6 +1661,80 @@ function renderAuditEvidencePanel(
   );
 }
 
+function attemptTone(attempt: OperatorWorkflowCandidateAttempt): "success" | "danger" | "warning" {
+  const candidateState = attempt.candidateState.toLowerCase();
+  const guardStatus = attempt.guardStatus.toLowerCase();
+
+  if (attempt.executed || attempt.approved) {
+    return "success";
+  }
+
+  if (
+    candidateState === "blocked" ||
+    candidateState === "invalidated" ||
+    candidateState === "stale" ||
+    guardStatus === "blocked" ||
+    guardStatus === "invalidated" ||
+    guardStatus === "requires_revalidation"
+  ) {
+    return "danger";
+  }
+
+  return "warning";
+}
+
+function renderCandidateAttemptComparison(attempts: OperatorWorkflowCandidateAttempt[]) {
+  if (attempts.length < 2) {
+    return null;
+  }
+
+  return (
+    <section className="surface surface-secondary">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Candidate attempts</p>
+          <h2 className="panel-title">Guard outcome comparison</h2>
+        </div>
+        <span className="surface-badge surface-badge-code">Read only</span>
+      </div>
+      <div className="attempt-list" aria-label="candidate attempt guard comparison">
+        {attempts.map((attempt) => (
+          <div
+            className={`attempt-item attempt-item-${attemptTone(attempt)}`}
+            key={attempt.candidateId}
+          >
+            <div className="attempt-heading">
+              <strong>{attempt.candidateId}</strong>
+              <span className={`surface-badge surface-badge-${attemptTone(attempt)}`}>
+                {attempt.executed
+                  ? "Executed"
+                  : attempt.approved
+                    ? "Approved"
+                    : attempt.candidateState}
+              </span>
+            </div>
+            <span>Request {attempt.requestId}</span>
+            <span>
+              Guard {attempt.guardStatus}
+              {attempt.guardDecision ? ` / ${attempt.guardDecision}` : ""}
+            </span>
+            {attempt.primaryDenyCode ? <span>Deny code: {attempt.primaryDenyCode}</span> : null}
+            {attempt.denialReason ? <span>Reason: {attempt.denialReason}</span> : null}
+            <span>
+              {attempt.sourceId} / {attempt.sourceFamily}
+              {attempt.sourceFlavor ? ` / ${attempt.sourceFlavor}` : ""}
+            </span>
+            <span>
+              Contract v{attempt.datasetContractVersion}; schema v{attempt.schemaSnapshotVersion}
+            </span>
+            <span>{attempt.occurredAt}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function renderStatePanel(
   state: CanonicalWorkflowState,
   question: string,
@@ -1962,6 +2039,12 @@ export function QueryWorkflowShell({
   const selectedHistoryItem = historyRecordId
     ? operatorWorkflow.history.find((item) => item.recordId === historyRecordId)
     : undefined;
+  const selectedCandidateAttemptHistory =
+    selectedHistoryItem ??
+    (candidatePreview
+      ? operatorWorkflow.history.find((item) => item.recordId === candidatePreview.candidateId)
+      : undefined);
+  const selectedCandidateAttempts = selectedCandidateAttemptHistory?.candidateAttempts ?? [];
   const selectedRevisionDraft = revisionDraftFromSelectedContext(
     normalizedState,
     candidatePreview,
@@ -2732,6 +2815,8 @@ export function QueryWorkflowShell({
             selectedExecutedEvidence,
             selectedRetrievedCitations
           )}
+
+          {renderCandidateAttemptComparison(selectedCandidateAttempts)}
 
           <section className="surface surface-secondary">
             <div className="section-header">

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -23,13 +23,33 @@ export type SourceOption = {
 export type OperatorWorkflowAuditEvent = {
   candidateId: string | null;
   candidateState: string | null;
+  denialReason: string | null;
   eventId: string;
   eventType: string;
+  guardDecision: string | null;
   occurredAt: string;
   primaryDenyCode: string | null;
   requestId: string;
   resultTruncated: boolean | null;
   rowCount: number | null;
+  sourceId: string;
+};
+
+export type OperatorWorkflowCandidateAttempt = {
+  approved: boolean;
+  candidateId: string;
+  candidateState: string;
+  datasetContractVersion: number;
+  denialReason: string | null;
+  executed: boolean;
+  guardDecision: string | null;
+  guardStatus: string;
+  occurredAt: string;
+  primaryDenyCode: string | null;
+  requestId: string;
+  schemaSnapshotVersion: number;
+  sourceFamily: string;
+  sourceFlavor: string | null;
   sourceId: string;
 };
 
@@ -66,6 +86,7 @@ export type OperatorWorkflowRevisionContext = {
 
 export type OperatorHistoryItem = {
   auditEvents: OperatorWorkflowAuditEvent[];
+  candidateAttempts: OperatorWorkflowCandidateAttempt[];
   candidateSql?: string | null;
   executedEvidence: OperatorWorkflowExecutedEvidence[];
   guardStatus?: string | null;
@@ -166,13 +187,65 @@ function parseAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
   return {
     candidateId: readOptionalString(value.candidateId) ?? null,
     candidateState: readOptionalString(value.candidateState) ?? null,
+    denialReason: readOptionalString(value.denialReason) ?? null,
     eventId,
     eventType,
+    guardDecision: readOptionalString(value.guardDecision) ?? null,
     occurredAt,
     primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
     requestId,
     resultTruncated: typeof value.resultTruncated === "boolean" ? value.resultTruncated : null,
     rowCount: readOptionalNonNegativeInteger(value.rowCount) ?? null,
+    sourceId
+  };
+}
+
+function parseCandidateAttempt(value: unknown): OperatorWorkflowCandidateAttempt | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const candidateId = readOptionalString(value.candidateId);
+  const candidateState = readOptionalString(value.candidateState);
+  const datasetContractVersion = readOptionalNonNegativeInteger(value.datasetContractVersion);
+  const guardStatus = readOptionalString(value.guardStatus);
+  const occurredAt = readOptionalString(value.occurredAt);
+  const requestId = readOptionalString(value.requestId);
+  const schemaSnapshotVersion = readOptionalNonNegativeInteger(value.schemaSnapshotVersion);
+  const sourceFamily = readOptionalString(value.sourceFamily);
+  const sourceId = readOptionalString(value.sourceId);
+
+  if (
+    !candidateId ||
+    !candidateState ||
+    datasetContractVersion === undefined ||
+    !guardStatus ||
+    !occurredAt ||
+    !requestId ||
+    schemaSnapshotVersion === undefined ||
+    !sourceFamily ||
+    !sourceId ||
+    typeof value.approved !== "boolean" ||
+    typeof value.executed !== "boolean"
+  ) {
+    return null;
+  }
+
+  return {
+    approved: value.approved,
+    candidateId,
+    candidateState,
+    datasetContractVersion,
+    denialReason: readOptionalString(value.denialReason) ?? null,
+    executed: value.executed,
+    guardDecision: readOptionalString(value.guardDecision) ?? null,
+    guardStatus,
+    occurredAt,
+    primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
+    requestId,
+    schemaSnapshotVersion,
+    sourceFamily,
+    sourceFlavor: readOptionalString(value.sourceFlavor) ?? null,
     sourceId
   };
 }
@@ -344,6 +417,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   const lifecycleState = readOptionalString(value.lifecycleState);
   const occurredAt = readOptionalString(value.occurredAt);
   const auditEvents = parseArray(value.auditEvents, parseAuditEvent);
+  const candidateAttempts = parseArray(value.candidateAttempts, parseCandidateAttempt);
   const executedEvidence = parseArray(value.executedEvidence, parseExecutedEvidence);
   const retrievedCitations = parseArray(value.retrievedCitations, parseRetrievedCitation);
   const revisionContext = parseRevisionContext(value.revisionContext);
@@ -357,6 +431,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     !lifecycleState ||
     !occurredAt ||
     auditEvents === null ||
+    candidateAttempts === null ||
     executedEvidence === null ||
     retrievedCitations === null
   ) {
@@ -365,6 +440,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
 
   return {
     auditEvents,
+    candidateAttempts,
     candidateSql: readOptionalString(value.candidateSql) ?? null,
     executedEvidence,
     guardStatus: readOptionalString(value.guardStatus) ?? null,


### PR DESCRIPTION
## Summary
- add persisted operator history candidateAttempts for revised candidate attempt comparison
- include guard outcome, deny code/reason, source metadata, and approved/executed state without SQL/result rows
- render the comparison as read-only frontend evidence while preserving existing execute eligibility checks

## Verification
- cd backend && python3 -m pytest tests/test_operator_workflow_history.py tests/test_operator_history_payloads.py -q
- cd frontend && npm test -- --run
- cd frontend && npx tsc --noEmit

Closes #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator workflows now display a history of candidate attempts with approval/execution status and guard decision details (including denial reasons where applicable).
  * Candidate attempt comparisons are presented in a read-only format for workflow review and audit purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->