### PR TITLE
Define future source-family activation criteria

### DIFF
--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -119,20 +119,21 @@ Required readiness evidence before `active-baseline`:
   missing evaluation readiness.
 - Dataset-contract readiness: the family has an approved dataset contract,
   schema snapshot linkage, entitlement posture, row-level or view-level exposure
-  scope where applicable, and stale-contract denial behavior.
+  scope where applicable, and stale-contract denial behavior. The explicit
+  blocker is missing dataset-contract readiness.
 - Row-bounds readiness: the family has one approved bounded-read strategy that
   runs before guard, preview, and execution, with tests for unbounded reads,
   conflicting limits, offset behavior, truncation metadata, and audit
-  reconstruction.
+  reconstruction. The explicit blocker is missing row-bounds readiness.
 
 No planned or unsupported family may dispatch connector code, appear in active
 execution coverage, or be treated as runtime-capable because it appears in a
 roadmap, matrix, sample config, adapter output, analyst artifact, MLflow trace,
 or operator-facing label. `activation-candidate` is also non-executable until
-the gate is approved. If any required guard, runtime, secrets, audit, or
-evaluation evidence is missing, malformed, stale, or only inferred from a
-non-authoritative surface, SafeQuery must reject activation and keep the family
-non-executable.
+the gate is approved. If any required guard, runtime, secrets, audit,
+evaluation, dataset-contract, or row-bounds evidence is missing, malformed,
+stale, or only inferred from a non-authoritative surface, SafeQuery must reject
+activation and keep the family non-executable.
 
 ## Health Checks
 

--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -72,6 +72,68 @@ When a source changes to a non-executable state, SafeQuery should treat previous
 - invalidate them proactively
 - deny execution with an explicit stale-policy or invalidation outcome
 
+## Future Source-Family Activation Gate
+
+Future source families and flavors must move through explicit activation states
+before they can become executable. The gate applies to MySQL, MariaDB, Aurora,
+Oracle, and later families without implying that any connector work starts in
+this document.
+
+Activation states:
+
+- `planned`: product or architecture intent exists, but the family is metadata
+  only and cannot be selected for execution.
+- `unsupported`: the family is intentionally rejected even if a request, adapter
+  hint, source label, driver name, or connection shape claims it is available.
+- `activation-candidate`: all required evidence has been assembled for review,
+  but connector dispatch remains disabled until the gate is approved.
+- `active-baseline`: the backend-owned registry, connector, guard, audit,
+  evaluation, dataset, and runtime controls are approved together and covered by
+  release-gate reconstruction.
+
+Required readiness evidence before `active-baseline`:
+
+- Guard readiness: the family has an approved dialect profile, canonicalization
+  behavior, deny catalog mapping, deny corpus, parser-failure behavior, and
+  profile-version drift test. The explicit blocker is missing guard readiness.
+- Runtime readiness: the family has backend-owned connector selection, driver
+  availability checks, timeout handling, cancellation behavior, source
+  unavailable classification, rate or concurrency limits where applicable, and
+  no path that trusts adapter or client-supplied runtime hints. The explicit
+  blocker is missing runtime readiness.
+- Secrets readiness: the registry points only to backend-owned secret
+  indirection, health checks prove the secret reference can be resolved by the
+  trusted backend, and placeholder credentials, sample credentials, raw
+  connection strings, or client-supplied connection material are rejected.
+  The explicit blocker is missing secrets readiness.
+- Audit readiness: source id, source family, optional source flavor, dataset
+  contract, schema snapshot, execution policy, connector profile, dialect
+  profile, guard version, deny code, row count, truncation state, request id,
+  candidate id, approval id, and correlation id are present in source-aware
+  audit events where applicable. The explicit blocker is missing audit
+  readiness.
+- Evaluation readiness: positive, safety-deny, connector-selection, lifecycle,
+  runtime-control, audit reconstruction, release-gate reconstruction, and
+  operator-history scenarios exist as SafeQuery-owned evaluation artifacts for
+  the family or explicitly approved flavor inheritance. The explicit blocker is
+  missing evaluation readiness.
+- Dataset-contract readiness: the family has an approved dataset contract,
+  schema snapshot linkage, entitlement posture, row-level or view-level exposure
+  scope where applicable, and stale-contract denial behavior.
+- Row-bounds readiness: the family has one approved bounded-read strategy that
+  runs before guard, preview, and execution, with tests for unbounded reads,
+  conflicting limits, offset behavior, truncation metadata, and audit
+  reconstruction.
+
+No planned or unsupported family may dispatch connector code, appear in active
+execution coverage, or be treated as runtime-capable because it appears in a
+roadmap, matrix, sample config, adapter output, analyst artifact, MLflow trace,
+or operator-facing label. `activation-candidate` is also non-executable until
+the gate is approved. If any required guard, runtime, secrets, audit, or
+evaluation evidence is missing, malformed, stale, or only inferred from a
+non-authoritative surface, SafeQuery must reject activation and keep the family
+non-executable.
+
 ## Health Checks
 
 Registry-aware health checks should verify the backend can still resolve:

--- a/tests/test_source_family_activation_criteria_docs.py
+++ b/tests/test_source_family_activation_criteria_docs.py
@@ -7,9 +7,13 @@ ACTIVATION_DOC = REPO_ROOT / "docs" / "design" / "target-source-registry.md"
 
 def test_future_source_family_activation_gate_is_documented() -> None:
     content = ACTIVATION_DOC.read_text(encoding="utf-8")
-    normalized_content = " ".join(content.split())
+    header = "## Future Source-Family Activation Gate"
+    start = content.find(header)
+    assert start != -1
 
-    assert "## Future Source-Family Activation Gate" in content
+    next_section = content.find("\n## ", start + len(header))
+    activation_section = content[start : next_section if next_section != -1 else len(content)]
+    normalized_activation_section = " ".join(activation_section.split())
 
     required_states = [
         "`planned`",
@@ -18,7 +22,7 @@ def test_future_source_family_activation_gate_is_documented() -> None:
         "`active-baseline`",
     ]
     for state in required_states:
-        assert state in content
+        assert state in activation_section
 
     required_categories = [
         "Guard readiness",
@@ -30,7 +34,7 @@ def test_future_source_family_activation_gate_is_documented() -> None:
         "Row-bounds readiness",
     ]
     for category in required_categories:
-        assert category in content
+        assert category in activation_section
 
     fail_closed_blockers = [
         "missing guard readiness",
@@ -42,6 +46,9 @@ def test_future_source_family_activation_gate_is_documented() -> None:
         "missing row-bounds readiness",
     ]
     for blocker in fail_closed_blockers:
-        assert blocker in normalized_content
+        assert blocker in normalized_activation_section
 
-    assert "No planned or unsupported family may dispatch connector code" in content
+    assert (
+        "No planned or unsupported family may dispatch connector code"
+        in normalized_activation_section
+    )

--- a/tests/test_source_family_activation_criteria_docs.py
+++ b/tests/test_source_family_activation_criteria_docs.py
@@ -38,6 +38,8 @@ def test_future_source_family_activation_gate_is_documented() -> None:
         "missing secrets readiness",
         "missing audit readiness",
         "missing evaluation readiness",
+        "missing dataset-contract readiness",
+        "missing row-bounds readiness",
     ]
     for blocker in fail_closed_blockers:
         assert blocker in normalized_content

--- a/tests/test_source_family_activation_criteria_docs.py
+++ b/tests/test_source_family_activation_criteria_docs.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ACTIVATION_DOC = REPO_ROOT / "docs" / "design" / "target-source-registry.md"
+
+
+def test_future_source_family_activation_gate_is_documented() -> None:
+    content = ACTIVATION_DOC.read_text(encoding="utf-8")
+    normalized_content = " ".join(content.split())
+
+    assert "## Future Source-Family Activation Gate" in content
+
+    required_states = [
+        "`planned`",
+        "`unsupported`",
+        "`activation-candidate`",
+        "`active-baseline`",
+    ]
+    for state in required_states:
+        assert state in content
+
+    required_categories = [
+        "Guard readiness",
+        "Runtime readiness",
+        "Secrets readiness",
+        "Audit readiness",
+        "Evaluation readiness",
+        "Dataset-contract readiness",
+        "Row-bounds readiness",
+    ]
+    for category in required_categories:
+        assert category in content
+
+    fail_closed_blockers = [
+        "missing guard readiness",
+        "missing runtime readiness",
+        "missing secrets readiness",
+        "missing audit readiness",
+        "missing evaluation readiness",
+    ]
+    for blocker in fail_closed_blockers:
+        assert blocker in normalized_content
+
+    assert "No planned or unsupported family may dispatch connector code" in content


### PR DESCRIPTION
## Summary
- Document the future source-family activation gate in the target source registry design doc
- Define planned, unsupported, activation-candidate, and active-baseline states
- Add a focused regression test for required readiness categories and fail-closed blockers

## Verification
- python3 -m pytest tests/test_source_family_activation_criteria_docs.py tests/test_check_repository_hygiene.py -q
- bash tests/smoke/test-doc-entrypoints-current-set.sh

Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Future Source-Family Activation Gate" spec defining four activation states, detailed readiness categories (guard/dialect, runtime, secrets, audit, evaluation, dataset-contract, bounded-read/row-bounds), required evidence for each, and fail-closed rules preventing execution when evidence is missing, malformed, stale, or derived from non-authoritative surfaces.

* **Tests**
  * Added a validation that the activation-gate documentation includes the section, states, readiness headings, fail-closed blocker phrases, and the exact fail-closed rule string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->