### PR TITLE
Guard planned source workflow options

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -15,8 +15,13 @@ from app.db.models.preview import (
     PreviewRequest,
 )
 from app.db.models.schema_snapshot import SchemaSnapshot
-from app.db.models.source_registry import RegisteredSource
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.governance_bindings import normalize_governance_binding
+from app.services.source_family_profiles import (
+    ACTIVE_SOURCE_FAMILIES,
+    get_planned_source_family_profile_requirements,
+    get_planned_source_flavor_profile_requirements,
+)
 
 
 GovernanceBindingState = Literal[
@@ -218,11 +223,43 @@ class OperatorWorkflowSnapshot(BaseModel):
     history: list[OperatorWorkflowHistoryItem] = Field(default_factory=list)
 
 
-def _source_description(source: RegisteredSource) -> str:
+def _operator_activation_posture(source: RegisteredSource) -> SourceActivationPosture:
+    posture = SourceActivationPosture(source.activation_posture)
+    if posture is not SourceActivationPosture.ACTIVE:
+        return posture
+
+    source_family = source.source_family.strip().lower()
+    source_flavor = (
+        source.source_flavor.strip().lower() if source.source_flavor else None
+    )
+    planned_family = get_planned_source_family_profile_requirements(source_family)
+    planned_flavor = (
+        get_planned_source_flavor_profile_requirements(
+            source_family=source_family,
+            source_flavor=source_flavor,
+        )
+        if source_flavor is not None
+        else None
+    )
+    if (
+        source_family not in ACTIVE_SOURCE_FAMILIES
+        or planned_family is not None
+        or planned_flavor is not None
+    ):
+        return SourceActivationPosture.BLOCKED
+
+    return posture
+
+
+def _source_description(
+    source: RegisteredSource,
+    *,
+    activation_posture: SourceActivationPosture,
+) -> str:
     flavor = f" / {source.source_flavor}" if source.source_flavor else ""
     return (
         f"{source.source_family}{flavor} source with "
-        f"{source.activation_posture.value} activation posture."
+        f"{activation_posture.value} activation posture."
     )
 
 
@@ -890,23 +927,28 @@ def get_operator_workflow_snapshot(session: Session) -> OperatorWorkflowSnapshot
         ).all()
     )
 
-    source_options = [
-        OperatorWorkflowSourceOption(
-            source_id=source.source_id,
-            display_label=source.display_label,
-            description=_source_description(source),
-            activation_posture=source.activation_posture.value,
-            source_family=source.source_family,
-            source_flavor=source.source_flavor,
-            governance_bindings=_source_governance_bindings(
-                source=source,
-                contract=dataset_contract,
-                schema_snapshot=schema_snapshot,
-                latest_contract_version=latest_contract_versions.get(source.id),
-            ),
+    source_options = []
+    for source, dataset_contract, schema_snapshot in source_rows:
+        activation_posture = _operator_activation_posture(source)
+        source_options.append(
+            OperatorWorkflowSourceOption(
+                source_id=source.source_id,
+                display_label=source.display_label,
+                description=_source_description(
+                    source,
+                    activation_posture=activation_posture,
+                ),
+                activation_posture=activation_posture.value,
+                source_family=source.source_family,
+                source_flavor=source.source_flavor,
+                governance_bindings=_source_governance_bindings(
+                    source=source,
+                    contract=dataset_contract,
+                    schema_snapshot=schema_snapshot,
+                    latest_contract_version=latest_contract_versions.get(source.id),
+                ),
+            )
         )
-        for source, dataset_contract, schema_snapshot in source_rows
-    ]
 
     return OperatorWorkflowSnapshot(
         sources=source_options,

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -131,6 +131,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         *,
         source_id: str,
         source_posture: SourceActivationPosture,
+        source_family: str = "postgresql",
+        source_flavor: Optional[str] = "warehouse",
         snapshot_status: SchemaSnapshotReviewStatus = SchemaSnapshotReviewStatus.APPROVED,
         owner_binding: str = "group:finance-analysts",
         security_review_binding: Optional[str] = None,
@@ -140,8 +142,8 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
             id=uuid4(),
             source_id=source_id,
             display_label=f"{source_id} display",
-            source_family="postgresql",
-            source_flavor="warehouse",
+            source_family=source_family,
+            source_flavor=source_flavor,
             activation_posture=source_posture,
             connector_profile_id=None,
             dialect_profile_id=None,
@@ -565,6 +567,61 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
         self.assertEqual(payload["history"], [])
         self.assertNotIn("connection_reference", response.text)
         self.assertNotIn("vault:", response.text)
+
+    def test_operator_workflow_snapshot_does_not_make_planned_families_executable(
+        self,
+    ) -> None:
+        self._seed_authoritative_source_governance(
+            source_id="mysql-planned-ledger",
+            source_posture=SourceActivationPosture.ACTIVE,
+            source_family="mysql",
+            source_flavor="mysql-8",
+        )
+        self._seed_authoritative_source_governance(
+            source_id="aurora-planned-ledger",
+            source_posture=SourceActivationPosture.ACTIVE,
+            source_family="postgresql",
+            source_flavor="aurora-postgresql",
+        )
+        self._seed_authoritative_source_governance(
+            source_id="unsupported-ledger",
+            source_posture=SourceActivationPosture.ACTIVE,
+            source_family="unsupported-family",
+            source_flavor="warehouse",
+        )
+        self._seed_authoritative_source_governance(
+            source_id="sap-approved-spend",
+            source_posture=SourceActivationPosture.ACTIVE,
+        )
+
+        response = self.client.get("/operator/workflow")
+
+        self.assertEqual(response.status_code, 200)
+        sources_by_id = {
+            source["sourceId"]: source for source in response.json()["sources"]
+        }
+        self.assertEqual(
+            sources_by_id["sap-approved-spend"]["activationPosture"],
+            "active",
+        )
+        for source_id in (
+            "mysql-planned-ledger",
+            "aurora-planned-ledger",
+            "unsupported-ledger",
+        ):
+            with self.subTest(source_id=source_id):
+                self.assertNotEqual(
+                    sources_by_id[source_id]["activationPosture"],
+                    "active",
+                )
+                self.assertEqual(
+                    sources_by_id[source_id]["activationPosture"],
+                    "blocked",
+                )
+                self.assertIn(
+                    "blocked activation posture",
+                    sources_by_id[source_id]["description"],
+                )
 
     def test_preview_submission_rejects_subject_matching_only_security_review_binding(self) -> None:
         self.app.dependency_overrides[require_authenticated_subject] = lambda: AuthenticatedSubject(


### PR DESCRIPTION
## Summary
- add backend smoke coverage for planned family, planned flavor, and unsupported source-family workflow options
- compute an operator-facing source activation posture so planned/unsupported rows cannot appear executable
- keep active PostgreSQL workflow options exposed as active

## Tests
- python3 -m pytest tests/test_request_source_selection.py::RequestSourceSelectionTestCase::test_operator_workflow_snapshot_does_not_make_planned_families_executable -q
- python3 -m pytest tests/test_source_family_profiles.py -q
- python3 -m pytest tests/test_request_source_selection.py tests/test_source_registry_posture.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed operator workflow source activation logic to correctly enforce restrictions on sources with planned profile requirements, preventing unintended activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->