### PR TITLE
[X-2] Map vendor spend demo to semantic contract

### DIFF
--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -24,6 +24,13 @@ from app.features.audit.event_model import (
 )
 
 SemanticContractStatus = Literal["draft", "active", "retired"]
+SemanticIntentClassification = Literal["supported", "ambiguous", "unsupported"]
+SemanticRankingDirection = Literal["asc", "desc"]
+SemanticTiesPolicy = Literal[
+    "clarify",
+    "include_all_ties",
+    "stable_secondary_sort",
+]
 TimeGrain = Literal[
     "day",
     "week",
@@ -184,6 +191,51 @@ class SemanticMetric(_SemanticContractModel):
         return self
 
 
+class SemanticRankingBehavior(_SemanticContractModel):
+    ranking_id: SourceIdentifier
+    label: NonEmptyTrimmedString
+    order_metric: SourceIdentifier
+    order_direction: SemanticRankingDirection
+    partition_dimensions: tuple[SourceIdentifier, ...] = Field(default_factory=tuple)
+    limit_per_partition: PositiveInt
+    ties_policy: SemanticTiesPolicy
+
+    @model_validator(mode="after")
+    def validate_partition_dimensions(self) -> "SemanticRankingBehavior":
+        _require_unique(
+            self.partition_dimensions,
+            "Ranking behavior partition dimensions",
+        )
+        return self
+
+
+class SemanticIntentMapping(_SemanticContractModel):
+    mapping_id: SourceIdentifier
+    label: NonEmptyTrimmedString
+    canonical_question: NonEmptyTrimmedString
+    classification: SemanticIntentClassification
+    metric: SourceIdentifier
+    dimensions: tuple[SourceIdentifier, ...] = Field(default_factory=tuple)
+    filters: tuple[SourceIdentifier, ...] = Field(default_factory=tuple)
+    ranking_behavior_id: Optional[SourceIdentifier] = None
+    ambiguity_rule_refs: tuple[SourceIdentifier, ...] = Field(default_factory=tuple)
+
+    @model_validator(mode="after")
+    def validate_mapping_collections(self) -> "SemanticIntentMapping":
+        _require_unique(self.dimensions, "Intent mapping dimensions")
+        _require_unique(self.filters, "Intent mapping filters")
+        _require_unique(self.ambiguity_rule_refs, "Intent mapping ambiguity refs")
+        if self.classification == "supported" and self.ambiguity_rule_refs:
+            raise ValueError(
+                "Supported intent mappings must not require ambiguity rules."
+            )
+        if self.classification == "ambiguous" and not self.ambiguity_rule_refs:
+            raise ValueError(
+                "Ambiguous intent mappings must reference ambiguity rules."
+            )
+        return self
+
+
 class SemanticContractTimeSemantics(_SemanticContractModel):
     default_grain: TimeGrain
     allowed_grains: tuple[TimeGrain, ...]
@@ -223,6 +275,10 @@ class SemanticContractDefinition(_SemanticContractModel):
     dimensions: tuple[SemanticDimension, ...] = Field(default_factory=tuple)
     filters: tuple[SemanticFilter, ...] = Field(default_factory=tuple)
     metrics: tuple[SemanticMetric, ...]
+    ranking_behaviors: tuple[SemanticRankingBehavior, ...] = Field(
+        default_factory=tuple
+    )
+    intent_mappings: tuple[SemanticIntentMapping, ...] = Field(default_factory=tuple)
     time_semantics: SemanticContractTimeSemantics
     sensitive_concepts: tuple[SensitiveSemanticConcept, ...] = Field(
         default_factory=tuple
@@ -295,6 +351,21 @@ class SemanticContractDefinition(_SemanticContractModel):
                 raise ValueError(
                     "Declared ambiguous terms must have matching ambiguity_rules."
                 )
+
+        metrics_by_id = {metric.metric_id: metric for metric in self.metrics}
+        ranking_behaviors_by_id = _index_ranking_behaviors(
+            self.ranking_behaviors,
+            metrics_by_id,
+            dimensions_by_id,
+        )
+        _validate_intent_mappings(
+            self.intent_mappings,
+            metrics_by_id,
+            dimensions_by_id,
+            filters_by_id,
+            ranking_behaviors_by_id,
+            self.ambiguity_rules,
+        )
         if (
             _contract_requires_spend_definition(self)
             and "spend_definition" not in self.ambiguity_rules
@@ -412,6 +483,112 @@ def _require_unique_sensitive_concepts(
         lambda item: item.concept_id,
         "Contract sensitive concepts",
     )
+
+
+def _index_ranking_behaviors(
+    ranking_behaviors: Iterable[SemanticRankingBehavior],
+    metrics_by_id: Mapping[SourceIdentifier, SemanticMetric],
+    dimensions_by_id: Mapping[SourceIdentifier, SemanticDimension],
+) -> dict[SourceIdentifier, SemanticRankingBehavior]:
+    ranking_behaviors_by_id = _unique_concepts_by_id(
+        ranking_behaviors,
+        lambda item: item.ranking_id,
+        "Contract ranking behaviors",
+    )
+    for ranking_behavior in ranking_behaviors:
+        metric = metrics_by_id.get(ranking_behavior.order_metric)
+        if metric is None:
+            raise ValueError(
+                f"Ranking behavior {ranking_behavior.ranking_id} references "
+                "undeclared order metric"
+            )
+        _require_subset(
+            ranking_behavior.partition_dimensions,
+            set(dimensions_by_id),
+            (
+                f"Ranking behavior {ranking_behavior.ranking_id} references "
+                "undeclared partition dimensions"
+            ),
+        )
+        _require_subset(
+            ranking_behavior.partition_dimensions,
+            set(metric.allowed_dimensions),
+            (
+                f"Ranking behavior {ranking_behavior.ranking_id} references "
+                "partition dimensions not allowed by the order metric"
+            ),
+        )
+    return ranking_behaviors_by_id
+
+
+def _validate_intent_mappings(
+    intent_mappings: Iterable[SemanticIntentMapping],
+    metrics_by_id: Mapping[SourceIdentifier, SemanticMetric],
+    dimensions_by_id: Mapping[SourceIdentifier, SemanticDimension],
+    filters_by_id: Mapping[SourceIdentifier, SemanticFilter],
+    ranking_behaviors_by_id: Mapping[SourceIdentifier, SemanticRankingBehavior],
+    ambiguity_rules: Mapping[SourceIdentifier, NonEmptyTrimmedString],
+) -> None:
+    _unique_concepts_by_id(
+        intent_mappings,
+        lambda item: item.mapping_id,
+        "Contract intent mappings",
+    )
+    for intent_mapping in intent_mappings:
+        metric = metrics_by_id.get(intent_mapping.metric)
+        if metric is None:
+            raise ValueError(
+                f"Intent mapping {intent_mapping.mapping_id} references "
+                "undeclared metric"
+            )
+        _require_subset(
+            intent_mapping.dimensions,
+            set(dimensions_by_id),
+            (
+                f"Intent mapping {intent_mapping.mapping_id} references "
+                "undeclared dimensions"
+            ),
+        )
+        _require_subset(
+            intent_mapping.dimensions,
+            set(metric.allowed_dimensions),
+            (
+                f"Intent mapping {intent_mapping.mapping_id} references "
+                "dimensions not allowed by the metric"
+            ),
+        )
+        _require_subset(
+            intent_mapping.filters,
+            set(filters_by_id),
+            (
+                f"Intent mapping {intent_mapping.mapping_id} references "
+                "undeclared filters"
+            ),
+        )
+        _require_subset(
+            intent_mapping.filters,
+            set(metric.default_filters),
+            (
+                f"Intent mapping {intent_mapping.mapping_id} references "
+                "filters not allowed by the metric"
+            ),
+        )
+        if (
+            intent_mapping.ranking_behavior_id is not None
+            and intent_mapping.ranking_behavior_id not in ranking_behaviors_by_id
+        ):
+            raise ValueError(
+                f"Intent mapping {intent_mapping.mapping_id} references "
+                "undeclared ranking behavior"
+            )
+        _require_subset(
+            intent_mapping.ambiguity_rule_refs,
+            set(ambiguity_rules),
+            (
+                f"Intent mapping {intent_mapping.mapping_id} references "
+                "undeclared ambiguity rules"
+            ),
+        )
 
 
 def _require_subset(

--- a/backend/app/features/semantic_contract/schema.py
+++ b/backend/app/features/semantic_contract/schema.py
@@ -573,13 +573,27 @@ def _validate_intent_mappings(
                 "filters not allowed by the metric"
             ),
         )
-        if (
-            intent_mapping.ranking_behavior_id is not None
-            and intent_mapping.ranking_behavior_id not in ranking_behaviors_by_id
-        ):
-            raise ValueError(
-                f"Intent mapping {intent_mapping.mapping_id} references "
-                "undeclared ranking behavior"
+        if intent_mapping.ranking_behavior_id is not None:
+            ranking_behavior = ranking_behaviors_by_id.get(
+                intent_mapping.ranking_behavior_id
+            )
+            if ranking_behavior is None:
+                raise ValueError(
+                    f"Intent mapping {intent_mapping.mapping_id} references "
+                    "undeclared ranking behavior"
+                )
+            if ranking_behavior.order_metric != intent_mapping.metric:
+                raise ValueError(
+                    f"Intent mapping {intent_mapping.mapping_id} references "
+                    "ranking behavior with a different order metric"
+                )
+            _require_subset(
+                ranking_behavior.partition_dimensions,
+                set(intent_mapping.dimensions),
+                (
+                    f"Intent mapping {intent_mapping.mapping_id} references "
+                    "ranking partition dimensions missing from the mapping"
+                ),
             )
         _require_subset(
             intent_mapping.ambiguity_rule_refs,

--- a/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
+++ b/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
@@ -95,7 +95,7 @@
           "fiscal_quarter"
         ],
         "filters": [
-          "approval_status equals approved"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {
@@ -188,7 +188,7 @@
           "fiscal_quarter"
         ],
         "filters": [
-          "approval_status equals approved"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {
@@ -305,13 +305,12 @@
       },
       "expected_intent": "The user requests quarterly approved spend but refund inclusion or exclusion changes the metric definition.",
       "expected_semantic_mapping": {
-        "metric": "sum_approved_vendor_spend with unresolved refund treatment",
+        "metric": "sum_approved_vendor_spend",
         "dimensions": [
           "fiscal_quarter"
         ],
         "filters": [
-          "approval_status equals approved",
-          "refund treatment unspecified"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {
@@ -352,10 +351,10 @@
       "expected_semantic_mapping": {
         "metric": "sum_approved_vendor_spend",
         "dimensions": [
-          "quarter"
+          "fiscal_quarter"
         ],
         "filters": [
-          "Q1 period, unresolved calendar or fiscal quarter"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {
@@ -395,13 +394,12 @@
       },
       "expected_intent": "The user asks for approved spend but does not define whether approval means transaction-time approval or current approval status.",
       "expected_semantic_mapping": {
-        "metric": "sum_approved_vendor_spend with unresolved approval timing",
+        "metric": "sum_approved_vendor_spend",
         "dimensions": [
           "vendor_name"
         ],
         "filters": [
-          "approval timing unspecified",
-          "approved status source of truth unspecified"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {
@@ -440,13 +438,12 @@
       },
       "expected_intent": "The user asks to normalize vendor names without an authoritative alias or vendor-master binding.",
       "expected_semantic_mapping": {
-        "metric": "sum_approved_vendor_spend with unresolved vendor normalization",
+        "metric": "sum_approved_vendor_spend",
         "dimensions": [
           "vendor_name"
         ],
         "filters": [
-          "approval_status equals approved",
-          "vendor alias mapping unspecified"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {
@@ -485,14 +482,13 @@
       },
       "expected_intent": "The user requests a top-N ranking but does not specify whether ties at the rank boundary should expand the row count or require a deterministic tie-breaker.",
       "expected_semantic_mapping": {
-        "metric": "sum_approved_vendor_spend with unresolved top-N tie handling",
+        "metric": "sum_approved_vendor_spend",
         "dimensions": [
           "vendor_name",
           "fiscal_quarter"
         ],
         "filters": [
-          "approval_status equals approved",
-          "top-N tie policy unspecified"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {
@@ -725,7 +721,7 @@
           "tax_identifier"
         ],
         "filters": [
-          "approval_status equals approved"
+          "approved_spend_only"
         ]
       },
       "acceptable_sql_shape": {

--- a/backend/tests/fixtures/semantic_contract_vendor_spend.v1.json
+++ b/backend/tests/fixtures/semantic_contract_vendor_spend.v1.json
@@ -71,6 +71,90 @@
       }
     }
   ],
+  "ranking_behaviors": [
+    {
+      "ranking_id": "top_approved_vendors_by_quarterly_spend",
+      "label": "Top approved vendors by quarterly spend",
+      "order_metric": "sum_approved_vendor_spend",
+      "order_direction": "desc",
+      "partition_dimensions": [
+        "fiscal_quarter"
+      ],
+      "limit_per_partition": 10,
+      "ties_policy": "clarify"
+    }
+  ],
+  "intent_mappings": [
+    {
+      "mapping_id": "show_top_approved_vendors_by_quarterly_spend",
+      "label": "Show top approved vendors by quarterly spend",
+      "canonical_question": "Show the top approved vendors by quarterly spend.",
+      "classification": "supported",
+      "metric": "sum_approved_vendor_spend",
+      "dimensions": [
+        "vendor_name",
+        "fiscal_quarter"
+      ],
+      "filters": [
+        "approved_spend_only"
+      ],
+      "ranking_behavior_id": "top_approved_vendors_by_quarterly_spend",
+      "ambiguity_rule_refs": []
+    },
+    {
+      "mapping_id": "clarify_refund_inclusion",
+      "label": "Clarify refund inclusion",
+      "canonical_question": "Show vendor spend after refunds by quarter.",
+      "classification": "ambiguous",
+      "metric": "sum_approved_vendor_spend",
+      "dimensions": [
+        "vendor_name",
+        "fiscal_quarter"
+      ],
+      "filters": [
+        "approved_spend_only"
+      ],
+      "ranking_behavior_id": null,
+      "ambiguity_rule_refs": [
+        "spend_definition"
+      ]
+    },
+    {
+      "mapping_id": "clarify_calendar_vs_fiscal_quarter",
+      "label": "Clarify calendar versus fiscal quarter",
+      "canonical_question": "Show approved vendor spend by calendar quarter.",
+      "classification": "ambiguous",
+      "metric": "sum_approved_vendor_spend",
+      "dimensions": [
+        "fiscal_quarter"
+      ],
+      "filters": [
+        "approved_spend_only"
+      ],
+      "ranking_behavior_id": null,
+      "ambiguity_rule_refs": [
+        "quarter"
+      ]
+    },
+    {
+      "mapping_id": "clarify_top_n_ties",
+      "label": "Clarify top-N ties",
+      "canonical_question": "Show the top two approved vendors by quarterly spend including ties.",
+      "classification": "ambiguous",
+      "metric": "sum_approved_vendor_spend",
+      "dimensions": [
+        "vendor_name",
+        "fiscal_quarter"
+      ],
+      "filters": [
+        "approved_spend_only"
+      ],
+      "ranking_behavior_id": "top_approved_vendors_by_quarterly_spend",
+      "ambiguity_rule_refs": [
+        "top_n_ties"
+      ]
+    }
+  ],
   "time_semantics": {
     "default_grain": "fiscal_quarter",
     "allowed_grains": [
@@ -91,6 +175,7 @@
   ],
   "ambiguity_rules": {
     "quarter": "Clarify fiscal versus calendar quarter before mapping.",
-    "spend_definition": "Clarify gross spend versus net-of-refunds spend before mapping."
+    "spend_definition": "Clarify gross spend versus net-of-refunds spend before mapping.",
+    "top_n_ties": "Clarify whether ties at the cutoff should be included or broken by a stable secondary sort before mapping."
   }
 }

--- a/backend/tests/test_governed_answer_fixtures.py
+++ b/backend/tests/test_governed_answer_fixtures.py
@@ -89,6 +89,23 @@ def _fixtures_by_scenario_id(fixture_set: dict[str, Any]) -> dict[str, dict[str,
     }
 
 
+def _assert_fixture_mappings_follow_semantic_contract(
+    fixture_set: dict[str, Any],
+    semantic_contract: dict[str, Any],
+) -> None:
+    contract = validate_semantic_contract_definition(semantic_contract)
+    metrics_by_id = {metric.metric_id: metric for metric in contract.metrics}
+
+    for fixture in fixture_set["fixtures"]:
+        if fixture["case_type"] not in {"positive", "ambiguous"}:
+            continue
+        mapping = fixture["expected_semantic_mapping"]
+        assert mapping["metric"] in metrics_by_id
+        metric = metrics_by_id[mapping["metric"]]
+        assert set(mapping["dimensions"]) <= set(metric.allowed_dimensions)
+        assert set(mapping["filters"]) <= set(metric.default_filters)
+
+
 def test_governed_answer_vendor_spend_fixture_set_is_schema_valid() -> None:
     fixture_set = _load_fixture_set()
     validated = validate_governed_answer_fixture_set(fixture_set)
@@ -320,20 +337,53 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
 
 
 def test_governed_answer_fixture_mappings_reference_semantic_contract_concepts() -> None:
-    contract = validate_semantic_contract_definition(_load_semantic_contract())
     fixture_set = _load_fixture_set()
+    _assert_fixture_mappings_follow_semantic_contract(
+        fixture_set,
+        _load_semantic_contract(),
+    )
 
-    metric_ids = {metric.metric_id for metric in contract.metrics}
-    dimension_ids = {dimension.dimension_id for dimension in contract.dimensions}
-    filter_ids = {semantic_filter.filter_id for semantic_filter in contract.filters}
 
-    for fixture in fixture_set["fixtures"]:
-        if fixture["case_type"] not in {"positive", "ambiguous"}:
-            continue
-        mapping = fixture["expected_semantic_mapping"]
-        assert mapping["metric"] in metric_ids
-        assert set(mapping["dimensions"]) <= dimension_ids
-        assert set(mapping["filters"]) <= filter_ids
+def test_fixture_mapping_guard_rejects_metric_incompatible_contract_concepts() -> None:
+    fixture_set = _load_fixture_set()
+    semantic_contract = _load_semantic_contract()
+    semantic_contract["dimensions"].append(
+        {
+            "dimension_id": "invoice_id",
+            "label": "Invoice id",
+            "source_column": "finance.approved_vendor_spend.invoice_id",
+            "allowed_source_ids": ["business-postgres-source"],
+        }
+    )
+    semantic_contract["filters"].append(
+        {
+            "filter_id": "paid_spend_only",
+            "label": "Paid spend only",
+            "expression": "payment_status = 'paid'",
+            "allowed_source_ids": ["business-postgres-source"],
+            "locked": True,
+        }
+    )
+    fixture_set["fixtures"][0]["expected_semantic_mapping"]["dimensions"].append(
+        "invoice_id"
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_fixture_mappings_follow_semantic_contract(
+            fixture_set,
+            semantic_contract,
+        )
+
+    fixture_set = _load_fixture_set()
+    fixture_set["fixtures"][0]["expected_semantic_mapping"]["filters"].append(
+        "paid_spend_only"
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_fixture_mappings_follow_semantic_contract(
+            fixture_set,
+            semantic_contract,
+        )
 
 
 def test_governed_answer_vendor_spend_fixtures_cover_adversarial_fail_closed_suite() -> None:

--- a/backend/tests/test_governed_answer_fixtures.py
+++ b/backend/tests/test_governed_answer_fixtures.py
@@ -14,12 +14,16 @@ from app.features.evaluation import (
     validate_governed_answer_fixture_set,
 )
 from app.features.guard.deny_taxonomy import GUARD_DENY_CODES
+from app.features.semantic_contract import validate_semantic_contract_definition
 
 
 FIXTURE_PATH = (
     Path(__file__).parent
     / "fixtures"
     / "governed_answer_vendor_spend_fixtures.json"
+)
+SEMANTIC_CONTRACT_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "semantic_contract_vendor_spend.v1.json"
 )
 
 
@@ -72,6 +76,10 @@ EXPECTED_ADVERSARIAL_GUARD_DENIALS = {
 
 def _load_fixture_set() -> dict[str, Any]:
     return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _load_semantic_contract() -> dict[str, Any]:
+    return json.loads(SEMANTIC_CONTRACT_FIXTURE_PATH.read_text(encoding="utf-8"))
 
 
 def _fixtures_by_scenario_id(fixture_set: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -201,7 +209,7 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
     assert top_vendors["expected_semantic_mapping"] == {
         "metric": "sum_approved_vendor_spend",
         "dimensions": ["vendor_name", "fiscal_quarter"],
-        "filters": ["approval_status equals approved"],
+        "filters": ["approved_spend_only"],
     }
     assert top_vendors["expected_result_shape"]["row_grain"] == (
         "one row per approved vendor per fiscal quarter"
@@ -309,6 +317,23 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
     assert "ties at rank 2" in top_n_tie_ambiguity["acceptable_sql_shape"][
         "required_clarification"
     ]
+
+
+def test_governed_answer_fixture_mappings_reference_semantic_contract_concepts() -> None:
+    contract = validate_semantic_contract_definition(_load_semantic_contract())
+    fixture_set = _load_fixture_set()
+
+    metric_ids = {metric.metric_id for metric in contract.metrics}
+    dimension_ids = {dimension.dimension_id for dimension in contract.dimensions}
+    filter_ids = {semantic_filter.filter_id for semantic_filter in contract.filters}
+
+    for fixture in fixture_set["fixtures"]:
+        if fixture["case_type"] not in {"positive", "ambiguous"}:
+            continue
+        mapping = fixture["expected_semantic_mapping"]
+        assert mapping["metric"] in metric_ids
+        assert set(mapping["dimensions"]) <= dimension_ids
+        assert set(mapping["filters"]) <= filter_ids
 
 
 def test_governed_answer_vendor_spend_fixtures_cover_adversarial_fail_closed_suite() -> None:

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -417,6 +417,34 @@ def test_spend_definition_detection_catches_camel_compound_terms() -> None:
             ),
             "references undeclared ranking behavior",
         ),
+        (
+            lambda payload: payload["intent_mappings"][0].__setitem__(
+                "metric", "sum_other_approved_vendor_spend"
+            )
+            or payload["metrics"].append(
+                {
+                    "metric_id": "sum_other_approved_vendor_spend",
+                    "label": "Other approved vendor spend",
+                    "expression_owner": "finance_analytics",
+                    "expression": "SUM(other_approved_spend)",
+                    "allowed_source_ids": ["business-postgres-source"],
+                    "allowed_dimensions": ["vendor_name", "fiscal_quarter"],
+                    "default_filters": ["approved_spend_only"],
+                    "time_range_semantics": {
+                        "default_grain": "fiscal_quarter",
+                        "allowed_grains": ["fiscal_quarter"],
+                        "requires_explicit_range": False,
+                    },
+                }
+            ),
+            "references ranking behavior with a different order metric",
+        ),
+        (
+            lambda payload: payload["intent_mappings"][0].__setitem__(
+                "dimensions", ["vendor_name"]
+            ),
+            "references ranking partition dimensions missing from the mapping",
+        ),
     ],
 )
 def test_semantic_contract_schema_fails_closed_for_malformed_definitions(

--- a/backend/tests/test_semantic_contract_schema.py
+++ b/backend/tests/test_semantic_contract_schema.py
@@ -37,9 +37,12 @@ def _make_non_spend_contract(payload: dict[str, Any]) -> dict[str, Any]:
     payload["metrics"][0]["label"] = "Closed tickets"
     payload["metrics"][0]["expression"] = "COUNT(ticket_id)"
     payload["metrics"][0]["default_filters"] = ["closed_tickets_only"]
+    payload["ranking_behaviors"] = []
+    payload["intent_mappings"] = []
     payload["sensitive_concepts"][0]["reason"] = (
         "Ticket status handling requires review."
     )
+    payload["ambiguity_rules"].pop("top_n_ties", None)
     return payload
 
 
@@ -56,6 +59,29 @@ def test_vendor_spend_semantic_contract_fixture_validates_and_serializes() -> No
         "fiscal_quarter",
     )
     assert contract.metrics[0].default_filters == ("approved_spend_only",)
+    assert contract.ranking_behaviors[0].ranking_id == (
+        "top_approved_vendors_by_quarterly_spend"
+    )
+    assert contract.ranking_behaviors[0].order_metric == "sum_approved_vendor_spend"
+    assert contract.ranking_behaviors[0].partition_dimensions == ("fiscal_quarter",)
+    assert contract.ranking_behaviors[0].limit_per_partition == 10
+    assert contract.ranking_behaviors[0].ties_policy == "clarify"
+    assert contract.intent_mappings[0].mapping_id == (
+        "show_top_approved_vendors_by_quarterly_spend"
+    )
+    assert contract.intent_mappings[0].canonical_question == (
+        "Show the top approved vendors by quarterly spend."
+    )
+    assert contract.intent_mappings[0].classification == "supported"
+    assert contract.intent_mappings[0].metric == "sum_approved_vendor_spend"
+    assert contract.intent_mappings[0].dimensions == (
+        "vendor_name",
+        "fiscal_quarter",
+    )
+    assert contract.intent_mappings[0].filters == ("approved_spend_only",)
+    assert contract.intent_mappings[0].ranking_behavior_id == (
+        "top_approved_vendors_by_quarterly_spend"
+    )
     assert contract.time_semantics.default_grain == "fiscal_quarter"
     assert contract.time_semantics.ambiguous_terms == ("quarter",)
     assert contract.ambiguity_rules["quarter"] == (
@@ -70,8 +96,39 @@ def test_vendor_spend_semantic_contract_fixture_validates_and_serializes() -> No
     assert serialized["contractId"] == "approved_vendor_spend"
     assert serialized["version"]["identifier"] == "approved_vendor_spend.v1"
     assert serialized["metrics"][0]["metricId"] == "sum_approved_vendor_spend"
+    assert serialized["rankingBehaviors"][0]["rankingId"] == (
+        "top_approved_vendors_by_quarterly_spend"
+    )
+    assert serialized["intentMappings"][0]["mappingId"] == (
+        "show_top_approved_vendors_by_quarterly_spend"
+    )
     assert serialized["timeSemantics"]["defaultGrain"] == "fiscal_quarter"
     assert "contract_id" not in serialized
+
+
+def test_vendor_spend_contract_represents_ambiguous_demo_variations() -> None:
+    contract = validate_semantic_contract_definition(_load_contract())
+    mappings_by_id = {
+        mapping.mapping_id: mapping for mapping in contract.intent_mappings
+    }
+
+    assert mappings_by_id[
+        "clarify_refund_inclusion"
+    ].ambiguity_rule_refs == ("spend_definition",)
+    assert mappings_by_id[
+        "clarify_calendar_vs_fiscal_quarter"
+    ].ambiguity_rule_refs == ("quarter",)
+    assert mappings_by_id["clarify_top_n_ties"].ambiguity_rule_refs == (
+        "top_n_ties",
+    )
+    assert all(
+        mappings_by_id[mapping_id].classification == "ambiguous"
+        for mapping_id in (
+            "clarify_refund_inclusion",
+            "clarify_calendar_vs_fiscal_quarter",
+            "clarify_top_n_ties",
+        )
+    )
 
 
 def test_validated_semantic_contract_collections_are_immutable() -> None:
@@ -219,9 +276,12 @@ def test_spend_definition_detection_catches_camel_compound_terms() -> None:
     payload["metrics"][0]["label"] = "ApprovedVendorSpend"
     payload["metrics"][0]["expression"] = "SUM(approved_amount)"
     payload["metrics"][0]["default_filters"] = ["approved_amount_only"]
+    payload["ranking_behaviors"] = []
+    payload["intent_mappings"] = []
     payload["sensitive_concepts"][0]["reason"] = (
         "Refund handling changes gross-versus-net amount definition."
     )
+    payload["ambiguity_rules"].pop("top_n_ties", None)
     payload["ambiguity_rules"].pop("spend_definition")
 
     with pytest.raises(
@@ -332,6 +392,30 @@ def test_spend_definition_detection_catches_camel_compound_terms() -> None:
                 "requires_explicit_range", "false"
             ),
             "Input should be a valid boolean",
+        ),
+        (
+            lambda payload: payload["ranking_behaviors"][0].__setitem__(
+                "order_metric", "undeclared_metric"
+            ),
+            "references undeclared order metric",
+        ),
+        (
+            lambda payload: payload["intent_mappings"][0].__setitem__(
+                "metric", "undeclared_metric"
+            ),
+            "references undeclared metric",
+        ),
+        (
+            lambda payload: payload["intent_mappings"][0]["filters"].append(
+                "undeclared_filter"
+            ),
+            "references undeclared filters",
+        ),
+        (
+            lambda payload: payload["intent_mappings"][0].__setitem__(
+                "ranking_behavior_id", "undeclared_ranking"
+            ),
+            "references undeclared ranking behavior",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- add semantic intent and ranking behavior records to the approved vendor spend contract schema
- map the canonical top approved vendors by quarterly spend question to metric, dimension, filter, and ranking concept ids
- tighten AA governed-answer fixture checks so positive and ambiguous mappings reference contract concepts instead of free-form labels

## Verification
- cd backend && python3 -m pytest tests/test_semantic_contract_schema.py tests/test_governed_answer_fixtures.py tests/test_release_gate.py -q
- git diff --check

Closes #439