### PR TITLE
Select Aurora PostgreSQL activation planning candidate

### DIFF
--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -87,18 +87,20 @@ This reading order is intended to help new contributors understand SafeQuery fro
     Review the family and flavor rollout matrix before planning connector, guard, or evaluation work for additional sources.
 34. [design/dialect-guard-readiness-checklists.md](./design/dialect-guard-readiness-checklists.md)
     Use this as the review checklist for guard readiness evidence before any planned MySQL, MariaDB, Aurora, or Oracle source can be considered for connector activation.
-35. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
+35. [design/source-family-activation-selection.md](./design/source-family-activation-selection.md)
+    Read this after the activation criteria and guard checklists to see the Epic V recommendation for the first future source flavor that should advance toward active implementation planning.
+36. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
     Read this to understand why the product shell is workflow-first and why the Epic A shell remains a developer state demo.
-36. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
+37. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
     Review how SafeQuery may borrow OSS ergonomics without turning the product into a generic chat shell or moving trust boundaries.
-37. [implementation-roadmap.md](./implementation-roadmap.md)
+38. [implementation-roadmap.md](./implementation-roadmap.md)
     Finish this section with the current implementation sequence so roadmap work stays aligned with the reviewed docs direction.
 
 ### 6. Local Setup and Threat Review
 
-38. [local-development.md](./local-development.md)
+39. [local-development.md](./local-development.md)
     Use this once the document set is clear so local startup follows the reviewed topology and role split.
-39. [security/threat-model.md](./security/threat-model.md)
+40. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks for the current source-aware and UX-foundation baseline before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 - [design/target-source-registry.md](./design/target-source-registry.md): backend-owned registry model, activation semantics, and secret indirection expectations
 - [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md): compact family and flavor rollout matrix for connector, guard, and evaluation planning
 - [design/dialect-guard-readiness-checklists.md](./design/dialect-guard-readiness-checklists.md): reviewable guard readiness evidence checklist for planned MySQL, MariaDB, Aurora, and Oracle support
+- [design/source-family-activation-selection.md](./design/source-family-activation-selection.md): Epic V recommendation for the first future source flavor to advance toward active implementation planning
 - [implementation-roadmap.md](./implementation-roadmap.md): current implementation sequence after Epic A, Epic A follow-up, and UX-1
 
 ## Documentation Intent

--- a/docs/design/source-family-activation-selection.md
+++ b/docs/design/source-family-activation-selection.md
@@ -1,0 +1,131 @@
+# Source-Family Activation Selection
+
+## Purpose
+
+This document records the Epic V selection of the first future source family or
+flavor that should advance toward active implementation planning. It compares
+the planned families against the activation gate, connector threat model,
+dialect capability matrix, guard readiness checklist, runtime and secret
+requirements, and evaluation fixture requirements.
+
+The selection is planning only. It does not approve activation, and active
+connector implementation is out of scope.
+
+## Selection
+
+Recommended first planning candidate: Aurora PostgreSQL.
+
+The selected candidate is the Aurora PostgreSQL flavor represented as
+`source_family=postgresql` with `source_flavor=aurora-postgresql`, not a new
+top-level source family. This keeps the first future planning step closest to
+the existing PostgreSQL active baseline while still requiring Aurora-specific
+runtime, connector-profile, secret, endpoint, audit, and release-gate evidence
+before any executable support can be scoped.
+
+The recommendation depends on these Epic V sources:
+
+- `target-source-registry.md`: defines the activation states, required
+  readiness evidence, runtime and secret prerequisites, and the Aurora flavor
+  registry binding.
+- `security/threat-model.md`: records Aurora PostgreSQL risks for authoritative
+  flavor binding, connector profile and dataset contract evidence, runtime
+  behavior, secrets readiness, row bounds, and audit reconstruction.
+- `dialect-capability-matrix.md`: records Aurora PostgreSQL as a planned
+  flavor that inherits PostgreSQL generation, canonicalization, guard, deny
+  corpus, and row-bounding posture, with Aurora-specific runtime and
+  release-gate regressions.
+- `dialect-guard-readiness-checklists.md`: requires Aurora PostgreSQL flavor
+  regression evidence before activation review.
+- `evaluation-harness.md`: requires positive, deny, malformed, metadata-only,
+  schema-bound, runtime-unavailable, audit reconstruction, release-gate
+  reconstruction, and operator-history coverage before activation.
+
+Aurora PostgreSQL is selected for active implementation planning because it has
+the smallest safe planning distance from an existing active baseline:
+
+- The authoritative family remains `postgresql`, which already has an active
+  baseline and SafeQuery-owned guard, canonicalization, deny-corpus, and
+  row-bounding posture.
+- The planned delta is flavor-specific: backend-owned registry flavor binding,
+  Aurora endpoint posture, TLS posture, engine version, timeout behavior,
+  cancellation behavior, connector profile evidence, and flavor regression
+  coverage.
+- The decision avoids treating MySQL-family or Oracle-specific dialect work as
+  implicitly solved by nearby roadmap text.
+
+## Deferred Families
+
+`mysql` is deferred because it still has missing MySQL-specific guard
+readiness, missing MySQL runtime readiness, missing MySQL secrets readiness,
+missing MySQL dataset-contract and row-bounds readiness, and missing MySQL
+release-gate reconstruction. MySQL remains planned metadata only until a
+registry-owned `mysql` source profile, connector profile, dialect profile,
+guard profile, audit contract, evaluation corpus, and backend-owned secret
+indirection are approved together.
+
+`mariadb` is deferred because it still has missing MariaDB-specific guard
+readiness, missing MariaDB runtime readiness, missing MariaDB secrets readiness,
+missing MariaDB dataset-contract and row-bounds readiness, and missing MariaDB
+release-gate reconstruction. MariaDB must stay a distinct
+`source_family=mariadb` profile and must not silently inherit MySQL connector or
+guard approval.
+
+`mysql` / `aurora-mysql` is deferred because it is blocked by the underlying
+MySQL family and still has missing Aurora MySQL flavor regression evidence.
+Aurora MySQL cannot become executable before MySQL family readiness is approved,
+and its cluster endpoint, TLS, engine-version, timeout, cancellation,
+connector-profile, secret, audit, and release-gate deltas still need separate
+proof.
+
+`oracle` is deferred because it still has missing Oracle-specific guard
+readiness, missing Oracle runtime and wallet readiness, missing Oracle secrets
+readiness, missing Oracle dataset-contract and row-bounds readiness, and missing
+Oracle release-gate reconstruction. Oracle remains long-range planned metadata
+until Oracle-specific connector, dialect, guard, audit, entitlement, candidate
+lifecycle, operator-history, and release-gate requirements are approved
+together.
+
+Other future families remain unselected until they have an explicit source
+registry model, threat model, dialect profile, guard checklist, runtime and
+secret readiness plan, and SafeQuery-owned evaluation fixture plan comparable to
+the Epic V sources cited above.
+
+## Non-Executable Boundary
+
+This selection does not add connector code, does not wire runtime drivers, does
+not add secret handling, and does not add SQL execution support.
+
+Aurora PostgreSQL remains planned metadata only. It must not appear in active
+execution coverage, runtime-capable UI/API metadata, first-run doctor success
+claims, support-bundle readiness claims, or connector dispatch paths until a
+later activation gate approves the complete evidence package.
+
+The selection must not be used as evidence that Aurora support can be inferred
+from hostnames, labels, adapter output, driver names, generated SQL text,
+connection URLs, analyst artifacts, MLflow traces, or operator-facing summary
+text. The backend-owned source registry record remains the authoritative source
+of `source_family=postgresql` and `source_flavor=aurora-postgresql`.
+
+## Next-Roadmap Handoff
+
+The next-roadmap handoff artifact should be an Aurora PostgreSQL activation
+planning packet. It must be reviewed before active connector implementation is
+scoped.
+
+The packet should include:
+
+- registry profile draft for an Aurora PostgreSQL planned source record
+- flavor-specific runtime readiness plan for endpoint posture, TLS posture,
+  engine version, timeout behavior, cancellation behavior, source-unavailable
+  classification, and retry boundaries
+- backend-owned secret indirection plan using the approved PostgreSQL-family
+  secret reference pattern without exposing secret values
+- connector-profile and dialect-profile version plan showing exactly what is
+  inherited from PostgreSQL and what is Aurora-specific
+- fixture manifest covering allow, deny, malformed, metadata-only,
+  schema-bound, runtime-unavailable, audit reconstruction, release-gate
+  reconstruction, and operator-history scenarios
+- release-gate reconstruction plan that proves the Aurora flavor from
+  SafeQuery-owned evaluation outcomes and source-aware audit events
+- operator-history checklist that records how planned metadata, activation
+  candidate review, and active-baseline approval will remain distinguishable

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -74,11 +74,18 @@ If an optional track is enabled, its governance, audit, and evaluation requireme
 
 ## Later Family Expansion
 
-After the two-source core path is stable:
+After the two-source core path is stable, use
+`docs/design/source-family-activation-selection.md` as the current Epic V
+handoff for active implementation planning. That selection recommends Aurora
+PostgreSQL as the first planning candidate while keeping it non-executable
+until a later activation gate approves the full evidence package.
+
+For the families and flavors not selected by that handoff, the remaining
+directional sequence is:
 
 1. onboard `mysql`
 2. evaluate `mariadb` as a sibling or delta profile
-3. add Aurora as source flavors on top of PostgreSQL or MySQL families
+3. add Aurora MySQL as a source flavor after the MySQL family is approved
 4. define `oracle` as long-range planned metadata only, then onboard it last
    after Oracle-specific connector, dialect, guard, audit, entitlement,
    candidate lifecycle, operator-history, and release-gate reconstruction

--- a/tests/test_source_family_activation_selection_docs.py
+++ b/tests/test_source_family_activation_selection_docs.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SELECTION_DOC = REPO_ROOT / "docs" / "design" / "source-family-activation-selection.md"
+
+
+def _section(content: str, header: str) -> str:
+    start = content.find(header)
+    assert start != -1, f"missing section {header}"
+    next_section = content.find("\n## ", start + len(header))
+    return content[start : next_section if next_section != -1 else len(content)]
+
+
+def test_first_planning_candidate_selection_is_recorded() -> None:
+    content = SELECTION_DOC.read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    assert "Recommended first planning candidate: Aurora PostgreSQL" in content
+    assert "`source_family=postgresql`" in content
+    assert "`source_flavor=aurora-postgresql`" in content
+    assert "active connector implementation is out of scope" in normalized
+
+    for source in [
+        "target-source-registry.md",
+        "security/threat-model.md",
+        "dialect-capability-matrix.md",
+        "dialect-guard-readiness-checklists.md",
+        "evaluation-harness.md",
+    ]:
+        assert source in content
+
+
+def test_deferred_families_have_explicit_blockers() -> None:
+    content = SELECTION_DOC.read_text(encoding="utf-8")
+    deferral_section = _section(content, "## Deferred Families")
+    normalized_deferral_section = " ".join(deferral_section.split())
+
+    expected_blockers = {
+        "`mysql`": [
+            "missing MySQL-specific guard readiness",
+            "missing MySQL runtime readiness",
+            "missing MySQL secrets readiness",
+            "missing MySQL release-gate reconstruction",
+        ],
+        "`mariadb`": [
+            "missing MariaDB-specific guard readiness",
+            "missing MariaDB runtime readiness",
+            "missing MariaDB secrets readiness",
+            "missing MariaDB release-gate reconstruction",
+        ],
+        "`mysql` / `aurora-mysql`": [
+            "blocked by the underlying MySQL family",
+            "missing Aurora MySQL flavor regression evidence",
+        ],
+        "`oracle`": [
+            "missing Oracle-specific guard readiness",
+            "missing Oracle runtime and wallet readiness",
+            "missing Oracle release-gate reconstruction",
+        ],
+    }
+
+    for family, blockers in expected_blockers.items():
+        assert family in deferral_section
+        for blocker in blockers:
+            assert blocker in normalized_deferral_section
+
+
+def test_selection_preserves_non_executable_metadata_boundary() -> None:
+    content = SELECTION_DOC.read_text(encoding="utf-8")
+    boundary_section = _section(content, "## Non-Executable Boundary")
+    normalized_boundary = " ".join(boundary_section.split())
+
+    for phrase in [
+        "does not add connector code",
+        "does not wire runtime drivers",
+        "does not add secret handling",
+        "does not add SQL execution support",
+        "planned metadata only",
+        "must not appear in active execution coverage",
+    ]:
+        assert phrase in normalized_boundary
+
+
+def test_next_roadmap_handoff_artifact_is_defined() -> None:
+    content = SELECTION_DOC.read_text(encoding="utf-8")
+    handoff_section = _section(content, "## Next-Roadmap Handoff")
+    normalized_handoff_section = " ".join(handoff_section.split())
+
+    for requirement in [
+        "Aurora PostgreSQL activation planning packet",
+        "registry profile draft",
+        "flavor-specific runtime readiness plan",
+        "backend-owned secret indirection plan",
+        "fixture manifest",
+        "release-gate reconstruction plan",
+        "operator-history checklist",
+        "must be reviewed before active connector implementation is scoped",
+    ]:
+        assert requirement in normalized_handoff_section


### PR DESCRIPTION
## Summary
- record the Epic V-6 selection artifact recommending Aurora PostgreSQL as the first active implementation planning candidate
- document explicit blockers for MySQL, MariaDB, Aurora MySQL, Oracle, and other future families
- add a focused docs regression test and index the new artifact from the docs entrypoints and roadmap

## Verification
- python3 -m pytest tests/test_source_family_activation_selection_docs.py -q
- python3 -m pytest tests/test_source_family_activation_selection_docs.py tests/test_source_family_activation_criteria_docs.py tests/test_dialect_guard_readiness_checklist_docs.py tests/test_connector_threat_model_docs.py tests/test_check_repository_hygiene.py -q
- PYTHONPATH=backend python3 -m pytest backend/tests/test_evaluation_harness.py::test_source_regression_matrix_covers_active_families_and_keeps_planned_non_executable -q
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- bash tests/smoke/test-pilot-safety-checklist.sh
- bash tests/smoke/test-local-startup-docs.sh

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new design guidance for planning the next source family activation, with Aurora PostgreSQL as the current candidate for future implementation planning.
  * Updated reading order and documentation index to reference the new design document.
  * Clarified implementation roadmap guidance for future family expansion.

* **Tests**
  * Added test coverage to verify new design documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->