### PR TITLE
Return controlled errors for missing audit context

### DIFF
--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -26,6 +26,7 @@ _SAFE_API_ERROR_CODES = frozenset(
         "preview_generation_failed",
         "preview_source_malformed",
         "preview_source_unavailable",
+        "request_context_unavailable",
     }
 )
 
@@ -75,6 +76,15 @@ _SAFE_EXECUTION_AUDIT_FIELDS = frozenset(
         "primary_deny_code",
         "denial_cause",
         "candidate_state",
+    }
+)
+
+_SAFE_REQUEST_CONTEXT_AUDIT_FIELDS = frozenset(
+    {
+        "event_type",
+        "operation",
+        "candidate_id",
+        "denial_cause",
     }
 )
 
@@ -176,6 +186,8 @@ def _safe_http_exception_audit(
         "execution_unavailable",
     }:
         safe_fields = _SAFE_EXECUTION_AUDIT_FIELDS
+    elif exc.status_code == 503 and code == "request_context_unavailable":
+        safe_fields = _SAFE_REQUEST_CONTEXT_AUDIT_FIELDS
     else:
         return None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -250,6 +250,39 @@ def _serialize_execution_audit_events(
     return serialized
 
 
+def _raise_request_context_unavailable(
+    request: Request,
+    *,
+    operation: str,
+    candidate_id: str | None = None,
+) -> None:
+    audit_event: dict[str, object] = {
+        "event_type": "request_context_unavailable",
+        "operation": operation,
+        "denial_cause": "missing_request_audit_context",
+    }
+    if candidate_id is not None:
+        audit_event["candidate_id"] = candidate_id
+
+    get_logger().warning(
+        "request.audit_context_unavailable",
+        extra={
+            "event_data": {
+                "event": "request.audit_context_unavailable",
+                "method": request.method,
+                "path": request.url.path,
+                **audit_event,
+            }
+        },
+    )
+    raise api_error(
+        503,
+        "request_context_unavailable",
+        "Request processing context is unavailable.",
+        audit_events=[audit_event],
+    )
+
+
 def _require_execution_connector_configuration(
     *,
     connector_id: str,
@@ -594,9 +627,9 @@ def create_app() -> FastAPI:
         try:
             request_id = getattr(request.state, "request_id", None)
             if not isinstance(request_id, str) or not request_id.strip():
-                raise HTTPException(
-                    status_code=500,
-                    detail="Request audit context is unavailable.",
+                _raise_request_context_unavailable(
+                    request,
+                    operation="preview",
                 )
 
             user_subject = authenticated_subject.normalized_subject_id()
@@ -652,9 +685,10 @@ def create_app() -> FastAPI:
     ) -> CandidateExecuteResponse:
         request_id = getattr(http_request.state, "request_id", None)
         if not isinstance(request_id, str) or not request_id.strip():
-            raise HTTPException(
-                status_code=500,
-                detail="Request audit context is unavailable.",
+            _raise_request_context_unavailable(
+                http_request,
+                operation="execute",
+                candidate_id=candidate_id,
             )
 
         occurred_at = datetime.now(timezone.utc)

--- a/backend/tests/test_api_errors.py
+++ b/backend/tests/test_api_errors.py
@@ -3,12 +3,27 @@ import json
 import os
 import unittest
 from io import StringIO
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from app.core.config import get_settings
 from app.core.errors import _http_error_message
 from app.core.logging import JsonLogFormatter, get_logger
+from app.db.session import require_preview_submission_session
+from app.features.auth.context import (
+    AuthenticatedSubject,
+    require_authenticated_subject,
+)
+from app.features.auth.session import (
+    ApplicationSessionContext,
+    require_application_session,
+)
+
+
+class _BlankRequestId:
+    def __str__(self) -> str:
+        return " "
 
 
 class ApiErrorHandlingTestCase(unittest.TestCase):
@@ -160,6 +175,59 @@ class ApiErrorHandlingTestCase(unittest.TestCase):
         self.assertNotIn(raw_token, response.text)
         self.assertNotIn(raw_cookie, response.text)
         self.assertNotIn("csrf-token-should-not-render", response.text)
+
+    def test_preview_missing_request_id_uses_controlled_fail_closed_error(
+        self,
+    ) -> None:
+        self.app.dependency_overrides[require_authenticated_subject] = (
+            lambda: AuthenticatedSubject(
+                subject_id="user:demo-local-operator",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            )
+        )
+        self.app.dependency_overrides[require_application_session] = (
+            lambda: ApplicationSessionContext(
+                subject_id="user:demo-local-operator",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+                auth_source="test-helper",
+            )
+        )
+        self.app.dependency_overrides[require_preview_submission_session] = object
+        main_module = importlib.import_module("app.main")
+
+        try:
+            with patch.object(main_module, "uuid4", return_value=_BlankRequestId()):
+                response = self.client.post(
+                    "/requests/preview",
+                    json={
+                        "question": "Show approved vendors by quarterly spend",
+                        "source_id": "finance-postgres",
+                    },
+                )
+
+            self.assertEqual(response.status_code, 503)
+            self.assertEqual(
+                response.json(),
+                {
+                    "error": {
+                        "code": "request_context_unavailable",
+                        "message": "Request processing context is unavailable.",
+                    },
+                    "audit": {
+                        "events": [
+                            {
+                                "event_type": "request_context_unavailable",
+                                "operation": "preview",
+                                "denial_cause": "missing_request_audit_context",
+                            }
+                        ]
+                    },
+                },
+            )
+            self.assertNotIn("Request audit context is unavailable", response.text)
+            self.assertNotIn("Traceback", response.text)
+        finally:
+            self.app.dependency_overrides.clear()
 
     def test_unhandled_errors_and_logs_do_not_leak_secrets(self) -> None:
         test_token = "test-token-1234"

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -31,6 +31,11 @@ from app.services.candidate_lifecycle import (
 )
 
 
+class _BlankRequestId:
+    def __str__(self) -> str:
+        return " "
+
+
 class CandidateExecuteApiTestCase(unittest.TestCase):
     """Lower-level execute revalidation tests seed approved candidates directly."""
 
@@ -323,6 +328,46 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             self.assertEqual(event.audit_payload["execution_policy_version"], 3)
             self.assertNotIn("safequery_exec:secret", str(event.audit_payload))
             self.assertNotIn("business-postgres-source", str(event.audit_payload))
+
+    def test_execute_candidate_missing_request_id_uses_controlled_fail_closed_error(
+        self,
+    ) -> None:
+        calls: list[str] = []
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        main_module = importlib.import_module("app.main")
+
+        with patch.object(main_module, "uuid4", return_value=_BlankRequestId()):
+            response = self._client(lambda **_: calls.append("called")).post(
+                "/candidates/candidate-123/execute",
+                headers=app_session.headers,
+                cookies=app_session.cookies,
+                json={"selected_source_id": "demo-business-postgres"},
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.json(),
+            {
+                "error": {
+                    "code": "request_context_unavailable",
+                    "message": "Request processing context is unavailable.",
+                },
+                "audit": {
+                    "events": [
+                        {
+                            "event_type": "request_context_unavailable",
+                            "operation": "execute",
+                            "candidate_id": "candidate-123",
+                            "denial_cause": "missing_request_audit_context",
+                        }
+                    ]
+                },
+            },
+        )
+        self.assertEqual(calls, [])
+        self.assertNotIn("Request audit context is unavailable", response.text)
+        self.assertNotIn("Traceback", response.text)
+        self.assertEqual(self.session.query(PreviewAuditEvent).count(), 0)
 
     def test_execute_candidate_api_runs_approved_snapshot_after_preview_row_drift(
         self,


### PR DESCRIPTION
## Summary
- replace preview and execute missing request audit context 500s with the shared API error envelope
- add a deterministic request_context_unavailable code with sanitized audit payload allowlisting
- cover preview and execute missing/blank request-id behavior with focused regression tests

## Verification
- PYTHONPATH=backend python3 -m pytest backend/tests/test_api_errors.py backend/tests/test_candidate_execute_api.py backend/tests/test_audit_event_model.py

Closes #413