### PR TITLE
Add connector activation gate requirements

### DIFF
--- a/backend/app/services/source_family_profiles.py
+++ b/backend/app/services/source_family_profiles.py
@@ -14,9 +14,14 @@ class ConnectorProfileRequirements(BaseModel):
     profile_id: str
     owner: Literal["backend"]
     read_only_posture: Literal["required"]
+    runtime_driver_dependencies: tuple[str, ...]
     secret_reference_pattern: str
+    secret_loading_owner: Literal["trusted_backend"]
+    secret_readiness_checks: tuple[str, ...]
+    connection_string_redaction: Literal["required_before_logs_exports_or_support_bundles"]
     connection_identity_fields: tuple[str, ...]
     required_controls: tuple[str, ...]
+    activation_gate_checks: tuple[str, ...]
     application_postgres_separation: str
 
 
@@ -191,6 +196,23 @@ FUTURE_FAMILY_SUPPLEMENTAL_ONLY_ARTIFACTS: tuple[str, ...] = (
     "adapter_traces",
 )
 
+FUTURE_FAMILY_SECRET_READINESS_CHECKS: tuple[str, ...] = (
+    "backend_secret_indirection_required",
+    "secret_reference_resolves_before_activation",
+    "blank_secret_rejected",
+    "placeholder_secret_rejected",
+    "raw_connection_string_rejected",
+    "connection_string_redaction_required",
+    "client_supplied_connection_material_rejected",
+)
+
+FUTURE_FAMILY_ACTIVATION_GATE_CHECKS: tuple[str, ...] = (
+    "driver_import_or_installation_check",
+    "first_run_doctor_family_runtime_check",
+    "support_bundle_redacted_readiness_snapshot",
+    "application_postgres_separation_check",
+)
+
 MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
     source_family="mysql",
     rollout_status="planned",
@@ -224,7 +246,11 @@ MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
         profile_id="mysql.readonly.planned.v1",
         owner="backend",
         read_only_posture="required",
+        runtime_driver_dependencies=("mysqlclient_or_pymysql",),
         secret_reference_pattern="safequery/business/mysql/<source_id>/reader",  # noqa: S106 - reference template, not a credential
+        secret_loading_owner="trusted_backend",
+        secret_readiness_checks=FUTURE_FAMILY_SECRET_READINESS_CHECKS,
+        connection_string_redaction="required_before_logs_exports_or_support_bundles",
         connection_identity_fields=(
             "host",
             "port",
@@ -237,6 +263,7 @@ MYSQL_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
             "statement_timeout_seconds",
             "cancellation_probe",
         ),
+        activation_gate_checks=FUTURE_FAMILY_ACTIVATION_GATE_CHECKS,
         application_postgres_separation=(
             "mysql business source credentials and endpoints must be distinct from "
             "the application PostgreSQL system of record"
@@ -355,7 +382,11 @@ MARIADB_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
         profile_id="mariadb.readonly.planned.v1",
         owner="backend",
         read_only_posture="required",
+        runtime_driver_dependencies=("mariadb_connector_or_pymysql",),
         secret_reference_pattern="safequery/business/mariadb/<source_id>/reader",  # noqa: S106 - reference template, not a credential
+        secret_loading_owner="trusted_backend",
+        secret_readiness_checks=FUTURE_FAMILY_SECRET_READINESS_CHECKS,
+        connection_string_redaction="required_before_logs_exports_or_support_bundles",
         connection_identity_fields=(
             "host",
             "port",
@@ -369,6 +400,7 @@ MARIADB_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
             "statement_timeout_seconds",
             "cancellation_probe",
         ),
+        activation_gate_checks=FUTURE_FAMILY_ACTIVATION_GATE_CHECKS,
         application_postgres_separation=(
             "mariadb business source credentials and endpoints must be distinct from "
             "the application PostgreSQL system of record"
@@ -493,7 +525,14 @@ ORACLE_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
         profile_id="oracle.readonly.long-range.v1",
         owner="backend",
         read_only_posture="required",
+        runtime_driver_dependencies=(
+            "python-oracledb",
+            "oracle_client_or_wallet_when_required",
+        ),
         secret_reference_pattern="safequery/business/oracle/<source_id>/reader",  # noqa: S106 - reference template, not a credential
+        secret_loading_owner="trusted_backend",
+        secret_readiness_checks=FUTURE_FAMILY_SECRET_READINESS_CHECKS,
+        connection_string_redaction="required_before_logs_exports_or_support_bundles",
         connection_identity_fields=(
             "connect_descriptor",
             "service_name",
@@ -506,6 +545,7 @@ ORACLE_FAMILY_PROFILE_REQUIREMENTS = SourceFamilyProfileRequirements(
             "statement_timeout_seconds",
             "cancellation_probe",
         ),
+        activation_gate_checks=FUTURE_FAMILY_ACTIVATION_GATE_CHECKS,
         application_postgres_separation=(
             "oracle business source credentials and endpoints must be distinct from "
             "the application PostgreSQL system of record"
@@ -645,9 +685,13 @@ AURORA_POSTGRESQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
         profile_id="postgresql.aurora-readonly.planned.v1",
         owner="backend",
         read_only_posture="required",
+        runtime_driver_dependencies=("psycopg",),
         secret_reference_pattern=(
             "safequery/business/postgresql/<source_id>/reader"
         ),  # noqa: S106 - reference template, not a credential
+        secret_loading_owner="trusted_backend",
+        secret_readiness_checks=FUTURE_FAMILY_SECRET_READINESS_CHECKS,
+        connection_string_redaction="required_before_logs_exports_or_support_bundles",
         connection_identity_fields=(
             "cluster_endpoint",
             "port",
@@ -661,6 +705,7 @@ AURORA_POSTGRESQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
             "statement_timeout_seconds",
             "cancellation_probe",
         ),
+        activation_gate_checks=FUTURE_FAMILY_ACTIVATION_GATE_CHECKS,
         application_postgres_separation=(
             "aurora postgresql source credentials and endpoints must be distinct from "
             "the application PostgreSQL system of record"
@@ -772,9 +817,13 @@ AURORA_MYSQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
         profile_id="mysql.aurora-readonly.planned.v1",
         owner="backend",
         read_only_posture="required",
+        runtime_driver_dependencies=("mysqlclient_or_pymysql",),
         secret_reference_pattern=(
             "safequery/business/mysql/<source_id>/reader"
         ),  # noqa: S106 - reference template, not a credential
+        secret_loading_owner="trusted_backend",
+        secret_readiness_checks=FUTURE_FAMILY_SECRET_READINESS_CHECKS,
+        connection_string_redaction="required_before_logs_exports_or_support_bundles",
         connection_identity_fields=(
             "cluster_endpoint",
             "port",
@@ -788,6 +837,7 @@ AURORA_MYSQL_FLAVOR_PROFILE_REQUIREMENTS = SourceFlavorProfileRequirements(
             "statement_timeout_seconds",
             "cancellation_probe",
         ),
+        activation_gate_checks=FUTURE_FAMILY_ACTIVATION_GATE_CHECKS,
         application_postgres_separation=(
             "aurora mysql source credentials and endpoints must be distinct from "
             "the application PostgreSQL system of record"

--- a/backend/tests/test_source_family_profiles.py
+++ b/backend/tests/test_source_family_profiles.py
@@ -86,6 +86,53 @@ def test_future_family_activation_checklist_requires_authoritative_coverage() ->
         }.issubset(audit_and_evaluation.authoritative_release_gate_artifacts)
 
 
+def test_future_family_activation_gate_requires_runtime_driver_and_secret_readiness() -> None:
+    required_secret_checks = {
+        "backend_secret_indirection_required",
+        "secret_reference_resolves_before_activation",
+        "blank_secret_rejected",
+        "placeholder_secret_rejected",
+        "raw_connection_string_rejected",
+        "connection_string_redaction_required",
+        "client_supplied_connection_material_rejected",
+    }
+    required_activation_checks = {
+        "driver_import_or_installation_check",
+        "first_run_doctor_family_runtime_check",
+        "support_bundle_redacted_readiness_snapshot",
+        "application_postgres_separation_check",
+    }
+
+    expected_driver_dependencies = {
+        "mysql": ("mysqlclient_or_pymysql",),
+        "mariadb": ("mariadb_connector_or_pymysql",),
+        "oracle": ("python-oracledb", "oracle_client_or_wallet_when_required"),
+        "aurora-postgresql": ("psycopg",),
+        "aurora-mysql": ("mysqlclient_or_pymysql",),
+    }
+
+    for requirements in _future_family_requirements():
+        connector = requirements.connector
+        profile_key = getattr(
+            requirements,
+            "source_flavor",
+            requirements.source_family,
+        )
+
+        assert set(connector.runtime_driver_dependencies) == set(
+            expected_driver_dependencies[profile_key]
+        )
+        assert required_secret_checks.issubset(set(connector.secret_readiness_checks))
+        assert required_activation_checks.issubset(
+            set(connector.activation_gate_checks)
+        )
+        assert connector.secret_loading_owner == "trusted_backend"
+        assert (
+            connector.connection_string_redaction
+            == "required_before_logs_exports_or_support_bundles"
+        )
+
+
 def test_active_source_runtime_posture_is_explicit_for_timeout_retry_and_pooling() -> None:
     for source_family in ACTIVE_SOURCE_FAMILIES:
         posture = get_active_source_runtime_posture_requirements(source_family)
@@ -295,7 +342,19 @@ def test_mysql_family_requirements_cover_connector_dialect_guard_and_audit() -> 
         "profile_id": "mysql.readonly.planned.v1",
         "owner": "backend",
         "read_only_posture": "required",
+        "runtime_driver_dependencies": ("mysqlclient_or_pymysql",),
         "secret_reference_pattern": "safequery/business/mysql/<source_id>/reader",
+        "secret_loading_owner": "trusted_backend",
+        "secret_readiness_checks": (
+            "backend_secret_indirection_required",
+            "secret_reference_resolves_before_activation",
+            "blank_secret_rejected",
+            "placeholder_secret_rejected",
+            "raw_connection_string_rejected",
+            "connection_string_redaction_required",
+            "client_supplied_connection_material_rejected",
+        ),
+        "connection_string_redaction": "required_before_logs_exports_or_support_bundles",
         "connection_identity_fields": (
             "host",
             "port",
@@ -307,6 +366,12 @@ def test_mysql_family_requirements_cover_connector_dialect_guard_and_audit() -> 
             "connect_timeout_seconds",
             "statement_timeout_seconds",
             "cancellation_probe",
+        ),
+        "activation_gate_checks": (
+            "driver_import_or_installation_check",
+            "first_run_doctor_family_runtime_check",
+            "support_bundle_redacted_readiness_snapshot",
+            "application_postgres_separation_check",
         ),
         "application_postgres_separation": (
             "mysql business source credentials and endpoints must be distinct from "
@@ -368,7 +433,19 @@ def test_mariadb_delta_requirements_cover_shared_and_specific_boundaries() -> No
         "profile_id": "mariadb.readonly.planned.v1",
         "owner": "backend",
         "read_only_posture": "required",
+        "runtime_driver_dependencies": ("mariadb_connector_or_pymysql",),
         "secret_reference_pattern": "safequery/business/mariadb/<source_id>/reader",
+        "secret_loading_owner": "trusted_backend",
+        "secret_readiness_checks": (
+            "backend_secret_indirection_required",
+            "secret_reference_resolves_before_activation",
+            "blank_secret_rejected",
+            "placeholder_secret_rejected",
+            "raw_connection_string_rejected",
+            "connection_string_redaction_required",
+            "client_supplied_connection_material_rejected",
+        ),
+        "connection_string_redaction": "required_before_logs_exports_or_support_bundles",
         "connection_identity_fields": (
             "host",
             "port",
@@ -381,6 +458,12 @@ def test_mariadb_delta_requirements_cover_shared_and_specific_boundaries() -> No
             "connect_timeout_seconds",
             "statement_timeout_seconds",
             "cancellation_probe",
+        ),
+        "activation_gate_checks": (
+            "driver_import_or_installation_check",
+            "first_run_doctor_family_runtime_check",
+            "support_bundle_redacted_readiness_snapshot",
+            "application_postgres_separation_check",
         ),
         "application_postgres_separation": (
             "mariadb business source credentials and endpoints must be distinct from "
@@ -422,7 +505,22 @@ def test_oracle_requirements_cover_connector_dialect_guard_and_audit() -> None:
         "profile_id": "oracle.readonly.long-range.v1",
         "owner": "backend",
         "read_only_posture": "required",
+        "runtime_driver_dependencies": (
+            "python-oracledb",
+            "oracle_client_or_wallet_when_required",
+        ),
         "secret_reference_pattern": "safequery/business/oracle/<source_id>/reader",
+        "secret_loading_owner": "trusted_backend",
+        "secret_readiness_checks": (
+            "backend_secret_indirection_required",
+            "secret_reference_resolves_before_activation",
+            "blank_secret_rejected",
+            "placeholder_secret_rejected",
+            "raw_connection_string_rejected",
+            "connection_string_redaction_required",
+            "client_supplied_connection_material_rejected",
+        ),
+        "connection_string_redaction": "required_before_logs_exports_or_support_bundles",
         "connection_identity_fields": (
             "connect_descriptor",
             "service_name",
@@ -434,6 +532,12 @@ def test_oracle_requirements_cover_connector_dialect_guard_and_audit() -> None:
             "connect_timeout_seconds",
             "statement_timeout_seconds",
             "cancellation_probe",
+        ),
+        "activation_gate_checks": (
+            "driver_import_or_installation_check",
+            "first_run_doctor_family_runtime_check",
+            "support_bundle_redacted_readiness_snapshot",
+            "application_postgres_separation_check",
         ),
         "application_postgres_separation": (
             "oracle business source credentials and endpoints must be distinct from "

--- a/docs/design/dialect-guard-readiness-checklists.md
+++ b/docs/design/dialect-guard-readiness-checklists.md
@@ -176,3 +176,17 @@ readiness, secrets readiness, audit readiness, evaluation readiness,
 dataset-contract readiness, and row-bounds readiness. If any evidence is
 missing, malformed, partial, stale, or inferred from a derived surface, the
 family must remain non-executable and fail closed.
+
+Runtime readiness evidence is connector-specific. MySQL and Aurora MySQL require
+an approved `mysqlclient` or `PyMySQL` backend driver check, MariaDB requires an
+approved MariaDB connector or reviewed `PyMySQL` compatibility check, Aurora
+PostgreSQL requires `psycopg`, and Oracle requires `python-oracledb` plus Oracle
+client or wallet prerequisites when that deployment shape requires them.
+
+Secrets readiness evidence must prove backend-owned secret indirection for the
+planned source profile. Blank secrets, TODO/sample credentials, raw connection
+strings, application PostgreSQL credentials, and client-supplied connection
+material are activation blockers. First-run doctor and support-bundle output may
+name dependency and readiness states, but any connection string, endpoint
+credential, or secret-bearing diagnostic must be redacted before logs, exports,
+or support bundles are emitted.

--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -135,6 +135,26 @@ evaluation, dataset-contract, or row-bounds evidence is missing, malformed,
 stale, or only inferred from a non-authoritative surface, SafeQuery must reject
 activation and keep the family non-executable.
 
+Runtime and secret evidence must be family-specific before activation:
+
+| Family or flavor | Driver/runtime prerequisite | Secret reference pattern |
+| --- | --- | --- |
+| MySQL | `mysqlclient` or `PyMySQL` import/install check | `safequery/business/mysql/<source_id>/reader` |
+| MariaDB | `mariadb` connector or approved `PyMySQL` compatibility check | `safequery/business/mariadb/<source_id>/reader` |
+| Aurora PostgreSQL | `psycopg` import/install check plus Aurora endpoint/TLS posture | `safequery/business/postgresql/<source_id>/reader` |
+| Aurora MySQL | MySQL driver prerequisite plus Aurora endpoint/TLS posture | `safequery/business/mysql/<source_id>/reader` |
+| Oracle | `python-oracledb` import/install check plus client or wallet prerequisite when required | `safequery/business/oracle/<source_id>/reader` |
+
+The activation gate must prove the backend can load the referenced secret
+without exposing its value. Blank secrets, placeholder values, sample
+credentials, raw connection strings, client-supplied connection material, and
+application PostgreSQL credentials are activation blockers. Any connection
+string or connection identity that appears in logs, doctor output, exports, or
+support bundles must be redacted before it leaves the trusted backend boundary.
+First-run doctor and support-bundle surfaces may report readiness state,
+dependency names, profile identifiers, source identity, and redaction posture,
+but they must not contain secret values or real connection strings.
+
 ## Health Checks
 
 Registry-aware health checks should verify the backend can still resolve:


### PR DESCRIPTION
## Summary
- add planned connector profile metadata for runtime driver dependencies, trusted backend secret loading, redaction, and activation gate checks
- document per-family runtime and secret readiness expectations for planned MySQL, MariaDB, Aurora, and Oracle activation
- add a focused regression test covering runtime, first-run doctor, support-bundle, and fail-closed secret requirements

## Verification
- PYTHONPATH=backend python3 -m pytest backend/tests/test_source_family_profiles.py -q
- PYTHONPATH=backend python3 -m pytest backend/tests/test_first_run_doctor.py -q
- git diff --check
- changed-file scan for workstation-local paths and obvious secret/connection-string literals returned no matches

Closes #400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime driver dependency validation for database connectors
  * Implemented secret handling ownership and readiness checks for sources
  * Added connection string redaction requirements for logs, exports, and support bundles
  * Introduced activation gate checks to enforce source readiness before execution

* **Documentation**
  * Updated connector activation and readiness checklist specifications
  * Enhanced secret handling and redaction policies for database sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->