### PR TITLE
[X-1] Define semantic contract schema

### DIFF
--- a/backend/app/features/semantic_contract/__init__.py
+++ b/backend/app/features/semantic_contract/__init__.py
@@ -1,0 +1,11 @@
+"""Semantic contract schema definitions for governed business intent."""
+
+from app.features.semantic_contract.schema import (
+    SemanticContractDefinition,
+    validate_semantic_contract_definition,
+)
+
+__all__ = [
+    "SemanticContractDefinition",
+    "validate_semantic_contract_definition",
+]

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence, MutableSet
-from types import MappingProxyType
-from typing import Callable, Literal, Optional, TypeVar, get_args, get_origin
+from typing import Callable, Iterator, Literal, Optional, TypeVar, get_args, get_origin
 
 from pydantic import (
     BaseModel,
@@ -44,6 +43,29 @@ SEMANTIC_CONTRACT_MODEL_CONFIG = ConfigDict(
     frozen=True,
     populate_by_name=True,
 )
+
+
+class _FrozenMapping(Mapping[SourceIdentifier, NonEmptyTrimmedString]):
+    __slots__ = ("_values",)
+
+    def __init__(
+        self, values: Mapping[SourceIdentifier, NonEmptyTrimmedString]
+    ) -> None:
+        self._values = dict(values)
+
+    def __getitem__(self, key: SourceIdentifier) -> NonEmptyTrimmedString:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[SourceIdentifier]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "_FrozenMapping":
+        copied = type(self)(self._values.copy())
+        memo[id(self)] = copied
+        return copied
 
 
 def _annotation_allows_mutable_collection(annotation: object) -> bool:
@@ -206,7 +228,7 @@ class SemanticContractDefinition(_SemanticContractModel):
         default_factory=tuple
     )
     ambiguity_rules: Mapping[SourceIdentifier, NonEmptyTrimmedString] = Field(
-        default_factory=lambda: MappingProxyType({})
+        default_factory=lambda: _FrozenMapping({})
     )
 
     def to_wire_payload(self) -> dict[str, object]:
@@ -217,7 +239,7 @@ class SemanticContractDefinition(_SemanticContractModel):
     def freeze_ambiguity_rules(
         cls, value: Mapping[SourceIdentifier, NonEmptyTrimmedString]
     ) -> Mapping[SourceIdentifier, NonEmptyTrimmedString]:
-        return MappingProxyType(dict(value))
+        return _FrozenMapping(value)
 
     @field_serializer("ambiguity_rules")
     def serialize_ambiguity_rules(

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -39,6 +39,12 @@ SPEND_CONCEPT_PATTERN = re.compile(
     r"|(?<=[a-z0-9])(?:Spend|spend)(?=$|[^a-z0-9]|[A-Z0-9])"
 )
 SemanticConceptT = TypeVar("SemanticConceptT")
+SEMANTIC_CONTRACT_MODEL_CONFIG = ConfigDict(
+    alias_generator=to_camel,
+    extra="forbid",
+    frozen=True,
+    populate_by_name=True,
+)
 
 
 def _annotation_allows_mutable_collection(annotation: object) -> bool:
@@ -61,12 +67,7 @@ def _is_mutable_collection_type(candidate: object) -> bool:
 
 
 class _SemanticContractModel(BaseModel):
-    model_config = ConfigDict(
-        alias_generator=to_camel,
-        extra="forbid",
-        frozen=True,
-        populate_by_name=True,
-    )
+    model_config = SEMANTIC_CONTRACT_MODEL_CONFIG
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: object) -> None:
@@ -231,17 +232,20 @@ class SemanticContractDefinition(_SemanticContractModel):
             [item.source_id for item in self.source_bindings],
             "Contract source bindings",
         )
-        dimension_ids = _unique_ids(
-            [item.dimension_id for item in self.dimensions],
+        dimensions_by_id = _unique_concepts_by_id(
+            self.dimensions,
+            lambda item: item.dimension_id,
             "Contract dimensions",
         )
-        filter_ids = _unique_ids(
-            [item.filter_id for item in self.filters],
+        filters_by_id = _unique_concepts_by_id(
+            self.filters,
+            lambda item: item.filter_id,
             "Contract filters",
         )
         _unique_ids([item.metric_id for item in self.metrics], "Contract metrics")
-        _unique_ids(
-            [item.concept_id for item in self.sensitive_concepts],
+        _unique_concepts_by_id(
+            self.sensitive_concepts,
+            lambda item: item.concept_id,
             "Contract sensitive concepts",
         )
 
@@ -278,14 +282,13 @@ class SemanticContractDefinition(_SemanticContractModel):
             )
             _require_subset(
                 metric.allowed_dimensions,
-                dimension_ids,
+                set(dimensions_by_id),
                 f"Metric {metric.metric_id} references undeclared dimensions",
             )
             _require_referenced_concept_source_overlap(
                 metric.allowed_source_ids,
-                (dimension for dimension in self.dimensions),
+                dimensions_by_id,
                 metric.allowed_dimensions,
-                lambda dimension: dimension.dimension_id,
                 lambda dimension: dimension.allowed_source_ids,
                 (
                     f"Metric {metric.metric_id} references dimensions without "
@@ -294,14 +297,13 @@ class SemanticContractDefinition(_SemanticContractModel):
             )
             _require_subset(
                 metric.default_filters,
-                filter_ids,
+                set(filters_by_id),
                 f"Metric {metric.metric_id} references undeclared default filters",
             )
             _require_referenced_concept_source_overlap(
                 metric.allowed_source_ids,
-                (semantic_filter for semantic_filter in self.filters),
+                filters_by_id,
                 metric.default_filters,
-                lambda semantic_filter: semantic_filter.filter_id,
                 lambda semantic_filter: semantic_filter.allowed_source_ids,
                 (
                     f"Metric {metric.metric_id} references default filters without "
@@ -389,6 +391,20 @@ def _unique_ids(
     return set(values)
 
 
+def _unique_concepts_by_id(
+    concepts: Iterable[SemanticConceptT],
+    get_id: Callable[[SemanticConceptT], SourceIdentifier],
+    label: str,
+) -> dict[SourceIdentifier, SemanticConceptT]:
+    concepts_by_id: dict[SourceIdentifier, SemanticConceptT] = {}
+    for concept in concepts:
+        concept_id = get_id(concept)
+        if concept_id in concepts_by_id:
+            raise ValueError(f"{label} must not contain duplicate values.")
+        concepts_by_id[concept_id] = concept
+    return concepts_by_id
+
+
 def _require_subset(
     values: Iterable[object],
     allowed_values: set[object],
@@ -400,18 +416,16 @@ def _require_subset(
 
 def _require_referenced_concept_source_overlap(
     metric_source_ids: Iterable[SourceIdentifier],
-    concepts: Iterable[SemanticConceptT],
+    concepts_by_id: Mapping[SourceIdentifier, SemanticConceptT],
     referenced_ids: Iterable[SourceIdentifier],
-    get_id: Callable[[SemanticConceptT], SourceIdentifier],
     get_source_ids: Callable[[SemanticConceptT], Iterable[SourceIdentifier]],
     message: str,
 ) -> None:
     metric_source_id_set = set(metric_source_ids)
-    concepts_by_id = {get_id(concept): concept for concept in concepts}
     for referenced_id in referenced_ids:
         concept = concepts_by_id.get(referenced_id)
         if concept is None:
-            continue
+            raise ValueError(message)
         if metric_source_id_set.isdisjoint(set(get_source_ids(concept))):
             raise ValueError(message)
 

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -35,7 +35,8 @@ TimeGrain = Literal[
 ]
 TimeRangePolicy = Literal["required", "optional", "clarify_when_unspecified"]
 SPEND_CONCEPT_PATTERN = re.compile(
-    r"(?i:(?<![a-z0-9])spend(?![a-z0-9]))"
+    r"(?i:(?<![a-z0-9])spend[a-z0-9]*(?=$|[^a-z0-9]))"
+    r"|(?<=[a-z0-9])Spend[a-z0-9]*(?=$|[^a-z0-9]|[A-Z0-9])"
     r"|(?<=[a-z0-9])(?:Spend|spend)(?=$|[^a-z0-9]|[A-Z0-9])"
 )
 SemanticConceptT = TypeVar("SemanticConceptT")

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
+from types import MappingProxyType
 from typing import Literal, Optional
 
 from pydantic import (
@@ -7,6 +9,8 @@ from pydantic import (
     ConfigDict,
     Field,
     PositiveInt,
+    StrictBool,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -60,7 +64,7 @@ class SemanticDimension(_SemanticContractModel):
     dimension_id: SourceIdentifier
     label: NonEmptyTrimmedString
     source_column: NonEmptyTrimmedString
-    allowed_source_ids: list[SourceIdentifier]
+    allowed_source_ids: tuple[SourceIdentifier, ...]
 
     @model_validator(mode="after")
     def validate_sources(self) -> "SemanticDimension":
@@ -72,7 +76,7 @@ class SemanticFilter(_SemanticContractModel):
     filter_id: SourceIdentifier
     label: NonEmptyTrimmedString
     expression: NonEmptyTrimmedString
-    allowed_source_ids: list[SourceIdentifier]
+    allowed_source_ids: tuple[SourceIdentifier, ...]
     locked: bool = False
 
     @model_validator(mode="after")
@@ -83,14 +87,16 @@ class SemanticFilter(_SemanticContractModel):
 
 class SemanticTimeRange(_SemanticContractModel):
     default_grain: TimeGrain
-    allowed_grains: list[TimeGrain]
+    allowed_grains: tuple[TimeGrain, ...]
     requires_explicit_range: bool
 
     @model_validator(mode="after")
     def validate_default_grain(self) -> "SemanticTimeRange":
         _require_non_empty_unique(self.allowed_grains, "Time range")
         if self.default_grain not in self.allowed_grains:
-            raise ValueError("Time range default grain must be one of the allowed time grains.")
+            raise ValueError(
+                "Time range default grain must be one of the allowed time grains."
+            )
         return self
 
 
@@ -99,9 +105,9 @@ class SemanticMetric(_SemanticContractModel):
     label: NonEmptyTrimmedString
     expression_owner: SourceIdentifier
     expression: NonEmptyTrimmedString
-    allowed_source_ids: list[SourceIdentifier]
-    allowed_dimensions: list[SourceIdentifier] = Field(default_factory=list)
-    default_filters: list[SourceIdentifier] = Field(default_factory=list)
+    allowed_source_ids: tuple[SourceIdentifier, ...]
+    allowed_dimensions: tuple[SourceIdentifier, ...] = Field(default_factory=tuple)
+    default_filters: tuple[SourceIdentifier, ...] = Field(default_factory=tuple)
     time_range_semantics: SemanticTimeRange
 
     @model_validator(mode="after")
@@ -114,8 +120,8 @@ class SemanticMetric(_SemanticContractModel):
 
 class SemanticContractTimeSemantics(_SemanticContractModel):
     default_grain: TimeGrain
-    allowed_grains: list[TimeGrain]
-    ambiguous_terms: list[SourceIdentifier] = Field(default_factory=list)
+    allowed_grains: tuple[TimeGrain, ...]
+    ambiguous_terms: tuple[SourceIdentifier, ...] = Field(default_factory=tuple)
     range_policy: TimeRangePolicy
 
     @model_validator(mode="after")
@@ -123,7 +129,9 @@ class SemanticContractTimeSemantics(_SemanticContractModel):
         _require_non_empty_unique(self.allowed_grains, "Contract time semantics")
         _require_unique(self.ambiguous_terms, "Contract ambiguous time terms")
         if self.default_grain not in self.allowed_grains:
-            raise ValueError("Contract default grain must be one of the allowed time grains.")
+            raise ValueError(
+                "Contract default grain must be one of the allowed time grains."
+            )
         return self
 
 
@@ -131,7 +139,7 @@ class SensitiveSemanticConcept(_SemanticContractModel):
     concept_id: SourceIdentifier
     label: NonEmptyTrimmedString
     reason: NonEmptyTrimmedString
-    requires_review: bool
+    requires_review: StrictBool
 
     @field_validator("requires_review")
     @classmethod
@@ -145,18 +153,33 @@ class SemanticContractDefinition(_SemanticContractModel):
     contract_id: SourceIdentifier
     domain: SourceIdentifier
     version: SemanticContractVersionMetadata
-    source_bindings: list[SemanticSourceBinding]
-    dimensions: list[SemanticDimension] = Field(default_factory=list)
-    filters: list[SemanticFilter] = Field(default_factory=list)
-    metrics: list[SemanticMetric]
+    source_bindings: tuple[SemanticSourceBinding, ...]
+    dimensions: tuple[SemanticDimension, ...] = Field(default_factory=tuple)
+    filters: tuple[SemanticFilter, ...] = Field(default_factory=tuple)
+    metrics: tuple[SemanticMetric, ...]
     time_semantics: SemanticContractTimeSemantics
-    sensitive_concepts: list[SensitiveSemanticConcept] = Field(default_factory=list)
-    ambiguity_rules: dict[SourceIdentifier, NonEmptyTrimmedString] = Field(
-        default_factory=dict
+    sensitive_concepts: tuple[SensitiveSemanticConcept, ...] = Field(
+        default_factory=tuple
+    )
+    ambiguity_rules: Mapping[SourceIdentifier, NonEmptyTrimmedString] = Field(
+        default_factory=lambda: MappingProxyType({})
     )
 
     def to_wire_payload(self) -> dict[str, object]:
         return self.model_dump(mode="json", by_alias=True)
+
+    @field_validator("ambiguity_rules", mode="after")
+    @classmethod
+    def freeze_ambiguity_rules(
+        cls, value: Mapping[SourceIdentifier, NonEmptyTrimmedString]
+    ) -> Mapping[SourceIdentifier, NonEmptyTrimmedString]:
+        return MappingProxyType(dict(value))
+
+    @field_serializer("ambiguity_rules")
+    def serialize_ambiguity_rules(
+        self, value: Mapping[SourceIdentifier, NonEmptyTrimmedString]
+    ) -> dict[SourceIdentifier, NonEmptyTrimmedString]:
+        return dict(value)
 
     @model_validator(mode="after")
     def validate_contract_references(self) -> "SemanticContractDefinition":
@@ -183,14 +206,20 @@ class SemanticContractDefinition(_SemanticContractModel):
             _require_subset(
                 dimension.allowed_source_ids,
                 source_ids,
-                f"Dimension {dimension.dimension_id} references undeclared allowed sources",
+                (
+                    f"Dimension {dimension.dimension_id} references undeclared "
+                    "allowed sources"
+                ),
             )
 
         for semantic_filter in self.filters:
             _require_subset(
                 semantic_filter.allowed_source_ids,
                 source_ids,
-                f"Filter {semantic_filter.filter_id} references undeclared allowed sources",
+                (
+                    f"Filter {semantic_filter.filter_id} references undeclared "
+                    "allowed sources"
+                ),
             )
 
         for metric in self.metrics:
@@ -220,7 +249,10 @@ class SemanticContractDefinition(_SemanticContractModel):
             and "quarter" not in self.ambiguity_rules
         ):
             raise ValueError("Quarter ambiguity must be explicit in ambiguity_rules.")
-        if "spend_definition" not in self.ambiguity_rules:
+        if (
+            _contract_requires_spend_definition(self)
+            and "spend_definition" not in self.ambiguity_rules
+        ):
             raise ValueError(
                 "Spend definition ambiguity must be explicit in ambiguity_rules."
             )
@@ -234,24 +266,57 @@ def validate_semantic_contract_definition(
     return SemanticContractDefinition.model_validate(payload)
 
 
-def _require_unique(values: list[object], label: str) -> None:
-    if len(set(values)) != len(values):
+def _contract_requires_spend_definition(contract: SemanticContractDefinition) -> bool:
+    spend_terms = [
+        contract.contract_id,
+        contract.domain,
+    ]
+    for dimension in contract.dimensions:
+        spend_terms.extend(
+            [dimension.dimension_id, dimension.label, dimension.source_column]
+        )
+    for semantic_filter in contract.filters:
+        spend_terms.extend(
+            [
+                semantic_filter.filter_id,
+                semantic_filter.label,
+                semantic_filter.expression,
+            ]
+        )
+    for metric in contract.metrics:
+        spend_terms.extend(
+            [
+                metric.metric_id,
+                metric.label,
+                metric.expression_owner,
+                metric.expression,
+            ]
+        )
+    return any("spend" in term.lower() for term in spend_terms)
+
+
+def _require_unique(values: Iterable[object], label: str) -> None:
+    values_tuple = tuple(values)
+    if len(set(values_tuple)) != len(values_tuple):
         raise ValueError(f"{label} must not contain duplicate values.")
 
 
-def _require_non_empty_unique(values: list[object], label: str) -> None:
-    if not values:
+def _require_non_empty_unique(values: Iterable[object], label: str) -> None:
+    values_tuple = tuple(values)
+    if not values_tuple:
         raise ValueError(f"{label} must declare at least one allowed source.")
-    _require_unique(values, label)
+    _require_unique(values_tuple, label)
 
 
-def _unique_ids(values: list[SourceIdentifier], label: str) -> set[SourceIdentifier]:
+def _unique_ids(
+    values: Iterable[SourceIdentifier], label: str
+) -> set[SourceIdentifier]:
     _require_unique(values, label)
     return set(values)
 
 
 def _require_subset(
-    values: list[object],
+    values: Iterable[object],
     allowed_values: set[object],
     message: str,
 ) -> None:

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -229,22 +229,7 @@ class SemanticContractDefinition(_SemanticContractModel):
 
     @model_validator(mode="after")
     def validate_contract_references(self) -> "SemanticContractDefinition":
-        source_ids = _unique_ids(
-            [item.source_id for item in self.source_bindings],
-            "Contract source bindings",
-        )
-        dimensions_by_id = _unique_concepts_by_id(
-            self.dimensions,
-            lambda item: item.dimension_id,
-            "Contract dimensions",
-        )
-        filters_by_id = _unique_concepts_by_id(
-            self.filters,
-            lambda item: item.filter_id,
-            "Contract filters",
-        )
-        _unique_ids([item.metric_id for item in self.metrics], "Contract metrics")
-        _require_unique_sensitive_concepts(self.sensitive_concepts)
+        source_ids, dimensions_by_id, filters_by_id = _index_contract_references(self)
 
         if not source_ids:
             raise ValueError("Contract must declare at least one allowed source.")
@@ -372,6 +357,32 @@ def _unique_concepts_by_id(
             raise ValueError(f"{label} must not contain duplicate values.")
         concepts_by_id[concept_id] = concept
     return concepts_by_id
+
+
+def _index_contract_references(
+    contract: SemanticContractDefinition,
+) -> tuple[
+    set[SourceIdentifier],
+    dict[SourceIdentifier, SemanticDimension],
+    dict[SourceIdentifier, SemanticFilter],
+]:
+    source_ids = _unique_ids(
+        [item.source_id for item in contract.source_bindings],
+        "Contract source bindings",
+    )
+    dimensions_by_id = _unique_concepts_by_id(
+        contract.dimensions,
+        lambda item: item.dimension_id,
+        "Contract dimensions",
+    )
+    filters_by_id = _unique_concepts_by_id(
+        contract.filters,
+        lambda item: item.filter_id,
+        "Contract filters",
+    )
+    _unique_ids([item.metric_id for item in contract.metrics], "Contract metrics")
+    _require_unique_sensitive_concepts(contract.sensitive_concepts)
+    return source_ids, dimensions_by_id, filters_by_id
 
 
 def _require_unique_sensitive_concepts(

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -34,7 +34,10 @@ TimeGrain = Literal[
     "year",
 ]
 TimeRangePolicy = Literal["required", "optional", "clarify_when_unspecified"]
-SPEND_TOKEN_PATTERN = re.compile(r"(?<![a-z0-9])spend(?![a-z0-9])", re.IGNORECASE)
+SPEND_CONCEPT_PATTERN = re.compile(
+    r"(?i:(?<![a-z0-9])spend(?![a-z0-9]))"
+    r"|(?<=[a-z0-9])(?:Spend|spend)(?=$|[^a-z0-9]|[A-Z0-9])"
+)
 SemanticConceptT = TypeVar("SemanticConceptT")
 
 
@@ -118,7 +121,7 @@ class SemanticFilter(_SemanticContractModel):
     label: NonEmptyTrimmedString
     expression: NonEmptyTrimmedString
     allowed_source_ids: tuple[SourceIdentifier, ...]
-    locked: bool = False
+    locked: StrictBool = False
 
     @model_validator(mode="after")
     def validate_sources(self) -> "SemanticFilter":
@@ -129,7 +132,7 @@ class SemanticFilter(_SemanticContractModel):
 class SemanticTimeRange(_SemanticContractModel):
     default_grain: TimeGrain
     allowed_grains: tuple[TimeGrain, ...]
-    requires_explicit_range: bool
+    requires_explicit_range: StrictBool
 
     @model_validator(mode="after")
     def validate_default_grain(self) -> "SemanticTimeRange":
@@ -359,7 +362,11 @@ def _contract_requires_spend_definition(contract: SemanticContractDefinition) ->
                 metric.expression,
             ]
         )
-    return any(SPEND_TOKEN_PATTERN.search(term) for term in spend_terms)
+    return any(_contains_spend_concept(term) for term in spend_terms)
+
+
+def _contains_spend_concept(term: str) -> bool:
+    return bool(SPEND_CONCEPT_PATTERN.search(term))
 
 
 def _require_unique(values: Iterable[object], label: str) -> None:

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence, MutableSet
 from types import MappingProxyType
-from typing import Callable, Literal, Optional, TypeVar
+from typing import Callable, Literal, Optional, TypeVar, get_args, get_origin
 
 from pydantic import (
     BaseModel,
@@ -38,6 +38,25 @@ SPEND_TOKEN_PATTERN = re.compile(r"(?<![a-z0-9])spend(?![a-z0-9])", re.IGNORECAS
 SemanticConceptT = TypeVar("SemanticConceptT")
 
 
+def _annotation_allows_mutable_collection(annotation: object) -> bool:
+    origin = get_origin(annotation)
+    candidate = origin or annotation
+    if _is_mutable_collection_type(candidate):
+        return True
+    return any(
+        _annotation_allows_mutable_collection(arg)
+        for arg in get_args(annotation)
+        if arg is not Ellipsis
+    )
+
+
+def _is_mutable_collection_type(candidate: object) -> bool:
+    try:
+        return issubclass(candidate, (MutableMapping, MutableSequence, MutableSet))
+    except TypeError:
+        return False
+
+
 class _SemanticContractModel(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
@@ -45,6 +64,16 @@ class _SemanticContractModel(BaseModel):
         frozen=True,
         populate_by_name=True,
     )
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: object) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        for field_name, field_info in cls.model_fields.items():
+            if _annotation_allows_mutable_collection(field_info.annotation):
+                raise TypeError(
+                    f"{cls.__name__}.{field_name} must use immutable "
+                    "collection annotations."
+                )
 
     @model_validator(mode="after")
     def validate_immutable_collections(self) -> "_SemanticContractModel":

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence, MutableSet
 from types import MappingProxyType
 from typing import Literal, Optional
 
@@ -42,6 +42,15 @@ class _SemanticContractModel(BaseModel):
         frozen=True,
         populate_by_name=True,
     )
+
+    @model_validator(mode="after")
+    def validate_immutable_collections(self) -> "_SemanticContractModel":
+        for field_name in type(self).model_fields:
+            _reject_mutable_collections(
+                getattr(self, field_name),
+                f"{type(self).__name__}.{field_name}",
+            )
+        return self
 
 
 class SemanticContractVersionMetadata(_SemanticContractModel):
@@ -322,3 +331,26 @@ def _require_subset(
 ) -> None:
     if not set(values).issubset(allowed_values):
         raise ValueError(message)
+
+
+def _reject_mutable_collections(value: object, path: str) -> None:
+    if isinstance(value, (MutableMapping, MutableSequence, MutableSet)):
+        raise ValueError(f"{path} must use immutable collections after validation.")
+
+    if isinstance(value, _SemanticContractModel):
+        for field_name in type(value).model_fields:
+            _reject_mutable_collections(
+                getattr(value, field_name),
+                f"{path}.{field_name}",
+            )
+        return
+
+    if isinstance(value, tuple):
+        for index, item in enumerate(value):
+            _reject_mutable_collections(item, f"{path}[{index}]")
+        return
+
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            _reject_mutable_collections(key, f"{path}.key")
+            _reject_mutable_collections(item, f"{path}[{key!r}]")

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
+
+from app.features.audit.event_model import (
+    NonEmptyTrimmedString,
+    SourceFamily,
+    SourceFlavor,
+    SourceIdentifier,
+    to_camel,
+)
+
+SemanticContractStatus = Literal["draft", "active", "retired"]
+TimeGrain = Literal[
+    "day",
+    "week",
+    "month",
+    "calendar_quarter",
+    "fiscal_quarter",
+    "year",
+]
+TimeRangePolicy = Literal["required", "optional", "clarify_when_unspecified"]
+
+
+class _SemanticContractModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        frozen=True,
+        populate_by_name=True,
+    )
+
+
+class SemanticContractVersionMetadata(_SemanticContractModel):
+    identifier: SourceIdentifier
+    version: PositiveInt
+    status: SemanticContractStatus
+    owner: SourceIdentifier
+    created_for_issue: Optional[PositiveInt] = None
+
+
+class SemanticSourceBinding(_SemanticContractModel):
+    source_id: SourceIdentifier
+    source_family: SourceFamily
+    source_flavor: Optional[SourceFlavor] = None
+    dataset_contract_version: PositiveInt
+    schema_snapshot_version: PositiveInt
+
+
+class SemanticDimension(_SemanticContractModel):
+    dimension_id: SourceIdentifier
+    label: NonEmptyTrimmedString
+    source_column: NonEmptyTrimmedString
+    allowed_source_ids: list[SourceIdentifier]
+
+    @model_validator(mode="after")
+    def validate_sources(self) -> "SemanticDimension":
+        _require_non_empty_unique(self.allowed_source_ids, "Dimension")
+        return self
+
+
+class SemanticFilter(_SemanticContractModel):
+    filter_id: SourceIdentifier
+    label: NonEmptyTrimmedString
+    expression: NonEmptyTrimmedString
+    allowed_source_ids: list[SourceIdentifier]
+    locked: bool = False
+
+    @model_validator(mode="after")
+    def validate_sources(self) -> "SemanticFilter":
+        _require_non_empty_unique(self.allowed_source_ids, "Filter")
+        return self
+
+
+class SemanticTimeRange(_SemanticContractModel):
+    default_grain: TimeGrain
+    allowed_grains: list[TimeGrain]
+    requires_explicit_range: bool
+
+    @model_validator(mode="after")
+    def validate_default_grain(self) -> "SemanticTimeRange":
+        _require_non_empty_unique(self.allowed_grains, "Time range")
+        if self.default_grain not in self.allowed_grains:
+            raise ValueError("Time range default grain must be one of the allowed time grains.")
+        return self
+
+
+class SemanticMetric(_SemanticContractModel):
+    metric_id: SourceIdentifier
+    label: NonEmptyTrimmedString
+    expression_owner: SourceIdentifier
+    expression: NonEmptyTrimmedString
+    allowed_source_ids: list[SourceIdentifier]
+    allowed_dimensions: list[SourceIdentifier] = Field(default_factory=list)
+    default_filters: list[SourceIdentifier] = Field(default_factory=list)
+    time_range_semantics: SemanticTimeRange
+
+    @model_validator(mode="after")
+    def validate_sources(self) -> "SemanticMetric":
+        _require_non_empty_unique(self.allowed_source_ids, "Metric")
+        _require_unique(self.allowed_dimensions, "Metric allowed dimensions")
+        _require_unique(self.default_filters, "Metric default filters")
+        return self
+
+
+class SemanticContractTimeSemantics(_SemanticContractModel):
+    default_grain: TimeGrain
+    allowed_grains: list[TimeGrain]
+    ambiguous_terms: list[SourceIdentifier] = Field(default_factory=list)
+    range_policy: TimeRangePolicy
+
+    @model_validator(mode="after")
+    def validate_default_grain(self) -> "SemanticContractTimeSemantics":
+        _require_non_empty_unique(self.allowed_grains, "Contract time semantics")
+        _require_unique(self.ambiguous_terms, "Contract ambiguous time terms")
+        if self.default_grain not in self.allowed_grains:
+            raise ValueError("Contract default grain must be one of the allowed time grains.")
+        return self
+
+
+class SensitiveSemanticConcept(_SemanticContractModel):
+    concept_id: SourceIdentifier
+    label: NonEmptyTrimmedString
+    reason: NonEmptyTrimmedString
+    requires_review: bool
+
+    @field_validator("requires_review")
+    @classmethod
+    def validate_requires_review(cls, value: bool) -> bool:
+        if value is not True:
+            raise ValueError("Sensitive concepts must require review.")
+        return value
+
+
+class SemanticContractDefinition(_SemanticContractModel):
+    contract_id: SourceIdentifier
+    domain: SourceIdentifier
+    version: SemanticContractVersionMetadata
+    source_bindings: list[SemanticSourceBinding]
+    dimensions: list[SemanticDimension] = Field(default_factory=list)
+    filters: list[SemanticFilter] = Field(default_factory=list)
+    metrics: list[SemanticMetric]
+    time_semantics: SemanticContractTimeSemantics
+    sensitive_concepts: list[SensitiveSemanticConcept] = Field(default_factory=list)
+    ambiguity_rules: dict[SourceIdentifier, NonEmptyTrimmedString] = Field(
+        default_factory=dict
+    )
+
+    def to_wire_payload(self) -> dict[str, object]:
+        return self.model_dump(mode="json", by_alias=True)
+
+    @model_validator(mode="after")
+    def validate_contract_references(self) -> "SemanticContractDefinition":
+        source_ids = _unique_ids(
+            [item.source_id for item in self.source_bindings],
+            "Contract source bindings",
+        )
+        dimension_ids = _unique_ids(
+            [item.dimension_id for item in self.dimensions],
+            "Contract dimensions",
+        )
+        filter_ids = _unique_ids(
+            [item.filter_id for item in self.filters],
+            "Contract filters",
+        )
+        _unique_ids([item.metric_id for item in self.metrics], "Contract metrics")
+
+        if not source_ids:
+            raise ValueError("Contract must declare at least one allowed source.")
+        if not self.metrics:
+            raise ValueError("Contract must declare at least one metric.")
+
+        for dimension in self.dimensions:
+            _require_subset(
+                dimension.allowed_source_ids,
+                source_ids,
+                f"Dimension {dimension.dimension_id} references undeclared allowed sources",
+            )
+
+        for semantic_filter in self.filters:
+            _require_subset(
+                semantic_filter.allowed_source_ids,
+                source_ids,
+                f"Filter {semantic_filter.filter_id} references undeclared allowed sources",
+            )
+
+        for metric in self.metrics:
+            _require_subset(
+                metric.allowed_source_ids,
+                source_ids,
+                f"Metric {metric.metric_id} references undeclared allowed sources",
+            )
+            _require_subset(
+                metric.allowed_dimensions,
+                dimension_ids,
+                f"Metric {metric.metric_id} references undeclared dimensions",
+            )
+            _require_subset(
+                metric.default_filters,
+                filter_ids,
+                f"Metric {metric.metric_id} references undeclared default filters",
+            )
+            _require_subset(
+                metric.time_range_semantics.allowed_grains,
+                self.time_semantics.allowed_grains,
+                f"Metric {metric.metric_id} references undeclared time grains",
+            )
+
+        if (
+            "quarter" in self.time_semantics.ambiguous_terms
+            and "quarter" not in self.ambiguity_rules
+        ):
+            raise ValueError("Quarter ambiguity must be explicit in ambiguity_rules.")
+        if "spend_definition" not in self.ambiguity_rules:
+            raise ValueError(
+                "Spend definition ambiguity must be explicit in ambiguity_rules."
+            )
+
+        return self
+
+
+def validate_semantic_contract_definition(
+    payload: dict[str, object],
+) -> SemanticContractDefinition:
+    return SemanticContractDefinition.model_validate(payload)
+
+
+def _require_unique(values: list[object], label: str) -> None:
+    if len(set(values)) != len(values):
+        raise ValueError(f"{label} must not contain duplicate values.")
+
+
+def _require_non_empty_unique(values: list[object], label: str) -> None:
+    if not values:
+        raise ValueError(f"{label} must declare at least one allowed source.")
+    _require_unique(values, label)
+
+
+def _unique_ids(values: list[SourceIdentifier], label: str) -> set[SourceIdentifier]:
+    _require_unique(values, label)
+    return set(values)
+
+
+def _require_subset(
+    values: list[object],
+    allowed_values: set[object],
+    message: str,
+) -> None:
+    if not set(values).issubset(allowed_values):
+        raise ValueError(message)

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -244,11 +244,7 @@ class SemanticContractDefinition(_SemanticContractModel):
             "Contract filters",
         )
         _unique_ids([item.metric_id for item in self.metrics], "Contract metrics")
-        _unique_concepts_by_id(
-            self.sensitive_concepts,
-            lambda item: item.concept_id,
-            "Contract sensitive concepts",
-        )
+        _require_unique_sensitive_concepts(self.sensitive_concepts)
 
         if not source_ids:
             raise ValueError("Contract must declare at least one allowed source.")
@@ -281,36 +277,8 @@ class SemanticContractDefinition(_SemanticContractModel):
                 source_ids,
                 f"Metric {metric.metric_id} references undeclared allowed sources",
             )
-            _require_subset(
-                metric.allowed_dimensions,
-                set(dimensions_by_id),
-                f"Metric {metric.metric_id} references undeclared dimensions",
-            )
-            _require_referenced_concept_source_overlap(
-                metric.allowed_source_ids,
-                dimensions_by_id,
-                metric.allowed_dimensions,
-                lambda dimension: dimension.allowed_source_ids,
-                (
-                    f"Metric {metric.metric_id} references dimensions without "
-                    "compatible allowed sources"
-                ),
-            )
-            _require_subset(
-                metric.default_filters,
-                set(filters_by_id),
-                f"Metric {metric.metric_id} references undeclared default filters",
-            )
-            _require_referenced_concept_source_overlap(
-                metric.allowed_source_ids,
-                filters_by_id,
-                metric.default_filters,
-                lambda semantic_filter: semantic_filter.allowed_source_ids,
-                (
-                    f"Metric {metric.metric_id} references default filters without "
-                    "compatible allowed sources"
-                ),
-            )
+            _require_metric_dimensions_compatible(metric, dimensions_by_id)
+            _require_metric_default_filters_compatible(metric, filters_by_id)
             _require_subset(
                 metric.time_range_semantics.allowed_grains,
                 self.time_semantics.allowed_grains,
@@ -406,6 +374,16 @@ def _unique_concepts_by_id(
     return concepts_by_id
 
 
+def _require_unique_sensitive_concepts(
+    concepts: Iterable[SensitiveSemanticConcept],
+) -> None:
+    _unique_concepts_by_id(
+        concepts,
+        lambda item: item.concept_id,
+        "Contract sensitive concepts",
+    )
+
+
 def _require_subset(
     values: Iterable[object],
     allowed_values: set[object],
@@ -413,6 +391,48 @@ def _require_subset(
 ) -> None:
     if not set(values).issubset(allowed_values):
         raise ValueError(message)
+
+
+def _require_metric_dimensions_compatible(
+    metric: SemanticMetric,
+    dimensions_by_id: Mapping[SourceIdentifier, SemanticDimension],
+) -> None:
+    _require_subset(
+        metric.allowed_dimensions,
+        set(dimensions_by_id),
+        f"Metric {metric.metric_id} references undeclared dimensions",
+    )
+    _require_referenced_concept_source_overlap(
+        metric.allowed_source_ids,
+        dimensions_by_id,
+        metric.allowed_dimensions,
+        lambda dimension: dimension.allowed_source_ids,
+        (
+            f"Metric {metric.metric_id} references dimensions without "
+            "compatible allowed sources"
+        ),
+    )
+
+
+def _require_metric_default_filters_compatible(
+    metric: SemanticMetric,
+    filters_by_id: Mapping[SourceIdentifier, SemanticFilter],
+) -> None:
+    _require_subset(
+        metric.default_filters,
+        set(filters_by_id),
+        f"Metric {metric.metric_id} references undeclared default filters",
+    )
+    _require_referenced_concept_source_overlap(
+        metric.allowed_source_ids,
+        filters_by_id,
+        metric.default_filters,
+        lambda semantic_filter: semantic_filter.allowed_source_ids,
+        (
+            f"Metric {metric.metric_id} references default filters without "
+            "compatible allowed sources"
+        ),
+    )
 
 
 def _require_referenced_concept_source_overlap(

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -34,7 +34,7 @@ TimeGrain = Literal[
 ]
 TimeRangePolicy = Literal["required", "optional", "clarify_when_unspecified"]
 SPEND_CONCEPT_PATTERN = re.compile(
-    r"(?i)(?<!su)spend[a-z0-9]*(?=$|[^a-z0-9])"
+    r"(?i)(?<!su)spen[dt][a-z0-9]*(?=$|[^a-z0-9])"
 )
 SemanticConceptT = TypeVar("SemanticConceptT")
 SEMANTIC_CONTRACT_MODEL_CONFIG = ConfigDict(
@@ -472,12 +472,13 @@ def _require_referenced_concept_source_overlap(
     get_source_ids: Callable[[SemanticConceptT], Iterable[SourceIdentifier]],
     message: str,
 ) -> None:
-    metric_source_id_set = set(metric_source_ids)
+    common_source_ids = set(metric_source_ids)
     for referenced_id in referenced_ids:
         concept = concepts_by_id.get(referenced_id)
         if concept is None:
             raise ValueError(message)
-        if metric_source_id_set.isdisjoint(set(get_source_ids(concept))):
+        common_source_ids.intersection_update(set(get_source_ids(concept)))
+        if not common_source_ids:
             raise ValueError(message)
 
 

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -432,11 +432,11 @@ def _require_metric_dimensions_compatible(
         set(dimensions_by_id),
         f"Metric {metric.metric_id} references undeclared dimensions",
     )
-    _require_referenced_concept_source_overlap(
+    _require_referenced_concepts_share_metric_source(
         metric.allowed_source_ids,
         dimensions_by_id,
         metric.allowed_dimensions,
-        lambda dimension: dimension.allowed_source_ids,
+        _get_dimension_source_ids,
         (
             f"Metric {metric.metric_id} references dimensions without "
             "compatible allowed sources"
@@ -453,11 +453,11 @@ def _require_metric_default_filters_compatible(
         set(filters_by_id),
         f"Metric {metric.metric_id} references undeclared default filters",
     )
-    _require_referenced_concept_source_overlap(
+    _require_referenced_concepts_share_metric_source(
         metric.allowed_source_ids,
         filters_by_id,
         metric.default_filters,
-        lambda semantic_filter: semantic_filter.allowed_source_ids,
+        _get_filter_source_ids,
         (
             f"Metric {metric.metric_id} references default filters without "
             "compatible allowed sources"
@@ -465,7 +465,19 @@ def _require_metric_default_filters_compatible(
     )
 
 
-def _require_referenced_concept_source_overlap(
+def _get_dimension_source_ids(
+    dimension: SemanticDimension,
+) -> Iterable[SourceIdentifier]:
+    return dimension.allowed_source_ids
+
+
+def _get_filter_source_ids(
+    semantic_filter: SemanticFilter,
+) -> Iterable[SourceIdentifier]:
+    return semantic_filter.allowed_source_ids
+
+
+def _require_referenced_concepts_share_metric_source(
     metric_source_ids: Iterable[SourceIdentifier],
     concepts_by_id: Mapping[SourceIdentifier, SemanticConceptT],
     referenced_ids: Iterable[SourceIdentifier],

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Mapping, MutableMapping, MutableSequence, MutableSet
 from types import MappingProxyType
-from typing import Literal, Optional
+from typing import Callable, Literal, Optional, TypeVar
 
 from pydantic import (
     BaseModel,
@@ -33,6 +34,8 @@ TimeGrain = Literal[
     "year",
 ]
 TimeRangePolicy = Literal["required", "optional", "clarify_when_unspecified"]
+SPEND_TOKEN_PATTERN = re.compile(r"(?<![a-z0-9])spend(?![a-z0-9])", re.IGNORECASE)
+SemanticConceptT = TypeVar("SemanticConceptT")
 
 
 class _SemanticContractModel(BaseModel):
@@ -205,6 +208,10 @@ class SemanticContractDefinition(_SemanticContractModel):
             "Contract filters",
         )
         _unique_ids([item.metric_id for item in self.metrics], "Contract metrics")
+        _unique_ids(
+            [item.concept_id for item in self.sensitive_concepts],
+            "Contract sensitive concepts",
+        )
 
         if not source_ids:
             raise ValueError("Contract must declare at least one allowed source.")
@@ -242,10 +249,32 @@ class SemanticContractDefinition(_SemanticContractModel):
                 dimension_ids,
                 f"Metric {metric.metric_id} references undeclared dimensions",
             )
+            _require_referenced_concept_source_overlap(
+                metric.allowed_source_ids,
+                (dimension for dimension in self.dimensions),
+                metric.allowed_dimensions,
+                lambda dimension: dimension.dimension_id,
+                lambda dimension: dimension.allowed_source_ids,
+                (
+                    f"Metric {metric.metric_id} references dimensions without "
+                    "compatible allowed sources"
+                ),
+            )
             _require_subset(
                 metric.default_filters,
                 filter_ids,
                 f"Metric {metric.metric_id} references undeclared default filters",
+            )
+            _require_referenced_concept_source_overlap(
+                metric.allowed_source_ids,
+                (semantic_filter for semantic_filter in self.filters),
+                metric.default_filters,
+                lambda semantic_filter: semantic_filter.filter_id,
+                lambda semantic_filter: semantic_filter.allowed_source_ids,
+                (
+                    f"Metric {metric.metric_id} references default filters without "
+                    "compatible allowed sources"
+                ),
             )
             _require_subset(
                 metric.time_range_semantics.allowed_grains,
@@ -253,11 +282,11 @@ class SemanticContractDefinition(_SemanticContractModel):
                 f"Metric {metric.metric_id} references undeclared time grains",
             )
 
-        if (
-            "quarter" in self.time_semantics.ambiguous_terms
-            and "quarter" not in self.ambiguity_rules
-        ):
-            raise ValueError("Quarter ambiguity must be explicit in ambiguity_rules.")
+        for ambiguous_term in self.time_semantics.ambiguous_terms:
+            if ambiguous_term not in self.ambiguity_rules:
+                raise ValueError(
+                    "Declared ambiguous terms must have matching ambiguity_rules."
+                )
         if (
             _contract_requires_spend_definition(self)
             and "spend_definition" not in self.ambiguity_rules
@@ -301,7 +330,7 @@ def _contract_requires_spend_definition(contract: SemanticContractDefinition) ->
                 metric.expression,
             ]
         )
-    return any("spend" in term.lower() for term in spend_terms)
+    return any(SPEND_TOKEN_PATTERN.search(term) for term in spend_terms)
 
 
 def _require_unique(values: Iterable[object], label: str) -> None:
@@ -331,6 +360,24 @@ def _require_subset(
 ) -> None:
     if not set(values).issubset(allowed_values):
         raise ValueError(message)
+
+
+def _require_referenced_concept_source_overlap(
+    metric_source_ids: Iterable[SourceIdentifier],
+    concepts: Iterable[SemanticConceptT],
+    referenced_ids: Iterable[SourceIdentifier],
+    get_id: Callable[[SemanticConceptT], SourceIdentifier],
+    get_source_ids: Callable[[SemanticConceptT], Iterable[SourceIdentifier]],
+    message: str,
+) -> None:
+    metric_source_id_set = set(metric_source_ids)
+    concepts_by_id = {get_id(concept): concept for concept in concepts}
+    for referenced_id in referenced_ids:
+        concept = concepts_by_id.get(referenced_id)
+        if concept is None:
+            continue
+        if metric_source_id_set.isdisjoint(set(get_source_ids(concept))):
+            raise ValueError(message)
 
 
 def _reject_mutable_collections(value: object, path: str) -> None:

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -35,9 +35,7 @@ TimeGrain = Literal[
 ]
 TimeRangePolicy = Literal["required", "optional", "clarify_when_unspecified"]
 SPEND_CONCEPT_PATTERN = re.compile(
-    r"(?i:(?<![a-z0-9])spend[a-z0-9]*(?=$|[^a-z0-9]))"
-    r"|(?<=[a-z0-9])Spend[a-z0-9]*(?=$|[^a-z0-9]|[A-Z0-9])"
-    r"|(?<=[a-z0-9])(?:Spend|spend)(?=$|[^a-z0-9]|[A-Z0-9])"
+    r"(?i)(?<!su)spend[a-z0-9]*(?=$|[^a-z0-9])"
 )
 SemanticConceptT = TypeVar("SemanticConceptT")
 SEMANTIC_CONTRACT_MODEL_CONFIG = ConfigDict(
@@ -314,7 +312,6 @@ def _contract_requires_spend_definition(contract: SemanticContractDefinition) ->
             [
                 metric.metric_id,
                 metric.label,
-                metric.expression_owner,
                 metric.expression,
             ]
         )

--- a/backend/tests/fixtures/semantic_contract_vendor_spend.v1.json
+++ b/backend/tests/fixtures/semantic_contract_vendor_spend.v1.json
@@ -1,0 +1,96 @@
+{
+  "contract_id": "approved_vendor_spend",
+  "domain": "approved_vendor_spend",
+  "version": {
+    "identifier": "approved_vendor_spend.v1",
+    "version": 1,
+    "status": "active",
+    "owner": "finance_analytics",
+    "created_for_issue": 438
+  },
+  "source_bindings": [
+    {
+      "source_id": "business-postgres-source",
+      "source_family": "postgresql",
+      "source_flavor": "warehouse",
+      "dataset_contract_version": 4,
+      "schema_snapshot_version": 9
+    }
+  ],
+  "dimensions": [
+    {
+      "dimension_id": "vendor_name",
+      "label": "Vendor name",
+      "source_column": "finance.approved_vendor_spend.vendor_name",
+      "allowed_source_ids": [
+        "business-postgres-source"
+      ]
+    },
+    {
+      "dimension_id": "fiscal_quarter",
+      "label": "Fiscal quarter",
+      "source_column": "finance.approved_vendor_spend.fiscal_quarter",
+      "allowed_source_ids": [
+        "business-postgres-source"
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "filter_id": "approved_spend_only",
+      "label": "Approved spend only",
+      "expression": "approval_status = 'approved'",
+      "allowed_source_ids": [
+        "business-postgres-source"
+      ],
+      "locked": true
+    }
+  ],
+  "metrics": [
+    {
+      "metric_id": "sum_approved_vendor_spend",
+      "label": "Approved vendor spend",
+      "expression_owner": "finance_analytics",
+      "expression": "SUM(approved_spend)",
+      "allowed_source_ids": [
+        "business-postgres-source"
+      ],
+      "allowed_dimensions": [
+        "vendor_name",
+        "fiscal_quarter"
+      ],
+      "default_filters": [
+        "approved_spend_only"
+      ],
+      "time_range_semantics": {
+        "default_grain": "fiscal_quarter",
+        "allowed_grains": [
+          "fiscal_quarter"
+        ],
+        "requires_explicit_range": false
+      }
+    }
+  ],
+  "time_semantics": {
+    "default_grain": "fiscal_quarter",
+    "allowed_grains": [
+      "fiscal_quarter"
+    ],
+    "ambiguous_terms": [
+      "quarter"
+    ],
+    "range_policy": "clarify_when_unspecified"
+  },
+  "sensitive_concepts": [
+    {
+      "concept_id": "refund_amount",
+      "label": "Refund amount",
+      "reason": "Refund handling changes gross-versus-net spend definition.",
+      "requires_review": true
+    }
+  ],
+  "ambiguity_rules": {
+    "quarter": "Clarify fiscal versus calendar quarter before mapping.",
+    "spend_definition": "Clarify gross spend versus net-of-refunds spend before mapping."
+  }
+}

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import pytest
 from pydantic import ValidationError
@@ -23,6 +23,25 @@ def _load_contract() -> dict[str, object]:
     return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 
+def _make_non_spend_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    payload["contract_id"] = "support_ticket_volume"
+    payload["domain"] = "support_ticket_volume"
+    payload["version"]["identifier"] = "support_ticket_volume.v1"
+    payload["dimensions"][0]["source_column"] = "support.ticket_volume.vendor_name"
+    payload["dimensions"][1]["source_column"] = "support.ticket_volume.fiscal_quarter"
+    payload["filters"][0]["filter_id"] = "closed_tickets_only"
+    payload["filters"][0]["label"] = "Closed tickets only"
+    payload["filters"][0]["expression"] = "status = 'closed'"
+    payload["metrics"][0]["metric_id"] = "sum_closed_tickets"
+    payload["metrics"][0]["label"] = "Closed tickets"
+    payload["metrics"][0]["expression"] = "COUNT(ticket_id)"
+    payload["metrics"][0]["default_filters"] = ["closed_tickets_only"]
+    payload["sensitive_concepts"][0]["reason"] = (
+        "Ticket status handling requires review."
+    )
+    return payload
+
+
 def test_vendor_spend_semantic_contract_fixture_validates_and_serializes() -> None:
     contract = validate_semantic_contract_definition(_load_contract())
 
@@ -30,14 +49,14 @@ def test_vendor_spend_semantic_contract_fixture_validates_and_serializes() -> No
     assert contract.version.identifier == "approved_vendor_spend.v1"
     assert contract.version.status == "active"
     assert contract.metrics[0].metric_id == "sum_approved_vendor_spend"
-    assert contract.metrics[0].allowed_source_ids == ["business-postgres-source"]
-    assert contract.metrics[0].allowed_dimensions == [
+    assert contract.metrics[0].allowed_source_ids == ("business-postgres-source",)
+    assert contract.metrics[0].allowed_dimensions == (
         "vendor_name",
         "fiscal_quarter",
-    ]
-    assert contract.metrics[0].default_filters == ["approved_spend_only"]
+    )
+    assert contract.metrics[0].default_filters == ("approved_spend_only",)
     assert contract.time_semantics.default_grain == "fiscal_quarter"
-    assert contract.time_semantics.ambiguous_terms == ["quarter"]
+    assert contract.time_semantics.ambiguous_terms == ("quarter",)
     assert contract.ambiguity_rules["quarter"] == (
         "Clarify fiscal versus calendar quarter before mapping."
     )
@@ -52,6 +71,27 @@ def test_vendor_spend_semantic_contract_fixture_validates_and_serializes() -> No
     assert serialized["metrics"][0]["metricId"] == "sum_approved_vendor_spend"
     assert serialized["timeSemantics"]["defaultGrain"] == "fiscal_quarter"
     assert "contract_id" not in serialized
+
+
+def test_validated_semantic_contract_collections_are_immutable() -> None:
+    contract = validate_semantic_contract_definition(_load_contract())
+
+    with pytest.raises(AttributeError):
+        contract.metrics.append(contract.metrics[0])
+    with pytest.raises(AttributeError):
+        contract.metrics[0].allowed_source_ids.append("undeclared-source")
+    with pytest.raises(TypeError):
+        contract.ambiguity_rules["unchecked_rule"] = "mutated after validation."
+
+
+def test_non_spend_contract_does_not_require_spend_definition_ambiguity() -> None:
+    payload = _make_non_spend_contract(deepcopy(_load_contract()))
+    payload["ambiguity_rules"].pop("spend_definition")
+
+    contract = validate_semantic_contract_definition(payload)
+
+    assert contract.contract_id == "support_ticket_volume"
+    assert "spend_definition" not in contract.ambiguity_rules
 
 
 @pytest.mark.parametrize(
@@ -88,6 +128,12 @@ def test_vendor_spend_semantic_contract_fixture_validates_and_serializes() -> No
                 "requires_review", False
             ),
             "Sensitive concepts must require review",
+        ),
+        (
+            lambda payload: payload["sensitive_concepts"][0].__setitem__(
+                "requires_review", "true"
+            ),
+            "Input should be a valid boolean",
         ),
     ],
 )

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -85,10 +85,25 @@ def test_validated_semantic_contract_collections_are_immutable() -> None:
         contract.ambiguity_rules["unchecked_rule"] = "mutated after validation."
 
 
+def test_validated_contract_does_not_retain_mutable_payload_collections() -> None:
+    payload = _load_contract()
+
+    contract = validate_semantic_contract_definition(payload)
+    payload["metrics"][0]["allowed_source_ids"].append("undeclared-source")
+    payload["ambiguity_rules"]["unchecked_rule"] = "mutated after validation."
+
+    assert contract.metrics[0].allowed_source_ids == ("business-postgres-source",)
+    assert "unchecked_rule" not in contract.ambiguity_rules
+
+
 def test_semantic_contract_model_rejects_mutable_collection_annotations() -> None:
     with pytest.raises(TypeError, match="immutable collection annotations"):
         class MutableCollectionModel(_SemanticContractModel):
             values: list[str]
+
+    with pytest.raises(TypeError, match="immutable collection annotations"):
+        class MutableMappingModel(_SemanticContractModel):
+            values: dict[str, str]
 
     with pytest.raises(TypeError, match="immutable collection annotations"):
         class NestedMutableCollectionModel(_SemanticContractModel):

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -153,6 +153,28 @@ def test_spend_definition_detection_catches_compound_spend_terms() -> None:
         validate_semantic_contract_definition(payload)
 
 
+@pytest.mark.parametrize(
+    "metric_id, expression",
+    [
+        ("sum_spending_total", "SUM(spending_amount)"),
+        ("sum_spend2_amount", "SUM(spend2_amount)"),
+    ],
+)
+def test_spend_definition_detection_catches_spend_prefixed_terms(
+    metric_id: str, expression: str
+) -> None:
+    payload = _make_non_spend_contract(deepcopy(_load_contract()))
+    payload["metrics"][0]["metric_id"] = metric_id
+    payload["metrics"][0]["expression"] = expression
+    payload["ambiguity_rules"].pop("spend_definition")
+
+    with pytest.raises(
+        ValidationError,
+        match="Spend definition ambiguity must be explicit in ambiguity_rules",
+    ):
+        validate_semantic_contract_definition(payload)
+
+
 def test_spend_definition_detection_catches_camel_compound_terms() -> None:
     payload = deepcopy(_load_contract())
     payload["contract_id"] = "approved_amount"

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.semantic_contract.schema import (
+    SemanticContractDefinition,
+    validate_semantic_contract_definition,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "semantic_contract_vendor_spend.v1.json"
+)
+
+
+def _load_contract() -> dict[str, object]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_vendor_spend_semantic_contract_fixture_validates_and_serializes() -> None:
+    contract = validate_semantic_contract_definition(_load_contract())
+
+    assert contract.contract_id == "approved_vendor_spend"
+    assert contract.version.identifier == "approved_vendor_spend.v1"
+    assert contract.version.status == "active"
+    assert contract.metrics[0].metric_id == "sum_approved_vendor_spend"
+    assert contract.metrics[0].allowed_source_ids == ["business-postgres-source"]
+    assert contract.metrics[0].allowed_dimensions == [
+        "vendor_name",
+        "fiscal_quarter",
+    ]
+    assert contract.metrics[0].default_filters == ["approved_spend_only"]
+    assert contract.time_semantics.default_grain == "fiscal_quarter"
+    assert contract.time_semantics.ambiguous_terms == ["quarter"]
+    assert contract.ambiguity_rules["quarter"] == (
+        "Clarify fiscal versus calendar quarter before mapping."
+    )
+    assert contract.ambiguity_rules["spend_definition"] == (
+        "Clarify gross spend versus net-of-refunds spend before mapping."
+    )
+
+    serialized = contract.to_wire_payload()
+
+    assert serialized["contractId"] == "approved_vendor_spend"
+    assert serialized["version"]["identifier"] == "approved_vendor_spend.v1"
+    assert serialized["metrics"][0]["metricId"] == "sum_approved_vendor_spend"
+    assert serialized["timeSemantics"]["defaultGrain"] == "fiscal_quarter"
+    assert "contract_id" not in serialized
+
+
+@pytest.mark.parametrize(
+    "mutator, expected_message",
+    [
+        (
+            lambda payload: payload["metrics"][0].__setitem__("allowed_source_ids", []),
+            "at least one allowed source",
+        ),
+        (
+            lambda payload: payload["metrics"][0].__setitem__(
+                "allowed_dimensions", ["undeclared_dimension"]
+            ),
+            "undeclared dimensions",
+        ),
+        (
+            lambda payload: payload["metrics"][0].__setitem__(
+                "default_filters", ["missing_filter"]
+            ),
+            "undeclared default filters",
+        ),
+        (
+            lambda payload: payload["time_semantics"].__setitem__(
+                "default_grain", "calendar_quarter"
+            ),
+            "must be one of the allowed time grains",
+        ),
+        (
+            lambda payload: payload["ambiguity_rules"].pop("quarter"),
+            "Quarter ambiguity must be explicit",
+        ),
+        (
+            lambda payload: payload["sensitive_concepts"][0].__setitem__(
+                "requires_review", False
+            ),
+            "Sensitive concepts must require review",
+        ),
+    ],
+)
+def test_semantic_contract_schema_fails_closed_for_malformed_definitions(
+    mutator: Callable[[dict[str, object]], object],
+    expected_message: str,
+) -> None:
+    payload = deepcopy(_load_contract())
+    mutator(payload)
+
+    with pytest.raises(ValidationError, match=expected_message):
+        SemanticContractDefinition.model_validate(payload)

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -186,9 +186,10 @@ def test_spend_definition_detection_catches_compound_spend_terms() -> None:
         ("sum_spending_total", "SUM(spending_amount)"),
         ("sum_spend2_amount", "SUM(spend2_amount)"),
         ("sum_totalspending", "SUM(totalspending_amount)"),
+        ("sum_totalspent", "SUM(totalspent_amount)"),
     ],
 )
-def test_spend_definition_detection_catches_spend_prefixed_terms(
+def test_spend_definition_detection_catches_spend_and_spent_terms(
     metric_id: str, expression: str
 ) -> None:
     payload = _make_non_spend_contract(deepcopy(_load_contract()))
@@ -342,4 +343,65 @@ def test_semantic_contract_schema_fails_closed_for_malformed_definitions(
     mutator(payload)
 
     with pytest.raises(ValidationError, match=expected_message):
+        SemanticContractDefinition.model_validate(payload)
+
+
+def test_metric_dimensions_must_share_one_metric_source() -> None:
+    payload = deepcopy(_load_contract())
+    payload["source_bindings"].append(
+        {
+            "source_id": "support-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+            "dataset_contract_version": 1,
+            "schema_snapshot_version": 1,
+        }
+    )
+    payload["metrics"][0]["allowed_source_ids"] = [
+        "business-postgres-source",
+        "support-postgres-source",
+    ]
+    payload["dimensions"][0]["allowed_source_ids"] = ["business-postgres-source"]
+    payload["dimensions"][1]["allowed_source_ids"] = ["support-postgres-source"]
+
+    with pytest.raises(
+        ValidationError,
+        match="references dimensions without compatible allowed sources",
+    ):
+        SemanticContractDefinition.model_validate(payload)
+
+
+def test_metric_default_filters_must_share_one_metric_source() -> None:
+    payload = deepcopy(_load_contract())
+    payload["source_bindings"].append(
+        {
+            "source_id": "support-postgres-source",
+            "source_family": "postgresql",
+            "source_flavor": "warehouse",
+            "dataset_contract_version": 1,
+            "schema_snapshot_version": 1,
+        }
+    )
+    payload["filters"].append(
+        {
+            "filter_id": "support_spend_only",
+            "label": "Support spend only",
+            "expression": "support_status = 'approved'",
+            "allowed_source_ids": ["support-postgres-source"],
+            "locked": True,
+        }
+    )
+    payload["metrics"][0]["allowed_source_ids"] = [
+        "business-postgres-source",
+        "support-postgres-source",
+    ]
+    payload["metrics"][0]["default_filters"] = [
+        "approved_spend_only",
+        "support_spend_only",
+    ]
+
+    with pytest.raises(
+        ValidationError,
+        match="references default filters without compatible allowed sources",
+    ):
         SemanticContractDefinition.model_validate(payload)

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -85,12 +85,14 @@ def test_validated_semantic_contract_collections_are_immutable() -> None:
         contract.ambiguity_rules["unchecked_rule"] = "mutated after validation."
 
 
-def test_semantic_contract_model_rejects_mutable_collections_after_validation() -> None:
-    class MutableCollectionModel(_SemanticContractModel):
-        values: list[str]
+def test_semantic_contract_model_rejects_mutable_collection_annotations() -> None:
+    with pytest.raises(TypeError, match="immutable collection annotations"):
+        class MutableCollectionModel(_SemanticContractModel):
+            values: list[str]
 
-    with pytest.raises(ValidationError, match="immutable collections"):
-        MutableCollectionModel.model_validate({"values": ["mutable-value"]})
+    with pytest.raises(TypeError, match="immutable collection annotations"):
+        class NestedMutableCollectionModel(_SemanticContractModel):
+            values: tuple[list[str], ...]
 
 
 def test_non_spend_contract_does_not_require_spend_definition_ambiguity() -> None:

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -103,6 +103,25 @@ def test_non_spend_contract_does_not_require_spend_definition_ambiguity() -> Non
     assert "spend_definition" not in contract.ambiguity_rules
 
 
+def test_spend_definition_detection_uses_tokens_not_substrings() -> None:
+    payload = _make_non_spend_contract(deepcopy(_load_contract()))
+    payload["contract_id"] = "suspended_ticket_volume"
+    payload["domain"] = "suspended_ticket_volume"
+    payload["version"]["identifier"] = "suspended_ticket_volume.v1"
+    payload["dimensions"][0]["source_column"] = (
+        "support.suspended_ticket_volume.vendor_name"
+    )
+    payload["filters"][0]["expression"] = "status = 'suspended'"
+    payload["metrics"][0]["label"] = "Suspended ticket count"
+    payload["metrics"][0]["expression"] = "COUNT(suspended_ticket_id)"
+    payload["ambiguity_rules"].pop("spend_definition")
+
+    contract = validate_semantic_contract_definition(payload)
+
+    assert contract.contract_id == "suspended_ticket_volume"
+    assert "spend_definition" not in contract.ambiguity_rules
+
+
 @pytest.mark.parametrize(
     "mutator, expected_message",
     [
@@ -130,7 +149,58 @@ def test_non_spend_contract_does_not_require_spend_definition_ambiguity() -> Non
         ),
         (
             lambda payload: payload["ambiguity_rules"].pop("quarter"),
-            "Quarter ambiguity must be explicit",
+            "Declared ambiguous terms must have matching ambiguity_rules",
+        ),
+        (
+            lambda payload: payload["time_semantics"]["ambiguous_terms"].append(
+                "month"
+            ),
+            "Declared ambiguous terms must have matching ambiguity_rules",
+        ),
+        (
+            lambda payload: payload["sensitive_concepts"].append(
+                {
+                    "concept_id": "refund_amount",
+                    "label": "Refund amount duplicate",
+                    "reason": "Duplicate concept metadata must fail closed.",
+                    "requires_review": True,
+                }
+            ),
+            "Contract sensitive concepts must not contain duplicate values",
+        ),
+        (
+            lambda payload: (
+                payload["source_bindings"].append(
+                    {
+                        "source_id": "support-postgres-source",
+                        "source_family": "postgresql",
+                        "source_flavor": "warehouse",
+                        "dataset_contract_version": 1,
+                        "schema_snapshot_version": 1,
+                    }
+                ),
+                payload["dimensions"][0].__setitem__(
+                    "allowed_source_ids", ["support-postgres-source"]
+                ),
+            ),
+            "references dimensions without compatible allowed sources",
+        ),
+        (
+            lambda payload: (
+                payload["source_bindings"].append(
+                    {
+                        "source_id": "support-postgres-source",
+                        "source_family": "postgresql",
+                        "source_flavor": "warehouse",
+                        "dataset_contract_version": 1,
+                        "schema_snapshot_version": 1,
+                    }
+                ),
+                payload["filters"][0].__setitem__(
+                    "allowed_source_ids", ["support-postgres-source"]
+                ),
+            ),
+            "references default filters without compatible allowed sources",
         ),
         (
             lambda payload: payload["sensitive_concepts"][0].__setitem__(

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 from app.features.semantic_contract.schema import (
     SemanticContractDefinition,
+    _SemanticContractModel,
     validate_semantic_contract_definition,
 )
 
@@ -82,6 +83,14 @@ def test_validated_semantic_contract_collections_are_immutable() -> None:
         contract.metrics[0].allowed_source_ids.append("undeclared-source")
     with pytest.raises(TypeError):
         contract.ambiguity_rules["unchecked_rule"] = "mutated after validation."
+
+
+def test_semantic_contract_model_rejects_mutable_collections_after_validation() -> None:
+    class MutableCollectionModel(_SemanticContractModel):
+        values: list[str]
+
+    with pytest.raises(ValidationError, match="immutable collections"):
+        MutableCollectionModel.model_validate({"values": ["mutable-value"]})
 
 
 def test_non_spend_contract_does_not_require_spend_definition_ambiguity() -> None:

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -96,6 +96,22 @@ def test_validated_contract_does_not_retain_mutable_payload_collections() -> Non
     assert "unchecked_rule" not in contract.ambiguity_rules
 
 
+def test_validated_contract_supports_deep_copy_paths() -> None:
+    contract = validate_semantic_contract_definition(_load_contract())
+
+    copied = deepcopy(contract)
+    pydantic_copied = contract.model_copy(deep=True)
+
+    assert copied.to_wire_payload() == contract.to_wire_payload()
+    assert pydantic_copied.to_wire_payload() == contract.to_wire_payload()
+    assert copied.ambiguity_rules is not contract.ambiguity_rules
+    assert pydantic_copied.ambiguity_rules is not contract.ambiguity_rules
+    with pytest.raises(TypeError):
+        copied.ambiguity_rules["unchecked_rule"] = "mutated after copy."
+    with pytest.raises(TypeError):
+        pydantic_copied.ambiguity_rules["unchecked_rule"] = "mutated after copy."
+
+
 def test_semantic_contract_model_rejects_mutable_collection_annotations() -> None:
     with pytest.raises(TypeError, match="immutable collection annotations"):
         class MutableCollectionModel(_SemanticContractModel):

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -124,6 +124,47 @@ def test_spend_definition_detection_uses_tokens_not_substrings() -> None:
     assert "spend_definition" not in contract.ambiguity_rules
 
 
+def test_spend_definition_detection_catches_compound_spend_terms() -> None:
+    payload = _make_non_spend_contract(deepcopy(_load_contract()))
+    payload["metrics"][0]["metric_id"] = "sum_overspend_amount"
+    payload["metrics"][0]["label"] = "Vendor overage amount"
+    payload["metrics"][0]["expression"] = "SUM(overspend_amount)"
+    payload["ambiguity_rules"].pop("spend_definition")
+
+    with pytest.raises(
+        ValidationError,
+        match="Spend definition ambiguity must be explicit in ambiguity_rules",
+    ):
+        validate_semantic_contract_definition(payload)
+
+
+def test_spend_definition_detection_catches_camel_compound_terms() -> None:
+    payload = deepcopy(_load_contract())
+    payload["contract_id"] = "approved_amount"
+    payload["domain"] = "approved_amount"
+    payload["version"]["identifier"] = "approved_amount.v1"
+    payload["dimensions"][0]["source_column"] = "finance.approved_amount.vendor_name"
+    payload["dimensions"][1]["source_column"] = (
+        "finance.approved_amount.fiscal_quarter"
+    )
+    payload["filters"][0]["filter_id"] = "approved_amount_only"
+    payload["filters"][0]["label"] = "Approved amount only"
+    payload["metrics"][0]["metric_id"] = "sum_approved_vendor_amount"
+    payload["metrics"][0]["label"] = "ApprovedVendorSpend"
+    payload["metrics"][0]["expression"] = "SUM(approved_amount)"
+    payload["metrics"][0]["default_filters"] = ["approved_amount_only"]
+    payload["sensitive_concepts"][0]["reason"] = (
+        "Refund handling changes gross-versus-net amount definition."
+    )
+    payload["ambiguity_rules"].pop("spend_definition")
+
+    with pytest.raises(
+        ValidationError,
+        match="Spend definition ambiguity must be explicit in ambiguity_rules",
+    ):
+        validate_semantic_contract_definition(payload)
+
+
 @pytest.mark.parametrize(
     "mutator, expected_message",
     [
@@ -213,6 +254,16 @@ def test_spend_definition_detection_uses_tokens_not_substrings() -> None:
         (
             lambda payload: payload["sensitive_concepts"][0].__setitem__(
                 "requires_review", "true"
+            ),
+            "Input should be a valid boolean",
+        ),
+        (
+            lambda payload: payload["filters"][0].__setitem__("locked", "true"),
+            "Input should be a valid boolean",
+        ),
+        (
+            lambda payload: payload["metrics"][0]["time_range_semantics"].__setitem__(
+                "requires_explicit_range", "false"
             ),
             "Input should be a valid boolean",
         ),

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -120,6 +120,17 @@ def test_non_spend_contract_does_not_require_spend_definition_ambiguity() -> Non
     assert "spend_definition" not in contract.ambiguity_rules
 
 
+def test_metric_expression_owner_does_not_drive_spend_definition_ambiguity() -> None:
+    payload = _make_non_spend_contract(deepcopy(_load_contract()))
+    payload["metrics"][0]["expression_owner"] = "spend_analytics"
+    payload["ambiguity_rules"].pop("spend_definition")
+
+    contract = validate_semantic_contract_definition(payload)
+
+    assert contract.metrics[0].expression_owner == "spend_analytics"
+    assert "spend_definition" not in contract.ambiguity_rules
+
+
 def test_spend_definition_detection_uses_tokens_not_substrings() -> None:
     payload = _make_non_spend_contract(deepcopy(_load_contract()))
     payload["contract_id"] = "suspended_ticket_volume"
@@ -158,6 +169,7 @@ def test_spend_definition_detection_catches_compound_spend_terms() -> None:
     [
         ("sum_spending_total", "SUM(spending_amount)"),
         ("sum_spend2_amount", "SUM(spend2_amount)"),
+        ("sum_totalspending", "SUM(totalspending_amount)"),
     ],
 )
 def test_spend_definition_detection_catches_spend_prefixed_terms(


### PR DESCRIPTION
## Summary
- add a Pydantic semantic contract schema for metrics, dimensions, filters, time semantics, sensitive concepts, and version metadata
- add a vendor spend demo contract fixture that validates
- add fail-closed validation tests for malformed contract definitions

## Verification
- python3 -m pytest tests/test_semantic_contract_schema.py tests/test_governed_answer_fixtures.py -q
- python3 -m compileall app/features/semantic_contract tests/test_semantic_contract_schema.py -q

Closes #438