### PR TITLE
[X-3] Persist semantic contract preview version

### DIFF
--- a/backend/alembic/versions/0011_semantic_contract_preview_version.py
+++ b/backend/alembic/versions/0011_semantic_contract_preview_version.py
@@ -1,0 +1,32 @@
+"""Persist semantic contract version on preview lifecycle records."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0011_semantic_contract_preview_version"
+down_revision: str | None = "0010_preview_revision_context"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dataset_contracts",
+        sa.Column("semantic_contract_version", sa.String(length=255), nullable=True),
+    )
+    for table_name in ("preview_requests", "preview_candidates", "preview_audit_events"):
+        op.add_column(
+            table_name,
+            sa.Column("semantic_contract_version", sa.String(length=255), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    for table_name in ("preview_audit_events", "preview_candidates", "preview_requests"):
+        op.drop_column(table_name, "semantic_contract_version")
+    op.drop_column("dataset_contracts", "semantic_contract_version")

--- a/backend/app/db/models/dataset_contract.py
+++ b/backend/app/db/models/dataset_contract.py
@@ -52,6 +52,10 @@ class DatasetContract(Base):
         nullable=False,
     )
     contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    semantic_contract_version: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
     display_name: Mapped[str] = mapped_column(String(255), nullable=False)
     owner_binding: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     security_review_binding: Mapped[Optional[str]] = mapped_column(

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -46,6 +46,10 @@ class PreviewRequest(Base):
         nullable=False,
     )
     dataset_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    semantic_contract_version: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
     schema_snapshot_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("schema_snapshots.id"),
         nullable=False,
@@ -129,6 +133,10 @@ class PreviewCandidate(Base):
         nullable=False,
     )
     dataset_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    semantic_contract_version: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
     schema_snapshot_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey("schema_snapshots.id"),
         nullable=False,
@@ -314,6 +322,10 @@ class PreviewAuditEvent(Base):
     source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     dataset_contract_version: Mapped[Optional[int]] = mapped_column(
         Integer,
+        nullable=True,
+    )
+    semantic_contract_version: Mapped[Optional[str]] = mapped_column(
+        String(255),
         nullable=True,
     )
     schema_snapshot_version: Mapped[Optional[int]] = mapped_column(

--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -148,6 +148,7 @@ class SourceAwareAuditEvent(BaseModel):
     source_flavor: Optional[SourceFlavor] = None
     dialect_profile_version: Optional[PositiveInt] = None
     dataset_contract_version: Optional[PositiveInt] = None
+    semantic_contract_version: Optional[NonEmptyTrimmedString] = None
     schema_snapshot_version: Optional[PositiveInt] = None
     execution_policy_version: Optional[PositiveInt] = None
     connector_profile_version: Optional[PositiveInt] = None

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -71,6 +71,10 @@ class OperatorWorkflowHistoryItem(BaseModel):
     occurred_at: datetime = Field(serialization_alias="occurredAt")
     candidate_sql: Optional[str] = Field(default=None, serialization_alias="candidateSql")
     request_id: Optional[str] = Field(default=None, serialization_alias="requestId")
+    semantic_contract_version: Optional[str] = Field(
+        default=None,
+        serialization_alias="semanticContractVersion",
+    )
     guard_status: Optional[str] = Field(default=None, serialization_alias="guardStatus")
     primary_deny_code: Optional[str] = Field(
         default=None,
@@ -119,6 +123,10 @@ class OperatorWorkflowCandidateAttemptSummary(BaseModel):
     denial_reason: Optional[str] = Field(default=None, serialization_alias="denialReason")
     occurred_at: datetime = Field(serialization_alias="occurredAt")
     dataset_contract_version: int = Field(serialization_alias="datasetContractVersion")
+    semantic_contract_version: Optional[str] = Field(
+        default=None,
+        serialization_alias="semanticContractVersion",
+    )
     schema_snapshot_version: int = Field(serialization_alias="schemaSnapshotVersion")
     approved: bool
     executed: bool
@@ -143,6 +151,10 @@ class OperatorWorkflowAuditEventSummary(BaseModel):
     request_id: str = Field(serialization_alias="requestId")
     candidate_id: Optional[str] = Field(default=None, serialization_alias="candidateId")
     source_id: str = Field(serialization_alias="sourceId")
+    semantic_contract_version: Optional[str] = Field(
+        default=None,
+        serialization_alias="semanticContractVersion",
+    )
     candidate_state: Optional[str] = Field(default=None, serialization_alias="candidateState")
     primary_deny_code: Optional[str] = Field(default=None, serialization_alias="primaryDenyCode")
     guard_decision: Optional[str] = Field(default=None, serialization_alias="guardDecision")
@@ -474,6 +486,7 @@ def _audit_event_summary(event: PreviewAuditEvent) -> OperatorWorkflowAuditEvent
         request_id=event.request_id,
         candidate_id=event.candidate_id,
         source_id=event.source_id,
+        semantic_contract_version=event.semantic_contract_version,
         candidate_state=event.candidate_state,
         primary_deny_code=event.primary_deny_code,
         guard_decision=_read_text(event.audit_payload.get("guard_decision")),
@@ -679,6 +692,7 @@ def _candidate_attempts_by_candidate_id(
                     candidate.updated_at or candidate.created_at,
                 ),
                 dataset_contract_version=candidate.dataset_contract_version,
+                semantic_contract_version=candidate.semantic_contract_version,
                 schema_snapshot_version=candidate.schema_snapshot_version,
                 approved=candidate.candidate_id in approved_candidate_ids,
                 executed=candidate.candidate_id in executed_candidate_ids,
@@ -774,6 +788,7 @@ def _build_operator_history(
                 lifecycle_state=run_state,
                 occurred_at=_as_utc_datetime(event.occurred_at),
                 request_id=event.request_id,
+                semantic_contract_version=event.semantic_contract_version,
                 primary_deny_code=event.primary_deny_code,
                 result_truncated=_run_result_truncated_for_event(event, run_state),
                 row_count=_run_row_count_for_event(event, run_state),
@@ -805,6 +820,7 @@ def _build_operator_history(
                 ),
                 candidate_sql=candidate.candidate_sql,
                 request_id=candidate.request_id,
+                semantic_contract_version=candidate.semantic_contract_version,
                 guard_status=candidate.guard_status,
                 primary_deny_code=(
                     candidate_event.primary_deny_code if candidate_event else None
@@ -838,6 +854,7 @@ def _build_operator_history(
                 source_id=request.source_id,
                 source_label=source_labels.get(request.source_id, request.source_id),
                 lifecycle_state=request.request_state,
+                semantic_contract_version=request.semantic_contract_version,
                 occurred_at=_history_occurred_at(
                     request_event,
                     request.updated_at or request.created_at,

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -765,6 +765,17 @@ def _persist_preview_audit_events(
         if event.event_id in existing_event_ids:
             continue
         payload = event.model_dump(mode="json", exclude_none=True)
+        semantic_contract_version = (
+            event.semantic_contract_version
+            or (
+                preview_candidate.semantic_contract_version
+                if preview_candidate is not None
+                else None
+            )
+            or preview_request.semantic_contract_version
+        )
+        if semantic_contract_version is not None:
+            payload["semantic_contract_version"] = semantic_contract_version
         session.add(
             PreviewAuditEvent(
                 event_id=event.event_id,
@@ -800,7 +811,7 @@ def _persist_preview_audit_events(
                 source_family=event.source_family,
                 source_flavor=event.source_flavor,
                 dataset_contract_version=event.dataset_contract_version,
-                semantic_contract_version=event.semantic_contract_version,
+                semantic_contract_version=semantic_contract_version,
                 schema_snapshot_version=event.schema_snapshot_version,
                 primary_deny_code=event.primary_deny_code,
                 denial_cause=event.denial_cause,

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -158,6 +158,7 @@ class RequestRecord(BaseModel):
     question: str
     request_id: str
     source_id: str
+    semantic_contract_version: Optional[str] = None
     state: str
     revision_context: Optional["RevisionRecord"] = None
 
@@ -170,6 +171,7 @@ class CandidateRecord(BaseModel):
     source_family: str
     source_flavor: Optional[str]
     dataset_contract_version: int
+    semantic_contract_version: Optional[str] = None
     schema_snapshot_version: int
     state: str
     primary_deny_code: Optional[str] = None
@@ -383,6 +385,7 @@ def _build_preview_lifecycle_audit_events(
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
+            semantic_contract_version=dataset_contract.semantic_contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
             execution_policy_version=execution_policy_version,
             connector_profile_version=connector_profile_version,
@@ -502,6 +505,7 @@ def _build_preview_entitlement_denial_audit_event(
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
+            semantic_contract_version=dataset_contract.semantic_contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
             primary_deny_code="DENY_SOURCE_ENTITLEMENT",
             denial_cause="entitlement_denied",
@@ -541,6 +545,7 @@ def _build_preview_unavailable_audit_event(
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
+            semantic_contract_version=dataset_contract.semantic_contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
             primary_deny_code=primary_deny_code,
             denial_cause=denial_cause,
@@ -579,6 +584,7 @@ def _build_preview_generation_failed_audit_event(
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
+            semantic_contract_version=dataset_contract.semantic_contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
             primary_deny_code="DENY_SQL_GENERATION_FAILED",
             denial_cause=failure_code,
@@ -794,6 +800,7 @@ def _persist_preview_audit_events(
                 source_family=event.source_family,
                 source_flavor=event.source_flavor,
                 dataset_contract_version=event.dataset_contract_version,
+                semantic_contract_version=event.semantic_contract_version,
                 schema_snapshot_version=event.schema_snapshot_version,
                 primary_deny_code=event.primary_deny_code,
                 denial_cause=event.denial_cause,
@@ -1046,6 +1053,9 @@ def _persist_preview_submission_records(
             preview_request.source_flavor = resolved_source.source_flavor
             preview_request.dataset_contract_id = dataset_contract.id
             preview_request.dataset_contract_version = dataset_contract.contract_version
+            preview_request.semantic_contract_version = (
+                dataset_contract.semantic_contract_version
+            )
             preview_request.schema_snapshot_id = schema_snapshot.id
             preview_request.schema_snapshot_version = schema_snapshot.snapshot_version
             preview_request.authenticated_subject_id = subject_id
@@ -1132,6 +1142,9 @@ def _persist_preview_submission_records(
             preview_candidate.source_flavor = resolved_source.source_flavor
             preview_candidate.dataset_contract_id = dataset_contract.id
             preview_candidate.dataset_contract_version = dataset_contract.contract_version
+            preview_candidate.semantic_contract_version = (
+                dataset_contract.semantic_contract_version
+            )
             preview_candidate.schema_snapshot_id = schema_snapshot.id
             preview_candidate.schema_snapshot_version = schema_snapshot.snapshot_version
             preview_candidate.authenticated_subject_id = subject_id
@@ -1623,6 +1636,7 @@ def submit_preview_request(
             question=payload.question,
             request_id=request_id,
             source_id=resolved_source.source_id,
+            semantic_contract_version=dataset_contract.semantic_contract_version,
             state="submitted",
             revision_context=revision_record,
         ),
@@ -1634,6 +1648,7 @@ def submit_preview_request(
             source_family=resolved_source.source_family,
             source_flavor=resolved_source.source_flavor,
             dataset_contract_version=dataset_contract.contract_version,
+            semantic_contract_version=dataset_contract.semantic_contract_version,
             schema_snapshot_version=schema_snapshot.snapshot_version,
             state=candidate_state,
             primary_deny_code=primary_deny_code,

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -93,6 +93,7 @@ def _seed_authoritative_source_governance(
     source_family: str = "postgresql",
     source_flavor: str = "warehouse",
     dataset_contract_version: int = 1,
+    semantic_contract_version: str | None = "approved_vendor_spend.v1",
     schema_snapshot_version: int = 1,
 ) -> None:
     source = RegisteredSource(
@@ -127,6 +128,7 @@ def _seed_authoritative_source_governance(
         registered_source_id=source.id,
         schema_snapshot_id=snapshot.id,
         contract_version=dataset_contract_version,
+        semantic_contract_version=semantic_contract_version,
         display_name="SAP spend cube contract",
         owner_binding="group:finance-analysts",
         security_review_binding=None,
@@ -229,7 +231,13 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         response_candidate_id = response_payload["audit"]["events"][2]["query_candidate_id"]
 
         assert response_payload["request"]["request_id"] == request_id
+        assert response_payload["request"]["semantic_contract_version"] == (
+            "approved_vendor_spend.v1"
+        )
         assert response_payload["candidate"]["candidate_id"] == response_candidate_id
+        assert response_payload["candidate"]["semantic_contract_version"] == (
+            "approved_vendor_spend.v1"
+        )
         assert response_payload["candidate"]["guard_status"] == "pending"
         assert response_payload["candidate"]["candidate_sql"] is None
 
@@ -256,6 +264,7 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         assert persisted_request.auth_source == "test-helper"
         assert persisted_request.governance_bindings == "group:finance-analysts"
         assert persisted_request.dataset_contract_version == 1
+        assert persisted_request.semantic_contract_version == "approved_vendor_spend.v1"
         assert persisted_request.schema_snapshot_version == 1
 
         assert persisted_candidate.candidate_id == response_candidate_id
@@ -268,6 +277,9 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         assert persisted_candidate.candidate_sql is None
         assert persisted_candidate.authenticated_subject_id == "user:alice"
         assert persisted_candidate.dataset_contract_version == 1
+        assert persisted_candidate.semantic_contract_version == (
+            "approved_vendor_spend.v1"
+        )
         assert persisted_candidate.schema_snapshot_version == 1
         assert persisted_candidate.registered_source_id == persisted_request.registered_source_id
         assert persisted_candidate.dataset_contract_id == persisted_request.dataset_contract_id
@@ -304,6 +316,49 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         assert persisted_events[-1].audit_payload["event_type"] == "guard_evaluated"
         assert persisted_events[-1].audit_payload["query_candidate_id"] == (
             response_candidate_id
+        )
+        assert persisted_events[-1].semantic_contract_version == (
+            "approved_vendor_spend.v1"
+        )
+        assert persisted_events[-1].audit_payload["semantic_contract_version"] == (
+            "approved_vendor_spend.v1"
+        )
+        current_contract = session.get(
+            DatasetContract,
+            persisted_request.dataset_contract_id,
+        )
+        assert current_contract is not None
+        current_contract.semantic_contract_version = "approved_vendor_spend.v2"
+        session.commit()
+        session.refresh(persisted_request)
+        session.refresh(persisted_candidate)
+        session.refresh(persisted_events[-1])
+        assert persisted_request.semantic_contract_version == "approved_vendor_spend.v1"
+        assert persisted_candidate.semantic_contract_version == "approved_vendor_spend.v1"
+        assert persisted_events[-1].semantic_contract_version == (
+            "approved_vendor_spend.v1"
+        )
+        workflow_payload = get_operator_workflow_snapshot(session).model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
+        )
+        candidate_history_item = next(
+            item
+            for item in workflow_payload["history"]
+            if item["itemType"] == "candidate"
+        )
+        request_history_item = next(
+            item for item in workflow_payload["history"] if item["itemType"] == "request"
+        )
+        assert request_history_item["semanticContractVersion"] == (
+            "approved_vendor_spend.v1"
+        )
+        assert candidate_history_item["semanticContractVersion"] == (
+            "approved_vendor_spend.v1"
+        )
+        assert candidate_history_item["auditEvents"][0]["semanticContractVersion"] == (
+            "approved_vendor_spend.v1"
         )
         serialized_events = str([event.audit_payload for event in persisted_events])
         assert app_session.csrf_token not in serialized_events

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -500,6 +500,15 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
 
         assert execute_response.status_code == 200
         assert calls == ["called"]
+        persisted_execution_event = (
+            session.execute(
+                select(PreviewAuditEvent).where(
+                    PreviewAuditEvent.event_type == "execution_completed"
+                )
+            )
+            .scalars()
+            .one()
+        )
         session.refresh(persisted_approval)
         assert persisted_approval.approval_state == "executed"
         assert persisted_approval.executed_at is not None
@@ -518,6 +527,12 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
             "prompt_version": "sql_generation_adapter_request.v1",
             "prompt_fingerprint": persisted_candidate.prompt_fingerprint,
         }.items() <= persisted_generation_event.audit_payload.items()
+        assert persisted_execution_event.semantic_contract_version == (
+            persisted_candidate.semantic_contract_version
+        )
+        assert persisted_execution_event.audit_payload["semantic_contract_version"] == (
+            persisted_candidate.semantic_contract_version
+        )
     finally:
         session.close()
         engine.dispose()
@@ -993,6 +1008,15 @@ def test_http_preview_guard_denied_candidate_remains_non_executable(
         )
         assert all(
             event.source_id == fixture["source_id"]
+            for event in persisted_post_execute_events
+        )
+        assert all(
+            event.semantic_contract_version == persisted_candidate.semantic_contract_version
+            for event in persisted_post_execute_events
+        )
+        assert all(
+            event.audit_payload["semantic_contract_version"]
+            == persisted_candidate.semantic_contract_version
             for event in persisted_post_execute_events
         )
         assert "execution_run_id" not in str(

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1863,6 +1863,9 @@ function renderCandidateAttemptComparison(attempts: OperatorWorkflowCandidateAtt
             <span>
               Contract v{attempt.datasetContractVersion}; schema v{attempt.schemaSnapshotVersion}
             </span>
+            {attempt.semanticContractVersion ? (
+              <span>Semantic contract {attempt.semanticContractVersion}</span>
+            ) : null}
             <span>{attempt.occurredAt}</span>
           </div>
         ))}

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -38,6 +38,7 @@ export type OperatorWorkflowAuditEvent = {
   requestId: string;
   resultTruncated: boolean | null;
   rowCount: number | null;
+  semanticContractVersion?: string | null;
   sourceId: string;
 };
 
@@ -54,6 +55,7 @@ export type OperatorWorkflowCandidateAttempt = {
   primaryDenyCode: string | null;
   requestId: string;
   schemaSnapshotVersion: number;
+  semanticContractVersion?: string | null;
   sourceFamily: string;
   sourceFlavor: string | null;
   sourceId: string;
@@ -105,6 +107,7 @@ export type OperatorHistoryItem = {
   primaryDenyCode?: string | null;
   recordId: string;
   requestId?: string | null;
+  semanticContractVersion?: string | null;
   resultTruncated?: boolean | null;
   rowCount?: number | null;
   runState?: string | null;
@@ -205,6 +208,7 @@ function parseAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
     requestId,
     resultTruncated: typeof value.resultTruncated === "boolean" ? value.resultTruncated : null,
     rowCount: readOptionalNonNegativeInteger(value.rowCount) ?? null,
+    semanticContractVersion: readOptionalString(value.semanticContractVersion) ?? null,
     sourceId
   };
 }
@@ -253,6 +257,7 @@ function parseCandidateAttempt(value: unknown): OperatorWorkflowCandidateAttempt
     primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
     requestId,
     schemaSnapshotVersion,
+    semanticContractVersion: readOptionalString(value.semanticContractVersion) ?? null,
     sourceFamily,
     sourceFlavor: readOptionalString(value.sourceFlavor) ?? null,
     sourceId
@@ -468,6 +473,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
     recordId,
     requestId: readOptionalString(value.requestId) ?? null,
+    semanticContractVersion: readOptionalString(value.semanticContractVersion) ?? null,
     resultTruncated:
       typeof value.resultTruncated === "boolean" ? value.resultTruncated : null,
     rowCount: readOptionalNonNegativeInteger(value.rowCount) ?? null,


### PR DESCRIPTION
## Summary
- Add nullable semantic contract version columns to dataset contracts, preview requests, preview candidates, and preview audit events
- Snapshot semantic contract version into preview API responses and persisted lifecycle audit metadata
- Expose semantic contract evidence in operator workflow history, audit summaries, and candidate attempt payloads

## Verification
- uv run --with pytest --with httpx pytest tests/test_preview_persistence.py tests/test_operator_workflow_history.py tests/test_first_run_doctor.py -q
- npx tsc --noEmit

## Notes
- `npm test -- app/pilot-safety-smoke.test.tsx app/page.test.tsx` still has 3 unrelated pilot smoke failures where the mocked `/auth/dev/session` request never resolves, so the expected `/requests/preview` call is not reached.

Closes #440