### PR TITLE
[X-4] Add intent mapping before SQL generation

### DIFF
--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -141,6 +141,7 @@ class SourceAwareAuditEvent(BaseModel):
     retrieved_citations: Optional[list[RetrievalCitationAuditPayload]] = None
     executed_evidence: Optional[list[ExecutedEvidenceAuditPayload]] = None
     release_gate_scenario: Optional[ReleaseGateScenarioAuditPayload] = None
+    intent_mapping: Optional[dict[str, object]] = None
     analyst_mode_version: Optional[NonEmptyTrimmedString] = None
 
     source_id: SourceIdentifier

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -278,14 +278,28 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
             **base,
         )
-    if approved_vendor_intent:
+    if (
+        (
+            _contains_phrase(normalized, "approved vendor spend")
+            or _contains_phrase(normalized, "approved spend")
+        )
+        and (
+            _contains_phrase(normalized, "top")
+            or _contains_phrase(normalized, "highest spend")
+        )
+        and (
+            _contains_phrase(normalized, "records")
+            or _contains_phrase(normalized, "record")
+            or _contains_phrase(normalized, "rows")
+            or _contains_phrase(normalized, "row")
+        )
+    ):
         return IntentMappingOutput(
             status="mapped",
-            mapping_id="approved_vendor_spend_general",
-            dimensions=[],
+            mapping_id="show_top_approved_vendor_spend_rows",
+            dimensions=["vendor_name"],
             **base,
         )
-
     return IntentMappingOutput(
         status="unsupported",
         clarification=(

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -33,15 +33,14 @@ def _contains_phrase(normalized: str, phrase: str) -> bool:
 
 
 def _mentions_approved_vendor_intent(normalized: str) -> bool:
-    return any(
-        _contains_phrase(normalized, marker)
-        for marker in (
-            "approved vendor spend",
-            "approved vendors",
-            "approved vendor",
-            "approved spend",
-        )
-    )
+    if _contains_phrase(normalized, "approved vendor spend") or _contains_phrase(
+        normalized, "approved spend"
+    ):
+        return True
+    return (
+        _contains_phrase(normalized, "approved vendors")
+        or _contains_phrase(normalized, "approved vendor")
+    ) and _contains_phrase(normalized, "spend")
 
 
 def _mentions_negated_approved_vendor_intent(normalized: str) -> bool:

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -28,15 +28,18 @@ def _normalize_question(question: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", lowered).strip()
 
 
+def _contains_phrase(normalized: str, phrase: str) -> bool:
+    return re.search(rf"(?:^| ){re.escape(phrase)}(?: |$)", normalized) is not None
+
+
 def _mentions_approved_vendor_intent(normalized: str) -> bool:
     return any(
-        marker in normalized
+        _contains_phrase(normalized, marker)
         for marker in (
             "approved vendor spend",
             "approved vendors",
             "approved vendor",
             "approved spend",
-            "vendor spend",
         )
     )
 
@@ -45,15 +48,45 @@ def _mentions_quarter_shorthand(normalized: str) -> bool:
     return re.search(r"\bq[1-4]\b", normalized) is not None
 
 
+def _mentions_explicit_fiscal_quarter_shorthand(normalized: str) -> bool:
+    return re.search(r"\b(?:fiscal|fy[0-9]{2,4}) q[1-4]\b", normalized) is not None
+
+
+def _mentions_ambiguous_quarter_shorthand(normalized: str) -> bool:
+    return _mentions_quarter_shorthand(
+        normalized
+    ) and not _mentions_explicit_fiscal_quarter_shorthand(normalized)
+
+
 def _mentions_ambiguity_marker(normalized: str) -> bool:
     return (
         "refund" in normalized
         or "after refunds" in normalized
         or "calendar quarter" in normalized
-        or _mentions_quarter_shorthand(normalized)
+        or _mentions_ambiguous_quarter_shorthand(normalized)
         or "top 2" in normalized
         or "top two" in normalized
         or "including ties" in normalized
+    )
+
+
+def _mentions_unapproved_vendor_spend(normalized: str) -> bool:
+    return (
+        _contains_phrase(normalized, "unapproved vendor spend")
+        or (
+            _contains_phrase(normalized, "unapproved spend")
+            and (
+                _contains_phrase(normalized, "vendor")
+                or _contains_phrase(normalized, "vendors")
+            )
+        )
+        or (
+            (
+                _contains_phrase(normalized, "unapproved vendor")
+                or _contains_phrase(normalized, "unapproved vendors")
+            )
+            and _contains_phrase(normalized, "spend")
+        )
     )
 
 
@@ -70,10 +103,9 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ),
         )
 
-    if any(
+    if _mentions_unapproved_vendor_spend(normalized) or any(
         marker in normalized
         for marker in (
-            "unapproved vendor spend",
             "bank account numbers",
             "tax identifiers",
             "ignore the system prompt",
@@ -114,7 +146,9 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             clarification="Clarify gross spend versus net-of-refunds spend before mapping.",
             **base,
         )
-    if "calendar quarter" in normalized or _mentions_quarter_shorthand(normalized):
+    if "calendar quarter" in normalized or _mentions_ambiguous_quarter_shorthand(
+        normalized
+    ):
         return IntentMappingOutput(
             status="ambiguous",
             mapping_id="clarify_calendar_vs_fiscal_quarter",
@@ -139,7 +173,10 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             **base,
         )
 
-    if "approved vendor spend" in normalized and "quarter" in normalized:
+    if _contains_phrase(normalized, "approved vendor spend") and (
+        _contains_phrase(normalized, "quarter")
+        or _mentions_explicit_fiscal_quarter_shorthand(normalized)
+    ):
         return IntentMappingOutput(
             status="mapped",
             mapping_id="approved_vendor_spend_by_fiscal_quarter",
@@ -147,8 +184,11 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             **base,
         )
     if (
-        "approved vendors" in normalized
-        and ("quarterly spend" in normalized or "quarter spend" in normalized)
+        _contains_phrase(normalized, "approved vendors")
+        and (
+            _contains_phrase(normalized, "quarterly spend")
+            or _contains_phrase(normalized, "quarter spend")
+        )
     ):
         return IntentMappingOutput(
             status="mapped",
@@ -157,7 +197,9 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
             **base,
         )
-    if "approved vendor spend" in normalized or "approved vendors" in normalized:
+    if _contains_phrase(normalized, "approved vendor spend") or _contains_phrase(
+        normalized, "approved vendors"
+    ):
         return IntentMappingOutput(
             status="mapped",
             mapping_id="approved_vendor_spend_general",

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -112,18 +112,7 @@ def _mentions_unapproved_vendor_spend(normalized: str) -> bool:
 
 
 def _mentions_approval_timing_ambiguity(normalized: str) -> bool:
-    mentions_approved_vendor_domain = (
-        (
-            _contains_phrase(normalized, "approved")
-            and (
-                _contains_phrase(normalized, "vendor")
-                or _contains_phrase(normalized, "vendors")
-                or _contains_phrase(normalized, "spend")
-            )
-        )
-        or _mentions_approved_vendor_intent(normalized)
-    )
-    return mentions_approved_vendor_domain and (
+    return _mentions_approved_vendor_intent(normalized) and (
         _contains_phrase(normalized, "when the transaction happened")
         or _contains_phrase(normalized, "transaction time")
         or _contains_phrase(normalized, "approval timestamp")

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -28,6 +28,35 @@ def _normalize_question(question: str) -> str:
     return re.sub(r"[^a-z0-9]+", " ", lowered).strip()
 
 
+def _mentions_approved_vendor_intent(normalized: str) -> bool:
+    return any(
+        marker in normalized
+        for marker in (
+            "approved vendor spend",
+            "approved vendors",
+            "approved vendor",
+            "approved spend",
+            "vendor spend",
+        )
+    )
+
+
+def _mentions_quarter_shorthand(normalized: str) -> bool:
+    return re.search(r"\bq[1-4]\b", normalized) is not None
+
+
+def _mentions_ambiguity_marker(normalized: str) -> bool:
+    return (
+        "refund" in normalized
+        or "after refunds" in normalized
+        or "calendar quarter" in normalized
+        or _mentions_quarter_shorthand(normalized)
+        or "top 2" in normalized
+        or "top two" in normalized
+        or "including ties" in normalized
+    )
+
+
 def map_question_intent(question: str, *, semantic_contract_version: str | None) -> IntentMappingOutput:
     normalized = _normalize_question(question)
     if semantic_contract_version is None:
@@ -61,6 +90,18 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ),
         )
 
+    if (
+        _mentions_ambiguity_marker(normalized)
+        and not _mentions_approved_vendor_intent(normalized)
+    ):
+        return IntentMappingOutput(
+            status="unsupported",
+            clarification=(
+                "The ambiguous concept is not bound to approved vendor spend "
+                "in the selected semantic contract."
+            ),
+        )
+
     base = {
         "metric": "sum_approved_vendor_spend",
         "filters": ["approved_spend_only"],
@@ -73,7 +114,7 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             clarification="Clarify gross spend versus net-of-refunds spend before mapping.",
             **base,
         )
-    if "calendar quarter" in normalized or " q1" in f" {normalized}":
+    if "calendar quarter" in normalized or _mentions_quarter_shorthand(normalized):
         return IntentMappingOutput(
             status="ambiguous",
             mapping_id="clarify_calendar_vs_fiscal_quarter",

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -140,6 +140,16 @@ def _mentions_vendor_normalization_ambiguity(normalized: str) -> bool:
     )
 
 
+def _unsupported_no_approved_vendor_mapping_match() -> IntentMappingOutput:
+    return IntentMappingOutput(
+        status="unsupported",
+        clarification=(
+            "The question does not match an approved vendor spend semantic "
+            "contract intent mapping."
+        ),
+    )
+
+
 def map_question_intent(question: str, *, semantic_contract_version: str | None) -> IntentMappingOutput:
     normalized = _normalize_question(question)
     if semantic_contract_version is None:
@@ -300,10 +310,4 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             dimensions=["vendor_name"],
             **base,
         )
-    return IntentMappingOutput(
-        status="unsupported",
-        clarification=(
-            "The question does not match an approved vendor spend semantic "
-            "contract intent mapping."
-        ),
-    )
+    return _unsupported_no_approved_vendor_mapping_match()

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -289,7 +289,7 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
     return IntentMappingOutput(
         status="unsupported",
         clarification=(
-            "The question does not map to an approved vendor spend semantic "
-            "contract intent."
+            "The question does not match an approved vendor spend semantic "
+            "contract intent mapping."
         ),
     )

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -44,12 +44,34 @@ def _mentions_approved_vendor_intent(normalized: str) -> bool:
     )
 
 
+def _mentions_negated_approved_vendor_intent(normalized: str) -> bool:
+    return any(
+        _contains_phrase(normalized, marker)
+        for marker in (
+            "not approved vendor spend",
+            "not approved vendors",
+            "not approved vendor",
+            "not approved spend",
+            "non approved vendor spend",
+            "non approved vendors",
+            "non approved vendor",
+            "non approved spend",
+        )
+    )
+
+
 def _mentions_quarter_shorthand(normalized: str) -> bool:
     return re.search(r"\bq[1-4]\b", normalized) is not None
 
 
 def _mentions_explicit_fiscal_quarter_shorthand(normalized: str) -> bool:
-    return re.search(r"\b(?:fiscal|fy[0-9]{2,4}) q[1-4]\b", normalized) is not None
+    return (
+        re.search(
+            r"\b(?:fiscal|fy(?: ?[0-9]{2,4})?) q[1-4]\b",
+            normalized,
+        )
+        is not None
+    )
 
 
 def _mentions_ambiguous_quarter_shorthand(normalized: str) -> bool:
@@ -103,15 +125,19 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ),
         )
 
-    if _mentions_unapproved_vendor_spend(normalized) or any(
-        marker in normalized
-        for marker in (
-            "bank account numbers",
-            "tax identifiers",
-            "ignore the system prompt",
-            "dump every approved vendor spend row",
-            "every column and every row",
-            "whatever source has the vendor spend table",
+    if (
+        _mentions_unapproved_vendor_spend(normalized)
+        or _mentions_negated_approved_vendor_intent(normalized)
+        or any(
+            marker in normalized
+            for marker in (
+                "bank account numbers",
+                "tax identifiers",
+                "ignore the system prompt",
+                "dump every approved vendor spend row",
+                "every column and every row",
+                "whatever source has the vendor spend table",
+            )
         )
     ):
         return IntentMappingOutput(
@@ -173,7 +199,10 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             **base,
         )
 
-    if _contains_phrase(normalized, "approved vendor spend") and (
+    if (
+        _contains_phrase(normalized, "approved vendor spend")
+        or _contains_phrase(normalized, "approved spend")
+    ) and (
         _contains_phrase(normalized, "quarter")
         or _mentions_explicit_fiscal_quarter_shorthand(normalized)
     ):
@@ -197,9 +226,7 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
             **base,
         )
-    if _contains_phrase(normalized, "approved vendor spend") or _contains_phrase(
-        normalized, "approved vendors"
-    ):
+    if _mentions_approved_vendor_intent(normalized):
         return IntentMappingOutput(
             status="mapped",
             mapping_id="approved_vendor_spend_general",
@@ -208,6 +235,9 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
         )
 
     return IntentMappingOutput(
-        status="mapped",
-        mapping_id="legacy_guard_evaluated_mapping",
+        status="unsupported",
+        clarification=(
+            "The question does not map to an approved vendor spend semantic "
+            "contract intent."
+        ),
     )

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from typing_extensions import Annotated
+
+
+NonEmptyTrimmedString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+IntentMappingStatus = Literal["mapped", "ambiguous", "unsupported"]
+
+
+class IntentMappingOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: IntentMappingStatus
+    mapping_id: Optional[NonEmptyTrimmedString] = None
+    metric: Optional[NonEmptyTrimmedString] = None
+    dimensions: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    filters: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    ranking_behavior_id: Optional[NonEmptyTrimmedString] = None
+    clarification: Optional[NonEmptyTrimmedString] = None
+
+
+def _normalize_question(question: str) -> str:
+    lowered = question.strip().casefold()
+    return re.sub(r"[^a-z0-9]+", " ", lowered).strip()
+
+
+def map_question_intent(question: str, *, semantic_contract_version: str | None) -> IntentMappingOutput:
+    normalized = _normalize_question(question)
+    if semantic_contract_version is None:
+        return IntentMappingOutput(status="mapped", mapping_id="legacy_unversioned_mapping")
+    if semantic_contract_version != "approved_vendor_spend.v1":
+        return IntentMappingOutput(
+            status="unsupported",
+            clarification=(
+                "No authoritative semantic contract intent mapping is available "
+                "for the selected source."
+            ),
+        )
+
+    if any(
+        marker in normalized
+        for marker in (
+            "unapproved vendor spend",
+            "bank account numbers",
+            "tax identifiers",
+            "ignore the system prompt",
+            "dump every approved vendor spend row",
+            "every column and every row",
+            "whatever source has the vendor spend table",
+        )
+    ):
+        return IntentMappingOutput(
+            status="unsupported",
+            clarification=(
+                "The question references concepts outside the approved vendor "
+                "spend semantic contract."
+            ),
+        )
+
+    base = {
+        "metric": "sum_approved_vendor_spend",
+        "filters": ["approved_spend_only"],
+    }
+    if "refund" in normalized or "after refunds" in normalized:
+        return IntentMappingOutput(
+            status="ambiguous",
+            mapping_id="clarify_refund_inclusion",
+            dimensions=["vendor_name", "fiscal_quarter"],
+            clarification="Clarify gross spend versus net-of-refunds spend before mapping.",
+            **base,
+        )
+    if "calendar quarter" in normalized or " q1" in f" {normalized}":
+        return IntentMappingOutput(
+            status="ambiguous",
+            mapping_id="clarify_calendar_vs_fiscal_quarter",
+            dimensions=["fiscal_quarter"],
+            clarification="Clarify fiscal versus calendar quarter before mapping.",
+            **base,
+        )
+    if (
+        "top 2" in normalized
+        or "top two" in normalized
+        or "including ties" in normalized
+    ):
+        return IntentMappingOutput(
+            status="ambiguous",
+            mapping_id="clarify_top_n_ties",
+            dimensions=["vendor_name", "fiscal_quarter"],
+            ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
+            clarification=(
+                "Clarify whether ties at the cutoff should be included or broken "
+                "by a stable secondary sort before mapping."
+            ),
+            **base,
+        )
+
+    if "approved vendor spend" in normalized and "quarter" in normalized:
+        return IntentMappingOutput(
+            status="mapped",
+            mapping_id="approved_vendor_spend_by_fiscal_quarter",
+            dimensions=["fiscal_quarter"],
+            **base,
+        )
+    if (
+        "approved vendors" in normalized
+        and ("quarterly spend" in normalized or "quarter spend" in normalized)
+    ):
+        return IntentMappingOutput(
+            status="mapped",
+            mapping_id="show_top_approved_vendors_by_quarterly_spend",
+            dimensions=["vendor_name", "fiscal_quarter"],
+            ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
+            **base,
+        )
+    if "approved vendor spend" in normalized or "approved vendors" in normalized:
+        return IntentMappingOutput(
+            status="mapped",
+            mapping_id="approved_vendor_spend_general",
+            dimensions=[],
+            **base,
+        )
+
+    return IntentMappingOutput(
+        status="mapped",
+        mapping_id="legacy_guard_evaluated_mapping",
+    )

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -111,6 +111,35 @@ def _mentions_unapproved_vendor_spend(normalized: str) -> bool:
     )
 
 
+def _mentions_approval_timing_ambiguity(normalized: str) -> bool:
+    mentions_approved_vendor_domain = (
+        (
+            _contains_phrase(normalized, "approved")
+            and (
+                _contains_phrase(normalized, "vendor")
+                or _contains_phrase(normalized, "vendors")
+                or _contains_phrase(normalized, "spend")
+            )
+        )
+        or _mentions_approved_vendor_intent(normalized)
+    )
+    return mentions_approved_vendor_domain and (
+        _contains_phrase(normalized, "when the transaction happened")
+        or _contains_phrase(normalized, "transaction time")
+        or _contains_phrase(normalized, "approval timestamp")
+    )
+
+
+def _mentions_vendor_normalization_ambiguity(normalized: str) -> bool:
+    return _mentions_approved_vendor_intent(normalized) and (
+        _contains_phrase(normalized, "same vendor")
+        or _contains_phrase(normalized, "normalize vendor")
+        or _contains_phrase(normalized, "normalize vendors")
+        or _contains_phrase(normalized, "vendor normalization")
+        or _contains_phrase(normalized, "vendor name normalization")
+    )
+
+
 def map_question_intent(question: str, *, semantic_contract_version: str | None) -> IntentMappingOutput:
     normalized = _normalize_question(question)
     if semantic_contract_version is None:
@@ -163,6 +192,28 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
         "metric": "sum_approved_vendor_spend",
         "filters": ["approved_spend_only"],
     }
+    if _mentions_approval_timing_ambiguity(normalized):
+        return IntentMappingOutput(
+            status="ambiguous",
+            mapping_id="clarify_approval_timing",
+            dimensions=["vendor_name"],
+            clarification=(
+                "Clarify whether approval means transaction-time approval or "
+                "current approval status before mapping."
+            ),
+            **base,
+        )
+    if _mentions_vendor_normalization_ambiguity(normalized):
+        return IntentMappingOutput(
+            status="ambiguous",
+            mapping_id="clarify_vendor_name_normalization",
+            dimensions=["vendor_name"],
+            clarification=(
+                "Clarify the authoritative vendor-normalization or vendor-master "
+                "binding before mapping."
+            ),
+            **base,
+        )
     if "refund" in normalized or "after refunds" in normalized:
         return IntentMappingOutput(
             status="ambiguous",

--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -176,10 +176,9 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ),
         )
 
-    if (
-        _mentions_ambiguity_marker(normalized)
-        and not _mentions_approved_vendor_intent(normalized)
-    ):
+    approved_vendor_intent = _mentions_approved_vendor_intent(normalized)
+
+    if _mentions_ambiguity_marker(normalized) and not approved_vendor_intent:
         return IntentMappingOutput(
             status="unsupported",
             clarification=(
@@ -214,40 +213,43 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ),
             **base,
         )
-    if "refund" in normalized or "after refunds" in normalized:
-        return IntentMappingOutput(
-            status="ambiguous",
-            mapping_id="clarify_refund_inclusion",
-            dimensions=["vendor_name", "fiscal_quarter"],
-            clarification="Clarify gross spend versus net-of-refunds spend before mapping.",
-            **base,
-        )
-    if "calendar quarter" in normalized or _mentions_ambiguous_quarter_shorthand(
-        normalized
-    ):
-        return IntentMappingOutput(
-            status="ambiguous",
-            mapping_id="clarify_calendar_vs_fiscal_quarter",
-            dimensions=["fiscal_quarter"],
-            clarification="Clarify fiscal versus calendar quarter before mapping.",
-            **base,
-        )
-    if (
-        "top 2" in normalized
-        or "top two" in normalized
-        or "including ties" in normalized
-    ):
-        return IntentMappingOutput(
-            status="ambiguous",
-            mapping_id="clarify_top_n_ties",
-            dimensions=["vendor_name", "fiscal_quarter"],
-            ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
-            clarification=(
-                "Clarify whether ties at the cutoff should be included or broken "
-                "by a stable secondary sort before mapping."
-            ),
-            **base,
-        )
+    if approved_vendor_intent:
+        if "refund" in normalized or "after refunds" in normalized:
+            return IntentMappingOutput(
+                status="ambiguous",
+                mapping_id="clarify_refund_inclusion",
+                dimensions=["vendor_name", "fiscal_quarter"],
+                clarification=(
+                    "Clarify gross spend versus net-of-refunds spend before mapping."
+                ),
+                **base,
+            )
+        if "calendar quarter" in normalized or _mentions_ambiguous_quarter_shorthand(
+            normalized
+        ):
+            return IntentMappingOutput(
+                status="ambiguous",
+                mapping_id="clarify_calendar_vs_fiscal_quarter",
+                dimensions=["fiscal_quarter"],
+                clarification="Clarify fiscal versus calendar quarter before mapping.",
+                **base,
+            )
+        if (
+            "top 2" in normalized
+            or "top two" in normalized
+            or "including ties" in normalized
+        ):
+            return IntentMappingOutput(
+                status="ambiguous",
+                mapping_id="clarify_top_n_ties",
+                dimensions=["vendor_name", "fiscal_quarter"],
+                ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
+                clarification=(
+                    "Clarify whether ties at the cutoff should be included or broken "
+                    "by a stable secondary sort before mapping."
+                ),
+                **base,
+            )
 
     if (
         _contains_phrase(normalized, "approved vendor spend")
@@ -276,7 +278,7 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
             ranking_behavior_id="top_approved_vendors_by_quarterly_spend",
             **base,
         )
-    if _mentions_approved_vendor_intent(normalized):
+    if approved_vendor_intent:
         return IntentMappingOutput(
             status="mapped",
             mapping_id="approved_vendor_spend_general",

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -464,6 +464,16 @@ def _build_preview_lifecycle_audit_events(
     return events
 
 
+def _intent_blocked_candidate_state(
+    intent_mapping: IntentMappingOutput | None,
+) -> str | None:
+    if intent_mapping is None or intent_mapping.status == "mapped":
+        return None
+    if intent_mapping.status == "ambiguous":
+        return "clarification_required"
+    return "unsupported"
+
+
 def _contract_execution_entitlement_bindings(
     dataset_contract: DatasetContract,
 ) -> list[str]:
@@ -1576,14 +1586,12 @@ def submit_preview_request(
             payload.question,
             semantic_contract_version=dataset_contract.semantic_contract_version,
         )
-        if intent_mapping.status == "ambiguous":
-            candidate_state = "clarification_required"
+        intent_blocked_candidate_state = _intent_blocked_candidate_state(
+            intent_mapping
+        )
+        if intent_blocked_candidate_state is not None:
+            candidate_state = intent_blocked_candidate_state
             request_state = "blocked"
-            intent_blocked_candidate_state = candidate_state
-        elif intent_mapping.status == "unsupported":
-            candidate_state = "unsupported"
-            request_state = "blocked"
-            intent_blocked_candidate_state = candidate_state
         else:
             try:
                 prepared_context = prepare_generation_context(
@@ -1711,14 +1719,10 @@ def submit_preview_request(
         evaluation=EvaluationRecord(
             source_id=resolved_source.source_id,
             state=(
-                "pending"
-                if guard_evaluation is None and (
-                    intent_mapping is None or intent_mapping.status == "mapped"
-                )
-                else "clarification_required"
-                if intent_mapping is not None and intent_mapping.status == "ambiguous"
-                else "unsupported"
-                if intent_mapping is not None and intent_mapping.status == "unsupported"
+                intent_blocked_candidate_state
+                if intent_blocked_candidate_state is not None
+                else "pending"
+                if guard_evaluation is None
                 else "allowed"
                 if guard_evaluation.decision == "allow"
                 else "blocked"

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -51,6 +51,7 @@ from app.services.generation_context import (
     GenerationContextPreparationError,
     prepare_generation_context,
 )
+from app.services.intent_mapping import IntentMappingOutput, map_question_intent
 from app.services.sql_generation_adapter import (
     SQLGenerationAdapter,
     SQLGenerationAdapterConfigurationError,
@@ -176,6 +177,7 @@ class CandidateRecord(BaseModel):
     state: str
     primary_deny_code: Optional[str] = None
     denial_reason: Optional[str] = None
+    intent_mapping: Optional[IntentMappingOutput] = None
     revision_context: Optional["RevisionRecord"] = None
 
 
@@ -279,6 +281,7 @@ def _build_preview_lifecycle_audit_events(
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None,
     guard_evaluation: SQLGuardEvaluation | None = None,
     candidate_sql: str | None = None,
+    intent_mapping: IntentMappingOutput | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
         return []
@@ -415,6 +418,12 @@ def _build_preview_lifecycle_audit_events(
             denial_reason=(
                 _sanitized_guard_denial_reason(guard_evaluation)
                 if event_type == "guard_evaluated"
+                else None
+            ),
+            intent_mapping=(
+                intent_mapping.model_dump(mode="json", exclude_none=True)
+                if intent_mapping is not None
+                and event_type in {"generation_requested", "generation_completed", "guard_evaluated"}
                 else None
             ),
         )
@@ -1545,71 +1554,86 @@ def submit_preview_request(
     guard_status: GuardStatus = PREVIEW_PENDING_GUARD_STATUS
     candidate_state = "preview_ready"
     request_state = "previewed"
+    intent_mapping: IntentMappingOutput | None = None
     if sql_generation_adapter is not None:
         if audit_context is None:
             raise PreviewSubmissionContractError(
                 "SQL generation preview requires an audit context."
             )
-        try:
-            prepared_context = prepare_generation_context(
-                request_id=audit_context.request_id,
-                question=payload.question,
-                source_id=resolved_source.source_id,
-                authenticated_subject=authenticated_subject,
-                session=session,
-            )
-            adapter_request = build_sql_generation_adapter_request(prepared_context)
-            adapter_response = sql_generation_adapter.generate_sql(adapter_request)
-            candidate_sql = normalize_adapter_generated_sql(
-                adapter_response.candidate_sql
-            )
-            adapter_metadata = build_sql_generation_adapter_run_metadata(
-                adapter_request=adapter_request,
-                adapter_response=adapter_response,
-                adapter_run_id=audit_context.correlation_id,
-            )
-            guard_evaluation = _evaluate_preview_sql_guard(
-                candidate_sql=candidate_sql,
-                resolved_source=resolved_source,
-            )
-            if guard_evaluation.decision == "allow":
-                guard_status = "allow"
-            else:
-                guard_status = "blocked"
-                candidate_state = "blocked"
-                request_state = "blocked"
-        except (
-            GenerationContextPreparationError,
-            SQLGenerationAdapterConfigurationError,
-        ) as exc:
-            failure_code = getattr(exc, "code", "sql_generation_context_unavailable")
-            audit_events = _build_preview_generation_failed_audit_event(
-                resolved_source=resolved_source,
-                dataset_contract=dataset_contract,
-                schema_snapshot=schema_snapshot,
-                audit_context=audit_context,
-                failure_code=failure_code,
-            )
-            _persist_preview_denial_records(
-                session,
-                payload=payload,
-                resolved_source=resolved_source,
-                dataset_contract=dataset_contract,
-                schema_snapshot=schema_snapshot,
-                authenticated_subject=authenticated_subject,
-                audit_context=audit_context,
-                audit_events=audit_events,
-                request_state="preview_generation_failed",
-                entitlement_decision="allow",
-            )
-            raise PreviewSubmissionContractError(
-                str(exc),
-                public_code="preview_generation_failed",
-                public_message=(
-                    "SQL generation failed before an authoritative preview "
-                    "candidate was created."
-                ),
-            ) from exc
+        intent_mapping = map_question_intent(
+            payload.question,
+            semantic_contract_version=dataset_contract.semantic_contract_version,
+        )
+        if intent_mapping.status == "ambiguous":
+            candidate_state = "clarification_required"
+            request_state = "blocked"
+        elif intent_mapping.status == "unsupported":
+            candidate_state = "unsupported"
+            request_state = "blocked"
+        else:
+            try:
+                prepared_context = prepare_generation_context(
+                    request_id=audit_context.request_id,
+                    question=payload.question,
+                    source_id=resolved_source.source_id,
+                    authenticated_subject=authenticated_subject,
+                    session=session,
+                )
+                adapter_request = build_sql_generation_adapter_request(
+                    prepared_context,
+                    intent_mapping=intent_mapping,
+                )
+                adapter_response = sql_generation_adapter.generate_sql(adapter_request)
+                candidate_sql = normalize_adapter_generated_sql(
+                    adapter_response.candidate_sql
+                )
+                adapter_metadata = build_sql_generation_adapter_run_metadata(
+                    adapter_request=adapter_request,
+                    adapter_response=adapter_response,
+                    adapter_run_id=audit_context.correlation_id,
+                )
+                guard_evaluation = _evaluate_preview_sql_guard(
+                    candidate_sql=candidate_sql,
+                    resolved_source=resolved_source,
+                )
+                if guard_evaluation.decision == "allow":
+                    guard_status = "allow"
+                else:
+                    guard_status = "blocked"
+                    candidate_state = "blocked"
+                    request_state = "blocked"
+            except (
+                GenerationContextPreparationError,
+                SQLGenerationAdapterConfigurationError,
+            ) as exc:
+                failure_code = getattr(exc, "code", "sql_generation_context_unavailable")
+                audit_events = _build_preview_generation_failed_audit_event(
+                    resolved_source=resolved_source,
+                    dataset_contract=dataset_contract,
+                    schema_snapshot=schema_snapshot,
+                    audit_context=audit_context,
+                    failure_code=failure_code,
+                )
+                _persist_preview_denial_records(
+                    session,
+                    payload=payload,
+                    resolved_source=resolved_source,
+                    dataset_contract=dataset_contract,
+                    schema_snapshot=schema_snapshot,
+                    authenticated_subject=authenticated_subject,
+                    audit_context=audit_context,
+                    audit_events=audit_events,
+                    request_state="preview_generation_failed",
+                    entitlement_decision="allow",
+                )
+                raise PreviewSubmissionContractError(
+                    str(exc),
+                    public_code="preview_generation_failed",
+                    public_message=(
+                        "SQL generation failed before an authoritative preview "
+                        "candidate was created."
+                    ),
+                ) from exc
 
     audit = AuditRecord(
         source_id=resolved_source.source_id,
@@ -1622,6 +1646,7 @@ def submit_preview_request(
             adapter_metadata=adapter_metadata,
             guard_evaluation=guard_evaluation,
             candidate_sql=candidate_sql,
+            intent_mapping=intent_mapping,
         ),
     )
     request_id, candidate_id = _persist_preview_submission_records(
@@ -1664,6 +1689,7 @@ def submit_preview_request(
             state=candidate_state,
             primary_deny_code=primary_deny_code,
             denial_reason=denial_reason,
+            intent_mapping=intent_mapping,
             revision_context=revision_record,
         ),
         audit=audit,
@@ -1671,7 +1697,13 @@ def submit_preview_request(
             source_id=resolved_source.source_id,
             state=(
                 "pending"
-                if guard_evaluation is None
+                if guard_evaluation is None and (
+                    intent_mapping is None or intent_mapping.status == "mapped"
+                )
+                else "clarification_required"
+                if intent_mapping is not None and intent_mapping.status == "ambiguous"
+                else "unsupported"
+                if intent_mapping is not None and intent_mapping.status == "unsupported"
                 else "allowed"
                 if guard_evaluation.decision == "allow"
                 else "blocked"

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -282,7 +282,7 @@ def _build_preview_lifecycle_audit_events(
     guard_evaluation: SQLGuardEvaluation | None = None,
     candidate_sql: str | None = None,
     intent_mapping: IntentMappingOutput | None = None,
-    generation_blocked_by_intent: bool = False,
+    intent_blocked_candidate_state: str | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
         return []
@@ -295,7 +295,7 @@ def _build_preview_lifecycle_audit_events(
         "generation_completed",
         "guard_evaluated",
     )
-    if generation_blocked_by_intent:
+    if intent_blocked_candidate_state is not None:
         event_types = ("query_submitted", "generation_requested")
 
     for event_type in event_types:
@@ -400,6 +400,11 @@ def _build_preview_lifecycle_audit_events(
             candidate_state=(
                 "generated"
                 if adapter_metadata is not None and event_type == "generation_completed"
+                else intent_blocked_candidate_state
+                if (
+                    event_type == "generation_requested"
+                    and intent_blocked_candidate_state is not None
+                )
                 else (
                     "preview_ready"
                     if guard_evaluation is None or guard_evaluation.decision == "allow"
@@ -1561,7 +1566,7 @@ def submit_preview_request(
     candidate_state = "preview_ready"
     request_state = "previewed"
     intent_mapping: IntentMappingOutput | None = None
-    generation_blocked_by_intent = False
+    intent_blocked_candidate_state: str | None = None
     if sql_generation_adapter is not None:
         if audit_context is None:
             raise PreviewSubmissionContractError(
@@ -1574,11 +1579,11 @@ def submit_preview_request(
         if intent_mapping.status == "ambiguous":
             candidate_state = "clarification_required"
             request_state = "blocked"
-            generation_blocked_by_intent = True
+            intent_blocked_candidate_state = candidate_state
         elif intent_mapping.status == "unsupported":
             candidate_state = "unsupported"
             request_state = "blocked"
-            generation_blocked_by_intent = True
+            intent_blocked_candidate_state = candidate_state
         else:
             try:
                 prepared_context = prepare_generation_context(
@@ -1656,7 +1661,7 @@ def submit_preview_request(
             guard_evaluation=guard_evaluation,
             candidate_sql=candidate_sql,
             intent_mapping=intent_mapping,
-            generation_blocked_by_intent=generation_blocked_by_intent,
+            intent_blocked_candidate_state=intent_blocked_candidate_state,
         ),
     )
     request_id, candidate_id = _persist_preview_submission_records(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -459,6 +459,25 @@ def _build_preview_lifecycle_audit_events(
     return events
 
 
+def _build_preview_intent_blocked_lifecycle_audit_events(
+    *,
+    resolved_source: RegisteredSource,
+    dataset_contract: DatasetContract,
+    schema_snapshot: SchemaSnapshot,
+    audit_context: PreviewAuditContext | None,
+    intent_mapping: IntentMappingOutput,
+    intent_blocked_candidate_state: str,
+) -> list[SourceAwareAuditEvent]:
+    return _build_preview_lifecycle_audit_events(
+        resolved_source=resolved_source,
+        dataset_contract=dataset_contract,
+        schema_snapshot=schema_snapshot,
+        audit_context=audit_context,
+        intent_mapping=intent_mapping,
+        intent_blocked_candidate_state=intent_blocked_candidate_state,
+    )
+
+
 def _preview_lifecycle_event_types(
     *,
     intent_blocked_candidate_state: str | None,
@@ -1666,10 +1685,18 @@ def submit_preview_request(
                     ),
                 ) from exc
 
-    audit = AuditRecord(
-        source_id=resolved_source.source_id,
-        state="recorded",
-        events=_build_preview_lifecycle_audit_events(
+    if intent_blocked_candidate_state is not None:
+        assert intent_mapping is not None
+        audit_events = _build_preview_intent_blocked_lifecycle_audit_events(
+            resolved_source=resolved_source,
+            dataset_contract=dataset_contract,
+            schema_snapshot=schema_snapshot,
+            audit_context=audit_context,
+            intent_mapping=intent_mapping,
+            intent_blocked_candidate_state=intent_blocked_candidate_state,
+        )
+    else:
+        audit_events = _build_preview_lifecycle_audit_events(
             resolved_source=resolved_source,
             dataset_contract=dataset_contract,
             schema_snapshot=schema_snapshot,
@@ -1678,8 +1705,12 @@ def submit_preview_request(
             guard_evaluation=guard_evaluation,
             candidate_sql=candidate_sql,
             intent_mapping=intent_mapping,
-            intent_blocked_candidate_state=intent_blocked_candidate_state,
-        ),
+        )
+
+    audit = AuditRecord(
+        source_id=resolved_source.source_id,
+        state="recorded",
+        events=audit_events,
     )
     request_id, candidate_id = _persist_preview_submission_records(
         session,

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -289,14 +289,9 @@ def _build_preview_lifecycle_audit_events(
 
     events: list[SourceAwareAuditEvent] = []
     causation_event_id: UUID | None = None
-    event_types = (
-        "query_submitted",
-        "generation_requested",
-        "generation_completed",
-        "guard_evaluated",
+    event_types = _preview_lifecycle_event_types(
+        intent_blocked_candidate_state=intent_blocked_candidate_state,
     )
-    if intent_blocked_candidate_state is not None:
-        event_types = ("query_submitted", "generation_requested")
 
     for event_type in event_types:
         execution_policy_version = (
@@ -462,6 +457,20 @@ def _build_preview_lifecycle_audit_events(
         events.append(event)
 
     return events
+
+
+def _preview_lifecycle_event_types(
+    *,
+    intent_blocked_candidate_state: str | None,
+) -> tuple[str, ...]:
+    if intent_blocked_candidate_state is not None:
+        return ("query_submitted", "generation_requested")
+    return (
+        "query_submitted",
+        "generation_requested",
+        "generation_completed",
+        "guard_evaluated",
+    )
 
 
 def _intent_blocked_candidate_state(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1616,7 +1616,7 @@ def submit_preview_request(
             intent_mapping
         )
         if intent_blocked_candidate_state is not None:
-            candidate_state = intent_blocked_candidate_state
+            candidate_state = "blocked"
             request_state = "blocked"
         else:
             try:

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -497,9 +497,7 @@ def _intent_blocked_candidate_state(
 ) -> str | None:
     if intent_mapping is None or intent_mapping.status == "mapped":
         return None
-    if intent_mapping.status == "ambiguous":
-        return "clarification_required"
-    return "unsupported"
+    return "blocked"
 
 
 def _contract_execution_entitlement_bindings(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -282,18 +282,23 @@ def _build_preview_lifecycle_audit_events(
     guard_evaluation: SQLGuardEvaluation | None = None,
     candidate_sql: str | None = None,
     intent_mapping: IntentMappingOutput | None = None,
+    generation_blocked_by_intent: bool = False,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
         return []
 
     events: list[SourceAwareAuditEvent] = []
     causation_event_id: UUID | None = None
-    for event_type in (
+    event_types = (
         "query_submitted",
         "generation_requested",
         "generation_completed",
         "guard_evaluated",
-    ):
+    )
+    if generation_blocked_by_intent:
+        event_types = ("query_submitted", "generation_requested")
+
+    for event_type in event_types:
         execution_policy_version = (
             CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY.get(
                 resolved_source.source_family
@@ -423,7 +428,8 @@ def _build_preview_lifecycle_audit_events(
             intent_mapping=(
                 intent_mapping.model_dump(mode="json", exclude_none=True)
                 if intent_mapping is not None
-                and event_type in {"generation_requested", "generation_completed", "guard_evaluated"}
+                and event_type
+                in {"generation_requested", "generation_completed", "guard_evaluated"}
                 else None
             ),
         )
@@ -1555,6 +1561,7 @@ def submit_preview_request(
     candidate_state = "preview_ready"
     request_state = "previewed"
     intent_mapping: IntentMappingOutput | None = None
+    generation_blocked_by_intent = False
     if sql_generation_adapter is not None:
         if audit_context is None:
             raise PreviewSubmissionContractError(
@@ -1567,9 +1574,11 @@ def submit_preview_request(
         if intent_mapping.status == "ambiguous":
             candidate_state = "clarification_required"
             request_state = "blocked"
+            generation_blocked_by_intent = True
         elif intent_mapping.status == "unsupported":
             candidate_state = "unsupported"
             request_state = "blocked"
+            generation_blocked_by_intent = True
         else:
             try:
                 prepared_context = prepare_generation_context(
@@ -1647,6 +1656,7 @@ def submit_preview_request(
             guard_evaluation=guard_evaluation,
             candidate_sql=candidate_sql,
             intent_mapping=intent_mapping,
+            generation_blocked_by_intent=generation_blocked_by_intent,
         ),
     )
     request_id, candidate_id = _persist_preview_submission_records(

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -20,6 +20,7 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from app.core.config import SQLGenerationProvider, SQLGenerationSettings
+from app.services.intent_mapping import IntentMappingOutput
 from app.services.generation_context import PreparedGenerationContext
 
 
@@ -65,6 +66,12 @@ class SQLGenerationAdapterRequest(BaseModel):
 
     request_id: NonEmptyTrimmedString
     question: NonEmptyTrimmedString
+    intent_mapping: IntentMappingOutput = Field(
+        default_factory=lambda: IntentMappingOutput(
+            status="mapped",
+            mapping_id="legacy_adapter_request",
+        )
+    )
     source: SQLGenerationSourceBinding
     context: SQLGenerationContextReferences
 
@@ -371,6 +378,10 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
         }
         payload: dict[str, object] = {
             "question": request.question,
+            "intent_mapping": request.intent_mapping.model_dump(
+                mode="json",
+                exclude_none=True,
+            ),
             "source": request.source.model_dump(mode="json"),
             "context": context_payload,
         }
@@ -499,10 +510,17 @@ def resolve_sql_generation_adapter(
 
 def build_sql_generation_adapter_request(
     prepared_context: PreparedGenerationContext,
+    *,
+    intent_mapping: IntentMappingOutput | None = None,
 ) -> SQLGenerationAdapterRequest:
     return SQLGenerationAdapterRequest(
         request_id=prepared_context.request.request_id,
         question=prepared_context.request.question,
+        intent_mapping=(
+            intent_mapping
+            if intent_mapping is not None
+            else IntentMappingOutput(status="mapped", mapping_id="legacy_adapter_request")
+        ),
         source=SQLGenerationSourceBinding(
             source_id=prepared_context.source.source_id,
             source_family=prepared_context.source.source_family,

--- a/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
+++ b/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
@@ -385,7 +385,7 @@
         "schema_snapshot_version": 9,
         "semantic_contract_version": "governed_answer_assurance.v1"
       },
-      "question": "Show vendors that were approved when the transaction happened.",
+      "question": "Show approved vendor spend by vendor when the transaction happened.",
       "case_type": "ambiguous",
       "source_binding": {
         "source_id": "business-postgres-source",

--- a/backend/tests/test_adapter_credential_isolation.py
+++ b/backend/tests/test_adapter_credential_isolation.py
@@ -43,6 +43,15 @@ def test_build_sql_generation_adapter_request_uses_only_adapter_safe_fields() ->
     assert adapter_request.model_dump() == {
         "request_id": "req_82_preview",
         "question": "Show approved vendors by quarterly spend",
+        "intent_mapping": {
+            "status": "mapped",
+            "mapping_id": "legacy_adapter_request",
+            "metric": None,
+            "dimensions": [],
+            "filters": [],
+            "ranking_behavior_id": None,
+            "clarification": None,
+        },
         "source": {
             "source_id": "sap-approved-spend",
             "source_family": "postgresql",

--- a/backend/tests/test_adapter_single_source_validation.py
+++ b/backend/tests/test_adapter_single_source_validation.py
@@ -37,6 +37,15 @@ def test_adapter_request_accepts_single_source_context_fragments() -> None:
     assert request.model_dump() == {
         "request_id": "req_83_preview",
         "question": "Show approved vendors by quarterly spend",
+        "intent_mapping": {
+            "status": "mapped",
+            "mapping_id": "legacy_adapter_request",
+            "metric": None,
+            "dimensions": [],
+            "filters": [],
+            "ranking_behavior_id": None,
+            "clarification": None,
+        },
         "source": {
             "source_id": "sap-approved-spend",
             "source_family": "postgresql",

--- a/backend/tests/test_dataset_contract_models.py
+++ b/backend/tests/test_dataset_contract_models.py
@@ -12,6 +12,7 @@ def test_dataset_contracts_are_scoped_to_one_registered_source() -> None:
         "registered_source_id",
         "schema_snapshot_id",
         "contract_version",
+        "semantic_contract_version",
         "display_name",
         "owner_binding",
         "security_review_binding",

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -253,9 +253,18 @@ def test_intent_mapping_fails_closed_for_unsupported_epic_aa_fixture() -> None:
     assert mapping.clarification is not None
 
 
-def test_intent_mapping_fails_closed_when_no_approved_vendor_mapping_matches() -> None:
-    mapping = map_question_intent(
+@pytest.mark.parametrize(
+    "question",
+    [
         "Show supplier refunds by region.",
+        "What is revenue by region?",
+    ],
+)
+def test_intent_mapping_fails_closed_when_no_approved_vendor_mapping_matches(
+    question: str,
+) -> None:
+    mapping = map_question_intent(
+        question,
         semantic_contract_version="approved_vendor_spend.v1",
     )
 

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -135,6 +135,26 @@ def test_intent_mapping_maps_explicit_fy_quarter_shorthand(question: str) -> Non
 @pytest.mark.parametrize(
     "question",
     [
+        "Show the top approved vendor spend records.",
+        "Show the approved vendor spend rows with the highest spend.",
+    ],
+)
+def test_intent_mapping_maps_bounded_top_approved_spend_rows(question: str) -> None:
+    mapping = map_question_intent(
+        question,
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "mapped"
+    assert mapping.mapping_id == "show_top_approved_vendor_spend_rows"
+    assert mapping.metric == "sum_approved_vendor_spend"
+    assert mapping.dimensions == ["vendor_name"]
+    assert mapping.filters == ["approved_spend_only"]
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
         "Show refund totals by fiscal quarter.",
         "Show invoice totals by calendar quarter.",
         "Show revenue for Q3.",
@@ -256,6 +276,8 @@ def test_intent_mapping_fails_closed_for_unsupported_epic_aa_fixture() -> None:
 @pytest.mark.parametrize(
     "question",
     [
+        "Show approved vendor spend.",
+        "Summarize approved vendor spend by department.",
         "Show supplier spend by region.",
         "What is revenue by region?",
     ],

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -48,7 +48,7 @@ def test_intent_mapping_keeps_ambiguous_epic_aa_fixture_in_clarification_state()
     assert mapping.clarification is not None
 
 
-def test_intent_mapping_keeps_all_quarter_shorthand_in_clarification_state() -> None:
+def test_intent_mapping_keeps_bare_quarter_shorthand_in_clarification_state() -> None:
     mapping = map_question_intent(
         "Show approved vendor spend for Q3.",
         semantic_contract_version="approved_vendor_spend.v1",
@@ -61,9 +61,61 @@ def test_intent_mapping_keeps_all_quarter_shorthand_in_clarification_state() -> 
     assert mapping.filters == ["approved_spend_only"]
 
 
+def test_intent_mapping_maps_explicit_fiscal_quarter_shorthand() -> None:
+    mapping = map_question_intent(
+        "Show approved vendor spend for fiscal Q3.",
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "mapped"
+    assert mapping.mapping_id == "approved_vendor_spend_by_fiscal_quarter"
+    assert mapping.metric == "sum_approved_vendor_spend"
+    assert mapping.dimensions == ["fiscal_quarter"]
+    assert mapping.filters == ["approved_spend_only"]
+
+
 def test_intent_mapping_fails_closed_for_unrelated_ambiguity_markers() -> None:
     mapping = map_question_intent(
         "Show refund totals by calendar quarter.",
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None
+
+
+def test_intent_mapping_fails_closed_for_generic_vendor_spend_ambiguity_marker() -> None:
+    mapping = map_question_intent(
+        "Show vendor spend by calendar quarter.",
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None
+
+
+def test_intent_mapping_matches_approved_markers_on_token_boundaries() -> None:
+    mapping = map_question_intent(
+        "Show notapproved vendor spend for Q1.",
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None
+
+
+def test_intent_mapping_fails_closed_for_hyphenated_unapproved_spend() -> None:
+    mapping = map_question_intent(
+        "Compare approved and unapproved-spend by vendor for Q1.",
         semantic_contract_version="approved_vendor_spend.v1",
     )
 

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -256,7 +256,7 @@ def test_intent_mapping_fails_closed_for_unsupported_epic_aa_fixture() -> None:
 @pytest.mark.parametrize(
     "question",
     [
-        "Show supplier refunds by region.",
+        "Show supplier spend by region.",
         "What is revenue by region?",
     ],
 )
@@ -274,3 +274,4 @@ def test_intent_mapping_fails_closed_when_no_approved_vendor_mapping_matches(
     assert mapping.dimensions == []
     assert mapping.filters == []
     assert mapping.clarification is not None
+    assert "does not match" in mapping.clarification

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.services.intent_mapping import map_question_intent
+
+
+FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "governed_answer_vendor_spend_fixtures.json"
+)
+
+
+def _fixture_question(case_type: str) -> str:
+    fixture_set = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    for fixture in fixture_set["fixtures"]:
+        if fixture["case_type"] == case_type:
+            return fixture["question"]
+    raise AssertionError(f"Expected Epic AA fixture for case_type={case_type}")
+
+
+def test_intent_mapping_maps_positive_epic_aa_fixture_to_concepts() -> None:
+    mapping = map_question_intent(
+        _fixture_question("positive"),
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.model_dump(exclude_none=True) == {
+        "status": "mapped",
+        "mapping_id": "show_top_approved_vendors_by_quarterly_spend",
+        "metric": "sum_approved_vendor_spend",
+        "dimensions": ["vendor_name", "fiscal_quarter"],
+        "filters": ["approved_spend_only"],
+        "ranking_behavior_id": "top_approved_vendors_by_quarterly_spend",
+    }
+
+
+def test_intent_mapping_keeps_ambiguous_epic_aa_fixture_in_clarification_state() -> None:
+    mapping = map_question_intent(
+        _fixture_question("ambiguous"),
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "ambiguous"
+    assert mapping.metric == "sum_approved_vendor_spend"
+    assert mapping.dimensions == ["vendor_name", "fiscal_quarter"]
+    assert mapping.filters == ["approved_spend_only"]
+    assert mapping.clarification is not None
+
+
+def test_intent_mapping_fails_closed_for_unsupported_epic_aa_fixture() -> None:
+    mapping = map_question_intent(
+        _fixture_question("unsupported_answer"),
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -48,6 +48,32 @@ def test_intent_mapping_keeps_ambiguous_epic_aa_fixture_in_clarification_state()
     assert mapping.clarification is not None
 
 
+def test_intent_mapping_keeps_all_quarter_shorthand_in_clarification_state() -> None:
+    mapping = map_question_intent(
+        "Show approved vendor spend for Q3.",
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "ambiguous"
+    assert mapping.mapping_id == "clarify_calendar_vs_fiscal_quarter"
+    assert mapping.metric == "sum_approved_vendor_spend"
+    assert mapping.dimensions == ["fiscal_quarter"]
+    assert mapping.filters == ["approved_spend_only"]
+
+
+def test_intent_mapping_fails_closed_for_unrelated_ambiguity_markers() -> None:
+    mapping = map_question_intent(
+        "Show refund totals by calendar quarter.",
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None
+
+
 def test_intent_mapping_fails_closed_for_unsupported_epic_aa_fixture() -> None:
     mapping = map_question_intent(
         _fixture_question("unsupported_answer"),

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -21,6 +21,14 @@ def _fixture_question(case_type: str) -> str:
     raise AssertionError(f"Expected Epic AA fixture for case_type={case_type}")
 
 
+def _fixture_question_by_scenario_id(scenario_id: str) -> str:
+    fixture_set = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    for fixture in fixture_set["fixtures"]:
+        if fixture["metadata"]["scenario_id"] == scenario_id:
+            return fixture["question"]
+    raise AssertionError(f"Expected Epic AA fixture for scenario_id={scenario_id}")
+
+
 def test_intent_mapping_maps_positive_epic_aa_fixture_to_concepts() -> None:
     mapping = map_question_intent(
         _fixture_question("positive"),
@@ -46,6 +54,33 @@ def test_intent_mapping_keeps_ambiguous_epic_aa_fixture_in_clarification_state()
     assert mapping.status == "ambiguous"
     assert mapping.metric == "sum_approved_vendor_spend"
     assert mapping.dimensions == ["vendor_name", "fiscal_quarter"]
+    assert mapping.filters == ["approved_spend_only"]
+    assert mapping.clarification is not None
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "expected_mapping_id"),
+    [
+        ("gavsf-007-approval-timing-ambiguity", "clarify_approval_timing"),
+        (
+            "gavsf-008-vendor-name-normalization-ambiguity",
+            "clarify_vendor_name_normalization",
+        ),
+    ],
+)
+def test_intent_mapping_keeps_named_ambiguous_epic_aa_fixtures_in_clarification_state(
+    scenario_id: str,
+    expected_mapping_id: str,
+) -> None:
+    mapping = map_question_intent(
+        _fixture_question_by_scenario_id(scenario_id),
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "ambiguous"
+    assert mapping.mapping_id == expected_mapping_id
+    assert mapping.metric == "sum_approved_vendor_spend"
+    assert mapping.dimensions == ["vendor_name"]
     assert mapping.filters == ["approved_spend_only"]
     assert mapping.clarification is not None
 

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from app.services.intent_mapping import map_question_intent
 
 
@@ -74,9 +76,20 @@ def test_intent_mapping_maps_explicit_fiscal_quarter_shorthand() -> None:
     assert mapping.filters == ["approved_spend_only"]
 
 
-def test_intent_mapping_fails_closed_for_unrelated_ambiguity_markers() -> None:
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Show refund totals by fiscal quarter.",
+        "Show invoice totals by calendar quarter.",
+        "Show revenue for Q3.",
+        "Show top 2 suppliers including ties.",
+    ],
+)
+def test_intent_mapping_fails_closed_for_unrelated_ambiguity_markers(
+    question: str,
+) -> None:
     mapping = map_question_intent(
-        "Show refund totals by calendar quarter.",
+        question,
         semantic_contract_version="approved_vendor_spend.v1",
     )
 

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -134,6 +134,29 @@ def test_intent_mapping_fails_closed_for_generic_vendor_spend_ambiguity_marker()
     assert mapping.clarification is not None
 
 
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Show approved vendors by calendar quarter.",
+        "Show approved vendor refunds by fiscal quarter.",
+        "Show top 2 approved vendors by count.",
+    ],
+)
+def test_intent_mapping_fails_closed_when_approved_vendor_prompt_lacks_spend_metric(
+    question: str,
+) -> None:
+    mapping = map_question_intent(
+        question,
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None
+
+
 def test_intent_mapping_matches_approved_markers_on_token_boundaries() -> None:
     mapping = map_question_intent(
         "Show notapproved vendor spend for Q1.",

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -79,6 +79,27 @@ def test_intent_mapping_maps_explicit_fiscal_quarter_shorthand() -> None:
 @pytest.mark.parametrize(
     "question",
     [
+        "Show approved vendor spend for FY 2025 Q1.",
+        "Show approved spend for FY25 Q1.",
+        "Show approved spend for FY Q1.",
+    ],
+)
+def test_intent_mapping_maps_explicit_fy_quarter_shorthand(question: str) -> None:
+    mapping = map_question_intent(
+        question,
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "mapped"
+    assert mapping.mapping_id == "approved_vendor_spend_by_fiscal_quarter"
+    assert mapping.metric == "sum_approved_vendor_spend"
+    assert mapping.dimensions == ["fiscal_quarter"]
+    assert mapping.filters == ["approved_spend_only"]
+
+
+@pytest.mark.parametrize(
+    "question",
+    [
         "Show refund totals by fiscal quarter.",
         "Show invoice totals by calendar quarter.",
         "Show revenue for Q3.",
@@ -139,6 +160,28 @@ def test_intent_mapping_fails_closed_for_hyphenated_unapproved_spend() -> None:
     assert mapping.clarification is not None
 
 
+@pytest.mark.parametrize(
+    "question",
+    [
+        "Show not approved spend for fiscal Q1.",
+        "Show non-approved vendor spend by quarter.",
+    ],
+)
+def test_intent_mapping_fails_closed_for_negated_approved_spend(
+    question: str,
+) -> None:
+    mapping = map_question_intent(
+        question,
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None
+
+
 def test_intent_mapping_fails_closed_for_unsupported_epic_aa_fixture() -> None:
     mapping = map_question_intent(
         _fixture_question("unsupported_answer"),
@@ -146,6 +189,20 @@ def test_intent_mapping_fails_closed_for_unsupported_epic_aa_fixture() -> None:
     )
 
     assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.clarification is not None
+
+
+def test_intent_mapping_fails_closed_when_no_approved_vendor_mapping_matches() -> None:
+    mapping = map_question_intent(
+        "Show supplier refunds by region.",
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.mapping_id is None
     assert mapping.metric is None
     assert mapping.dimensions == []
     assert mapping.filters == []

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -195,6 +195,7 @@ def test_intent_mapping_fails_closed_for_generic_vendor_spend_ambiguity_marker()
         "Show approved vendors by calendar quarter.",
         "Show approved vendor refunds by fiscal quarter.",
         "Show top 2 approved vendors by count.",
+        "Which approved vendors were active when the transaction happened?",
     ],
 )
 def test_intent_mapping_fails_closed_when_approved_vendor_prompt_lacks_spend_metric(

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -653,15 +653,37 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             else None
         )
         assert response_payload["candidate"]["intent_mapping"]["clarification"] is not None
+        assert [event["event_type"] for event in response_payload["audit"]["events"]] == [
+            "query_submitted",
+            "generation_requested",
+        ]
+        assert response_payload["audit"]["events"][1]["intent_mapping"]["status"] == (
+            expected_status
+        )
 
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
         persisted_approval = session.execute(
             select(PreviewCandidateApproval)
         ).scalar_one()
+        persisted_events = (
+            session.execute(
+                select(PreviewAuditEvent).order_by(PreviewAuditEvent.lifecycle_order)
+            )
+            .scalars()
+            .all()
+        )
         assert persisted_candidate.candidate_sql is None
         assert persisted_candidate.candidate_state == expected_state
         assert persisted_candidate.guard_status == "pending"
         assert persisted_approval.approval_state == "invalidated"
+        assert [event.event_type for event in persisted_events] == [
+            "query_submitted",
+            "generation_requested",
+        ]
+        assert persisted_events[-1].candidate_state is None
+        assert persisted_events[-1].audit_payload["intent_mapping"]["status"] == (
+            expected_status
+        )
     finally:
         session.close()
         engine.dispose()

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -569,17 +569,16 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
 
 
 @pytest.mark.parametrize(
-    ("case_type", "expected_status", "expected_state"),
+    ("case_type", "expected_status"),
     [
-        ("ambiguous", "ambiguous", "clarification_required"),
-        ("unsupported_answer", "unsupported", "unsupported"),
+        ("ambiguous", "ambiguous"),
+        ("unsupported_answer", "unsupported"),
     ],
 )
 def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped_fixtures(
     monkeypatch,
     case_type: str,
     expected_status: str,
-    expected_state: str,
 ) -> None:
     fixture = _load_governed_answer_fixture_by_case(case_type)
     monkeypatch.setenv(
@@ -643,7 +642,7 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
         response_payload = response.json()
         assert adapter.adapter_request is None
         assert response_payload["candidate"]["candidate_sql"] is None
-        assert response_payload["candidate"]["state"] == expected_state
+        assert response_payload["candidate"]["state"] == "blocked"
         assert response_payload["candidate"]["intent_mapping"]["status"] == (
             expected_status
         )
@@ -667,7 +666,7 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             expected_status
         )
         assert response_payload["audit"]["events"][1]["candidate_state"] == (
-            expected_state
+            "blocked"
         )
 
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
@@ -682,7 +681,7 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             .all()
         )
         assert persisted_candidate.candidate_sql is None
-        assert persisted_candidate.candidate_state == expected_state
+        assert persisted_candidate.candidate_state == "blocked"
         assert persisted_candidate.guard_status == "pending"
         assert persisted_approval.approval_state == "invalidated"
         assert [event.event_type for event in persisted_events] == [
@@ -693,10 +692,38 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             event.event_type for event in persisted_events
         }
         assert "guard_evaluated" not in {event.event_type for event in persisted_events}
-        assert persisted_events[-1].candidate_state == expected_state
+        assert persisted_events[-1].candidate_state == "blocked"
         assert persisted_events[-1].audit_payload["intent_mapping"]["status"] == (
             expected_status
         )
+
+        revision_response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+                "revise_from": {
+                    "item_type": "candidate",
+                    "request_id": response_payload["request"]["request_id"],
+                    "candidate_id": response_payload["candidate"]["candidate_id"],
+                    "lifecycle_state": "blocked",
+                },
+            },
+        )
+
+        assert revision_response.status_code == 200
+        revision_payload = revision_response.json()
+        assert revision_payload["candidate"]["state"] == "preview_ready"
+        assert revision_payload["candidate"]["revision_context"] == {
+            "item_type": "candidate",
+            "request_id": response_payload["request"]["request_id"],
+            "candidate_id": response_payload["candidate"]["candidate_id"],
+            "run_id": None,
+            "source_id": "sap-approved-spend",
+            "lifecycle_state": "blocked",
+        }
     finally:
         session.close()
         engine.dispose()

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -657,6 +657,12 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             "query_submitted",
             "generation_requested",
         ]
+        assert "generation_completed" not in {
+            event["event_type"] for event in response_payload["audit"]["events"]
+        }
+        assert "guard_evaluated" not in {
+            event["event_type"] for event in response_payload["audit"]["events"]
+        }
         assert response_payload["audit"]["events"][1]["intent_mapping"]["status"] == (
             expected_status
         )
@@ -683,6 +689,10 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             "query_submitted",
             "generation_requested",
         ]
+        assert "generation_completed" not in {
+            event.event_type for event in persisted_events
+        }
+        assert "guard_evaluated" not in {event.event_type for event in persisted_events}
         assert persisted_events[-1].candidate_state == expected_state
         assert persisted_events[-1].audit_payload["intent_mapping"]["status"] == (
             expected_status

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -1025,7 +1025,7 @@ def test_http_preview_guard_denied_candidate_remains_non_executable(
             headers=app_session.headers,
             cookies=app_session.cookies,
             json={
-                "question": scenario.prompt,
+                "question": "Show approved vendor spend by fiscal quarter.",
                 "source_id": scenario.source.source_id,
             },
         )

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -171,6 +171,21 @@ class _RecordingHTTPPreviewAdapter:
         )
 
 
+def _load_governed_answer_fixture_by_case(case_type: str) -> dict[str, object]:
+    fixture_path = (
+        Path(__file__).parent
+        / "fixtures"
+        / "governed_answer_vendor_spend_fixtures.json"
+    )
+    fixture_set = json.loads(fixture_path.read_text(encoding="utf-8"))
+    matching = [
+        fixture for fixture in fixture_set["fixtures"]
+        if fixture["case_type"] == case_type
+    ]
+    assert matching, f"Expected Epic AA fixture for case_type={case_type}"
+    return matching[0]
+
+
 class _FailingHTTPPreviewAdapter:
     def generate_sql(self, request):
         raise SQLGenerationAdapterConfigurationError(
@@ -444,9 +459,22 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
         assert response_payload["candidate"]["candidate_sql"] == candidate_sql
         assert response_payload["candidate"]["guard_status"] == "allow"
         assert response_payload["candidate"]["state"] == "preview_ready"
+        assert response_payload["candidate"]["intent_mapping"]["status"] == "mapped"
+        assert response_payload["candidate"]["intent_mapping"]["metric"] == (
+            "sum_approved_vendor_spend"
+        )
 
         adapter_payload = adapter.adapter_request.model_dump(mode="json")
         assert adapter_payload["request_id"] == request_id
+        assert adapter_payload["intent_mapping"] == {
+            "status": "mapped",
+            "mapping_id": "show_top_approved_vendors_by_quarterly_spend",
+            "metric": "sum_approved_vendor_spend",
+            "dimensions": ["vendor_name", "fiscal_quarter"],
+            "filters": ["approved_spend_only"],
+            "ranking_behavior_id": "top_approved_vendors_by_quarterly_spend",
+            "clarification": None,
+        }
         assert adapter_payload["source"] == {
             "source_id": "sap-approved-spend",
             "source_family": "postgresql",
@@ -533,6 +561,107 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
         assert persisted_execution_event.audit_payload["semantic_contract_version"] == (
             persisted_candidate.semantic_contract_version
         )
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("case_type", "expected_status", "expected_state"),
+    [
+        ("ambiguous", "ambiguous", "clarification_required"),
+        ("unsupported_answer", "unsupported", "unsupported"),
+    ],
+)
+def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped_fixtures(
+    monkeypatch,
+    case_type: str,
+    expected_status: str,
+    expected_state: str,
+) -> None:
+    fixture = _load_governed_answer_fixture_by_case(case_type)
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    monkeypatch.setenv(
+        "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        "postgresql://safequery_exec:secret@business-postgres-source:5432/business",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    adapter = _RecordingHTTPPreviewAdapter()
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: adapter,
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(
+            session,
+            connection_reference="env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        )
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": fixture["question"],
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 200
+        response_payload = response.json()
+        assert adapter.adapter_request is None
+        assert response_payload["candidate"]["candidate_sql"] is None
+        assert response_payload["candidate"]["state"] == expected_state
+        assert response_payload["candidate"]["intent_mapping"]["status"] == (
+            expected_status
+        )
+        assert response_payload["candidate"]["intent_mapping"]["metric"] == (
+            "sum_approved_vendor_spend"
+            if expected_status == "ambiguous"
+            else None
+        )
+        assert response_payload["candidate"]["intent_mapping"]["clarification"] is not None
+
+        persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_approval = session.execute(
+            select(PreviewCandidateApproval)
+        ).scalar_one()
+        assert persisted_candidate.candidate_sql is None
+        assert persisted_candidate.candidate_state == expected_state
+        assert persisted_candidate.guard_status == "pending"
+        assert persisted_approval.approval_state == "invalidated"
     finally:
         session.close()
         engine.dispose()

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -660,6 +660,9 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
         assert response_payload["audit"]["events"][1]["intent_mapping"]["status"] == (
             expected_status
         )
+        assert response_payload["audit"]["events"][1]["candidate_state"] == (
+            expected_state
+        )
 
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
         persisted_approval = session.execute(
@@ -680,7 +683,7 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             "query_submitted",
             "generation_requested",
         ]
-        assert persisted_events[-1].candidate_state is None
+        assert persisted_events[-1].candidate_state == expected_state
         assert persisted_events[-1].audit_payload["intent_mapping"]["status"] == (
             expected_status
         )

--- a/backend/tests/test_source_bound_records.py
+++ b/backend/tests/test_source_bound_records.py
@@ -113,6 +113,7 @@ def test_preview_submission_binds_all_records_to_authoritative_source_id() -> No
             "question": "Show approved vendors by quarterly spend",
             "request_id": payload["request"]["request_id"],
             "revision_context": None,
+            "semantic_contract_version": None,
             "source_id": "sap-approved-spend",
             "state": "submitted",
         },

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -51,6 +51,15 @@ def test_sql_generation_adapter_request_is_source_aware_and_single_source() -> N
     assert request.model_dump() == {
         "request_id": "req_79_preview",
         "question": "Show approved vendors by quarterly spend",
+        "intent_mapping": {
+            "status": "mapped",
+            "mapping_id": "legacy_adapter_request",
+            "metric": None,
+            "dimensions": [],
+            "filters": [],
+            "ranking_behavior_id": None,
+            "clarification": None,
+        },
         "source": {
             "source_id": "sap-approved-spend",
             "source_family": "postgresql",
@@ -567,6 +576,12 @@ def test_vanna_generation_uses_curated_context_and_bounded_request(
     assert seen["body"] == {
         "question": "Show approved vendors",
         "model": "warehouse-assistant",
+        "intent_mapping": {
+            "status": "mapped",
+            "mapping_id": "legacy_adapter_request",
+            "dimensions": [],
+            "filters": [],
+        },
         "source": {
             "source_id": "sap-approved-spend",
             "source_family": "postgresql",


### PR DESCRIPTION
## Summary
- add structured intent mapping output for approved vendor spend preview requests
- pass mapped metric/dimension/filter concepts into SQL generation adapter requests
- stop ambiguous and unsupported Epic AA fixture questions before SQL generation

## Verification
- python3 -m pytest tests -q