### PR TITLE
[AA-6] Wire assurance harness into release gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,20 @@ against both real source containers, and checks persisted execution audit
 evidence. If Docker / Colima is unavailable, it exits with an explicit
 smoke-not-run status instead of reporting a product pass.
 
+Governed-answer assurance release gate:
+
+```bash
+cd backend
+python3 -m app.cli.release_gate
+python3 -m app.cli.release_gate --observed-answer-artifacts <observed-answer-artifacts.json>
+```
+
+The release-gate report separates Level 0 fixture-contract validation, Level 1
+positive governed-answer correctness, Level 2 clarification and guard-denial
+boundaries, and Level 3 unsupported-answer boundaries. Fixture levels with no
+observed artifacts are reported as `not_covered` with explicit coverage counts
+instead of being treated as passed.
+
 Startup-guard verification:
 
 ```bash

--- a/backend/app/cli/release_gate.py
+++ b/backend/app/cli/release_gate.py
@@ -31,12 +31,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    observed_answer_artifacts: tuple[dict[str, Any], ...] = ()
+    observed_answer_artifacts: tuple[Any, ...] = ()
     if args.observed_answer_artifacts is not None:
-        payload = json.loads(args.observed_answer_artifacts.read_text(encoding="utf-8"))
-        if isinstance(payload, dict):
-            payload = payload.get("observed_answer_artifacts", ())
-        observed_answer_artifacts = tuple(payload)
+        try:
+            payload = json.loads(args.observed_answer_artifacts.read_text(encoding="utf-8"))
+            observed_answer_artifacts = _observed_answer_artifacts_from_payload(payload)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            parser.error(str(exc))
 
     report = build_release_gate_assurance_report(
         fixture_set_path=args.fixture_set,
@@ -45,6 +46,24 @@ def main() -> None:
     print(json.dumps(report.model_dump(mode="json"), sort_keys=True))
     if report.status == "fail":
         raise SystemExit(1)
+
+
+def _observed_answer_artifacts_from_payload(payload: Any) -> tuple[Any, ...]:
+    if isinstance(payload, list):
+        return tuple(payload)
+    if isinstance(payload, dict):
+        if "observed_answer_artifacts" not in payload:
+            raise ValueError(
+                "Observed answer artifact envelope must include "
+                "'observed_answer_artifacts'."
+            )
+        artifacts = payload["observed_answer_artifacts"]
+        if not isinstance(artifacts, list):
+            raise ValueError("'observed_answer_artifacts' must be a JSON array.")
+        return tuple(artifacts)
+    raise ValueError(
+        "Observed answer artifacts JSON must be an array or an object envelope."
+    )
 
 
 if __name__ == "__main__":

--- a/backend/app/cli/release_gate.py
+++ b/backend/app/cli/release_gate.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from app.features.evaluation import build_release_gate_assurance_report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the SafeQuery governed-answer assurance release gate."
+    )
+    parser.add_argument(
+        "--fixture-set",
+        type=Path,
+        default=(
+            Path(__file__).resolve().parents[2]
+            / "tests"
+            / "fixtures"
+            / "governed_answer_vendor_spend_fixtures.json"
+        ),
+        help="Path to a governed_answer_assurance.v1 fixture set.",
+    )
+    parser.add_argument(
+        "--observed-answer-artifacts",
+        type=Path,
+        help="Optional JSON file containing observed governed-answer artifacts.",
+    )
+    args = parser.parse_args()
+
+    observed_answer_artifacts: tuple[dict[str, Any], ...] = ()
+    if args.observed_answer_artifacts is not None:
+        payload = json.loads(args.observed_answer_artifacts.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload = payload.get("observed_answer_artifacts", ())
+        observed_answer_artifacts = tuple(payload)
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=args.fixture_set,
+        observed_answer_artifacts=observed_answer_artifacts,
+    )
+    print(json.dumps(report.model_dump(mode="json"), sort_keys=True))
+    if report.status == "fail":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/backend/app/cli/release_gate.py
+++ b/backend/app/cli/release_gate.py
@@ -46,7 +46,7 @@ def main() -> None:
             fixture_set_path=args.fixture_set,
             observed_answer_artifacts=observed_answer_artifacts,
         )
-    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
         parser.error(str(exc))
     print(json.dumps(report.model_dump(mode="json"), sort_keys=True))
     if report.status == "fail":

--- a/backend/app/cli/release_gate.py
+++ b/backend/app/cli/release_gate.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from pydantic import ValidationError
+
 from app.features.evaluation import build_release_gate_assurance_report
 
 
@@ -39,10 +41,13 @@ def main() -> None:
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             parser.error(str(exc))
 
-    report = build_release_gate_assurance_report(
-        fixture_set_path=args.fixture_set,
-        observed_answer_artifacts=observed_answer_artifacts,
-    )
+    try:
+        report = build_release_gate_assurance_report(
+            fixture_set_path=args.fixture_set,
+            observed_answer_artifacts=observed_answer_artifacts,
+        )
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        parser.error(str(exc))
     print(json.dumps(report.model_dump(mode="json"), sort_keys=True))
     if report.status == "fail":
         raise SystemExit(1)

--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -38,10 +38,14 @@ from app.features.evaluation.governed_answer import (
 )
 from app.features.evaluation.release_gate import (
     ReleaseGateAuditArtifact,
+    ReleaseGateAssuranceLevelReport,
+    ReleaseGateAssuranceObservedAnswer,
+    ReleaseGateAssuranceReport,
     ReleaseGateDecision,
     ReleaseGateDiffArtifact,
     ReleaseGateDiffScenario,
     ReleaseGateFailure,
+    build_release_gate_assurance_report,
     reconstruct_release_gate,
 )
 
@@ -70,12 +74,16 @@ __all__ = [
     "MSSQLEvaluationScenario",
     "PostgreSQLEvaluationScenario",
     "ReleaseGateAuditArtifact",
+    "ReleaseGateAssuranceLevelReport",
+    "ReleaseGateAssuranceObservedAnswer",
+    "ReleaseGateAssuranceReport",
     "ReleaseGateDecision",
     "ReleaseGateDiffArtifact",
     "ReleaseGateDiffScenario",
     "ReleaseGateFailure",
     "SourceRegressionMatrixEntry",
     "compare_evaluation_outcomes",
+    "build_release_gate_assurance_report",
     "list_mssql_evaluation_scenarios",
     "list_postgresql_evaluation_scenarios",
     "list_source_regression_matrix",

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -34,6 +34,11 @@ AuditEvidenceStatus = Literal["matched", "missing", "stale", "not_evaluated"]
 ScenarioArtifact = Union[MSSQLEvaluationScenario, PostgreSQLEvaluationScenario]
 ReleaseGateAssuranceStatus = Literal["pass", "fail", "not_covered"]
 ReleaseGateAssuranceLevelName = Literal["level_0", "level_1", "level_2", "level_3"]
+_ASSURANCE_LEVEL_0_DENY_CODES = {
+    "DENY_DUPLICATE_ASSURANCE_ARTIFACT",
+    "DENY_MALFORMED_ASSURANCE_ARTIFACT",
+    "DENY_UNKNOWN_ASSURANCE_FIXTURE",
+}
 
 _SOURCE_REQUIRED_FIELDS = {
     "source.source_id",
@@ -523,7 +528,11 @@ def _assurance_level_report(
 ) -> ReleaseGateAssuranceLevelReport:
     if level == "level_0":
         covered_fixture_count = len(fixtures)
-        failure_count = 0
+        failure_count = sum(
+            1
+            for failure in failures
+            if failure.deny_code in _ASSURANCE_LEVEL_0_DENY_CODES
+        )
     else:
         covered_fixture_count = sum(
             1

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -543,8 +543,10 @@ def _assurance_level_report(
         failure_count = sum(
             1
             for failure in failures
-            if failure.scenario_id in fixture_ids
-            and failure.deny_code not in _ASSURANCE_LEVEL_0_DENY_CODES
+            if _is_assurance_behavior_failure_for_level(
+                failure,
+                fixture_ids=fixture_ids,
+            )
         )
     if failure_count:
         status: ReleaseGateAssuranceStatus = "fail"
@@ -561,6 +563,17 @@ def _assurance_level_report(
         covered_fixture_count=covered_fixture_count,
         not_covered_fixture_count=len(fixtures) - covered_fixture_count,
         failure_count=failure_count,
+    )
+
+
+def _is_assurance_behavior_failure_for_level(
+    failure: ReleaseGateFailure,
+    *,
+    fixture_ids: set[str],
+) -> bool:
+    return (
+        failure.scenario_id in fixture_ids
+        and failure.deny_code not in _ASSURANCE_LEVEL_0_DENY_CODES
     )
 
 

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable, Mapping
+from pathlib import Path
 from typing import Any, Iterable as TypingIterable, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.evaluation.comparison import (
@@ -19,11 +21,19 @@ from app.features.evaluation.harness import (
     list_mssql_evaluation_scenarios,
     list_postgresql_evaluation_scenarios,
 )
+from app.features.evaluation.governed_answer import (
+    GovernedAnswerFixture,
+    GovernedAnswerFixtureSet,
+    score_governed_answer_consistency,
+    validate_governed_answer_fixture_set,
+)
 
 
 ReleaseGateStatus = Literal["pass", "fail"]
 AuditEvidenceStatus = Literal["matched", "missing", "stale", "not_evaluated"]
 ScenarioArtifact = Union[MSSQLEvaluationScenario, PostgreSQLEvaluationScenario]
+ReleaseGateAssuranceStatus = Literal["pass", "fail", "not_covered"]
+ReleaseGateAssuranceLevelName = Literal["level_0", "level_1", "level_2", "level_3"]
 
 _SOURCE_REQUIRED_FIELDS = {
     "source.source_id",
@@ -141,6 +151,38 @@ class ReleaseGateDecision(BaseModel):
     diff_artifact: ReleaseGateDiffArtifact
 
 
+class ReleaseGateAssuranceObservedAnswer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scenario_id: str
+    answer_text: str
+    result_rows: tuple[dict[str, Any], ...] = ()
+    result_metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ReleaseGateAssuranceLevelReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    level: ReleaseGateAssuranceLevelName
+    label: str
+    status: ReleaseGateAssuranceStatus
+    fixture_count: int
+    covered_fixture_count: int
+    not_covered_fixture_count: int
+    failure_count: int
+
+
+class ReleaseGateAssuranceReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: ReleaseGateStatus
+    fixture_set: str
+    semantic_contract_version: str
+    fixture_coverage_count: dict[str, int]
+    levels: tuple[ReleaseGateAssuranceLevelReport, ...]
+    failures: tuple[ReleaseGateFailure, ...]
+
+
 def reconstruct_release_gate(
     *,
     observed_artifacts: TypingIterable[Union[EvaluationOutcomeRecord, Mapping[str, Any]]],
@@ -220,6 +262,52 @@ def reconstruct_release_gate(
     )
 
 
+def build_release_gate_assurance_report(
+    *,
+    fixture_set_path: Path,
+    observed_answer_artifacts: TypingIterable[
+        Union[ReleaseGateAssuranceObservedAnswer, Mapping[str, Any]]
+    ] = (),
+) -> ReleaseGateAssuranceReport:
+    fixture_set = _load_governed_answer_fixture_set(fixture_set_path)
+    observed_answers = _normalize_observed_answer_artifacts(observed_answer_artifacts)
+    observed_by_scenario_id = {
+        artifact.scenario_id: artifact for artifact in observed_answers
+    }
+    failures = _assurance_failures_for_observed_answers(
+        fixture_set=fixture_set,
+        observed_by_scenario_id=observed_by_scenario_id,
+    )
+    levels = tuple(
+        _assurance_level_report(
+            level=level,
+            label=label,
+            fixtures=fixtures,
+            observed_by_scenario_id=observed_by_scenario_id,
+            failures=failures,
+        )
+        for level, label, fixtures in _assurance_level_fixtures(fixture_set)
+    )
+    covered_count = sum(
+        1
+        for fixture in fixture_set.fixtures
+        if fixture.metadata.scenario_id in observed_by_scenario_id
+    )
+
+    return ReleaseGateAssuranceReport(
+        status="fail" if failures else "pass",
+        fixture_set=fixture_set.fixture_set,
+        semantic_contract_version=fixture_set.semantic_contract_version,
+        fixture_coverage_count={
+            "total": len(fixture_set.fixtures),
+            "covered": covered_count,
+            "not_covered": len(fixture_set.fixtures) - covered_count,
+        },
+        levels=levels,
+        failures=tuple(failures),
+    )
+
+
 def _decision(
     *,
     status: ReleaseGateStatus,
@@ -237,6 +325,156 @@ def _decision(
             failure_count=len(failures),
             scenarios=diff_scenarios,
         ),
+    )
+
+
+def _load_governed_answer_fixture_set(fixture_set_path: Path) -> GovernedAnswerFixtureSet:
+    fixture_payload = json.loads(fixture_set_path.read_text(encoding="utf-8"))
+    return validate_governed_answer_fixture_set(fixture_payload)
+
+
+def _normalize_observed_answer_artifacts(
+    observed_answer_artifacts: TypingIterable[
+        Union[ReleaseGateAssuranceObservedAnswer, Mapping[str, Any]]
+    ],
+) -> tuple[ReleaseGateAssuranceObservedAnswer, ...]:
+    artifacts: list[ReleaseGateAssuranceObservedAnswer] = []
+    for artifact in observed_answer_artifacts:
+        if isinstance(artifact, ReleaseGateAssuranceObservedAnswer):
+            artifacts.append(artifact)
+            continue
+        artifacts.append(ReleaseGateAssuranceObservedAnswer.model_validate(artifact))
+    return tuple(artifacts)
+
+
+def _assurance_failures_for_observed_answers(
+    *,
+    fixture_set: GovernedAnswerFixtureSet,
+    observed_by_scenario_id: Mapping[str, ReleaseGateAssuranceObservedAnswer],
+) -> list[ReleaseGateFailure]:
+    failures: list[ReleaseGateFailure] = []
+    fixture_by_scenario_id = {
+        fixture.metadata.scenario_id: fixture for fixture in fixture_set.fixtures
+    }
+    for observed in observed_by_scenario_id.values():
+        fixture = fixture_by_scenario_id.get(observed.scenario_id)
+        if fixture is None:
+            failures.append(
+                ReleaseGateFailure(
+                    deny_code="DENY_UNKNOWN_ASSURANCE_FIXTURE",
+                    source_id=fixture_set.source_profile.source_id,
+                    source_family=fixture_set.source_profile.source_family,
+                    scenario_id=observed.scenario_id,
+                    scenario_category=None,
+                    detail="Observed governed-answer artifact does not match a fixture.",
+                )
+            )
+            continue
+        if fixture.case_type not in {"positive"}:
+            continue
+
+        score = score_governed_answer_consistency(
+            fixture=fixture,
+            answer_text=observed.answer_text,
+            result_rows=observed.result_rows,
+            result_metadata=observed.result_metadata,
+        )
+        if score.passed:
+            continue
+        failures.append(
+            ReleaseGateFailure(
+                deny_code="DENY_UNSUPPORTED_ANSWER_CLAIM",
+                source_id=fixture_set.source_profile.source_id,
+                source_family=fixture_set.source_profile.source_family,
+                scenario_id=fixture.metadata.scenario_id,
+                scenario_category=fixture.case_type,
+                detail=(
+                    "Governed answer made unsupported claims: "
+                    f"{', '.join(score.unsupported_claims)}."
+                ),
+            )
+        )
+    return failures
+
+
+def _assurance_level_fixtures(
+    fixture_set: GovernedAnswerFixtureSet,
+) -> tuple[
+    tuple[ReleaseGateAssuranceLevelName, str, tuple[GovernedAnswerFixture, ...]],
+    ...,
+]:
+    return (
+        (
+            "level_0",
+            "Fixture contract",
+            tuple(fixture_set.fixtures),
+        ),
+        (
+            "level_1",
+            "Positive governed-answer correctness",
+            tuple(
+                fixture
+                for fixture in fixture_set.fixtures
+                if fixture.case_type == "positive"
+            ),
+        ),
+        (
+            "level_2",
+            "Clarification and guard-denial boundaries",
+            tuple(
+                fixture
+                for fixture in fixture_set.fixtures
+                if fixture.case_type in {"ambiguous", "unsafe"}
+            ),
+        ),
+        (
+            "level_3",
+            "Unsupported answer boundaries",
+            tuple(
+                fixture
+                for fixture in fixture_set.fixtures
+                if fixture.case_type == "unsupported_answer"
+            ),
+        ),
+    )
+
+
+def _assurance_level_report(
+    *,
+    level: ReleaseGateAssuranceLevelName,
+    label: str,
+    fixtures: tuple[GovernedAnswerFixture, ...],
+    observed_by_scenario_id: Mapping[str, ReleaseGateAssuranceObservedAnswer],
+    failures: list[ReleaseGateFailure],
+) -> ReleaseGateAssuranceLevelReport:
+    if level == "level_0":
+        covered_fixture_count = len(fixtures)
+        failure_count = 0
+    else:
+        covered_fixture_count = sum(
+            1
+            for fixture in fixtures
+            if fixture.metadata.scenario_id in observed_by_scenario_id
+        )
+        fixture_ids = {fixture.metadata.scenario_id for fixture in fixtures}
+        failure_count = sum(
+            1 for failure in failures if failure.scenario_id in fixture_ids
+        )
+    if failure_count:
+        status: ReleaseGateAssuranceStatus = "fail"
+    elif covered_fixture_count:
+        status = "pass"
+    else:
+        status = "not_covered"
+
+    return ReleaseGateAssuranceLevelReport(
+        level=level,
+        label=label,
+        status=status,
+        fixture_count=len(fixtures),
+        covered_fixture_count=covered_fixture_count,
+        not_covered_fixture_count=len(fixtures) - covered_fixture_count,
+        failure_count=failure_count,
     )
 
 

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -270,13 +270,22 @@ def build_release_gate_assurance_report(
     ] = (),
 ) -> ReleaseGateAssuranceReport:
     fixture_set = _load_governed_answer_fixture_set(fixture_set_path)
-    observed_answers = _normalize_observed_answer_artifacts(observed_answer_artifacts)
-    observed_by_scenario_id = {
-        artifact.scenario_id: artifact for artifact in observed_answers
-    }
-    failures = _assurance_failures_for_observed_answers(
+    observed_answers, failures = _normalize_observed_answer_artifacts(
+        observed_answer_artifacts,
         fixture_set=fixture_set,
-        observed_by_scenario_id=observed_by_scenario_id,
+    )
+    observed_by_scenario_id = _observed_answers_by_scenario_id(observed_answers)
+    failures.extend(
+        _duplicate_observed_answer_failures(
+            fixture_set=fixture_set,
+            observed_by_scenario_id=observed_by_scenario_id,
+        )
+    )
+    failures.extend(
+        _assurance_failures_for_observed_answers(
+            fixture_set=fixture_set,
+            observed_by_scenario_id=observed_by_scenario_id,
+        )
     )
     levels = tuple(
         _assurance_level_report(
@@ -337,63 +346,128 @@ def _normalize_observed_answer_artifacts(
     observed_answer_artifacts: TypingIterable[
         Union[ReleaseGateAssuranceObservedAnswer, Mapping[str, Any]]
     ],
-) -> tuple[ReleaseGateAssuranceObservedAnswer, ...]:
+    *,
+    fixture_set: GovernedAnswerFixtureSet,
+) -> tuple[tuple[ReleaseGateAssuranceObservedAnswer, ...], list[ReleaseGateFailure]]:
     artifacts: list[ReleaseGateAssuranceObservedAnswer] = []
+    failures: list[ReleaseGateFailure] = []
     for artifact in observed_answer_artifacts:
         if isinstance(artifact, ReleaseGateAssuranceObservedAnswer):
             artifacts.append(artifact)
             continue
-        artifacts.append(ReleaseGateAssuranceObservedAnswer.model_validate(artifact))
-    return tuple(artifacts)
+        try:
+            artifacts.append(ReleaseGateAssuranceObservedAnswer.model_validate(artifact))
+        except ValidationError as exc:
+            failures.append(
+                _assurance_artifact_validation_failure_for(
+                    artifact=artifact,
+                    error=exc,
+                    fixture_set=fixture_set,
+                )
+            )
+    return tuple(artifacts), failures
+
+
+def _observed_answers_by_scenario_id(
+    observed_answers: tuple[ReleaseGateAssuranceObservedAnswer, ...],
+) -> dict[str, tuple[ReleaseGateAssuranceObservedAnswer, ...]]:
+    grouped: dict[str, list[ReleaseGateAssuranceObservedAnswer]] = {}
+    for artifact in observed_answers:
+        grouped.setdefault(artifact.scenario_id, []).append(artifact)
+    return {scenario_id: tuple(artifacts) for scenario_id, artifacts in grouped.items()}
+
+
+def _duplicate_observed_answer_failures(
+    *,
+    fixture_set: GovernedAnswerFixtureSet,
+    observed_by_scenario_id: Mapping[str, tuple[ReleaseGateAssuranceObservedAnswer, ...]],
+) -> list[ReleaseGateFailure]:
+    fixture_by_scenario_id = {
+        fixture.metadata.scenario_id: fixture for fixture in fixture_set.fixtures
+    }
+    failures: list[ReleaseGateFailure] = []
+    for scenario_id, artifacts in sorted(observed_by_scenario_id.items()):
+        if len(artifacts) < 2:
+            continue
+        fixture = fixture_by_scenario_id.get(scenario_id)
+        failures.append(
+            ReleaseGateFailure(
+                deny_code="DENY_DUPLICATE_ASSURANCE_ARTIFACT",
+                source_id=fixture_set.source_profile.source_id,
+                source_family=fixture_set.source_profile.source_family,
+                scenario_id=scenario_id,
+                scenario_category=fixture.case_type if fixture is not None else None,
+                detail=(
+                    "Observed governed-answer artifacts must be unique per scenario; "
+                    f"received {len(artifacts)} artifacts."
+                ),
+            )
+        )
+    return failures
 
 
 def _assurance_failures_for_observed_answers(
     *,
     fixture_set: GovernedAnswerFixtureSet,
-    observed_by_scenario_id: Mapping[str, ReleaseGateAssuranceObservedAnswer],
+    observed_by_scenario_id: Mapping[str, tuple[ReleaseGateAssuranceObservedAnswer, ...]],
 ) -> list[ReleaseGateFailure]:
     failures: list[ReleaseGateFailure] = []
     fixture_by_scenario_id = {
         fixture.metadata.scenario_id: fixture for fixture in fixture_set.fixtures
     }
-    for observed in observed_by_scenario_id.values():
-        fixture = fixture_by_scenario_id.get(observed.scenario_id)
+    for scenario_id, artifacts in observed_by_scenario_id.items():
+        fixture = fixture_by_scenario_id.get(scenario_id)
         if fixture is None:
             failures.append(
                 ReleaseGateFailure(
                     deny_code="DENY_UNKNOWN_ASSURANCE_FIXTURE",
                     source_id=fixture_set.source_profile.source_id,
                     source_family=fixture_set.source_profile.source_family,
-                    scenario_id=observed.scenario_id,
+                    scenario_id=scenario_id,
                     scenario_category=None,
                     detail="Observed governed-answer artifact does not match a fixture.",
                 )
             )
             continue
-        if fixture.case_type not in {"positive"}:
+        if fixture.case_type != "positive":
+            failures.append(
+                ReleaseGateFailure(
+                    deny_code="DENY_UNSUPPORTED_ASSURANCE_FIXTURE_COVERAGE",
+                    source_id=fixture_set.source_profile.source_id,
+                    source_family=fixture_set.source_profile.source_family,
+                    scenario_id=scenario_id,
+                    scenario_category=fixture.case_type,
+                    detail=(
+                        "Observed governed-answer artifact covers a non-positive fixture "
+                        f"({fixture.case_type}), but this release gate only validates "
+                        "positive governed-answer outputs."
+                    ),
+                )
+            )
             continue
 
-        score = score_governed_answer_consistency(
-            fixture=fixture,
-            answer_text=observed.answer_text,
-            result_rows=observed.result_rows,
-            result_metadata=observed.result_metadata,
-        )
-        if score.passed:
-            continue
-        failures.append(
-            ReleaseGateFailure(
-                deny_code="DENY_UNSUPPORTED_ANSWER_CLAIM",
-                source_id=fixture_set.source_profile.source_id,
-                source_family=fixture_set.source_profile.source_family,
-                scenario_id=fixture.metadata.scenario_id,
-                scenario_category=fixture.case_type,
-                detail=(
-                    "Governed answer made unsupported claims: "
-                    f"{', '.join(score.unsupported_claims)}."
-                ),
+        for observed in artifacts:
+            score = score_governed_answer_consistency(
+                fixture=fixture,
+                answer_text=observed.answer_text,
+                result_rows=observed.result_rows,
+                result_metadata=observed.result_metadata,
             )
-        )
+            if score.passed:
+                continue
+            failures.append(
+                ReleaseGateFailure(
+                    deny_code="DENY_UNSUPPORTED_ANSWER_CLAIM",
+                    source_id=fixture_set.source_profile.source_id,
+                    source_family=fixture_set.source_profile.source_family,
+                    scenario_id=fixture.metadata.scenario_id,
+                    scenario_category=fixture.case_type,
+                    detail=(
+                        "Governed answer made unsupported claims: "
+                        f"{', '.join(score.unsupported_claims)}."
+                    ),
+                )
+            )
     return failures
 
 
@@ -444,7 +518,7 @@ def _assurance_level_report(
     level: ReleaseGateAssuranceLevelName,
     label: str,
     fixtures: tuple[GovernedAnswerFixture, ...],
-    observed_by_scenario_id: Mapping[str, ReleaseGateAssuranceObservedAnswer],
+    observed_by_scenario_id: Mapping[str, tuple[ReleaseGateAssuranceObservedAnswer, ...]],
     failures: list[ReleaseGateFailure],
 ) -> ReleaseGateAssuranceLevelReport:
     if level == "level_0":
@@ -475,6 +549,27 @@ def _assurance_level_report(
         covered_fixture_count=covered_fixture_count,
         not_covered_fixture_count=len(fixtures) - covered_fixture_count,
         failure_count=failure_count,
+    )
+
+
+def _assurance_artifact_validation_failure_for(
+    *,
+    artifact: Any,
+    error: ValidationError,
+    fixture_set: GovernedAnswerFixtureSet,
+) -> ReleaseGateFailure:
+    errors = error.errors()
+    artifact_map = artifact if isinstance(artifact, Mapping) else {}
+    return ReleaseGateFailure(
+        deny_code="DENY_MALFORMED_ASSURANCE_ARTIFACT",
+        source_id=fixture_set.source_profile.source_id,
+        source_family=fixture_set.source_profile.source_family,
+        scenario_id=_string_or_none(artifact_map.get("scenario_id")),
+        scenario_category=None,
+        detail="; ".join(
+            f"{_error_location(validation_error['loc'])}: {validation_error['msg']}"
+            for validation_error in errors
+        ),
     )
 
 

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -37,6 +37,7 @@ ReleaseGateAssuranceLevelName = Literal["level_0", "level_1", "level_2", "level_
 _ASSURANCE_LEVEL_0_DENY_CODES = {
     "DENY_DUPLICATE_ASSURANCE_ARTIFACT",
     "DENY_MALFORMED_ASSURANCE_ARTIFACT",
+    "DENY_UNSUPPORTED_ASSURANCE_FIXTURE_COVERAGE",
     "DENY_UNKNOWN_ASSURANCE_FIXTURE",
 }
 
@@ -537,7 +538,11 @@ def _assurance_level_report(
         covered_fixture_count = sum(
             1
             for fixture in fixtures
-            if fixture.metadata.scenario_id in observed_by_scenario_id
+            if _has_assurance_behavior_coverage_for_fixture(
+                fixture,
+                observed_by_scenario_id=observed_by_scenario_id,
+                failures=failures,
+            )
         )
         fixture_ids = {fixture.metadata.scenario_id for fixture in fixtures}
         failure_count = sum(
@@ -574,6 +579,22 @@ def _is_assurance_behavior_failure_for_level(
     return (
         failure.scenario_id in fixture_ids
         and failure.deny_code not in _ASSURANCE_LEVEL_0_DENY_CODES
+    )
+
+
+def _has_assurance_behavior_coverage_for_fixture(
+    fixture: GovernedAnswerFixture,
+    *,
+    observed_by_scenario_id: Mapping[str, tuple[ReleaseGateAssuranceObservedAnswer, ...]],
+    failures: list[ReleaseGateFailure],
+) -> bool:
+    scenario_id = fixture.metadata.scenario_id
+    if scenario_id not in observed_by_scenario_id:
+        return False
+    return not any(
+        failure.scenario_id == scenario_id
+        and failure.deny_code == "DENY_UNSUPPORTED_ASSURANCE_FIXTURE_COVERAGE"
+        for failure in failures
     )
 
 

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -545,14 +545,15 @@ def _assurance_level_report(
             )
         )
         fixture_ids = {fixture.metadata.scenario_id for fixture in fixtures}
-        failure_count = sum(
-            1
+        behavior_failures = tuple(
+            failure
             for failure in failures
             if _is_assurance_behavior_failure_for_level(
                 failure,
                 fixture_ids=fixture_ids,
             )
         )
+        failure_count = len(behavior_failures)
     if failure_count:
         status: ReleaseGateAssuranceStatus = "fail"
     elif covered_fixture_count:

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -541,7 +541,10 @@ def _assurance_level_report(
         )
         fixture_ids = {fixture.metadata.scenario_id for fixture in fixtures}
         failure_count = sum(
-            1 for failure in failures if failure.scenario_id in fixture_ids
+            1
+            for failure in failures
+            if failure.scenario_id in fixture_ids
+            and failure.deny_code not in _ASSURANCE_LEVEL_0_DENY_CODES
         )
     if failure_count:
         status: ReleaseGateAssuranceStatus = "fail"

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -8,7 +8,10 @@ from uuid import uuid4
 import pytest
 
 import app.features.evaluation.release_gate as release_gate_module
-from app.cli.release_gate import _observed_answer_artifacts_from_payload
+from app.cli.release_gate import (
+    _observed_answer_artifacts_from_payload,
+    main as release_gate_cli_main,
+)
 from app.features.evaluation import (
     EvaluationOutcomeRecord,
     build_release_gate_assurance_report,
@@ -321,14 +324,82 @@ def test_release_gate_assurance_report_structures_malformed_artifact_failure() -
     )
 
     assert report.status == "fail"
+    assert report.levels[0].status == "fail"
+    assert report.levels[0].failure_count == 1
     assert report.failures[0].deny_code == "DENY_MALFORMED_ASSURANCE_ARTIFACT"
     assert report.failures[0].scenario_id == "gavsf-002-vendor-spend-by-quarter"
     assert "answer_text" in report.failures[0].detail
 
 
+def test_release_gate_assurance_report_marks_unknown_fixture_as_level_0_failure() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(
+            {
+                "scenario_id": "unknown-scenario",
+                "answer_text": "The observed answer came from an unknown fixture.",
+                "result_rows": [],
+                "result_metadata": {"columns": [], "row_count": 0},
+            },
+        ),
+    )
+
+    assert report.status == "fail"
+    assert report.levels[0].status == "fail"
+    assert report.levels[0].failure_count == 1
+    assert report.failures[0].deny_code == "DENY_UNKNOWN_ASSURANCE_FIXTURE"
+
+
 def test_release_gate_cli_rejects_malformed_observed_artifact_envelope() -> None:
     with pytest.raises(ValueError, match="observed_answer_artifacts"):
         _observed_answer_artifacts_from_payload({"artifacts": []})
+
+
+def test_release_gate_cli_handles_fixture_set_load_error_as_parser_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_fixture_path = tmp_path / "missing-fixture-set.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        ["release-gate", "--fixture-set", str(missing_fixture_path)],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        release_gate_cli_main()
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "error:" in captured.err
+    assert missing_fixture_path.name in captured.err
+
+
+def test_release_gate_cli_handles_fixture_set_validation_error_as_parser_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    invalid_fixture_path = tmp_path / "invalid-fixture-set.json"
+    invalid_fixture_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["release-gate", "--fixture-set", str(invalid_fixture_path)],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        release_gate_cli_main()
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "error:" in captured.err
+    assert "fixture_set" in captured.err
 
 
 def test_release_gate_accepts_scenario_id_from_shared_audit_metadata() -> None:

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -299,6 +299,8 @@ def test_release_gate_assurance_report_preserves_duplicate_observed_artifacts() 
 
     assert report.status == "fail"
     assert report.fixture_coverage_count["covered"] == 1
+    assert report.levels[0].failure_count == 1
+    assert report.levels[1].failure_count == 1
     assert {
         failure.deny_code for failure in report.failures
     } == {
@@ -326,6 +328,8 @@ def test_release_gate_assurance_report_structures_malformed_artifact_failure() -
     assert report.status == "fail"
     assert report.levels[0].status == "fail"
     assert report.levels[0].failure_count == 1
+    assert report.levels[1].status == "not_covered"
+    assert report.levels[1].failure_count == 0
     assert report.failures[0].deny_code == "DENY_MALFORMED_ASSURANCE_ARTIFACT"
     assert report.failures[0].scenario_id == "gavsf-002-vendor-spend-by-quarter"
     assert "answer_text" in report.failures[0].detail
@@ -400,6 +404,28 @@ def test_release_gate_cli_handles_fixture_set_validation_error_as_parser_failure
     assert captured.out == ""
     assert "error:" in captured.err
     assert "fixture_set" in captured.err
+
+
+def test_release_gate_cli_handles_fixture_set_unicode_error_as_parser_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    invalid_fixture_path = tmp_path / "invalid-utf8-fixture-set.json"
+    invalid_fixture_path.write_bytes(b"\xff")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["release-gate", "--fixture-set", str(invalid_fixture_path)],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        release_gate_cli_main()
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "error:" in captured.err
+    assert "can't decode" in captured.err
 
 
 def test_release_gate_accepts_scenario_id_from_shared_audit_metadata() -> None:

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -309,6 +309,42 @@ def test_release_gate_assurance_report_preserves_duplicate_observed_artifacts() 
     }
 
 
+def test_release_gate_assurance_report_keeps_duplicate_only_failure_at_level_0() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+    passing_artifact = {
+        "scenario_id": "gavsf-002-vendor-spend-by-quarter",
+        "answer_text": (
+            "FY2025-Q1 approved spend is 125000.00. "
+            "FY2025-Q2 approved spend is 98000.00."
+        ),
+        "result_rows": [
+            {"fiscal_quarter": "FY2025-Q1", "approved_spend": "125000.00"},
+            {"fiscal_quarter": "FY2025-Q2", "approved_spend": "98000.00"},
+        ],
+        "result_metadata": {
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": 2,
+            "truncated": False,
+        },
+    }
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(passing_artifact, passing_artifact),
+    )
+
+    assert report.status == "fail"
+    assert report.levels[0].status == "fail"
+    assert report.levels[0].failure_count == 1
+    assert report.levels[1].status == "pass"
+    assert report.levels[1].failure_count == 0
+    assert {failure.deny_code for failure in report.failures} == {
+        "DENY_DUPLICATE_ASSURANCE_ARTIFACT"
+    }
+
+
 def test_release_gate_assurance_report_structures_malformed_artifact_failure() -> None:
     fixture_path = (
         Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from typing import Union
 from uuid import uuid4
 
+import pytest
+
 import app.features.evaluation.release_gate as release_gate_module
+from app.cli.release_gate import _observed_answer_artifacts_from_payload
 from app.features.evaluation import (
     EvaluationOutcomeRecord,
     build_release_gate_assurance_report,
@@ -221,6 +224,111 @@ def test_release_gate_assurance_report_marks_unimplemented_levels_not_covered() 
     assert report.levels[2].covered_fixture_count == 0
     assert report.levels[3].covered_fixture_count == 0
     assert report.failures == ()
+
+
+def test_release_gate_assurance_report_fails_on_non_positive_observed_fixture() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(
+            {
+                "scenario_id": "gavsf-003-approved-vs-unapproved-distinction",
+                "answer_text": "Approved spend and unapproved spend were compared.",
+                "result_rows": [],
+                "result_metadata": {"columns": [], "row_count": 0},
+            },
+        ),
+    )
+
+    assert report.status == "fail"
+    assert report.levels[3].status == "fail"
+    assert report.levels[3].covered_fixture_count == 1
+    assert report.failures[0].deny_code == "DENY_UNSUPPORTED_ASSURANCE_FIXTURE_COVERAGE"
+    assert report.failures[0].scenario_id == "gavsf-003-approved-vs-unapproved-distinction"
+
+
+def test_release_gate_assurance_report_preserves_duplicate_observed_artifacts() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(
+            {
+                "scenario_id": "gavsf-002-vendor-spend-by-quarter",
+                "answer_text": (
+                    "FY2025-Q1 approved spend is 125000.00. "
+                    "FY2025-Q2 approved spend is 98000.00. "
+                    "FY2025-Q3 approved spend is 42000.00."
+                ),
+                "result_rows": [
+                    {"fiscal_quarter": "FY2025-Q1", "approved_spend": "125000.00"},
+                    {"fiscal_quarter": "FY2025-Q2", "approved_spend": "98000.00"},
+                ],
+                "result_metadata": {
+                    "columns": ["fiscal_quarter", "approved_spend"],
+                    "row_count": 2,
+                    "truncated": False,
+                },
+            },
+            {
+                "scenario_id": "gavsf-002-vendor-spend-by-quarter",
+                "answer_text": (
+                    "FY2025-Q1 approved spend is 125000.00. "
+                    "FY2025-Q2 approved spend is 98000.00."
+                ),
+                "result_rows": [
+                    {"fiscal_quarter": "FY2025-Q1", "approved_spend": "125000.00"},
+                    {"fiscal_quarter": "FY2025-Q2", "approved_spend": "98000.00"},
+                ],
+                "result_metadata": {
+                    "columns": ["fiscal_quarter", "approved_spend"],
+                    "row_count": 2,
+                    "truncated": False,
+                },
+            },
+        ),
+    )
+
+    assert report.status == "fail"
+    assert report.fixture_coverage_count["covered"] == 1
+    assert {
+        failure.deny_code for failure in report.failures
+    } == {
+        "DENY_DUPLICATE_ASSURANCE_ARTIFACT",
+        "DENY_UNSUPPORTED_ANSWER_CLAIM",
+    }
+
+
+def test_release_gate_assurance_report_structures_malformed_artifact_failure() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(
+            {
+                "scenario_id": "gavsf-002-vendor-spend-by-quarter",
+                "result_rows": [],
+                "result_metadata": {},
+            },
+        ),
+    )
+
+    assert report.status == "fail"
+    assert report.failures[0].deny_code == "DENY_MALFORMED_ASSURANCE_ARTIFACT"
+    assert report.failures[0].scenario_id == "gavsf-002-vendor-spend-by-quarter"
+    assert "answer_text" in report.failures[0].detail
+
+
+def test_release_gate_cli_rejects_malformed_observed_artifact_envelope() -> None:
+    with pytest.raises(ValueError, match="observed_answer_artifacts"):
+        _observed_answer_artifacts_from_payload({"artifacts": []})
 
 
 def test_release_gate_accepts_scenario_id_from_shared_audit_metadata() -> None:

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -247,8 +247,11 @@ def test_release_gate_assurance_report_fails_on_non_positive_observed_fixture() 
     )
 
     assert report.status == "fail"
-    assert report.levels[3].status == "fail"
-    assert report.levels[3].covered_fixture_count == 1
+    assert report.levels[0].status == "fail"
+    assert report.levels[0].failure_count == 1
+    assert report.levels[3].status == "not_covered"
+    assert report.levels[3].covered_fixture_count == 0
+    assert report.levels[3].failure_count == 0
     assert report.failures[0].deny_code == "DENY_UNSUPPORTED_ASSURANCE_FIXTURE_COVERAGE"
     assert report.failures[0].scenario_id == "gavsf-003-approved-vs-unapproved-distinction"
 

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import app.features.evaluation.release_gate as release_gate_module
 from app.features.evaluation import (
     EvaluationOutcomeRecord,
+    build_release_gate_assurance_report,
     reconstruct_release_gate,
 )
 from app.features.evaluation.harness import (
@@ -134,6 +135,92 @@ def test_release_gate_passes_when_authoritative_records_match_harness() -> None:
     assert decision.status == "pass"
     assert decision.failure_count == 0
     assert decision.failures == ()
+
+
+def test_release_gate_assurance_report_fails_on_unsupported_answer_claims() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(
+            {
+                "scenario_id": "gavsf-002-vendor-spend-by-quarter",
+                "answer_text": (
+                    "FY2025-Q1 approved spend is 125000.00. "
+                    "FY2025-Q2 approved spend is 98000.00. "
+                    "FY2025-Q3 approved spend is 42000.00."
+                ),
+                "result_rows": [
+                    {"fiscal_quarter": "FY2025-Q1", "approved_spend": "125000.00"},
+                    {"fiscal_quarter": "FY2025-Q2", "approved_spend": "98000.00"},
+                ],
+                "result_metadata": {
+                    "columns": ["fiscal_quarter", "approved_spend"],
+                    "row_count": 2,
+                    "truncated": False,
+                },
+            },
+        ),
+    )
+
+    assert report.status == "fail"
+    assert report.fixture_coverage_count == {
+        "total": 14,
+        "covered": 1,
+        "not_covered": 13,
+    }
+    assert tuple(level.level for level in report.levels) == (
+        "level_0",
+        "level_1",
+        "level_2",
+        "level_3",
+    )
+    assert report.levels[0].status == "pass"
+    assert report.levels[1].status == "fail"
+    assert report.levels[2].status == "not_covered"
+    assert report.levels[3].status == "not_covered"
+    assert report.failures[0].deny_code == "DENY_UNSUPPORTED_ANSWER_CLAIM"
+    assert report.failures[0].scenario_id == "gavsf-002-vendor-spend-by-quarter"
+    assert "FY2025-Q3" in report.failures[0].detail
+
+
+def test_release_gate_assurance_report_marks_unimplemented_levels_not_covered() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(
+            {
+                "scenario_id": "gavsf-002-vendor-spend-by-quarter",
+                "answer_text": (
+                    "FY2025-Q1 approved spend is 125000.00. "
+                    "FY2025-Q2 approved spend is 98000.00."
+                ),
+                "result_rows": [
+                    {"fiscal_quarter": "FY2025-Q1", "approved_spend": "125000.00"},
+                    {"fiscal_quarter": "FY2025-Q2", "approved_spend": "98000.00"},
+                ],
+                "result_metadata": {
+                    "columns": ["fiscal_quarter", "approved_spend"],
+                    "row_count": 2,
+                    "truncated": False,
+                },
+            },
+        ),
+    )
+
+    assert report.status == "pass"
+    assert report.levels[0].status == "pass"
+    assert report.levels[1].status == "pass"
+    assert report.levels[2].status == "not_covered"
+    assert report.levels[3].status == "not_covered"
+    assert report.levels[2].covered_fixture_count == 0
+    assert report.levels[3].covered_fixture_count == 0
+    assert report.failures == ()
 
 
 def test_release_gate_accepts_scenario_id_from_shared_audit_metadata() -> None:


### PR DESCRIPTION
## Summary
- add governed-answer assurance release-gate report with Level 0-3 separation and fixture coverage counts
- fail release-gate reporting on unsupported governed-answer claims while marking unobserved levels as not_covered
- add a CLI entrypoint and README command notes for the assurance release-gate step

## Verification
- cd backend && python3 -m pytest tests/test_release_gate.py tests/test_governed_answer_fixtures.py
- cd backend && python3 -m pytest
- python3 -m pytest tests/test_check_repository_hygiene.py
- bash tests/smoke/test-doc-entrypoints-current-set.sh
- cd backend && python3 -m app.cli.release_gate
- cd backend && python3 -m app.cli.release_gate --observed-answer-artifacts <process-substitution injected unsupported claim>