### PR TITLE
Add audit evidence navigation links

### DIFF
--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -88,6 +88,7 @@ class ExecutedEvidenceAuditPayload(BaseModel):
     execution_policy_version: Optional[PositiveInt] = None
     connector_profile_version: Optional[PositiveInt] = None
     candidate_id: NonEmptyTrimmedString
+    execution_run_id: UUID
     execution_audit_event_id: UUID
     execution_audit_event_type: Literal["execution_completed"] = "execution_completed"
     row_count: NonNegativeInt

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -138,6 +138,7 @@ class ExecutionResult(BaseModel):
             or audit_event.execution_row_count is None
             or audit_event.execution_row_count < 0
             or audit_event.result_truncated is None
+            or self.metadata.execution_run_id is None
         ):
             return None
 
@@ -150,6 +151,7 @@ class ExecutionResult(BaseModel):
             execution_policy_version=audit_event.execution_policy_version,
             connector_profile_version=audit_event.connector_profile_version,
             candidate_id=audit_event.query_candidate_id,
+            execution_run_id=self.metadata.execution_run_id,
             execution_audit_event_id=audit_event.event_id,
             row_count=audit_event.execution_row_count,
             result_truncated=audit_event.result_truncated,

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -137,6 +137,7 @@ class OperatorWorkflowAuditEventSummary(BaseModel):
 
     event_id: str = Field(serialization_alias="eventId")
     event_type: str = Field(serialization_alias="eventType")
+    execution_run_id: Optional[str] = Field(default=None, serialization_alias="executionRunId")
     occurred_at: datetime = Field(serialization_alias="occurredAt")
     request_id: str = Field(serialization_alias="requestId")
     candidate_id: Optional[str] = Field(default=None, serialization_alias="candidateId")
@@ -158,6 +159,7 @@ class OperatorWorkflowExecutedEvidence(BaseModel):
         serialization_alias="canAuthorizeExecution",
     )
     candidate_id: str = Field(serialization_alias="candidateId")
+    execution_run_id: str = Field(serialization_alias="executionRunId")
     execution_audit_event_id: str = Field(serialization_alias="executionAuditEventId")
     execution_audit_event_type: Literal["execution_completed"] = Field(
         serialization_alias="executionAuditEventType",
@@ -434,10 +436,31 @@ def _read_payload_items(value: object) -> list[dict[str, object]]:
     return [item for item in value if isinstance(item, dict)]
 
 
+def _execution_run_id_for_event(event: PreviewAuditEvent) -> str:
+    for item in _read_payload_items(event.audit_payload.get("executed_evidence")):
+        if (
+            item.get("type") != "executed_evidence"
+            or item.get("authority") != "backend_execution_result"
+            or item.get("can_authorize_execution") is not False
+            or _read_text(item.get("source_id")) != event.source_id
+            or _read_text(item.get("execution_audit_event_id")) != str(event.event_id)
+        ):
+            continue
+
+        execution_run_id = _read_text(item.get("execution_run_id"))
+        if execution_run_id is not None:
+            return execution_run_id
+
+    return str(event.event_id)
+
+
 def _audit_event_summary(event: PreviewAuditEvent) -> OperatorWorkflowAuditEventSummary:
     return OperatorWorkflowAuditEventSummary(
         event_id=str(event.event_id),
         event_type=event.event_type,
+        execution_run_id=(
+            _execution_run_id_for_event(event) if _is_execution_event(event) else None
+        ),
         occurred_at=_as_utc_datetime(event.occurred_at),
         request_id=event.request_id,
         candidate_id=event.candidate_id,
@@ -464,6 +487,7 @@ def _executed_evidence_for_event(
             continue
 
         candidate_id = _read_text(item.get("candidate_id"))
+        execution_run_id = _read_text(item.get("execution_run_id"))
         execution_audit_event_id = _read_text(item.get("execution_audit_event_id"))
         row_count = _read_non_negative_int(item.get("row_count"))
         result_truncated = _read_bool(item.get("result_truncated"))
@@ -471,6 +495,7 @@ def _executed_evidence_for_event(
         source_family = _read_text(item.get("source_family"))
         if (
             candidate_id is None
+            or execution_run_id is None
             or execution_audit_event_id is None
             or item.get("execution_audit_event_type") != "execution_completed"
             or row_count is None
@@ -483,6 +508,7 @@ def _executed_evidence_for_event(
         evidence.append(
             OperatorWorkflowExecutedEvidence(
                 candidate_id=candidate_id,
+                execution_run_id=execution_run_id,
                 execution_audit_event_id=execution_audit_event_id,
                 execution_audit_event_type="execution_completed",
                 row_count=row_count,
@@ -732,7 +758,7 @@ def _build_operator_history(
         history.append(
             OperatorWorkflowHistoryItem(
                 item_type="run",
-                record_id=str(event.event_id),
+                record_id=_execution_run_id_for_event(event),
                 label=request_labels.get(event.request_id, "Execution run"),
                 source_id=event.source_id,
                 source_label=source_labels.get(event.source_id, event.source_id),

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -34,6 +34,7 @@ def _executed_evidence(source_id: str, source_family: str) -> dict[str, object]:
         "execution_policy_version": 3,
         "connector_profile_version": 11,
         "candidate_id": f"{source_id}-candidate-123",
+        "execution_run_id": uuid4(),
         "execution_audit_event_id": uuid4(),
         "execution_audit_event_type": "execution_completed",
         "row_count": 12,

--- a/backend/tests/test_audit_event_model.py
+++ b/backend/tests/test_audit_event_model.py
@@ -171,6 +171,7 @@ def test_retrieval_completed_audit_event_preserves_source_labeled_citations() ->
 
 def test_analyst_response_audit_event_keeps_executed_evidence_separate_from_citations() -> None:
     payload = _source_aware_payload()
+    execution_run_id = uuid4()
     execution_audit_event_id = uuid4()
     payload.update(
         {
@@ -200,6 +201,7 @@ def test_analyst_response_audit_event_keeps_executed_evidence_separate_from_cita
                     "execution_policy_version": 3,
                     "connector_profile_version": 11,
                     "candidate_id": "candidate-123",
+                    "execution_run_id": execution_run_id,
                     "execution_audit_event_id": execution_audit_event_id,
                     "execution_audit_event_type": "execution_completed",
                     "row_count": 12,
@@ -273,6 +275,7 @@ def test_executed_evidence_rejects_retrieval_citation_shape() -> None:
                     "dataset_contract_version": 2,
                     "schema_snapshot_version": 5,
                     "candidate_id": "candidate-123",
+                    "execution_run_id": uuid4(),
                     "execution_audit_event_id": uuid4(),
                     "row_count": 12,
                     "result_truncated": False,

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -647,6 +647,7 @@ def test_operator_workflow_history_includes_execution_run_records() -> None:
         {
             "eventId": "00000000-0000-4000-8000-000000000012",
             "eventType": "execution_completed",
+            "executionRunId": "00000000-0000-4000-8000-000000000012",
             "occurredAt": "2026-01-02T03:05:03Z",
             "requestId": "preview-request-234",
             "candidateId": "preview-candidate-234",
@@ -658,6 +659,7 @@ def test_operator_workflow_history_includes_execution_run_records() -> None:
 
 
 def test_operator_workflow_history_surfaces_safe_audit_evidence_and_citations() -> None:
+    execution_run_id = UUID("00000000-0000-4000-8000-000000000099")
     execution_event_id = UUID("00000000-0000-4000-8000-000000000012")
     with _session_scope() as session:
         _seed_authoritative_source_governance(session)
@@ -708,6 +710,7 @@ def test_operator_workflow_history_surfaces_safe_audit_evidence_and_citations() 
                             "dataset_contract_version": 1,
                             "schema_snapshot_version": 1,
                             "candidate_id": "preview-candidate-234",
+                            "execution_run_id": str(execution_run_id),
                             "execution_audit_event_id": str(execution_event_id),
                             "execution_audit_event_type": "execution_completed",
                             "row_count": 12,
@@ -725,10 +728,12 @@ def test_operator_workflow_history_surfaces_safe_audit_evidence_and_citations() 
         snapshot = get_operator_workflow_snapshot(session)
 
     run = snapshot.history[0].model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert run["recordId"] == str(execution_run_id)
     assert run["auditEvents"] == [
         {
             "eventId": str(execution_event_id),
             "eventType": "execution_completed",
+            "executionRunId": str(execution_run_id),
             "occurredAt": "2026-01-02T03:05:03Z",
             "requestId": "preview-request-234",
             "candidateId": "preview-candidate-234",
@@ -742,6 +747,7 @@ def test_operator_workflow_history_surfaces_safe_audit_evidence_and_citations() 
             "authority": "backend_execution_result",
             "canAuthorizeExecution": False,
             "candidateId": "preview-candidate-234",
+            "executionRunId": str(execution_run_id),
             "executionAuditEventId": str(execution_event_id),
             "executionAuditEventType": "execution_completed",
             "rowCount": 12,

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -314,6 +314,7 @@ def test_execute_candidate_sql_derives_source_labeled_executed_evidence(
         "schema_snapshot_version": 7,
         "connector_profile_version": 11,
         "candidate_id": "candidate-123",
+        "execution_run_id": result.audit_event.event_id,
         "execution_audit_event_id": result.audit_event.event_id,
         "execution_audit_event_type": "execution_completed",
         "row_count": 1,

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1981,6 +1981,7 @@ describe("HomePage", () => {
                       {
                         eventId: "00000000-0000-4000-8000-000000000012",
                         eventType: "execution_completed",
+                        executionRunId: "00000000-0000-4000-8000-000000000099",
                         occurredAt: "2026-04-21T14:42:17+09:00",
                         requestId: "request-selected",
                         candidateId: "candidate-selected",
@@ -1995,6 +1996,7 @@ describe("HomePage", () => {
                         authority: "backend_execution_result",
                         canAuthorizeExecution: false,
                         candidateId: "candidate-selected",
+                        executionRunId: "00000000-0000-4000-8000-000000000099",
                         executionAuditEventId: "00000000-0000-4000-8000-000000000012",
                         executionAuditEventType: "execution_completed",
                         rowCount: 12,
@@ -2009,7 +2011,7 @@ describe("HomePage", () => {
                     label: "Selected completed run",
                     lifecycleState: "completed",
                     occurredAt: "2026-04-21T14:42:17+09:00",
-                    recordId: "00000000-0000-4000-8000-000000000012",
+                    recordId: "00000000-0000-4000-8000-000000000099",
                     retrievedCitations: [
                       {
                         assetId: "spend-metric-definition",
@@ -2043,7 +2045,7 @@ describe("HomePage", () => {
       await HomePage({
         searchParams: {
           history_item_type: "run",
-          history_record_id: "00000000-0000-4000-8000-000000000012",
+          history_record_id: "00000000-0000-4000-8000-000000000099",
           question: "Selected completed run",
           source_id: "sap-approved-spend",
           state: "completed"
@@ -2085,11 +2087,11 @@ describe("HomePage", () => {
     }
     expect(
       evidence.getAllByRole("link", {
-        name: /open run 00000000-0000-4000-8000-000000000012/i
+        name: /open run 00000000-0000-4000-8000-000000000099/i
       }).every((runLink) =>
         runLink
           .getAttribute("href")
-          ?.includes("history_record_id=00000000-0000-4000-8000-000000000012")
+          ?.includes("history_record_id=00000000-0000-4000-8000-000000000099")
       )
     ).toBe(true);
     expect(screen.getAllByText(/cannot authorize execution: false/i).length).toBeGreaterThan(0);

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1933,7 +1933,7 @@ describe("HomePage", () => {
     expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
   });
 
-  it("renders audit context, executed evidence, and retrieved citations without sensitive fields", async () => {
+  it("renders audit context, executed evidence, and retrieved citations with authoritative navigation", async () => {
     const unsafeLocalPath = "/" + ["Users", "example", "secret-should-not-render"].join("/");
 
     vi.stubGlobal(
@@ -1947,6 +1947,35 @@ describe("HomePage", () => {
             json: () =>
               Promise.resolve({
                 history: [
+                  {
+                    auditEvents: [],
+                    candidateAttempts: [],
+                    executedEvidence: [],
+                    itemType: "request",
+                    label: "Selected completed run",
+                    lifecycleState: "previewed",
+                    occurredAt: "2026-04-21T14:40:00+09:00",
+                    recordId: "request-selected",
+                    retrievedCitations: [],
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
+                  {
+                    auditEvents: [],
+                    candidateAttempts: [],
+                    candidateSql: "select vendor_name from approved_vendor_spend",
+                    executedEvidence: [],
+                    guardStatus: "allow",
+                    itemType: "candidate",
+                    label: "Selected completed run",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:41:00+09:00",
+                    recordId: "candidate-selected",
+                    requestId: "request-selected",
+                    retrievedCitations: [],
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
                   {
                     auditEvents: [
                       {
@@ -1980,7 +2009,7 @@ describe("HomePage", () => {
                     label: "Selected completed run",
                     lifecycleState: "completed",
                     occurredAt: "2026-04-21T14:42:17+09:00",
-                    recordId: "run-authoritative-287",
+                    recordId: "00000000-0000-4000-8000-000000000012",
                     retrievedCitations: [
                       {
                         assetId: "spend-metric-definition",
@@ -2014,7 +2043,7 @@ describe("HomePage", () => {
       await HomePage({
         searchParams: {
           history_item_type: "run",
-          history_record_id: "run-authoritative-287",
+          history_record_id: "00000000-0000-4000-8000-000000000012",
           question: "Selected completed run",
           source_id: "sap-approved-spend",
           state: "completed"
@@ -2037,6 +2066,32 @@ describe("HomePage", () => {
     expect(screen.getByLabelText(/retrieved citation context/i)).toHaveTextContent(
       "advisory_context"
     );
+    const evidencePanel = screen.getByRole("heading", {
+      name: /operator evidence context/i
+    }).closest("section");
+    expect(evidencePanel).not.toBeNull();
+    const evidence = within(evidencePanel!);
+    expect(evidence.getByRole("link", { name: /open request request-selected/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("history_record_id=request-selected")
+    );
+    for (const candidateLink of evidence.getAllByRole("link", {
+      name: /open candidate candidate-selected/i
+    })) {
+      expect(candidateLink).toHaveAttribute(
+        "href",
+        expect.stringContaining("history_record_id=candidate-selected")
+      );
+    }
+    expect(
+      evidence.getAllByRole("link", {
+        name: /open run 00000000-0000-4000-8000-000000000012/i
+      }).every((runLink) =>
+        runLink
+          .getAttribute("href")
+          ?.includes("history_record_id=00000000-0000-4000-8000-000000000012")
+      )
+    ).toBe(true);
     expect(screen.getAllByText(/cannot authorize execution: false/i).length).toBeGreaterThan(0);
     expect(screen.queryByText(/session-secret-should-not-render/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/postgres:\/\/secret-should-not-render/i)).not.toBeInTheDocument();

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -64,6 +64,7 @@ function pilotWorkflowPayload() {
             authority: "backend_execution_result",
             canAuthorizeExecution: false,
             candidateId: "candidate-pilot-001",
+            executionRunId: "run-pilot-001",
             executionAuditEventId: "run-pilot-001",
             executionAuditEventType: "execution_completed",
             resultTruncated: false,

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -551,6 +551,7 @@ function parseExecuteAuditEvent(value: unknown): OperatorWorkflowAuditEvent | nu
     denialReason: readOptionalString(value.denial_reason),
     eventId,
     eventType,
+    executionRunId: null,
     guardDecision: readOptionalString(value.guard_decision),
     occurredAt,
     primaryDenyCode: readOptionalString(value.primary_deny_code),
@@ -622,8 +623,9 @@ function buildExecutedEvidenceFromExecuteResponse(
       event.sourceId === result.sourceId
   );
   const sourceFamily = readOptionalString(metadata.source_family);
+  const executionRunId = readOptionalString(metadata.execution_run_id);
 
-  if (!completedEvent || !sourceFamily) {
+  if (!completedEvent || !sourceFamily || !executionRunId) {
     return [];
   }
 
@@ -632,6 +634,7 @@ function buildExecutedEvidenceFromExecuteResponse(
       authority: "backend_execution_result",
       canAuthorizeExecution: false,
       candidateId: result.candidateId,
+      executionRunId,
       executionAuditEventId: completedEvent.eventId,
       executionAuditEventType: "execution_completed",
       resultTruncated: result.resultTruncated,
@@ -1680,7 +1683,11 @@ function renderAuditEvidencePanel(
               {event.candidateId
                 ? renderHistoryNavigation("candidate", event.candidateId, event.sourceId)
                 : null}
-              {renderHistoryNavigation("run", event.eventId, event.sourceId)}
+              {renderHistoryNavigation(
+                "run",
+                event.executionRunId ?? event.eventId,
+                event.sourceId
+              )}
               {event.rowCount !== null ? <span>{event.rowCount} rows</span> : null}
               {event.resultTruncated !== null ? (
                 <span>{event.resultTruncated ? "Result truncated" : "Result not truncated"}</span>
@@ -1698,7 +1705,7 @@ function renderAuditEvidencePanel(
               <strong>{evidence.authority}</strong>
               <span>{evidence.sourceId}</span>
               {renderHistoryNavigation("candidate", evidence.candidateId, evidence.sourceId)}
-              {renderHistoryNavigation("run", evidence.executionAuditEventId, evidence.sourceId)}
+              {renderHistoryNavigation("run", evidence.executionRunId, evidence.sourceId)}
               <span>{evidence.rowCount} rows</span>
               <span>{evidence.resultTruncated ? "Result truncated" : "Result not truncated"}</span>
               <span>Cannot authorize execution: {String(evidence.canAuthorizeExecution)}</span>

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1609,8 +1609,46 @@ function renderResultContent(
 function renderAuditEvidencePanel(
   auditEvents: OperatorWorkflowAuditEvent[],
   executedEvidence: OperatorWorkflowExecutedEvidence[],
-  retrievedCitations: OperatorWorkflowRetrievedCitation[]
+  retrievedCitations: OperatorWorkflowRetrievedCitation[],
+  history: OperatorHistoryItem[],
+  question: string
 ) {
+  function findNavigationTarget(
+    itemType: OperatorHistoryItem["itemType"],
+    recordId: string,
+    sourceId: string
+  ): OperatorHistoryItem | undefined {
+    return history.find(
+      (item) =>
+        item.itemType === itemType &&
+        item.recordId === recordId &&
+        item.sourceId === sourceId
+    );
+  }
+
+  function renderHistoryNavigation(
+    itemType: OperatorHistoryItem["itemType"],
+    recordId: string,
+    sourceId: string
+  ) {
+    const target = findNavigationTarget(itemType, recordId, sourceId);
+    if (!target) {
+      return <span>{`${itemType[0].toUpperCase()}${itemType.slice(1)} ${recordId}`}</span>;
+    }
+
+    return (
+      <a
+        className="inline-link"
+        href={buildStateHref(historyItemToState(target), target.label || question, target.sourceId, {
+          historyItemType: target.itemType,
+          historyRecordId: target.recordId
+        })}
+      >
+        Open {itemType} {recordId}
+      </a>
+    );
+  }
+
   return (
     <section className="surface surface-secondary">
       <div className="section-header">
@@ -1638,8 +1676,11 @@ function renderAuditEvidencePanel(
               <strong>{event.eventType}</strong>
               <span>{event.eventId}</span>
               <span>{event.occurredAt}</span>
-              <span>Request {event.requestId}</span>
-              {event.candidateId ? <span>Candidate {event.candidateId}</span> : null}
+              {renderHistoryNavigation("request", event.requestId, event.sourceId)}
+              {event.candidateId
+                ? renderHistoryNavigation("candidate", event.candidateId, event.sourceId)
+                : null}
+              {renderHistoryNavigation("run", event.eventId, event.sourceId)}
               {event.rowCount !== null ? <span>{event.rowCount} rows</span> : null}
               {event.resultTruncated !== null ? (
                 <span>{event.resultTruncated ? "Result truncated" : "Result not truncated"}</span>
@@ -1656,7 +1697,8 @@ function renderAuditEvidencePanel(
               <span className="meta-label">Executed evidence</span>
               <strong>{evidence.authority}</strong>
               <span>{evidence.sourceId}</span>
-              <span>Candidate {evidence.candidateId}</span>
+              {renderHistoryNavigation("candidate", evidence.candidateId, evidence.sourceId)}
+              {renderHistoryNavigation("run", evidence.executionAuditEventId, evidence.sourceId)}
               <span>{evidence.rowCount} rows</span>
               <span>{evidence.resultTruncated ? "Result truncated" : "Result not truncated"}</span>
               <span>Cannot authorize execution: {String(evidence.canAuthorizeExecution)}</span>
@@ -2835,7 +2877,9 @@ export function QueryWorkflowShell({
           {renderAuditEvidencePanel(
             selectedAuditEvents,
             selectedExecutedEvidence,
-            selectedRetrievedCitations
+            selectedRetrievedCitations,
+            operatorWorkflow.history,
+            submittedQuestion
           )}
 
           {renderCandidateAttemptComparison(selectedCandidateAttempts)}

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -27,6 +27,7 @@ function evidence(sourceId: string, sourceFamily: "mssql" | "postgresql") {
     executionPolicyVersion: 3,
     connectorProfileVersion: 11,
     candidateId: `${sourceId}-candidate-123`,
+    executionRunId: "5dbcc36c-c6d6-4755-b307-5a3af5d6ec24",
     executionAuditEventId: "5dbcc36c-c6d6-4755-b307-5a3af5d6ec25",
     executionAuditEventType: "execution_completed",
     rowCount: 12,

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -24,6 +24,7 @@ export type AnalystExecutedEvidence = {
   executionPolicyVersion: number | null;
   connectorProfileVersion: number | null;
   candidateId: string;
+  executionRunId: string;
   executionAuditEventId: string;
   executionAuditEventType: "execution_completed";
   rowCount: number;
@@ -263,6 +264,7 @@ function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
   const executionPolicyVersion = readOptionalPositiveInteger(value.executionPolicyVersion);
   const connectorProfileVersion = readOptionalPositiveInteger(value.connectorProfileVersion);
   const candidateId = readRequiredString(value.candidateId);
+  const executionRunId = readExecutionAuditEventId(value.executionRunId);
   const executionAuditEventId = readExecutionAuditEventId(value.executionAuditEventId);
   const rowCount = readNonNegativeInteger(value.rowCount);
 
@@ -276,6 +278,7 @@ function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
     executionPolicyVersion === undefined ||
     connectorProfileVersion === undefined ||
     !candidateId ||
+    !executionRunId ||
     !executionAuditEventId ||
     value.executionAuditEventType !== "execution_completed" ||
     rowCount === null ||
@@ -296,6 +299,7 @@ function parseExecutedEvidence(value: unknown): AnalystExecutedEvidence | null {
     executionPolicyVersion,
     connectorProfileVersion,
     candidateId,
+    executionRunId,
     executionAuditEventId,
     executionAuditEventType: "execution_completed",
     rowCount,

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -26,6 +26,7 @@ export type OperatorWorkflowAuditEvent = {
   denialReason: string | null;
   eventId: string;
   eventType: string;
+  executionRunId: string | null;
   guardDecision: string | null;
   occurredAt: string;
   primaryDenyCode: string | null;
@@ -57,6 +58,7 @@ export type OperatorWorkflowExecutedEvidence = {
   authority: "backend_execution_result";
   canAuthorizeExecution: false;
   candidateId: string;
+  executionRunId: string;
   executionAuditEventId: string;
   executionAuditEventType: "execution_completed";
   rowCount: number;
@@ -190,6 +192,7 @@ function parseAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
     denialReason: readOptionalString(value.denialReason) ?? null,
     eventId,
     eventType,
+    executionRunId: readOptionalString(value.executionRunId) ?? null,
     guardDecision: readOptionalString(value.guardDecision) ?? null,
     occurredAt,
     primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
@@ -256,6 +259,7 @@ function parseExecutedEvidence(value: unknown): OperatorWorkflowExecutedEvidence
   }
 
   const candidateId = readOptionalString(value.candidateId);
+  const executionRunId = readOptionalString(value.executionRunId);
   const executionAuditEventId = readOptionalString(value.executionAuditEventId);
   const rowCount = readOptionalNonNegativeInteger(value.rowCount);
   const sourceId = readOptionalString(value.sourceId);
@@ -265,6 +269,7 @@ function parseExecutedEvidence(value: unknown): OperatorWorkflowExecutedEvidence
     value.authority !== "backend_execution_result" ||
     value.canAuthorizeExecution !== false ||
     !candidateId ||
+    !executionRunId ||
     !executionAuditEventId ||
     value.executionAuditEventType !== "execution_completed" ||
     rowCount === undefined ||
@@ -279,6 +284,7 @@ function parseExecutedEvidence(value: unknown): OperatorWorkflowExecutedEvidence
     authority: "backend_execution_result",
     canAuthorizeExecution: false,
     candidateId,
+    executionRunId,
     executionAuditEventId,
     executionAuditEventType: "execution_completed",
     rowCount,


### PR DESCRIPTION
## Summary
- add read-only evidence-panel links back to matching request, candidate, and run history records
- preserve missing-record fallback text so evidence remains inspectable without inventing navigation authority
- tighten frontend regression coverage for authorized audit evidence navigation while retaining sensitive-field redaction checks

## Verification
- cd frontend && npm test -- --run app/page.test.tsx
- cd frontend && npm test -- --run
- cd backend && python3 -m pytest tests/test_operator_workflow_history.py tests/test_source_bound_execute_path.py -q
- cd backend && python3 -m pytest tests/test_dev_auth_preview_api.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator evidence panel now shows request, candidate and run as clickable "Open…" links that navigate to the persisted history entries (anchored to authoritative run records).

* **Bug Fixes**
  * Navigation targets now reliably point to authoritative history records so links open the intended request/candidate/run.

* **Tests**
  * Test suites updated to cover authoritative-run navigation and the presence of run identifiers in executed-evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->