### PR TITLE
Align runtime-flow limiter contract

### DIFF
--- a/docs/design/runtime-flow.md
+++ b/docs/design/runtime-flow.md
@@ -18,7 +18,7 @@ This SQL-backed path is the required Phase 1 core flow. Governed search, analyst
 
    The authenticated user submits a natural language question through the custom web UI.
 
-   Generate-path rate limits and concurrency checks apply before generation proceeds. If the request is rejected, the application records the rejection as an operational audit event.
+   The current backend authenticates the user, establishes application-session context, resolves the selected source, and performs source entitlement checks before generation proceeds. Preview-request rate-limit and concurrency enforcement is not active in this release; it is tracked as follow-up implementation work in [implementation-roadmap.md](../implementation-roadmap.md).
 
 3. Audit start
 
@@ -70,7 +70,7 @@ This SQL-backed path is the required Phase 1 core flow. Governed search, analyst
 
    If the approved candidate remains visible and unexpired, the user may explicitly trigger execution through the UI. The execution request submits the `query_candidate_id`, not raw SQL text. No silent automatic execution is assumed in the first PoC.
 
-   Execute-path rate limits and concurrency checks are applied separately from generate-path limits.
+   Execute requests keep the candidate-bound source and authenticated subject checks separate from preview submission. Dedicated execute-request rate-limit and concurrency enforcement is not active in this release; it is tracked as follow-up implementation work in [implementation-roadmap.md](../implementation-roadmap.md).
 
 11. Controlled SQL execution
 
@@ -130,7 +130,7 @@ stateDiagram-v2
 - If the client submits an expired or mismatched `query_candidate_id`, execution is denied.
 - If the current authenticated subject does not match candidate ownership or current authorization no longer permits execution, execution is denied.
 - If another request already claimed the candidate atomically, later requests are denied as replay or stale-claim attempts.
-- If rate limits or concurrency limits are exceeded, the affected request is rejected and audited.
+- Future preview and execute rate-limit or concurrency denials must reject the affected request and persist an audit denial event when that enforcement is implemented.
 - If SQL execution fails after approval, the failure is recorded as part of the audit trail.
 
 ## Key Design Rules

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -60,6 +60,10 @@ Focus areas:
 - complete preview-before-execute for the active source-aware path
 - complete source-aware audit and evaluation
 - complete result controls, kill switch behavior, and replay-safe execution handling
+- implement preview and execute rate-limit and concurrency enforcement with
+  separate keys that include authenticated subject, source, and endpoint kind;
+  return deterministic public deny codes, persist audit denial events with
+  request/candidate/source context, and cover source switching plus burst and concurrent request tests before documenting the controls as active
 - ship a core vertical slice that stays application-owned from request to execution
 
 ## Optional Extension Tracks

--- a/tests/test_runtime_flow_rate_limit_docs.py
+++ b/tests/test_runtime_flow_rate_limit_docs.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_FLOW_DOC = REPO_ROOT / "docs" / "design" / "runtime-flow.md"
+ROADMAP_DOC = REPO_ROOT / "docs" / "implementation-roadmap.md"
+
+
+def test_runtime_flow_does_not_claim_unimplemented_rate_or_concurrency_enforcement() -> None:
+    runtime_flow = RUNTIME_FLOW_DOC.read_text(encoding="utf-8")
+
+    overstatements = (
+        "Generate-path rate limits and concurrency checks apply",
+        "Execute-path rate limits and concurrency checks are applied",
+        "If rate limits or concurrency limits are exceeded",
+    )
+
+    for overstatement in overstatements:
+        assert overstatement not in runtime_flow
+
+
+def test_roadmap_tracks_preview_execute_rate_and_concurrency_enforcement() -> None:
+    roadmap = ROADMAP_DOC.read_text(encoding="utf-8")
+
+    required_phrases = (
+        "preview and execute rate-limit and concurrency enforcement",
+        "authenticated subject, source, and endpoint kind",
+        "deterministic public deny codes",
+        "audit denial events",
+        "burst and concurrent request tests",
+    )
+
+    for phrase in required_phrases:
+        assert phrase in roadmap


### PR DESCRIPTION
## Summary
- Downgrade runtime-flow preview/execute rate-limit and concurrency wording to future work instead of active enforcement
- Add a roadmap follow-up item covering subject/source/endpoint keys, deny codes, denial audit events, source switching, burst, and concurrency tests
- Add a focused docs regression test so runtime-flow cannot re-claim unimplemented enforcement without roadmap coverage

## Verification
- python3 -m pytest tests/test_runtime_flow_rate_limit_docs.py
- python3 -m pytest tests/test_runtime_flow_rate_limit_docs.py tests/test_connector_threat_model_docs.py tests/test_dialect_guard_readiness_checklist_docs.py tests/test_source_family_activation_criteria_docs.py tests/test_source_family_activation_selection_docs.py

Refs #414