### PR TITLE
Add dialect guard readiness checklists

### DIFF
--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -85,18 +85,20 @@ This reading order is intended to help new contributors understand SafeQuery fro
     Use this to understand the concrete registry model, source lifecycle expectations, and application PostgreSQL separation guardrails.
 33. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
     Review the family and flavor rollout matrix before planning connector, guard, or evaluation work for additional sources.
-34. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
+34. [design/dialect-guard-readiness-checklists.md](./design/dialect-guard-readiness-checklists.md)
+    Use this as the review checklist for guard readiness evidence before any planned MySQL, MariaDB, Aurora, or Oracle source can be considered for connector activation.
+35. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
     Read this to understand why the product shell is workflow-first and why the Epic A shell remains a developer state demo.
-35. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
+36. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
     Review how SafeQuery may borrow OSS ergonomics without turning the product into a generic chat shell or moving trust boundaries.
-36. [implementation-roadmap.md](./implementation-roadmap.md)
+37. [implementation-roadmap.md](./implementation-roadmap.md)
     Finish this section with the current implementation sequence so roadmap work stays aligned with the reviewed docs direction.
 
 ### 6. Local Setup and Threat Review
 
-37. [local-development.md](./local-development.md)
+38. [local-development.md](./local-development.md)
     Use this once the document set is clear so local startup follows the reviewed topology and role split.
-38. [security/threat-model.md](./security/threat-model.md)
+39. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks for the current source-aware and UX-foundation baseline before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md): UI stack and OSS adoption boundaries for the SafeQuery-owned operator shell
 - [design/target-source-registry.md](./design/target-source-registry.md): backend-owned registry model, activation semantics, and secret indirection expectations
 - [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md): compact family and flavor rollout matrix for connector, guard, and evaluation planning
+- [design/dialect-guard-readiness-checklists.md](./design/dialect-guard-readiness-checklists.md): reviewable guard readiness evidence checklist for planned MySQL, MariaDB, Aurora, and Oracle support
 - [implementation-roadmap.md](./implementation-roadmap.md): current implementation sequence after Epic A, Epic A follow-up, and UX-1
 
 ## Documentation Intent

--- a/docs/design/dialect-guard-readiness-checklists.md
+++ b/docs/design/dialect-guard-readiness-checklists.md
@@ -1,0 +1,178 @@
+# Dialect Guard Readiness Checklists
+
+## Purpose
+
+These checklists define the guard evidence required before a planned source
+family or flavor can move toward connector activation. This is
+checklist/evaluation planning only. No new guard profile is activated by this
+document, and no connector dispatch is enabled for MySQL, MariaDB, Aurora, or
+Oracle.
+
+Every planned family must remain non-executable until backend-owned registry
+state, dialect guard evidence, runtime controls, audit coverage, evaluation
+outcomes, and release-gate reconstruction agree. The explicit blocker is
+missing checklist evidence. Stale evidence or evidence inferred from adapter
+output, labels, hostnames, connection strings, driver names, traces, or other
+non-authoritative surfaces keeps the family fail-closed.
+
+## Common Evidence Required
+
+Each planned checklist item must be testable or reviewable before connector
+activation. The minimum evidence package for a family or flavor is:
+
+- Canonicalization fixtures proving single-statement normalization, identifier
+  handling, row-bound placement, parser-failure behavior, and profile-version
+  drift failure.
+- Deny corpus fixtures mapping every denial to the SafeQuery-owned deny catalog
+  and to a primary audit deny code.
+- System catalog access fixtures for dialect catalog tables, information schema
+  surfaces, metadata procedures, cross-database or cross-schema discovery, and
+  equivalent engine-specific metadata access.
+- Mutating statement fixtures for data writes, DDL, temp object mutation,
+  transaction control, grants, session state mutation, and any statement shape
+  that can change durable or session-visible state.
+- Comment and hint fixtures for inline comments, block comments, optimizer
+  hints, executable comments, and syntax that can hide or alter execution.
+- Function and procedure fixtures for stored procedure execution, package or
+  routine invocation, dynamic SQL, file or network access functions, sleep or
+  delay functions, and extension-specific unsafe functions.
+- Dialect-specific edge-case fixtures covering quoting, case handling,
+  escaping, row bounds, unsupported syntax, engine-version drift, flavor
+  inheritance, and connector or dialect profile mismatch.
+- Release-gate reconstruction evidence showing positive, guard-deny,
+  unsupported-binding, stale-policy, lifecycle, audit, and operator-history
+  scenarios are reconstructed from SafeQuery-owned evaluation outcomes and
+  source-aware audit events.
+
+The evidence package must include expected allow or reject decisions, source
+family, optional source flavor, connector profile version, dialect profile
+version, guard version, dataset contract, schema snapshot, execution policy,
+primary deny code, and the audit fields needed to prove which backend-selected
+profile was used.
+
+## MySQL Guard Readiness Checklist
+
+MySQL remains planned metadata only until this checklist is complete and
+reviewed with the activation gate.
+
+- Canonicalization: prove MySQL-aware single-statement canonicalization,
+  backtick identifier normalization, string escaping, comment stripping,
+  parser-failure denial, and profile-version drift rejection.
+- `sql_mode`: reject unsafe or unknown `sql_mode` assumptions, and include
+  fixtures for quoting, ANSI mode, backslash escaping, and version drift.
+- Deny corpus: include writes, DDL, transaction control, grants, multi-statement
+  SQL, temporary table mutation, stored procedure execution, dynamic SQL,
+  `LOAD DATA`, file access, sleep or benchmark functions, and unsupported
+  syntax.
+- System catalogs: deny unsafe access to `information_schema`, `mysql`, and
+  `performance_schema` unless a later approved dataset contract explicitly
+  exposes a reviewed view.
+- Row bounds: prove exactly one effective policy-bounded `LIMIT`; `OFFSET` is
+  allowed only with an explicit bounded `LIMIT`; conflicting or hidden limits
+  are rejected before preview and execution.
+- Comments and hints: include inline comments, block comments, version comments,
+  optimizer hints, and comment-wrapped deny patterns.
+- Evidence: provide MySQL positive, deny, row-bounding, connector-selection,
+  lifecycle, audit, operator-history, and release-gate reconstruction scenarios
+  before any source can leave non-executable planned state.
+
+## MariaDB Guard Readiness Checklist
+
+MariaDB is a distinct planned `source_family=mariadb` profile. It may reuse
+MySQL-family expectations only where an approved backend profile says so; it
+must not silently inherit the MySQL guard profile.
+
+- Canonicalization: prove MariaDB mode and version-specific canonicalization
+  drift, identifier quoting, string escaping, parser-failure denial, and
+  profile-version drift rejection.
+- Deny corpus: include writes, DDL, transaction control, grants, multi-statement
+  SQL, temporary object mutation, stored routine execution, dynamic SQL, file
+  access, sleep or benchmark functions, and unsupported syntax.
+- System catalogs: deny unsafe `information_schema`, `mysql`,
+  `performance_schema`, and MariaDB-specific catalog or status surfaces unless
+  explicitly exposed by an approved dataset contract.
+- Comments and hints: include optimizer hints, executable comments, versioned
+  comments, and comment-obfuscated deny patterns.
+- Row bounds: prove one policy-bounded `LIMIT`, safe `OFFSET` behavior only
+  with an explicit bounded `LIMIT`, and fail-closed handling for hidden or
+  conflicting row bounds after MariaDB delta review.
+- Evidence: provide a separate MariaDB positive, deny, row-bounding,
+  timeout/cancellation, audit, operator-history, and release-gate reconstruction
+  corpus, even when cases overlap MySQL.
+
+## Aurora PostgreSQL Guard Readiness Checklist
+
+Aurora PostgreSQL is a planned flavor selected only from backend registry
+metadata as `source_family=postgresql` and `source_flavor=aurora-postgresql`.
+It is not a top-level family and is not activated by labels, hostnames,
+connection URLs, driver names, adapter hints, or generated SQL text.
+
+- Inheritance: prove the source uses the PostgreSQL guard profile,
+  canonicalization rules, deny corpus, and row-bounding behavior unless an
+  approved flavor delta explicitly overrides a rule.
+- Flavor deltas: review cluster or instance endpoint identity, engine version,
+  TLS posture, timeout behavior, cancellation behavior, and source-unavailable
+  classification without trusting client-supplied metadata.
+- Deny corpus: run PostgreSQL system catalog, mutating statement, function,
+  comment, row-bound, unsupported syntax, stale-policy, and profile mismatch
+  denies against the Aurora flavor.
+- Evidence: provide flavor regression cases that prove release-gate
+  reconstruction records source id, family, flavor, connector profile, dialect
+  profile, guard version, dataset contract, schema snapshot, execution policy,
+  and primary deny code.
+
+## Aurora MySQL Guard Readiness Checklist
+
+Aurora MySQL is a planned flavor selected only from backend registry metadata as
+`source_family=mysql` and `source_flavor=aurora-mysql`. Because the underlying
+MySQL family remains planned, Aurora MySQL also remains non-executable until
+the MySQL guard, connector, audit, and evaluation evidence is approved.
+
+- Inheritance: prove the source uses the approved MySQL guard profile,
+  canonicalization rules, deny corpus, and row-bounding behavior unless an
+  approved flavor delta explicitly overrides a rule.
+- Flavor deltas: review cluster or instance endpoint identity, engine version,
+  TLS posture, timeout behavior, cancellation behavior, and source-unavailable
+  classification without trusting client-supplied metadata.
+- Deny corpus: run MySQL system catalog, mutating statement, stored procedure,
+  dynamic SQL, comment, hint, row-bound, unsupported syntax, stale-policy, and
+  profile mismatch denies against the Aurora flavor.
+- Evidence: provide flavor regression cases that prove release-gate
+  reconstruction records source id, family, flavor, connector profile, dialect
+  profile, guard version, dataset contract, schema snapshot, execution policy,
+  and primary deny code.
+
+## Oracle Guard Readiness Checklist
+
+Oracle remains long-range planned metadata only until this checklist is complete
+and reviewed with the activation gate.
+
+- Canonicalization: prove Oracle-aware single-statement canonicalization,
+  quoted identifier case preservation, schema qualification rules,
+  parser-failure denial, and profile-version drift rejection.
+- Row bounds: approve one policy-bounded shape, such as `FETCH FIRST` or
+  `ROWNUM`, before guard, preview, and execution; reject conflicting, hidden,
+  or post-filter row bounds.
+- Deny corpus: include writes, DDL, transaction control, grants, multi-statement
+  SQL, PL/SQL blocks, procedure execution, dynamic SQL, database link access,
+  package state mutation, session mutation, external file or network access,
+  unsafe functions, and unsupported syntax.
+- System catalogs: deny unsafe access to Oracle data dictionary and dynamic
+  performance views unless an approved dataset contract explicitly exposes a
+  reviewed view.
+- Comments and hints: include inline comments, block comments, optimizer hints,
+  hint-obfuscated deny patterns, and mixed-case quoted identifiers.
+- Evidence: provide Oracle positive, deny, identifier and quoting,
+  row-bounding, timeout/cancellation, audit, operator-history, and release-gate
+  reconstruction scenarios before any active connector work begins.
+
+## Activation Boundary
+
+The checklists are prerequisites for later activation review, not activation
+approval. A planned family or flavor cannot dispatch connector code, appear in
+active execution coverage, or be reported as runtime-capable unless the
+activation gate has authoritative evidence for guard readiness, runtime
+readiness, secrets readiness, audit readiness, evaluation readiness,
+dataset-contract readiness, and row-bounds readiness. If any evidence is
+missing, malformed, partial, stale, or inferred from a derived surface, the
+family must remain non-executable and fail closed.

--- a/tests/smoke/test-doc-entrypoints-current-set.sh
+++ b/tests/smoke/test-doc-entrypoints-current-set.sh
@@ -71,6 +71,7 @@ docs_index_required_links=(
   "adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md"
   "design/target-source-registry.md"
   "design/dialect-capability-matrix.md"
+  "design/dialect-guard-readiness-checklists.md"
   "implementation-roadmap.md"
 )
 
@@ -104,6 +105,7 @@ reading_order_required_links=(
   "adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md"
   "design/target-source-registry.md"
   "design/dialect-capability-matrix.md"
+  "design/dialect-guard-readiness-checklists.md"
   "adr/ADR-0013-operator-workflow-and-ui-foundation.md"
   "adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md"
   "implementation-roadmap.md"

--- a/tests/test_dialect_guard_readiness_checklist_docs.py
+++ b/tests/test_dialect_guard_readiness_checklist_docs.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKLIST_DOC = REPO_ROOT / "docs" / "design" / "dialect-guard-readiness-checklists.md"
+
+
+def _section(content: str, header: str) -> str:
+    start = content.find(header)
+    assert start != -1, f"missing section {header}"
+    next_section = content.find("\n## ", start + len(header))
+    return content[start : next_section if next_section != -1 else len(content)]
+
+
+def test_planned_dialect_guard_readiness_checklists_are_reviewable() -> None:
+    content = CHECKLIST_DOC.read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    for phrase in [
+        "checklist/evaluation planning only",
+        "No new guard profile is activated",
+        "release-gate reconstruction",
+        "must remain non-executable",
+        "missing checklist evidence",
+    ]:
+        assert phrase in normalized
+
+    common_section = _section(content, "## Common Evidence Required")
+    for requirement in [
+        "Canonicalization fixtures",
+        "Deny corpus fixtures",
+        "System catalog access fixtures",
+        "Mutating statement fixtures",
+        "Comment and hint fixtures",
+        "Function and procedure fixtures",
+        "Dialect-specific edge-case fixtures",
+    ]:
+        assert requirement in common_section
+
+    family_expectations = {
+        "## MySQL Guard Readiness Checklist": [
+            "backtick identifier",
+            "sql_mode",
+            "information_schema",
+            "multi-statement",
+            "LIMIT",
+            "stored procedure",
+        ],
+        "## MariaDB Guard Readiness Checklist": [
+            "MariaDB mode",
+            "version-specific",
+            "executable comments",
+            "optimizer hints",
+            "information_schema",
+            "separate MariaDB",
+        ],
+        "## Aurora PostgreSQL Guard Readiness Checklist": [
+            "source_family=postgresql",
+            "source_flavor=aurora-postgresql",
+            "PostgreSQL guard profile",
+            "cluster or instance endpoint",
+            "flavor regression",
+        ],
+        "## Aurora MySQL Guard Readiness Checklist": [
+            "source_family=mysql",
+            "source_flavor=aurora-mysql",
+            "MySQL guard profile",
+            "cluster or instance endpoint",
+            "underlying MySQL family",
+        ],
+        "## Oracle Guard Readiness Checklist": [
+            "PL/SQL",
+            "database link",
+            "package state",
+            "session mutation",
+            "FETCH FIRST",
+            "ROWNUM",
+        ],
+    }
+    for header, phrases in family_expectations.items():
+        family_section = _section(content, header)
+        normalized_family_section = " ".join(family_section.split())
+        for phrase in phrases:
+            assert phrase in normalized_family_section


### PR DESCRIPTION
## Summary
- add a planning-only dialect guard readiness checklist for MySQL, MariaDB, Aurora PostgreSQL, Aurora MySQL, and Oracle
- require reviewable guard evidence across canonicalization, deny corpus, system catalog access, mutating statements, comments, functions, dialect edge cases, and release-gate reconstruction
- link the checklist from docs entrypoints and keep planned families non-executable with no new guard profile activation

## Verification
- python3 -m pytest tests/test_dialect_guard_readiness_checklist_docs.py tests/test_source_family_activation_criteria_docs.py
- bash tests/smoke/test-doc-entrypoints-current-set.sh

Closes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guard-readiness checklist guidelines for database connector activation, covering MySQL, MariaDB, Aurora, and Oracle sources.
  * Updated documentation index and reading order to reflect new design materials.

* **Tests**
  * Enhanced documentation validation tests to ensure proper checklist references and content requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->