### PR TITLE
Clarify raw SQL review boundary

### DIFF
--- a/docs/design/audit-governance-export-bundle.md
+++ b/docs/design/audit-governance-export-bundle.md
@@ -100,6 +100,12 @@ passwords, no tokens, no cookies, no CSRF secrets, no private keys, no raw
 identity payloads, no raw SQL, no raw result rows, no source connection
 references, and no workstation-local absolute paths.
 
+This differs from the authorized operator workflow review surface. Operators may
+see raw candidate SQL there while reviewing a server-owned candidate under the
+authenticated SafeQuery workflow context, but that visibility does not carry into
+support bundles, handoff exports, dedicated governance review exports, MLflow
+artifacts, analyst context, or any other shared diagnostic artifact.
+
 Redacted fields should be omitted or replaced with stable redaction markers such
 as `<redacted>`. A missing field means unavailable or intentionally redacted; it
 is not proof that the omitted action was safe.

--- a/docs/design/operator-workflow-information-architecture.md
+++ b/docs/design/operator-workflow-information-architecture.md
@@ -60,6 +60,24 @@ one primary job obvious:
 Only one of those jobs should dominate the main surface at a time, even if nearby context remains
 visible.
 
+### Raw SQL review boundary
+
+Raw candidate SQL may be visible only inside the authorized operator workflow review surface. That
+surface is bound to the authenticated operator, selected source, server-owned request record,
+server-owned candidate record, guard posture, and direct audit context. It is not an export,
+support bundle, analyst handoff, MLflow artifact, or generic evidence surface.
+
+Operator copy should name the preview as an authorized review surface when raw candidate SQL is
+shown. It must not suggest that raw SQL can be copied into execute APIs, support artifacts, or
+handoff exports. Execution remains candidate-bound; clients still submit the server-owned candidate
+identifier and selected source binding, not raw SQL text.
+
+Support bundles, bounded handoff exports, dedicated governance review exports, and other shared
+diagnostic artifacts must stay redacted. They may carry candidate ids, source ids, lifecycle state,
+guard status, row counts, audit event ids, redaction posture, and bounded metadata, but they must
+exclude raw SQL, raw result rows, credentials, connection strings, source connection references,
+tokens, raw identity payloads, and workstation-local absolute paths.
+
 ### Support surfaces
 
 Support surfaces hold contextual information that should remain visible without overtaking the main

--- a/docs/pilot-deployment-profile.md
+++ b/docs/pilot-deployment-profile.md
@@ -160,6 +160,12 @@ include application version, environment label, source ids, source posture,
 health summaries, migration posture, workflow state summaries, lifecycle
 metrics, and audit completeness counts.
 
+They are not the same surface as authorized operator SQL review. Raw candidate
+SQL may appear in the SafeQuery operator workflow only for an authenticated,
+authorized operator reviewing a server-owned candidate in its selected source
+context. Sharing artifacts must use the redacted export or support-bundle
+boundary instead of carrying that raw preview text forward.
+
 Dedicated governance review exports are separate reviewer-scoped artifacts, not
 support bundles with a broader audience. Use
 `docs/design/audit-governance-export-bundle.md` for the required source/time

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -207,6 +207,12 @@ describe("pilot safety UI smoke", () => {
     expect(
       screen.getByText("select vendor_name from finance.approved_vendor_spend limit 10;")
     ).toBeInTheDocument();
+    expect(screen.getByLabelText(/authorized operator sql review/i)).toHaveTextContent(
+      /Raw candidate SQL is visible only inside this authorized operator workflow review/i
+    );
+    expect(screen.getByLabelText(/authorized operator sql review/i)).toHaveTextContent(
+      /Support bundles and handoff exports stay redacted/i
+    );
     expect(screen.getByText("candidate-pilot-001")).toBeInTheDocument();
     expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("guard_evaluated");
     expect(screen.getByLabelText(/retrieved citation context/i)).toHaveTextContent(

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -2842,6 +2842,14 @@ export function QueryWorkflowShell({
               </div>
               <span className="surface-badge surface-badge-code">Preview</span>
             </div>
+            <div className="state-callout" aria-label="Authorized operator SQL review">
+              <p className="state-callout-title">Authorized operator review surface</p>
+              <p>
+                Raw candidate SQL is visible only inside this authorized operator workflow review.
+                Support bundles and handoff exports stay redacted and exclude raw SQL, secrets,
+                connection strings, result rows, and local paths.
+              </p>
+            </div>
             {renderCandidateSqlPreview(candidatePreview)}
           </section>
 


### PR DESCRIPTION
## Summary
- Clarify that raw candidate SQL is visible only in the authorized operator workflow review surface
- Add UI copy distinguishing SQL preview from redacted support bundle and handoff export surfaces
- Update governance export and pilot deployment docs to keep shared artifacts redacted

## Verification
- cd frontend && npm test -- --run app/pilot-safety-smoke.test.tsx
- cd backend && python3 -m pytest tests/test_support_bundle.py

Closes #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UI callout documenting data exposure boundaries in the operator review interface, clarifying that raw SQL visibility is restricted to authenticated workflow review and excluded from support bundles and export artifacts.

* **Documentation**
  * Updated design and deployment guidance to explicitly distinguish data visibility rules between operator review surfaces and shared diagnostic exports, with redaction policies for sensitive content in external artifacts.

* **Tests**
  * Enhanced smoke tests to validate UI messaging around data visibility and export redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->