### PR TITLE
Add secret-safe bounded result summary export

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,7 +82,12 @@ from app.services.operator_workflow import (
     OperatorWorkflowSnapshot,
     get_operator_workflow_snapshot,
 )
-from app.services.support_bundle import SupportBundle, build_support_bundle
+from app.services.support_bundle import (
+    BoundedResultSummaryExport,
+    SupportBundle,
+    build_bounded_result_summary_export,
+    build_support_bundle,
+)
 
 configure_logging()
 
@@ -548,6 +553,31 @@ def create_app() -> FastAPI:
             database=database,
             sql_generation=sql_generation,
         )
+
+    @app.get(
+        "/candidates/{candidate_id}/bounded-result-summary",
+        response_model=BoundedResultSummaryExport,
+    )
+    def read_bounded_result_summary_export(
+        candidate_id: str,
+        authenticated_subject: AuthenticatedSubject = Depends(
+            require_authenticated_subject
+        ),
+        session: Session = Depends(require_preview_submission_session),
+    ) -> BoundedResultSummaryExport:
+        authenticated_subject.normalized_subject_id()
+        ensure_operator_evidence_read_authority(authenticated_subject)
+        export = build_bounded_result_summary_export(
+            session,
+            candidate_id=candidate_id,
+        )
+        if export is None:
+            raise api_error(
+                404,
+                "bounded_result_summary_not_found",
+                "Bounded result summary is unavailable.",
+            )
+        return export
 
     @app.post("/requests/preview", response_model=PreviewSubmissionResponse)
     def create_request_preview(

--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select, text
@@ -159,6 +159,83 @@ class SupportBundleRedaction(BaseModel):
     excluded: list[str]
 
 
+class BoundedResultSummaryRequestContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str = Field(serialization_alias="requestId")
+    request_state: str = Field(serialization_alias="requestState")
+
+
+class BoundedResultSummaryCandidateContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    candidate_id: str = Field(serialization_alias="candidateId")
+    candidate_state: str = Field(serialization_alias="candidateState")
+    guard_status: str = Field(serialization_alias="guardStatus")
+
+
+class BoundedResultSummaryRunContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    execution_run_id: str = Field(serialization_alias="executionRunId")
+    event_type: Literal["execution_completed"] = Field(serialization_alias="eventType")
+    occurred_at: datetime = Field(serialization_alias="occurredAt")
+
+
+class BoundedResultSummarySourceContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(serialization_alias="sourceId")
+    source_family: str = Field(serialization_alias="sourceFamily")
+    source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
+    dataset_contract_version: int = Field(serialization_alias="datasetContractVersion")
+    schema_snapshot_version: int = Field(serialization_alias="schemaSnapshotVersion")
+
+
+class BoundedResultSummaryAuditContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    audit_event_id: str = Field(serialization_alias="auditEventId")
+    correlation_id: str = Field(serialization_alias="correlationId")
+    lifecycle_order: int = Field(serialization_alias="lifecycleOrder")
+
+
+class BoundedResultSummaryResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    summary_kind: Literal["aggregate_only", "bounded_rows"] = Field(
+        serialization_alias="summaryKind",
+    )
+    row_count: int = Field(serialization_alias="rowCount")
+    result_truncated: bool = Field(serialization_alias="resultTruncated")
+    bounded_rows: list[dict[str, Any]] = Field(
+        default_factory=list,
+        serialization_alias="boundedRows",
+    )
+    bounded_row_count: int = Field(serialization_alias="boundedRowCount")
+    bounded_row_limit: int = Field(serialization_alias="boundedRowLimit")
+
+
+class BoundedResultSummaryExport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    export_version: Literal[1] = Field(default=1, serialization_alias="exportVersion")
+    export_type: Literal["bounded_result_summary"] = Field(
+        default="bounded_result_summary",
+        serialization_alias="exportType",
+    )
+    generated_at: datetime = Field(serialization_alias="generatedAt")
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    request: BoundedResultSummaryRequestContext
+    candidate: BoundedResultSummaryCandidateContext
+    run: BoundedResultSummaryRunContext
+    source: BoundedResultSummarySourceContext
+    audit: BoundedResultSummaryAuditContext
+    result: BoundedResultSummaryResult
+    limitations: list[str]
+    redaction: SupportBundleRedaction
+
+
 class GovernanceReviewLifecycleEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -299,6 +376,9 @@ class SupportBundle(BaseModel):
         serialization_alias="governanceReview",
     )
     redaction: SupportBundleRedaction
+
+
+_BOUNDED_RESULT_SUMMARY_ROW_LIMIT = 20
 
 
 def _active_sources(session: Session) -> list[SupportBundleSource]:
@@ -638,6 +718,7 @@ def _iter_string_values(
     if isinstance(value, dict):
         strings: list[tuple[tuple[str, ...], str]] = []
         for key, item in value.items():
+            strings.append(((*path, str(key)), str(key)))
             strings.extend(_iter_string_values(item, (*path, str(key))))
         return strings
     if isinstance(value, list):
@@ -667,6 +748,146 @@ def _assert_bundle_is_shareable(bundle: SupportBundle) -> None:
                 raise ValueError(
                     f"Support bundle contains non-shareable {category}."
                 )
+
+
+def _assert_bounded_result_summary_is_shareable(
+    export: BoundedResultSummaryExport,
+) -> None:
+    payload = export.model_dump(mode="json", by_alias=True, exclude_none=True)
+    for path, value in _iter_string_values(payload):
+        if _is_raw_identity_payload(path, value):
+            raise ValueError(
+                "Bounded result summary contains non-shareable raw identity payloads."
+            )
+        for category, pattern in _FORBIDDEN_EXPORT_VALUE_PATTERNS:
+            if pattern.search(value):
+                raise ValueError(
+                    f"Bounded result summary contains non-shareable {category}."
+                )
+
+
+def _bounded_operator_display_rows(
+    payload: Mapping[str, object],
+) -> list[dict[str, Any]]:
+    rows = payload.get("operator_display_rows")
+    if rows is None:
+        return []
+    if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+        raise ValueError(
+            "Bounded result summary contains malformed operator display rows."
+        )
+    if len(rows) > _BOUNDED_RESULT_SUMMARY_ROW_LIMIT:
+        raise ValueError(
+            "Bounded result summary contains too many operator display rows."
+        )
+    return [dict(row) for row in rows]
+
+
+def _latest_execution_completed_event(
+    session: Session,
+    *,
+    candidate_id: str,
+) -> PreviewAuditEvent | None:
+    return session.scalar(
+        select(PreviewAuditEvent)
+        .where(
+            PreviewAuditEvent.candidate_id == candidate_id,
+            PreviewAuditEvent.event_type == "execution_completed",
+        )
+        .order_by(
+            PreviewAuditEvent.occurred_at.desc(),
+            PreviewAuditEvent.lifecycle_order.desc(),
+            PreviewAuditEvent.event_id.desc(),
+        )
+        .limit(1)
+    )
+
+
+def build_bounded_result_summary_export(
+    session: Session,
+    *,
+    candidate_id: str,
+    generated_at: datetime | None = None,
+) -> BoundedResultSummaryExport | None:
+    candidate = session.scalar(
+        select(PreviewCandidate).where(PreviewCandidate.candidate_id == candidate_id)
+    )
+    if candidate is None:
+        return None
+
+    request = session.scalar(
+        select(PreviewRequest).where(PreviewRequest.request_id == candidate.request_id)
+    )
+    if request is None:
+        return None
+
+    execution_event = _latest_execution_completed_event(
+        session,
+        candidate_id=candidate_id,
+    )
+    if execution_event is None:
+        return None
+
+    row_count = _payload_non_negative_int(
+        execution_event.audit_payload,
+        "execution_row_count",
+    )
+    result_truncated = _payload_bool(
+        execution_event.audit_payload,
+        "result_truncated",
+    )
+    if row_count is None or result_truncated is None:
+        return None
+
+    bounded_rows = _bounded_operator_display_rows(execution_event.audit_payload)
+    generated_at = generated_at or datetime.now(timezone.utc)
+    export = BoundedResultSummaryExport(
+        generated_at=generated_at.astimezone(timezone.utc),
+        request=BoundedResultSummaryRequestContext(
+            request_id=request.request_id,
+            request_state=request.request_state,
+        ),
+        candidate=BoundedResultSummaryCandidateContext(
+            candidate_id=candidate.candidate_id,
+            candidate_state=candidate.candidate_state,
+            guard_status=candidate.guard_status,
+        ),
+        run=BoundedResultSummaryRunContext(
+            execution_run_id=str(execution_event.event_id),
+            event_type="execution_completed",
+            occurred_at=_as_utc_datetime(execution_event.occurred_at),
+        ),
+        source=BoundedResultSummarySourceContext(
+            source_id=execution_event.source_id,
+            source_family=execution_event.source_family,
+            source_flavor=execution_event.source_flavor,
+            dataset_contract_version=execution_event.dataset_contract_version
+            or candidate.dataset_contract_version,
+            schema_snapshot_version=execution_event.schema_snapshot_version
+            or candidate.schema_snapshot_version,
+        ),
+        audit=BoundedResultSummaryAuditContext(
+            audit_event_id=str(execution_event.event_id),
+            correlation_id=execution_event.correlation_id,
+            lifecycle_order=execution_event.lifecycle_order,
+        ),
+        result=BoundedResultSummaryResult(
+            summary_kind="bounded_rows" if bounded_rows else "aggregate_only",
+            row_count=row_count,
+            result_truncated=result_truncated,
+            bounded_rows=bounded_rows,
+            bounded_row_count=len(bounded_rows),
+            bounded_row_limit=_BOUNDED_RESULT_SUMMARY_ROW_LIMIT,
+        ),
+        limitations=[
+            "Export is a bounded operator handoff summary, not an authoritative audit bundle.",
+            "Raw SQL, connection details, credentials, tokens, raw result rows, and workstation-local paths are excluded.",
+            "Rows are included only when they were already persisted as bounded operator-display rows.",
+        ],
+        redaction=_redaction_policy(),
+    )
+    _assert_bounded_result_summary_is_shareable(export)
+    return export
 
 
 def build_support_bundle(

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -25,7 +25,10 @@ from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
 from app.services.demo_source_seed import seed_demo_source_governance
-from app.services.support_bundle import build_support_bundle
+from app.services.support_bundle import (
+    build_bounded_result_summary_export,
+    build_support_bundle,
+)
 
 
 @contextmanager
@@ -739,4 +742,208 @@ def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:
         "workstation_local_paths",
         "source_connection_references",
     ]
+    _assert_secret_safe(response.text)
+
+
+def test_bounded_result_summary_export_includes_execution_context_without_raw_rows(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session, execution_row_count=225)
+        export = build_bounded_result_summary_export(
+            session,
+            candidate_id="candidate-governance-bundle",
+            generated_at=datetime(2026, 1, 2, 3, 12, 5, tzinfo=timezone.utc),
+        )
+
+    payload = export.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert payload == {
+        "exportVersion": 1,
+        "exportType": "bounded_result_summary",
+        "generatedAt": "2026-01-02T03:12:05Z",
+        "authority": "safequery_control_plane",
+        "request": {
+            "requestId": "request-governance-bundle",
+            "requestState": "executed",
+        },
+        "candidate": {
+            "candidateId": "candidate-governance-bundle",
+            "candidateState": "executed",
+            "guardStatus": "passed",
+        },
+        "run": {
+            "executionRunId": payload["run"]["executionRunId"],
+            "eventType": "execution_completed",
+            "occurredAt": "2026-01-02T03:11:05Z",
+        },
+        "source": {
+            "sourceId": "demo-business-postgres",
+            "sourceFamily": "postgresql",
+            "sourceFlavor": "warehouse",
+            "datasetContractVersion": 1,
+            "schemaSnapshotVersion": 1,
+        },
+        "audit": {
+            "auditEventId": payload["audit"]["auditEventId"],
+            "correlationId": "correlation-governance-bundle",
+            "lifecycleOrder": 7,
+        },
+        "result": {
+            "summaryKind": "aggregate_only",
+            "rowCount": 225,
+            "resultTruncated": False,
+            "boundedRows": [],
+            "boundedRowCount": 0,
+            "boundedRowLimit": 20,
+        },
+        "limitations": [
+            "Export is a bounded operator handoff summary, not an authoritative audit bundle.",
+            "Raw SQL, connection details, credentials, tokens, raw result rows, and workstation-local paths are excluded.",
+            "Rows are included only when they were already persisted as bounded operator-display rows.",
+        ],
+        "redaction": {
+            "excluded": [
+                "connection_strings",
+                "raw_credentials",
+                "tokens",
+                "raw_result_rows",
+                "candidate_sql",
+                "raw_identity_payloads",
+                "workstation_local_paths",
+                "source_connection_references",
+            ]
+        },
+    }
+    serialized = json.dumps(payload, sort_keys=True)
+    _assert_secret_safe(serialized)
+    assert "raw_private_rows" not in serialized
+
+
+def test_bounded_result_summary_export_includes_only_bounded_operator_display_rows(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session, execution_row_count=2)
+        execution_event = (
+            session.query(PreviewAuditEvent)
+            .filter_by(
+                candidate_id="candidate-governance-bundle",
+                event_type="execution_completed",
+            )
+            .one()
+        )
+        execution_event.audit_payload = {
+            **execution_event.audit_payload,
+            "operator_display_rows": [
+                {"vendorName": "Acme", "approvedSpend": 100},
+                {"vendorName": "Beta", "approvedSpend": 200},
+            ],
+        }
+        session.commit()
+
+        export = build_bounded_result_summary_export(
+            session,
+            candidate_id="candidate-governance-bundle",
+            generated_at=datetime(2026, 1, 2, 3, 12, 5, tzinfo=timezone.utc),
+        )
+
+    payload = export.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert payload["result"] == {
+        "summaryKind": "bounded_rows",
+        "rowCount": 2,
+        "resultTruncated": False,
+        "boundedRows": [
+            {"vendorName": "Acme", "approvedSpend": 100},
+            {"vendorName": "Beta", "approvedSpend": 200},
+        ],
+        "boundedRowCount": 2,
+        "boundedRowLimit": 20,
+    }
+    _assert_secret_safe(json.dumps(payload, sort_keys=True))
+
+
+def test_bounded_result_summary_export_rejects_unbounded_operator_display_rows(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session, execution_row_count=25)
+        execution_event = (
+            session.query(PreviewAuditEvent)
+            .filter_by(
+                candidate_id="candidate-governance-bundle",
+                event_type="execution_completed",
+            )
+            .one()
+        )
+        execution_event.audit_payload = {
+            **execution_event.audit_payload,
+            "operator_display_rows": [
+                {"vendorName": f"Vendor {index}"} for index in range(21)
+            ],
+        }
+        session.commit()
+
+        try:
+            build_bounded_result_summary_export(
+                session,
+                candidate_id="candidate-governance-bundle",
+                generated_at=datetime(2026, 1, 2, 3, 12, 5, tzinfo=timezone.utc),
+            )
+        except ValueError as exc:
+            message = str(exc)
+        else:
+            raise AssertionError("Expected unbounded operator display rows to fail.")
+
+    assert "too many operator display rows" in message
+
+
+def test_bounded_result_summary_endpoint_returns_secret_safe_json(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_ENVIRONMENT", "development")
+    monkeypatch.setenv("SAFEQUERY_DEV_AUTH_ENABLED", "true")
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session, execution_row_count=3)
+        response = _client(session).get(
+            "/candidates/candidate-governance-bundle/bounded-result-summary"
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["exportType"] == "bounded_result_summary"
+    assert payload["candidate"]["candidateId"] == "candidate-governance-bundle"
+    assert payload["result"] == {
+        "summaryKind": "aggregate_only",
+        "rowCount": 3,
+        "resultTruncated": False,
+        "boundedRows": [],
+        "boundedRowCount": 0,
+        "boundedRowLimit": 20,
+    }
     _assert_secret_safe(response.text)


### PR DESCRIPTION
## Summary
- add a distinct bounded result summary export for executed candidate workflows
- include request, candidate, run, source, audit, and bounded result context without raw SQL, credentials, connection details, raw rows, or workstation-local paths
- expose the export through an operator evidence-read endpoint and cover aggregate-only, bounded-row, oversized-row rejection, and endpoint redaction behavior

## Verification
- cd backend && python3 -m pytest tests/test_support_bundle.py tests/test_candidate_execute_api.py -q

Closes #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API endpoint for retrieving bounded result summaries for specific candidates
  * Includes strict security validation to prevent sharing of unsafe or sensitive data
  * Automatically truncates result sets when exceeding configured row limits
  * Returns comprehensive summary context with request details, candidate information, and audit information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->