### PR TITLE
Update connector threat model for future source families

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -90,6 +90,99 @@ This document summarizes the initial SafeQuery threat model for the pilot-safe P
 - retrieval corpus change review and citation anomaly review
 - monitoring for unexpected sensitive-field exports into MLflow
 
+## Future Connector Threat Model
+
+This section records threat-model requirements for planned connector families
+before any activation candidate is selected. It is documentation only: it does
+not add runtime connector behavior, local services, driver dependencies, or
+active execution coverage.
+
+SafeQuery remains the application-owned trusted control boundary for source
+registration, connector selection, dialect and guard profile selection, secrets
+resolution, candidate lifecycle checks, result bounding, and audit records.
+External systems, database drivers, adapter output, request metadata, hostnames,
+connection strings, MLflow traces, analyst artifacts, and operator-facing labels
+are not authority sources. No planned family or flavor may dispatch connector
+code until the source registry and activation gate approve the family or flavor
+with connector, guard, audit, runtime, secrets, dataset, row-bound, and
+evaluation evidence together.
+
+### MySQL
+
+MySQL is planned metadata only. The backend-owned source registry must select
+`source_family=mysql`, connector profile, dialect profile, secret indirection,
+dataset contract, schema snapshot, and activation posture before any MySQL
+source can become an activation candidate.
+
+| Connector risk | Activation blocker | Mitigation requirement |
+| --- | --- | --- |
+| dialect ambiguity between MySQL modes, generated SQL, adapter hints, driver names, and hostname or URL shapes | missing backend-selected MySQL dialect profile, guard profile, and drift coverage | select MySQL only from the source registry; require MySQL-aware canonicalization, unsafe `sql_mode` rejection, deny corpus coverage, and profile-version drift tests |
+| privilege scope that can expose cross-database objects, system catalogs, temporary object mutation, or write paths | missing read-only database identity and approved dataset contract | require least-privilege read-only credentials, approved schema snapshot linkage, entitlement posture, and denies for writes, cross-database references, system catalog access, and temporary mutation |
+| driver behavior around connection timeout, statement timeout, cancellation, retry classification, and cursor/result materialization | missing runtime readiness for the selected backend-owned connector profile | prove driver availability, connect timeout, statement timeout, cancellation probe, source-unavailable classification, and no retry for malformed or policy-denied states |
+| secret handling through raw connection strings, placeholder credentials, client-supplied connection material, or application PostgreSQL reuse | missing secrets readiness | resolve only backend-owned secret indirection such as a per-source reader handle; reject placeholder credentials, sample secrets, raw credentials, and application PostgreSQL credential reuse |
+| result bounds using implicit driver defaults, unsafe `LIMIT` or `OFFSET`, or unbounded reads | missing row-bounds readiness | enforce one policy-bounded `LIMIT`; allow `OFFSET` only with an explicit bounded `LIMIT`; audit truncation state and deny conflicting or missing row bounds |
+| audit evidence that cannot reconstruct the selected source, connector profile, dialect profile, guard version, or primary deny code | missing audit and release-gate reconstruction readiness | emit SafeQuery-owned source-aware audit events and evaluation evidence for source id, family, flavor, dataset contract, schema snapshot, execution policy, connector profile, dialect profile, guard version, request id, candidate id, approval id, and primary deny code |
+
+### MariaDB
+
+MariaDB is a distinct planned `source_family=mariadb` profile, not an
+adapter-inferred MySQL alias. It may share MySQL-family concepts only where a
+backend-owned MariaDB profile explicitly approves them.
+
+| Connector risk | Activation blocker | Mitigation requirement |
+| --- | --- | --- |
+| dialect ambiguity from MySQL overlap, MariaDB mode and version drift, executable comments, optimizer hints, driver names, and connection labels | missing MariaDB-specific dialect and guard readiness | require a separate MariaDB delta profile, canonicalization drift coverage, MariaDB deny fixtures, and no silent MySQL guard reuse |
+| privilege scope that exposes information schema, system catalogs, cross-database objects, write paths, or temporary/session mutation | missing MariaDB dataset-contract and privilege evidence | require a least-privilege read-only MariaDB identity, approved dataset contract, approved schema snapshot, entitlement posture, and deny fixtures for writes and unauthorized metadata access |
+| driver behavior that differs from MySQL for timeouts, cancellation, retry posture, result cursor handling, or version-specific behavior | missing MariaDB runtime readiness | prove backend-owned connector selection, driver availability, timeout, cancellation, source-unavailable classification, and malformed or denied state handling for MariaDB specifically |
+| secret handling through MySQL secret reuse, raw URLs, placeholder credentials, or client-supplied connection material | missing MariaDB secrets readiness | require backend-owned MariaDB secret indirection and reject MySQL credential reuse unless the authoritative profile explicitly binds the same controlled source |
+| result bounds that assume MySQL behavior without MariaDB delta review | missing MariaDB row-bounds readiness | require one policy-bounded `LIMIT`, explicit bounded `LIMIT` for `OFFSET`, MariaDB delta tests, truncation metadata, and deny behavior for unsafe bounds |
+| audit evidence that collapses MariaDB into MySQL or omits profile-version proof | missing MariaDB audit and release-gate reconstruction readiness | preserve `source_family=mariadb`, optional flavor, dataset contract, schema snapshot, execution policy, connector profile, dialect profile, guard version, and primary deny code in SafeQuery-owned audit and evaluation artifacts |
+
+### Aurora PostgreSQL
+
+Aurora PostgreSQL is a planned flavor of the PostgreSQL family. Its authoritative
+identity is `source_family=postgresql` plus
+`source_flavor=aurora-postgresql` in the backend-owned source registry.
+
+| Connector risk | Activation blocker | Mitigation requirement |
+| --- | --- | --- |
+| dialect ambiguity from treating Aurora PostgreSQL as a top-level family or from trusting hostnames, driver names, request hints, generated SQL, or adapter output | missing authoritative flavor binding and PostgreSQL inheritance evidence | resolve the flavor only from the source registry; inherit PostgreSQL generation, canonicalization, guard, deny corpus, and row-bounding behavior only when the registry says so |
+| privilege scope across Aurora cluster endpoints, replicas, databases, schemas, or application PostgreSQL identity | missing Aurora PostgreSQL connector-profile and dataset-contract evidence | require read-only backend-owned connector identity, explicit cluster or instance endpoint posture, approved schema snapshot, entitlement posture, and separation from application PostgreSQL credentials |
+| driver behavior that changes timeout, cancellation, TLS, failover, replica, or source-unavailable semantics | missing Aurora PostgreSQL runtime readiness | reverify PostgreSQL driver behavior against Aurora endpoint posture, engine version, TLS posture, connection timeout, statement timeout, cancellation probe, and retry classification |
+| secret handling through reused PostgreSQL application credentials, raw cluster URLs, placeholders, or client-provided connection material | missing Aurora PostgreSQL secrets readiness | require backend-owned flavor-specific secret indirection and reject application PostgreSQL secrets, placeholder credentials, raw connection strings, and request-provided material |
+| result bounds that rely on generic PostgreSQL behavior without Aurora flavor regression coverage | missing Aurora PostgreSQL row-bounds readiness | preserve PostgreSQL bounded canonical SQL behavior and add Aurora flavor regressions for row bounds, truncation metadata, timeout, and cancellation |
+| audit evidence that cannot distinguish business PostgreSQL from Aurora PostgreSQL | missing Aurora PostgreSQL audit and release-gate reconstruction readiness | include source id, `source_family=postgresql`, `source_flavor=aurora-postgresql`, dataset contract, schema snapshot, execution policy, connector profile, dialect profile, guard version, endpoint posture evidence, and primary deny code |
+
+### Aurora MySQL
+
+Aurora MySQL is a planned flavor of the MySQL family. Because MySQL remains
+planned metadata only, Aurora MySQL cannot become executable before MySQL family
+activation is approved.
+
+| Connector risk | Activation blocker | Mitigation requirement |
+| --- | --- | --- |
+| dialect ambiguity from treating Aurora MySQL as a top-level family or from trusting hostnames, driver names, request hints, generated SQL, connection URLs, or adapter output | missing authoritative flavor binding and approved MySQL-family readiness | resolve `source_family=mysql` and `source_flavor=aurora-mysql` only from the source registry; inherit MySQL behavior only after MySQL family profiles are approved |
+| privilege scope across Aurora cluster endpoints, replicas, databases, system catalogs, or write paths | missing Aurora MySQL connector-profile and dataset-contract evidence | require read-only backend-owned connector identity, explicit cluster or instance endpoint posture, approved schema snapshot, entitlement posture, and MySQL-family deny coverage |
+| driver behavior that changes timeout, cancellation, TLS, failover, replica, or source-unavailable semantics | missing Aurora MySQL runtime readiness | reverify MySQL driver behavior against Aurora endpoint posture, engine version, TLS posture, connection timeout, statement timeout, cancellation probe, and retry classification |
+| secret handling through MySQL secret reuse without an explicit source binding, raw cluster URLs, placeholders, or client-provided connection material | missing Aurora MySQL secrets readiness | require backend-owned flavor-specific secret indirection and reject placeholder credentials, raw connection strings, and request-provided material |
+| result bounds that assume MySQL behavior without Aurora flavor regression coverage | missing Aurora MySQL row-bounds readiness | preserve the approved MySQL bounded `LIMIT` posture and add Aurora MySQL regressions for row bounds, truncation metadata, timeout, and cancellation |
+| audit evidence that cannot prove the Aurora MySQL flavor or underlying MySQL profile versions | missing Aurora MySQL audit and release-gate reconstruction readiness | include source id, `source_family=mysql`, `source_flavor=aurora-mysql`, dataset contract, schema snapshot, execution policy, connector profile, dialect profile, guard version, endpoint posture evidence, and primary deny code |
+
+### Oracle
+
+Oracle is long-range planned metadata only. Oracle support must not activate
+connector dispatch, runtime defaults, local startup services, guard behavior, or
+release-gate coverage until a distinct Oracle source-family gate is approved.
+
+| Connector risk | Activation blocker | Mitigation requirement |
+| --- | --- | --- |
+| dialect ambiguity from Oracle version differences, quoted identifier case, PL/SQL, database links, package/session state, connection descriptors, driver names, request hints, generated SQL, or adapter output | missing Oracle-specific dialect and guard readiness | require Oracle-aware canonicalization, explicit quoted identifier handling, a distinct fail-closed guard profile, and denies for PL/SQL, procedure execution, dynamic SQL, database links, package/session mutation, unsupported syntax, and profile drift |
+| privilege scope that exposes schemas, packages, database links, system catalogs, external data access, or write paths | missing Oracle dataset-contract and least-privilege evidence | require read-only database identity, approved dataset contract, schema snapshot, entitlement posture, and deny fixtures for writes, metadata access, external access, database links, and session/package mutation |
+| driver behavior around connect descriptors, wallets, TLS, service names, timeout support, cancellation, cursor materialization, and source-unavailable classification | missing Oracle runtime readiness | prove backend-owned Oracle connector selection, driver availability, wallet and TLS posture, connect timeout, statement timeout, cancellation probe, result materialization, and fail-closed retry classification |
+| secret handling through raw descriptors, wallet material, placeholder credentials, sample secrets, or client-provided connection material | missing Oracle secrets readiness | resolve only backend-owned Oracle secret indirection for service name, username, wallet reference, and TLS posture; reject raw credentials, placeholder secrets, sample secrets, and client-supplied material |
+| result bounds that rely on ambiguous `FETCH FIRST`, `ROWNUM`, pagination, or nested query behavior | missing Oracle row-bounds readiness | approve one canonical policy-bounded row-limit shape before guard, preview, and execution; test conflicting bounds, unbounded reads, truncation metadata, and audit reconstruction |
+| audit evidence that cannot reconstruct Oracle connector identity, wallet reference posture, dialect profile, guard version, or deny reason | missing Oracle audit and release-gate reconstruction readiness | preserve source id, `source_family=oracle`, flavor, dataset contract, schema snapshot, execution policy, connector profile, dialect profile, guard version, wallet reference posture, request id, candidate id, approval id, and primary deny code in SafeQuery-owned audit and evaluation evidence |
+
 ## Residual Risks
 
 - generation quality may still be poor even when safety controls hold

--- a/tests/test_connector_threat_model_docs.py
+++ b/tests/test_connector_threat_model_docs.py
@@ -9,8 +9,54 @@ def _section(content: str, header: str) -> str:
     start = content.find(header)
     assert start != -1, f"Missing section: {header}"
 
-    next_section = content.find("\n### ", start + len(header))
+    header_prefix = header.split(" ", maxsplit=1)[0]
+    assert header_prefix and set(header_prefix) == {"#"}, f"Invalid header: {header}"
+
+    next_sections = [
+        content.find(f"\n{'#' * level} ", start + len(header))
+        for level in range(1, len(header_prefix) + 1)
+    ]
+    next_sections = [index for index in next_sections if index != -1]
+    next_section = min(next_sections) if next_sections else -1
     return content[start : next_section if next_section != -1 else len(content)]
+
+
+def test_section_stops_at_same_or_higher_heading_boundary() -> None:
+    content = "\n".join(
+        [
+            "## Future Connector Threat Model",
+            "intro",
+            "### MySQL",
+            "mysql details",
+            "#### Nested context",
+            "nested details",
+            "### MariaDB",
+            "mariadb details",
+            "## Residual Risks",
+            "residual details",
+        ]
+    )
+
+    assert _section(content, "### MySQL") == "\n".join(
+        [
+            "### MySQL",
+            "mysql details",
+            "#### Nested context",
+            "nested details",
+        ]
+    )
+    assert _section(content, "## Future Connector Threat Model") == "\n".join(
+        [
+            "## Future Connector Threat Model",
+            "intro",
+            "### MySQL",
+            "mysql details",
+            "#### Nested context",
+            "nested details",
+            "### MariaDB",
+            "mariadb details",
+        ]
+    )
 
 
 def test_connector_threat_model_covers_planned_families_and_flavors() -> None:

--- a/tests/test_connector_threat_model_docs.py
+++ b/tests/test_connector_threat_model_docs.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+THREAT_MODEL_DOC = REPO_ROOT / "docs" / "security" / "threat-model.md"
+
+
+def _section(content: str, header: str) -> str:
+    start = content.find(header)
+    assert start != -1, f"Missing section: {header}"
+
+    next_section = content.find("\n### ", start + len(header))
+    return content[start : next_section if next_section != -1 else len(content)]
+
+
+def test_connector_threat_model_covers_planned_families_and_flavors() -> None:
+    content = THREAT_MODEL_DOC.read_text(encoding="utf-8")
+    connector_header = "## Future Connector Threat Model"
+    start = content.find(connector_header)
+    assert start != -1
+
+    connector_section = content[start:]
+    for header in [
+        "### MySQL",
+        "### MariaDB",
+        "### Aurora PostgreSQL",
+        "### Aurora MySQL",
+        "### Oracle",
+    ]:
+        family_section = _section(connector_section, header)
+        normalized = " ".join(family_section.split())
+        for required_risk in [
+            "dialect ambiguity",
+            "privilege scope",
+            "driver behavior",
+            "secret handling",
+            "result bounds",
+            "audit evidence",
+        ]:
+            assert required_risk in normalized
+
+        assert "Activation blocker" in family_section
+        assert "Mitigation requirement" in family_section
+
+
+def test_connector_threat_model_preserves_safequery_authority_boundary() -> None:
+    content = THREAT_MODEL_DOC.read_text(encoding="utf-8")
+    connector_section = _section(content, "## Future Connector Threat Model")
+    normalized = " ".join(connector_section.split())
+
+    required_boundary_claims = [
+        "SafeQuery remains the application-owned trusted control boundary",
+        "External systems, database drivers, adapter output, request metadata, hostnames, connection strings, MLflow traces, analyst artifacts, and operator-facing labels are not authority sources",
+        "No planned family or flavor may dispatch connector code",
+        "source registry",
+        "activation gate",
+    ]
+    for claim in required_boundary_claims:
+        assert claim in normalized


### PR DESCRIPTION
## Summary
- add focused documentation regression for planned connector threat-model coverage
- document MySQL, MariaDB, Aurora PostgreSQL, Aurora MySQL, and Oracle connector risks with activation blockers and mitigations
- preserve SafeQuery-owned registry, activation gate, connector dispatch, and audit authority boundaries

## Verification
- python3 -m pytest tests/test_connector_threat_model_docs.py tests/test_source_family_activation_criteria_docs.py -q
- python3 -m pytest tests -q
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- bash tests/smoke/test-design-contract.sh
- bash tests/smoke/test-pilot-safety-checklist.sh
- git diff --check

Closes #397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive threat model documentation for planned connector families, establishing security requirements, activation blockers, and mitigation strategies for MySQL, MariaDB, Aurora PostgreSQL, Aurora MySQL, and Oracle.

* **Tests**
  * Added automated validation tests to ensure threat model documentation consistency and completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->