### PR TITLE
Fail release gate on missing assurance coverage

### DIFF
--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -293,6 +293,25 @@ def build_release_gate_assurance_report(
             observed_by_scenario_id=observed_by_scenario_id,
         )
     )
+    covered_count = sum(
+        1
+        for fixture in fixture_set.fixtures
+        if fixture.metadata.scenario_id in observed_by_scenario_id
+    )
+    if fixture_set.fixtures and covered_count == 0:
+        failures.append(
+            ReleaseGateFailure(
+                deny_code="DENY_MISSING_ASSURANCE_COVERAGE",
+                source_id=fixture_set.source_profile.source_id,
+                source_family=fixture_set.source_profile.source_family,
+                scenario_id=None,
+                scenario_category=None,
+                detail=(
+                    "Governed-answer assurance release gate has no observed "
+                    "governed-answer artifacts covering any fixture."
+                ),
+            )
+        )
     levels = tuple(
         _assurance_level_report(
             level=level,
@@ -302,11 +321,6 @@ def build_release_gate_assurance_report(
             failures=failures,
         )
         for level, label, fixtures in _assurance_level_fixtures(fixture_set)
-    )
-    covered_count = sum(
-        1
-        for fixture in fixture_set.fixtures
-        if fixture.metadata.scenario_id in observed_by_scenario_id
     )
 
     return ReleaseGateAssuranceReport(

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -192,6 +192,31 @@ def test_release_gate_assurance_report_fails_on_unsupported_answer_claims() -> N
     assert "FY2025-Q3" in report.failures[0].detail
 
 
+def test_release_gate_assurance_report_fails_closed_on_zero_observed_coverage() -> None:
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+    )
+
+    report = build_release_gate_assurance_report(
+        fixture_set_path=fixture_path,
+        observed_answer_artifacts=(),
+    )
+
+    assert report.status == "fail"
+    assert report.fixture_coverage_count == {
+        "total": 14,
+        "covered": 0,
+        "not_covered": 14,
+    }
+    assert report.levels[0].status == "pass"
+    assert report.levels[1].status == "not_covered"
+    assert report.levels[2].status == "not_covered"
+    assert report.levels[3].status == "not_covered"
+    assert report.failures[0].deny_code == "DENY_MISSING_ASSURANCE_COVERAGE"
+    assert report.failures[0].scenario_id is None
+    assert "no observed governed-answer artifacts" in report.failures[0].detail
+
+
 def test_release_gate_assurance_report_marks_unimplemented_levels_not_covered() -> None:
     fixture_path = (
         Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"


### PR DESCRIPTION
## Summary
- fail governed-answer assurance release gate when no observed artifacts cover any fixture
- keep Level 0 contract reporting separate from Level 1/2/3 not-covered behavior levels
- add regression coverage for zero observed artifacts

## Verification
- PYTHONPATH=backend python3 -m pytest backend/tests/test_release_gate.py -q
- PYTHONPATH=backend python3 -m app.cli.release_gate
- python3 scripts/ci/check_repository_hygiene.py

Closes #434