### PR TITLE
Enforce preview source activation gate

### DIFF
--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -17,11 +17,7 @@ from app.db.models.preview import (
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.governance_bindings import normalize_governance_binding
-from app.services.source_family_profiles import (
-    ACTIVE_SOURCE_FAMILIES,
-    get_planned_source_family_profile_requirements,
-    get_planned_source_flavor_profile_requirements,
-)
+from app.services.source_registry import effective_source_activation_posture
 
 
 GovernanceBindingState = Literal[
@@ -224,31 +220,7 @@ class OperatorWorkflowSnapshot(BaseModel):
 
 
 def _operator_activation_posture(source: RegisteredSource) -> SourceActivationPosture:
-    posture = SourceActivationPosture(source.activation_posture)
-    if posture is not SourceActivationPosture.ACTIVE:
-        return posture
-
-    source_family = source.source_family.strip().lower()
-    source_flavor = (
-        source.source_flavor.strip().lower() if source.source_flavor else None
-    )
-    planned_family = get_planned_source_family_profile_requirements(source_family)
-    planned_flavor = (
-        get_planned_source_flavor_profile_requirements(
-            source_family=source_family,
-            source_flavor=source_flavor,
-        )
-        if source_flavor is not None
-        else None
-    )
-    if (
-        source_family not in ACTIVE_SOURCE_FAMILIES
-        or planned_family is not None
-        or planned_flavor is not None
-    ):
-        return SourceActivationPosture.BLOCKED
-
-    return posture
+    return effective_source_activation_posture(source)
 
 
 def _source_description(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -43,7 +43,10 @@ from app.services.source_governance import (
     SourceGovernanceResolutionError,
     resolve_authoritative_source_governance,
 )
-from app.services.source_registry import SourceRegistryPostureError
+from app.services.source_registry import (
+    SourceRegistryActivationGateError,
+    SourceRegistryPostureError,
+)
 from app.services.generation_context import (
     GenerationContextPreparationError,
     prepare_generation_context,
@@ -1421,6 +1424,12 @@ def submit_preview_request(
         )
     except SourceEntitlementError as exc:
         if isinstance(exc.__cause__, (SourceRegistryPostureError, ValueError)):
+            if isinstance(exc.__cause__, SourceRegistryActivationGateError):
+                raise PreviewSubmissionContractError(
+                    str(exc),
+                    public_code="preview_source_unavailable",
+                    public_message="Selected source is unavailable for preview.",
+                ) from exc
             _enrich_preview_audit_context(
                 audit_context,
                 authenticated_subject=authenticated_subject,

--- a/backend/app/services/source_registry.py
+++ b/backend/app/services/source_registry.py
@@ -1,18 +1,63 @@
 from __future__ import annotations
 
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.services.source_family_profiles import (
+    ACTIVE_SOURCE_FAMILIES,
+    get_planned_source_family_profile_requirements,
+    get_planned_source_flavor_profile_requirements,
+)
 
 
 class SourceRegistryPostureError(RuntimeError):
     """Raised when a source is not executable under its current registry posture."""
 
 
+class SourceRegistryActivationGateError(SourceRegistryPostureError):
+    """Raised when rollout metadata blocks source execution."""
+
+
+def effective_source_activation_posture(
+    source: RegisteredSource,
+) -> SourceActivationPosture:
+    posture = SourceActivationPosture(source.activation_posture)
+    if posture is not SourceActivationPosture.ACTIVE:
+        return posture
+
+    source_family = source.source_family.strip().lower()
+    source_flavor = (
+        source.source_flavor.strip().lower() if source.source_flavor else None
+    )
+    planned_family = get_planned_source_family_profile_requirements(source_family)
+    planned_flavor = (
+        get_planned_source_flavor_profile_requirements(
+            source_family=source_family,
+            source_flavor=source_flavor,
+        )
+        if source_flavor is not None
+        else None
+    )
+    if (
+        source_family not in ACTIVE_SOURCE_FAMILIES
+        or planned_family is not None
+        or planned_flavor is not None
+    ):
+        return SourceActivationPosture.BLOCKED
+
+    return posture
+
+
 def ensure_source_is_executable(source: RegisteredSource) -> RegisteredSource:
     posture = SourceActivationPosture(source.activation_posture)
-    if posture.is_executable:
+    effective_posture = effective_source_activation_posture(source)
+    if posture.is_executable and effective_posture.is_executable:
         return source
 
-    raise SourceRegistryPostureError(
+    error_class = (
+        SourceRegistryActivationGateError
+        if posture.is_executable and effective_posture is SourceActivationPosture.BLOCKED
+        else SourceRegistryPostureError
+    )
+    raise error_class(
         f"Registered source '{source.source_id}' is not executable while in "
-        f"{posture.value} posture."
+        f"{effective_posture.value} posture."
     )

--- a/backend/tests/test_request_source_selection.py
+++ b/backend/tests/test_request_source_selection.py
@@ -14,6 +14,7 @@ from sqlalchemy.pool import StaticPool
 from app.core.config import get_settings
 from app.db.base import Base
 from app.db.models.dataset_contract import DatasetContract
+from app.db.models.preview import PreviewAuditEvent, PreviewCandidate, PreviewRequest
 from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.db.session import require_preview_submission_session
@@ -621,6 +622,58 @@ class RequestSourceSelectionTestCase(unittest.TestCase):
                 self.assertIn(
                     "blocked activation posture",
                     sources_by_id[source_id]["description"],
+                )
+
+    def test_preview_submission_rejects_planned_or_unsupported_source_activation(
+        self,
+    ) -> None:
+        for source_id, source_family, source_flavor in (
+            ("mysql-planned-ledger", "mysql", "mysql-8"),
+            ("aurora-planned-ledger", "postgresql", "aurora-postgresql"),
+            ("unsupported-ledger", "unsupported-family", "warehouse"),
+        ):
+            with self.subTest(source_id=source_id):
+                self._seed_authoritative_source_governance(
+                    source_id=source_id,
+                    source_posture=SourceActivationPosture.ACTIVE,
+                    source_family=source_family,
+                    source_flavor=source_flavor,
+                )
+
+                response = self._post_preview(
+                    {
+                        "question": "Show approved vendors by quarterly spend",
+                        "source_id": source_id,
+                    },
+                )
+
+                self.assertEqual(response.status_code, 422)
+                self.assertEqual(
+                    response.json(),
+                    {
+                        "error": {
+                            "code": "preview_source_unavailable",
+                            "message": "Selected source is unavailable for preview.",
+                        }
+                    },
+                )
+                self.assertEqual(
+                    self.session.query(PreviewRequest)
+                    .filter_by(source_id=source_id)
+                    .count(),
+                    0,
+                )
+                self.assertEqual(
+                    self.session.query(PreviewCandidate)
+                    .filter_by(source_id=source_id)
+                    .count(),
+                    0,
+                )
+                self.assertEqual(
+                    self.session.query(PreviewAuditEvent)
+                    .filter_by(source_id=source_id)
+                    .count(),
+                    0,
                 )
 
     def test_preview_submission_rejects_subject_matching_only_security_review_binding(self) -> None:

--- a/backend/tests/test_source_registry_posture.py
+++ b/backend/tests/test_source_registry_posture.py
@@ -3,6 +3,7 @@ import uuid
 
 from app.db.models.source_registry import RegisteredSource
 from app.services.source_registry import (
+    SourceRegistryActivationGateError,
     SourceRegistryPostureError,
     ensure_source_is_executable,
 )
@@ -50,6 +51,36 @@ class SourceRegistryPostureTestCase(unittest.TestCase):
                 with self.assertRaisesRegex(
                     SourceRegistryPostureError,
                     f"{posture} posture",
+                ):
+                    ensure_source_is_executable(source)
+
+    def test_planned_or_unsupported_active_sources_are_rejected_fail_closed(
+        self,
+    ) -> None:
+        for source_id, source_family, source_flavor in (
+            ("mysql-planned-ledger", "mysql", "mysql-8"),
+            ("aurora-planned-ledger", "postgresql", "aurora-postgresql"),
+            ("unsupported-ledger", "unsupported-family", "warehouse"),
+        ):
+            with self.subTest(source_id=source_id):
+                source = RegisteredSource(
+                    id=uuid.uuid4(),
+                    source_id=source_id,
+                    display_label=f"{source_id} display",
+                    source_family=source_family,
+                    source_flavor=source_flavor,
+                    activation_posture="active",
+                    connector_profile_id=None,
+                    dialect_profile_id=None,
+                    dataset_contract_id=None,
+                    schema_snapshot_id=None,
+                    execution_policy_id=None,
+                    connection_reference=f"vault:{source_id}",
+                )
+
+                with self.assertRaisesRegex(
+                    SourceRegistryActivationGateError,
+                    "blocked posture",
                 ):
                     ensure_source_is_executable(source)
 


### PR DESCRIPTION
## Summary
- move planned/unsupported source-family activation gating into the shared source executable check
- keep operator workflow posture derived from the shared effective activation posture
- reject planned family, planned flavor, and unsupported preview submissions before preview records, candidates, or lifecycle audit events are created

## Verification
- cd backend && python3 -m pytest tests/test_source_registry_posture.py tests/test_request_source_selection.py tests/test_source_family_profiles.py -q
- cd backend && python3 -m pytest -q
- python3 -m pytest tests/test_source_family_activation_criteria_docs.py tests/test_source_family_activation_selection_docs.py tests/test_check_repository_hygiene.py -q

Closes #411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sources marked as planned or unsupported are now properly blocked from execution, even if marked as active.
  * Preview requests now reject unavailable sources with a clear error message ("Selected source is unavailable for preview").

* **Tests**
  * Added test coverage for proper rejection of planned and unsupported sources in preview submissions.
  * Added validation tests for source activation gating based on rollout and profile requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->