### PR TITLE
Improve bounded result inspection UX

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1263,6 +1263,8 @@ describe("HomePage", () => {
     expect(resultsSection).not.toBeNull();
     const results = within(resultsSection!);
     expect(results.getByRole("table", { name: /execute response result rows/i })).toBeInTheDocument();
+    expect(results.getByText(/2 rows reported for this selected run/i)).toBeInTheDocument();
+    expect(results.getByText(/showing bounded result rows attached to this selected run only/i)).toBeInTheDocument();
     expect(results.getByText("vendor_name")).toBeInTheDocument();
     expect(results.getByText("total_spend")).toBeInTheDocument();
     expect(results.getByText("Acme Supplies")).toBeInTheDocument();
@@ -1280,6 +1282,114 @@ describe("HomePage", () => {
     expect(screen.queryByText(/row-token-should-not-render/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/session-secret-should-not-render/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/token-secret-should-not-render/i)).not.toBeInTheDocument();
+  });
+
+  it("renders truncated execute responses as bounded previews without requiring unbounded rows", async () => {
+    const csrfToken = document.createElement("meta");
+    csrfToken.name = "safequery-csrf-token";
+    csrfToken.content = "csrf-from-session-bootstrap";
+    document.head.appendChild(csrfToken);
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              history: [
+                {
+                  candidateSql: "select vendor_name, total_spend from approved_vendor_spend;",
+                  guardStatus: "passed",
+                  itemType: "candidate",
+                  label: "Selected candidate",
+                  lifecycleState: "preview_ready",
+                  occurredAt: "2026-04-21T14:24:00Z",
+                  recordId: "candidate-selected",
+                  requestId: "request-selected",
+                  sourceId: "sap-approved-spend",
+                  sourceLabel: "SAP spend cube / approved_vendor_spend"
+                }
+              ],
+              sources: workflowPayload().sources
+            })
+        });
+      }
+
+      if (url.endsWith("/candidates/candidate-selected/execute")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [
+                  {
+                    candidate_state: "executed",
+                    event_id: "00000000-0000-4000-8000-000000000300",
+                    event_type: "execution_completed",
+                    execution_row_count: 25,
+                    occurred_at: "2026-04-21T14:44:17+09:00",
+                    query_candidate_id: "candidate-selected",
+                    request_id: "request-selected",
+                    result_truncated: true,
+                    source_id: "sap-approved-spend"
+                  }
+                ]
+              },
+              candidate_id: "candidate-selected",
+              connector_id: "postgresql_readonly",
+              metadata: {
+                candidate_id: "candidate-selected",
+                execution_run_id: "00000000-0000-4000-8000-000000000300",
+                result_truncated: true,
+                row_count: 25,
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                truncation_reason: "row_limit"
+              },
+              rows: [
+                { total_spend: 1200, vendor_name: "Acme Supplies" },
+                { total_spend: 980, vendor_name: "Globex Services" }
+              ],
+              source_id: "sap-approved-spend"
+            })
+        });
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-selected",
+          question: "Selected candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /execute reviewed candidate/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/execution completed/i).length).toBeGreaterThan(0);
+    });
+
+    const resultsSection = screen.getByRole("heading", { name: /completed result set/i }).closest("section");
+    expect(resultsSection).not.toBeNull();
+    const results = within(resultsSection!);
+    expect(results.getByText(/truncated bounded result metadata/i)).toBeInTheDocument();
+    expect(results.getByText(/25 rows reported for this selected run/i)).toBeInTheDocument();
+    expect(results.getByText(/bounded preview of 2 displayed rows for 25 rows/i)).toBeInTheDocument();
+    expect(results.getByText(/not complete dataset access/i)).toBeInTheDocument();
+    expect(results.getByText("Acme Supplies")).toBeInTheDocument();
+    expect(results.getByText("Globex Services")).toBeInTheDocument();
+    expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("Result truncated");
   });
 
   it("renders zero-row execute response audit context on the empty state", async () => {
@@ -1376,7 +1486,11 @@ describe("HomePage", () => {
       expect(screen.getByRole("heading", { name: /empty state/i })).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/0 rows returned; result payload not truncated/i)).toBeInTheDocument();
+    expect(screen.getByText(/empty result state reached/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/approved workflow executed successfully and returned zero rows/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/0 rows reported for this selected run/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("execution_completed");
     expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent(
       "00000000-0000-4000-8000-000000000299"
@@ -1812,9 +1926,9 @@ describe("HomePage", () => {
     expect(resultsSection).not.toBeNull();
     const results = within(resultsSection!);
 
-    expect(results.getByText(/authoritative result metadata/i)).toBeInTheDocument();
-    expect(results.getByText(/12 rows/i)).toBeInTheDocument();
-    expect(results.getByText(/truncated/i)).toBeInTheDocument();
+    expect(results.getByText(/truncated bounded result metadata/i)).toBeInTheDocument();
+    expect(results.getByText(/12 rows reported for this selected run/i)).toBeInTheDocument();
+    expect(results.getByText(/truncated by SafeQuery display limits/i)).toBeInTheDocument();
     expect(results.queryByText(/99 rows/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
   });
@@ -1940,7 +2054,7 @@ describe("HomePage", () => {
       })
     );
 
-    expect(screen.getByText(/empty state reached/i)).toBeInTheDocument();
+    expect(screen.getByText(/empty result state reached/i)).toBeInTheDocument();
 
     rerender(
       await HomePage({

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -170,7 +170,7 @@ describe("pilot safety UI smoke", () => {
     );
 
     expect(screen.getByRole("heading", { name: /completed state/i })).toBeInTheDocument();
-    expect(screen.getByText(/2 rows returned; result payload not truncated/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 rows reported for this selected run/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("backend_execution_result");
     expect(screen.queryByText(/execution results unavailable/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -771,7 +771,8 @@ function parseExecuteSubmissionResult(
     rowCount < 0 ||
     typeof resultTruncated !== "boolean" ||
     rows === null ||
-    rows.length !== rowCount
+    rows.length > rowCount ||
+    (!resultTruncated && rows.length !== rowCount)
   ) {
     return null;
   }
@@ -1418,7 +1419,7 @@ function resultColumns(rows: ResultRow[]): string[] {
   return columns;
 }
 
-function renderResultRows(rows: ResultRow[]) {
+function renderResultRows(rows: ResultRow[], rowCount: number, resultTruncated: boolean) {
   if (rows.length === 0) {
     return null;
   }
@@ -1460,9 +1461,19 @@ function renderResultRows(rows: ResultRow[]) {
       </table>
       {rowsTruncated ? (
         <p className="section-copy">
-          Showing {displayedRows.length} of {rows.length} returned rows.
+          Showing {displayedRows.length} of {rows.length} rows attached to this bounded payload.
         </p>
       ) : null}
+      {resultTruncated ? (
+        <p className="section-copy">
+          SafeQuery returned a bounded preview of {rows.length} displayed rows for {rowCount} rows
+          reported by execution metadata; this is not complete dataset access.
+        </p>
+      ) : (
+        <p className="section-copy">
+          Showing bounded result rows attached to this selected run only.
+        </p>
+      )}
     </div>
   );
 }
@@ -1482,13 +1493,23 @@ function renderResultContent(
       return (
         <>
           <div className="state-callout state-callout-success">
-            <p className="state-callout-title">Authoritative result metadata</p>
+            <p className="state-callout-title">
+              {runContext.resultTruncated
+                ? "Truncated bounded result metadata"
+                : "Bounded result metadata"}
+            </p>
             <p>
-              {runContext.rowCount} rows returned; result payload{" "}
-              {runContext.resultTruncated ? "truncated" : "not truncated"}.
+              {runContext.rowCount} rows reported for this selected run; result payload{" "}
+              {runContext.resultTruncated
+                ? "was truncated by SafeQuery display limits."
+                : "was not truncated."}
             </p>
           </div>
-          {renderResultRows(runContext.resultRows ?? [])}
+          {renderResultRows(
+            runContext.resultRows ?? [],
+            runContext.rowCount,
+            runContext.resultTruncated
+          )}
         </>
       );
     }
@@ -1520,16 +1541,17 @@ function renderResultContent(
     return (
       <>
         <div className="state-callout state-callout-empty">
-          <p className="state-callout-title">Empty state reached</p>
+          <p className="state-callout-title">Empty result state reached</p>
           <p>
-            The approved workflow returned zero rows. Keep the question, SQL preview, and guard
-            history intact so the operator can revise without losing context.
+            The approved workflow executed successfully and returned zero rows. This is distinct
+            from denied or failed execution, and the candidate and run context remain attached for
+            revision.
           </p>
         </div>
         {runContext?.rowCount === 0 && runContext.resultTruncated === false ? (
           <div className="state-callout state-callout-success">
-            <p className="state-callout-title">Authoritative result metadata</p>
-            <p>0 rows returned; result payload not truncated.</p>
+            <p className="state-callout-title">Bounded result metadata</p>
+            <p>0 rows reported for this selected run; result payload was not truncated.</p>
           </div>
         ) : null}
       </>


### PR DESCRIPTION
## Summary
- distinguish empty result success from denied or failed execution in the result panel
- render truncated execution results as bounded previews tied to the selected run
- accept explicitly truncated execute payloads when metadata reports more rows than the bounded row payload

## Verification
- cd frontend && npm test -- --run app/page.test.tsx app/pilot-safety-smoke.test.tsx components/health-status-card.test.tsx
- PYTHONPATH=backend python3 -m pytest backend/tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_persists_source_aware_execution_audit_events backend/tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_runs_only_approved_candidate_identifier
- cd frontend && npm test -- --run app/pilot-safety-smoke.test.tsx components/health-status-card.test.tsx

Closes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improved Result Display Messaging**
  * Updated copy to better distinguish between complete, truncated, and bounded query results
  * Added clearer indication of rows reported per selected run

* **Enhanced Empty-State Feedback**
  * Refined messaging to explicitly clarify successful zero-row execution versus other outcomes

* **Result Validation Refinement**
  * Adjusted result parsing logic to better handle truncated result detection and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->