### PR TITLE
[codex] Add evidence-cited supplemental analyst narrative panel

### DIFF
--- a/backend/app/features/analyst_response/schema.py
+++ b/backend/app/features/analyst_response/schema.py
@@ -183,6 +183,11 @@ class AnalystResponsePayload(BaseModel):
                 "Analyst narrative must not imply execution approval authority."
             )
 
+        if not self.executed_evidence:
+            raise ValueError(
+                "Analyst responses must cite source-labeled executed evidence."
+            )
+
         if not self.executed_evidence and _EXECUTION_CLAIM_PATTERN.search(narrative):
             raise ValueError(
                 "Analyst narrative must not claim executed evidence without source-labeled executed evidence."

--- a/backend/tests/test_analyst_response_schema.py
+++ b/backend/tests/test_analyst_response_schema.py
@@ -307,6 +307,20 @@ def test_analyst_response_payload_rejects_execution_claims_without_executed_evid
         )
 
 
+def test_analyst_response_payload_rejects_retrieval_only_narratives() -> None:
+    with pytest.raises(ValidationError, match="executed evidence"):
+        AnalystResponsePayload(
+            response_id="analyst-response-123",
+            request_id="request-123",
+            narrative="Retrieved metric definitions provide advisory context for the operator.",
+            advisory_only=True,
+            can_authorize_execution=False,
+            analyst_mode_version="analyst-schema-v1",
+            retrieval_citations=[_citation("business-postgres-source", "postgresql")],
+            executed_evidence=[],
+        )
+
+
 def test_analyst_response_payload_rejects_execution_approval_narratives() -> None:
     with pytest.raises(ValidationError, match="execution approval"):
         AnalystResponsePayload(

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -45,6 +45,65 @@ function pilotWorkflowPayload() {
         sourceLabel: "Demo business PostgreSQL / approved_vendor_spend"
       },
       {
+        analystResponse: {
+          responseId: "analyst-response-pilot-001",
+          requestId: "request-pilot-001",
+          narrative:
+            "Supplemental analyst context: the completed SafeQuery run returned two approved vendors for this selected candidate.",
+          advisoryOnly: true,
+          canAuthorizeExecution: false,
+          analystModeVersion: "analyst-schema-v1",
+          confidence: "medium",
+          caveats: ["Use the persisted run record for workflow decisions."],
+          sourceSummaries: [
+            {
+              sourceId: "demo-business-postgres",
+              sourceFamily: "postgresql",
+              sourceFlavor: "warehouse",
+              datasetContractVersion: 2,
+              schemaSnapshotVersion: 7,
+              executionPolicyVersion: 3
+            }
+          ],
+          retrievalCitations: [
+            {
+              assetId: "schema-snapshot-7",
+              assetKind: "schema_snapshot",
+              authority: "advisory_context",
+              canAuthorizeExecution: false,
+              citationLabel: "Approved spend schema snapshot",
+              datasetContractVersion: 2,
+              schemaSnapshotVersion: 7,
+              sourceFamily: "postgresql",
+              sourceFlavor: "warehouse",
+              sourceId: "demo-business-postgres"
+            }
+          ],
+          executedEvidence: [
+            {
+              type: "executed_evidence",
+              authority: "backend_execution_result",
+              canAuthorizeExecution: false,
+              candidateId: "candidate-pilot-001",
+              connectorProfileVersion: 11,
+              datasetContractVersion: 2,
+              executionPolicyVersion: 3,
+              executionRunId: "5dbcc36c-c6d6-4755-b307-5a3af5d6ec24",
+              executionAuditEventId: "5dbcc36c-c6d6-4755-b307-5a3af5d6ec25",
+              executionAuditEventType: "execution_completed",
+              resultTruncated: false,
+              rowCount: 2,
+              schemaSnapshotVersion: 7,
+              sourceFamily: "postgresql",
+              sourceFlavor: "warehouse",
+              sourceId: "demo-business-postgres"
+            }
+          ],
+          operatorHistoryHooks: {
+            auditEventId: "5dbcc36c-c6d6-4755-b307-5a3af5d6ec25",
+            historyRecordIds: ["request-pilot-001", "candidate-pilot-001", "run-pilot-001"]
+          }
+        },
         auditEvents: [
           {
             candidateId: "candidate-pilot-001",
@@ -173,6 +232,15 @@ describe("pilot safety UI smoke", () => {
     expect(screen.getByRole("heading", { name: /completed state/i })).toBeInTheDocument();
     expect(screen.getByText(/2 rows reported for this selected run/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("backend_execution_result");
+    expect(
+      screen.getByRole("heading", { name: /supplemental analyst narrative/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/supplemental analyst narrative/i)).toHaveTextContent(
+      "Supplemental analyst context"
+    );
+    expect(screen.getByLabelText(/supplemental analyst narrative/i)).toHaveTextContent(
+      "Cannot authorize execution: false"
+    );
     expect(screen.queryByText(/execution results unavailable/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/placeholder query results/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/run-sq-204/i)).not.toBeInTheDocument();

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -2,6 +2,7 @@
 
 import { type FormEvent, useEffect, useState } from "react";
 import { HealthStatusCard } from "./health-status-card";
+import type { AnalystResponsePayload } from "../lib/analyst-response";
 import type { HealthSnapshot } from "../lib/health";
 import type {
   GovernanceBindingStatus,
@@ -168,6 +169,7 @@ type AuthoritativeCandidatePreview = {
 };
 
 type AuthoritativeRunContext = {
+  analystResponse: AnalystResponsePayload | null;
   auditEvents: OperatorWorkflowAuditEvent[];
   executedEvidence: OperatorWorkflowExecutedEvidence[];
   lifecycleState: string;
@@ -1096,6 +1098,7 @@ function findAuthoritativeRunContext(
   }
 
   return {
+    analystResponse: run.analystResponse,
     auditEvents: run.auditEvents,
     executedEvidence: run.executedEvidence,
     lifecycleState: run.lifecycleState,
@@ -1108,6 +1111,60 @@ function findAuthoritativeRunContext(
     runState: run.runState,
     sourceLabel: run.sourceLabel
   };
+}
+
+function renderSupplementalAnalystNarrative(analystResponse: AnalystResponsePayload | null) {
+  if (!analystResponse) {
+    return null;
+  }
+
+  return (
+    <section className="surface surface-secondary" aria-label="supplemental analyst narrative">
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Supplemental context</p>
+          <h2 className="panel-title">Supplemental analyst narrative</h2>
+        </div>
+        <span className="surface-badge surface-badge-code">Non-authoritative</span>
+      </div>
+      <p className="section-copy">{analystResponse.narrative}</p>
+      <div className="state-callout">
+        <p className="state-callout-title">Workflow authority remains SafeQuery records</p>
+        <p>
+          This narrative cannot unlock execute, approval, export, audit, authorization, or
+          governance decisions.
+        </p>
+      </div>
+      <div className="evidence-list" aria-label="analyst run citations">
+        {analystResponse.executedEvidence.map((evidence) => (
+          <div className="evidence-item" key={evidence.executionAuditEventId}>
+            <span className="meta-label">Executed evidence citation</span>
+            <strong>{evidence.authority}</strong>
+            <span>{evidence.sourceId}</span>
+            <span>Candidate {evidence.candidateId}</span>
+            <span>Run {evidence.executionRunId}</span>
+            <span>Audit event {evidence.executionAuditEventId}</span>
+            <span>{evidence.rowCount} rows</span>
+            <span>Cannot authorize execution: {String(evidence.canAuthorizeExecution)}</span>
+          </div>
+        ))}
+      </div>
+      {analystResponse.retrievalCitations.length > 0 ? (
+        <div className="evidence-list" aria-label="analyst retrieval citations">
+          {analystResponse.retrievalCitations.map((citation) => (
+            <div className="evidence-item" key={`${citation.assetKind}:${citation.assetId}`}>
+              <span className="meta-label">Retrieval citation reference</span>
+              <strong>{citation.citationLabel}</strong>
+              <span>{citation.assetKind}</span>
+              <span>{citation.assetId}</span>
+              <span>{citation.authority}</span>
+              <span>Cannot authorize execution: {String(citation.canAuthorizeExecution)}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
 }
 
 function revisionDraftFromSelectedContext(
@@ -2361,6 +2418,7 @@ export function QueryWorkflowShell({
         if (hasCanceledAuditEvent(payload)) {
           setSubmittedState("canceled");
           setSubmittedRunContext({
+            analystResponse: null,
             auditEvents: [],
             executedEvidence: [],
             lifecycleState: "canceled",
@@ -2418,6 +2476,7 @@ export function QueryWorkflowShell({
       const nextState = result.rowCount === 0 ? "empty" : "completed";
       setSubmittedState(nextState);
       setSubmittedRunContext({
+        analystResponse: null,
         auditEvents: result.auditEvents,
         executedEvidence: result.executedEvidence,
         lifecycleState: nextState,
@@ -2888,6 +2947,8 @@ export function QueryWorkflowShell({
             operatorWorkflow.history,
             submittedQuestion
           )}
+
+          {renderSupplementalAnalystNarrative(historyRunContext?.analystResponse ?? null)}
 
           {renderCandidateAttemptComparison(selectedCandidateAttempts)}
 

--- a/frontend/lib/analyst-response.test.ts
+++ b/frontend/lib/analyst-response.test.ts
@@ -329,6 +329,21 @@ describe("parseAnalystResponsePayload", () => {
     ).toBeNull();
   });
 
+  it("rejects retrieval-only narratives without executed evidence citations", () => {
+    expect(
+      parseAnalystResponsePayload({
+        responseId: "analyst-response-123",
+        requestId: "request-123",
+        narrative: "Retrieved metric definitions provide advisory context for the operator.",
+        advisoryOnly: true,
+        canAuthorizeExecution: false,
+        analystModeVersion: "analyst-schema-v1",
+        retrievalCitations: [citation("business-postgres-source", "postgresql")],
+        executedEvidence: []
+      })
+    ).toBeNull();
+  });
+
   it("rejects execution approval narratives", () => {
     expect(
       parseAnalystResponsePayload({

--- a/frontend/lib/analyst-response.ts
+++ b/frontend/lib/analyst-response.ts
@@ -448,7 +448,7 @@ export function parseAnalystResponsePayload(value: unknown): AnalystResponsePayl
     executedEvidence === null ||
     operatorHistoryHooks === null ||
     validationOutcome === null ||
-    (retrievalCitations.length === 0 && executedEvidence.length === 0) ||
+    executedEvidence.length === 0 ||
     !validateNarrativeAuthority(narrative, retrievalCitations, executedEvidence)
   ) {
     return null;

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -1,3 +1,8 @@
+import {
+  parseAnalystResponsePayload,
+  type AnalystResponsePayload
+} from "./analyst-response";
+
 export type SourceActivationPosture = "active" | "paused" | "blocked" | "retired";
 export type GovernanceBindingState = "valid" | "missing" | "ambiguous" | "stale" | "drifted";
 export type GovernanceBindingRole = "owner" | "security_review" | "exception_policy";
@@ -87,6 +92,7 @@ export type OperatorWorkflowRevisionContext = {
 };
 
 export type OperatorHistoryItem = {
+  analystResponse: AnalystResponsePayload | null;
   auditEvents: OperatorWorkflowAuditEvent[];
   candidateAttempts: OperatorWorkflowCandidateAttempt[];
   candidateSql?: string | null;
@@ -427,6 +433,10 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   const executedEvidence = parseArray(value.executedEvidence, parseExecutedEvidence);
   const retrievedCitations = parseArray(value.retrievedCitations, parseRetrievedCitation);
   const revisionContext = parseRevisionContext(value.revisionContext);
+  const analystResponse =
+    value.analystResponse === undefined || value.analystResponse === null
+      ? null
+      : parseAnalystResponsePayload(value.analystResponse);
 
   if (
     (itemType !== "request" && itemType !== "candidate" && itemType !== "run") ||
@@ -445,6 +455,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   }
 
   return {
+    analystResponse,
     auditEvents,
     candidateAttempts,
     candidateSql: readOptionalString(value.candidateSql) ?? null,


### PR DESCRIPTION
## Summary
- add a supplemental analyst narrative panel for selected run history when the narrative cites executed SafeQuery evidence
- require analyst response payloads to include source-labeled executed evidence before frontend/backend contracts accept them
- keep narrative citations non-authoritative and separate from execute, approval, export, audit, authorization, and governance state

## Validation
- cd frontend && npm test -- --run lib/analyst-response.test.ts app/pilot-safety-smoke.test.tsx
- cd backend && python3 -m pytest tests/test_analyst_response_schema.py

Closes #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supplemental analyst narrative now displays in workflow results, including execution authorization status and supporting evidence.

* **Bug Fixes**
  * Strengthened validation to ensure analyst responses without execution capability include required executed evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->