### PR TITLE
Gate source-family fixtures for activation

### DIFF
--- a/docs/design/evaluation-harness.md
+++ b/docs/design/evaluation-harness.md
@@ -44,9 +44,12 @@ evaluation assets include source-aware scenarios for:
 
 - positive read-only outcomes
 - safety deny outcomes
+- malformed input, unsupported syntax, and malformed artifact outcomes
+- metadata-only records that prove planned families remain non-executable
+- schema-bound dataset, schema snapshot, entitlement, and row-bound outcomes
 - connector-selection denies
 - candidate lifecycle revalidation
-- runtime timeout, cancellation, and kill-switch behavior
+- runtime unavailable, timeout, cancellation, and kill-switch behavior
 - source-aware audit artifact reconstruction
 - release-gate reconstruction
 - operator-history implications
@@ -55,6 +58,13 @@ Each scenario must carry source identity, source family, source flavor, dataset
 contract version, schema snapshot version, execution policy version, connector
 profile version, dialect profile version, expected outcome, and expected primary
 deny code when the outcome is a rejection.
+
+The release gate must treat allow, deny, malformed, metadata-only,
+schema-bound, and runtime-unavailable fixtures as activation prerequisites for
+future source families. Planned entries may document requirements, but they do
+not represent active runtime support until the release gate can reconstruct each
+required fixture category from SafeQuery-owned evaluation outcomes and
+source-aware audit events.
 
 Dialect, connector, or profile version drift must be represented as an explicit
 evaluation scenario and must fail closed when the observed artifact no longer

--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -126,6 +126,33 @@ Required readiness evidence before `active-baseline`:
   conflicting limits, offset behavior, truncation metadata, and audit
   reconstruction. The explicit blocker is missing row-bounds readiness.
 
+Minimum source-family evaluation fixture categories:
+
+- allow fixtures: approved read-only prompts and expected successful outcomes
+  for the reviewed source family or explicitly approved flavor inheritance.
+- deny fixtures: guard, entitlement, stale-policy, unsupported-binding,
+  connector-selection, and lifecycle rejection cases with expected primary deny
+  codes.
+- malformed fixtures: parser failures, unsupported syntax, profile-version
+  drift, malformed source identity, malformed audit evidence, and malformed
+  evaluation artifacts that must fail closed.
+- metadata-only fixtures: planned-family and planned-flavor records that prove
+  roadmap entries, matrices, labels, adapter output, traces, and sample config
+  cannot make a family executable or runtime-capable.
+- schema-bound fixtures: dataset-contract, schema snapshot, row-bound,
+  entitlement, and stale-schema cases that prove execution remains tied to the
+  backend-selected authoritative source record.
+- runtime-unavailable fixtures: missing driver, missing secret reference,
+  unresolved backend-owned secret, source unavailable, timeout, cancellation,
+  kill-switch, and rate-limit cases that must deny before unsafe dispatch.
+
+Release-gate reconstruction must include these fixture categories before a
+planned family or flavor can move from `activation-candidate` to
+`active-baseline`. Missing category coverage, stale category evidence, or
+coverage inferred from non-authoritative projections must keep the family
+non-executable. Planned metadata must not count as active runtime support, and
+metadata-only fixtures must prove that boundary explicitly.
+
 No planned or unsupported family may dispatch connector code, appear in active
 execution coverage, or be treated as runtime-capable because it appears in a
 roadmap, matrix, sample config, adapter output, analyst artifact, MLflow trace,

--- a/tests/test_source_family_activation_criteria_docs.py
+++ b/tests/test_source_family_activation_criteria_docs.py
@@ -52,3 +52,33 @@ def test_future_source_family_activation_gate_is_documented() -> None:
         "No planned or unsupported family may dispatch connector code"
         in normalized_activation_section
     )
+
+
+def test_source_family_fixture_categories_are_release_gate_requirements() -> None:
+    content = ACTIVATION_DOC.read_text(encoding="utf-8")
+    header = "## Future Source-Family Activation Gate"
+    start = content.find(header)
+    assert start != -1
+
+    next_section = content.find("\n## ", start + len(header))
+    activation_section = content[start : next_section if next_section != -1 else len(content)]
+    normalized_activation_section = " ".join(activation_section.split())
+
+    assert "Minimum source-family evaluation fixture categories" in activation_section
+    assert "release-gate reconstruction" in normalized_activation_section
+
+    fixture_categories = [
+        "allow fixtures",
+        "deny fixtures",
+        "malformed fixtures",
+        "metadata-only fixtures",
+        "schema-bound fixtures",
+        "runtime-unavailable fixtures",
+    ]
+    for fixture_category in fixture_categories:
+        assert fixture_category in normalized_activation_section
+
+    assert (
+        "planned metadata must not count as active runtime support"
+        in normalized_activation_section.lower()
+    )


### PR DESCRIPTION
## Summary
- define required source-family evaluation fixture categories for future activation
- tie those categories to release-gate reconstruction before active-baseline status
- tighten docs coverage so planned metadata does not read as runtime support

## Tests
- python3 -m pytest tests/test_source_family_activation_criteria_docs.py tests/test_dialect_guard_readiness_checklist_docs.py tests/test_check_repository_hygiene.py -q
- cd backend && python3 -m pytest tests/test_source_family_profiles.py -q
- python3 scripts/ci/check_repository_hygiene.py

Refs #401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation harness and source-family activation documentation with enhanced requirements for fixture categories and runtime prerequisites.

* **Tests**
  * Added validation test to ensure documentation reflects activation criteria requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->