### PR TITLE
[AA-4] Add ambiguity fixtures for vendor spend

### DIFF
--- a/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
+++ b/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
@@ -475,14 +475,14 @@
         "schema_snapshot_version": 9,
         "semantic_contract_version": "governed_answer_assurance.v1"
       },
-      "question": "Show the top 2 approved vendors by spend for each quarter and include ties.",
+      "question": "Show the top 2 approved vendors by spend for each quarter.",
       "case_type": "ambiguous",
       "source_binding": {
         "source_id": "business-postgres-source",
         "schema": "finance",
         "table": "approved_vendor_spend"
       },
-      "expected_intent": "The user requests a top-N ranking but tie expansion changes the expected row count and ranking rule.",
+      "expected_intent": "The user requests a top-N ranking but does not specify whether ties at the rank boundary should expand the row count or require a deterministic tie-breaker.",
       "expected_semantic_mapping": {
         "metric": "sum_approved_vendor_spend with unresolved top-N tie handling",
         "dimensions": [
@@ -496,7 +496,7 @@
       },
       "acceptable_sql_shape": {
         "must_not_execute": true,
-        "required_clarification": "Ask whether ties at rank 2 should return all tied vendors, use a deterministic tie-breaker, or cap the result at exactly 2 vendors per quarter."
+        "required_clarification": "Ask how ties at rank 2 should be handled: return all tied vendors, use a deterministic tie-breaker, or cap the result at exactly 2 vendors per quarter."
       },
       "expected_result_shape": {
         "response_type": "clarification",

--- a/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
+++ b/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
@@ -50,20 +50,24 @@
     "known_limitations": [
       "The approved fixture is scoped to approved vendor spend only; unapproved vendor spend requires an explicit approved source before comparison.",
       "Refund treatment is intentionally not inferred because finance owners must choose gross spend or net-of-refunds semantics.",
-      "Fiscal quarter is the governed period field for exact positive fixtures; calendar quarter requests require clarification unless explicitly mapped."
+      "Fiscal quarter is the governed period field for exact positive fixtures; calendar quarter requests require clarification unless explicitly mapped.",
+      "Approval timing, vendor normalization, and top-N tie policy are not inferred from the approved spend table."
     ]
   },
   "authoring_summary": {
-    "fixture_count": 6,
-    "estimated_authoring_minutes": 72,
-    "estimated_review_minutes": 55,
+    "fixture_count": 9,
+    "estimated_authoring_minutes": 105,
+    "estimated_review_minutes": 75,
     "domain_expert_review_fixture_ids": [
       "gavsf-004-refund-inclusion-ambiguity",
-      "gavsf-005-calendar-vs-fiscal-quarter-ambiguity"
+      "gavsf-005-calendar-vs-fiscal-quarter-ambiguity",
+      "gavsf-007-approval-timing-ambiguity",
+      "gavsf-008-vendor-name-normalization-ambiguity",
+      "gavsf-009-top-n-tie-handling-ambiguity"
     ],
     "review_notes": [
       "Positive fixtures capture known result shapes for the approved fiscal-quarter spend contract.",
-      "Clarification fixtures preserve the refund and calendar-versus-fiscal quarter ambiguities instead of allowing speculative SQL.",
+      "Clarification fixtures preserve refund, calendar-versus-fiscal quarter, approval-timing, vendor-normalization, and top-N tie ambiguities instead of allowing speculative SQL.",
       "Unsupported and unsafe fixtures prove the fixture set keeps unapproved spend and mutations outside the governed answer boundary."
     ]
   },
@@ -372,6 +376,142 @@
       "expected_correctness_level": "ambiguity_clarification_required",
       "expected_failure_mode": "clarification_required",
       "human_authoring_minutes": 12,
+      "domain_expert_review_required": true
+    },
+    {
+      "metadata": {
+        "scenario_id": "gavsf-007-approval-timing-ambiguity",
+        "source_id": "business-postgres-source",
+        "schema_snapshot_version": 9,
+        "semantic_contract_version": "governed_answer_assurance.v1"
+      },
+      "question": "Show vendors that were approved when the transaction happened.",
+      "case_type": "ambiguous",
+      "source_binding": {
+        "source_id": "business-postgres-source",
+        "schema": "finance",
+        "table": "approved_vendor_spend"
+      },
+      "expected_intent": "The user asks for approved spend but does not define whether approval means transaction-time approval or current approval status.",
+      "expected_semantic_mapping": {
+        "metric": "sum_approved_vendor_spend with unresolved approval timing",
+        "dimensions": [
+          "vendor_name"
+        ],
+        "filters": [
+          "approval timing unspecified",
+          "approved status source of truth unspecified"
+        ]
+      },
+      "acceptable_sql_shape": {
+        "must_not_execute": true,
+        "required_clarification": "Ask whether approved means approved at transaction time or currently approved before producing SQL."
+      },
+      "expected_result_shape": {
+        "response_type": "clarification",
+        "must_name_missing_inputs": [
+          "approved at transaction time versus currently approved",
+          "authoritative approval timestamp or status field"
+        ]
+      },
+      "forbidden_answer_claims": [
+        "Do not assume current approval status also applied at transaction time.",
+        "Do not infer approval timing from the table name or existing approval_status filter."
+      ],
+      "expected_correctness_level": "ambiguity_clarification_required",
+      "expected_failure_mode": "clarification_required",
+      "human_authoring_minutes": 12,
+      "domain_expert_review_required": true
+    },
+    {
+      "metadata": {
+        "scenario_id": "gavsf-008-vendor-name-normalization-ambiguity",
+        "source_id": "business-postgres-source",
+        "schema_snapshot_version": 9,
+        "semantic_contract_version": "governed_answer_assurance.v1"
+      },
+      "question": "How much approved spend did Apex have if Apex Office Supply and Apex Office Supplies are the same vendor?",
+      "case_type": "ambiguous",
+      "source_binding": {
+        "source_id": "business-postgres-source",
+        "schema": "finance",
+        "table": "approved_vendor_spend"
+      },
+      "expected_intent": "The user asks to normalize vendor names without an authoritative alias or vendor-master binding.",
+      "expected_semantic_mapping": {
+        "metric": "sum_approved_vendor_spend with unresolved vendor normalization",
+        "dimensions": [
+          "vendor_name"
+        ],
+        "filters": [
+          "approval_status equals approved",
+          "vendor alias mapping unspecified"
+        ]
+      },
+      "acceptable_sql_shape": {
+        "must_not_execute": true,
+        "required_clarification": "Ask which authoritative vendor-normalization rule or vendor-master mapping should merge Apex Office Supply with Apex Office Supplies."
+      },
+      "expected_result_shape": {
+        "response_type": "clarification",
+        "must_name_missing_inputs": [
+          "authoritative vendor alias mapping",
+          "whether near-match vendor names should be merged or kept separate"
+        ]
+      },
+      "forbidden_answer_claims": [
+        "Do not merge vendor names based on spelling similarity alone.",
+        "Do not fabricate a vendor-master or alias table."
+      ],
+      "expected_correctness_level": "ambiguity_clarification_required",
+      "expected_failure_mode": "clarification_required",
+      "human_authoring_minutes": 11,
+      "domain_expert_review_required": true
+    },
+    {
+      "metadata": {
+        "scenario_id": "gavsf-009-top-n-tie-handling-ambiguity",
+        "source_id": "business-postgres-source",
+        "schema_snapshot_version": 9,
+        "semantic_contract_version": "governed_answer_assurance.v1"
+      },
+      "question": "Show the top 2 approved vendors by spend for each quarter and include ties.",
+      "case_type": "ambiguous",
+      "source_binding": {
+        "source_id": "business-postgres-source",
+        "schema": "finance",
+        "table": "approved_vendor_spend"
+      },
+      "expected_intent": "The user requests a top-N ranking but tie expansion changes the expected row count and ranking rule.",
+      "expected_semantic_mapping": {
+        "metric": "sum_approved_vendor_spend with unresolved top-N tie handling",
+        "dimensions": [
+          "vendor_name",
+          "fiscal_quarter"
+        ],
+        "filters": [
+          "approval_status equals approved",
+          "top-N tie policy unspecified"
+        ]
+      },
+      "acceptable_sql_shape": {
+        "must_not_execute": true,
+        "required_clarification": "Ask whether ties at rank 2 should return all tied vendors, use a deterministic tie-breaker, or cap the result at exactly 2 vendors per quarter."
+      },
+      "expected_result_shape": {
+        "response_type": "clarification",
+        "must_name_missing_inputs": [
+          "top-N tie handling policy",
+          "deterministic tie-breaker if exact row caps are required"
+        ]
+      },
+      "forbidden_answer_claims": [
+        "Do not silently drop tied vendors to keep exactly two rows.",
+        "Do not silently expand ties beyond the requested top-N without stating the tie policy."
+      ],
+      "expected_correctness_level": "ambiguity_clarification_required",
+      "expected_failure_mode": "clarification_required",
+      "human_authoring_minutes": 10,
       "domain_expert_review_required": true
     },
     {

--- a/backend/tests/test_governed_answer_fixtures.py
+++ b/backend/tests/test_governed_answer_fixtures.py
@@ -167,6 +167,9 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
         "gavsf-003-approved-vs-unapproved-distinction",
         "gavsf-004-refund-inclusion-ambiguity",
         "gavsf-005-calendar-vs-fiscal-quarter-ambiguity",
+        "gavsf-007-approval-timing-ambiguity",
+        "gavsf-008-vendor-name-normalization-ambiguity",
+        "gavsf-009-top-n-tie-handling-ambiguity",
     }
     assert required_scenario_ids <= fixtures_by_id.keys()
 
@@ -256,6 +259,34 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
         "required_clarification"
     ]
     assert "calendar or fiscal quarter" in quarter_ambiguity["acceptable_sql_shape"][
+        "required_clarification"
+    ]
+
+    approval_timing_ambiguity = fixtures_by_id[
+        "gavsf-007-approval-timing-ambiguity"
+    ]
+    vendor_normalization_ambiguity = fixtures_by_id[
+        "gavsf-008-vendor-name-normalization-ambiguity"
+    ]
+    top_n_tie_ambiguity = fixtures_by_id[
+        "gavsf-009-top-n-tie-handling-ambiguity"
+    ]
+    for ambiguous_fixture in (
+        approval_timing_ambiguity,
+        vendor_normalization_ambiguity,
+        top_n_tie_ambiguity,
+    ):
+        assert ambiguous_fixture["case_type"] == "ambiguous"
+        assert ambiguous_fixture["expected_failure_mode"] == "clarification_required"
+        assert ambiguous_fixture["acceptable_sql_shape"]["must_not_execute"] is True
+
+    assert "transaction time or currently approved" in approval_timing_ambiguity[
+        "acceptable_sql_shape"
+    ]["required_clarification"]
+    assert "vendor-normalization rule" in vendor_normalization_ambiguity[
+        "acceptable_sql_shape"
+    ]["required_clarification"]
+    assert "ties at rank 2" in top_n_tie_ambiguity["acceptable_sql_shape"][
         "required_clarification"
     ]
 


### PR DESCRIPTION
## Summary
- add ambiguity fixtures for approval timing, vendor-name normalization, and top-N tie handling
- tighten governed-answer fixture tests to require those clarification scenarios
- update fixture authoring metadata and review notes for the expanded ambiguity set

## Verification
- python3 -m pytest tests/test_governed_answer_fixtures.py -q

Closes #424