### PR TITLE
[X-5] Fail closed for unsupported business concepts

### DIFF
--- a/backend/app/services/intent_mapping.py
+++ b/backend/app/services/intent_mapping.py
@@ -21,6 +21,7 @@ class IntentMappingOutput(BaseModel):
     filters: list[NonEmptyTrimmedString] = Field(default_factory=list)
     ranking_behavior_id: Optional[NonEmptyTrimmedString] = None
     clarification: Optional[NonEmptyTrimmedString] = None
+    unsupported_concepts: Optional[list[NonEmptyTrimmedString]] = None
 
 
 def _normalize_question(question: str) -> str:
@@ -139,6 +140,60 @@ def _unsupported_no_approved_vendor_mapping_match() -> IntentMappingOutput:
     )
 
 
+def _unsupported_business_concept_match(
+    unsupported_concepts: list[str],
+) -> IntentMappingOutput:
+    return IntentMappingOutput(
+        status="unsupported",
+        unsupported_concepts=unsupported_concepts,
+        clarification=(
+            "The requested business concept is not approved for the selected "
+            "semantic contract."
+        ),
+    )
+
+
+def _unsupported_metric_concepts(normalized: str) -> list[str]:
+    concepts: list[str] = []
+    if _contains_phrase(normalized, "revenue"):
+        concepts.append("metric:revenue")
+    if _contains_phrase(normalized, "invoice totals") or _contains_phrase(
+        normalized, "invoice total"
+    ):
+        concepts.append("metric:invoice_total")
+    if _contains_phrase(normalized, "supplier spend"):
+        concepts.append("metric:supplier_spend")
+    if _contains_phrase(normalized, "vendor count") or (
+        _contains_phrase(normalized, "by count")
+        and (
+            _contains_phrase(normalized, "vendor")
+            or _contains_phrase(normalized, "vendors")
+        )
+    ):
+        concepts.append("metric:vendor_count")
+    return concepts
+
+
+def _unsupported_dimension_concepts(normalized: str) -> list[str]:
+    concepts: list[str] = []
+    if _contains_phrase(normalized, "department"):
+        concepts.append("dimension:department")
+    if _contains_phrase(normalized, "region"):
+        concepts.append("dimension:region")
+    return concepts
+
+
+def _unsupported_business_concepts(normalized: str) -> list[str]:
+    return list(
+        dict.fromkeys(
+            [
+                *_unsupported_metric_concepts(normalized),
+                *_unsupported_dimension_concepts(normalized),
+            ]
+        )
+    )
+
+
 def map_question_intent(question: str, *, semantic_contract_version: str | None) -> IntentMappingOutput:
     normalized = _normalize_question(question)
     if semantic_contract_version is None:
@@ -151,6 +206,10 @@ def map_question_intent(question: str, *, semantic_contract_version: str | None)
                 "for the selected source."
             ),
         )
+
+    unsupported_concepts = _unsupported_business_concepts(normalized)
+    if unsupported_concepts:
+        return _unsupported_business_concept_match(unsupported_concepts)
 
     if (
         _mentions_unapproved_vendor_spend(normalized)

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -88,6 +88,18 @@ _SQL_GUARD_EVALUATOR_BY_SOURCE_FAMILY = {
     "mssql": evaluate_mssql_sql_guard,
     "postgresql": evaluate_postgresql_sql_guard,
 }
+_INTENT_DENIAL_CODE_BY_STATUS = {
+    "ambiguous": "DENY_AMBIGUOUS_INTENT",
+    "unsupported": "DENY_UNSUPPORTED_INTENT",
+}
+_INTENT_DENIAL_CAUSE_BY_STATUS = {
+    "ambiguous": "ambiguous_intent",
+    "unsupported": "unsupported_intent",
+}
+_DEFAULT_INTENT_DENIAL_REASON_BY_STATUS = {
+    "ambiguous": "The requested business concept requires clarification before SQL generation.",
+    "unsupported": "The requested business concept is not approved for the selected semantic contract.",
+}
 
 
 def _resolve_sql_guard_controls(source_family: str) -> tuple[str, Any]:
@@ -135,6 +147,36 @@ def _primary_guard_deny_code(
     ):
         return None
     return guard_evaluation.rejections[0].code
+
+
+def _intent_denial_code(intent_mapping: IntentMappingOutput | None) -> str | None:
+    if intent_mapping is None or intent_mapping.status == "mapped":
+        return None
+    return _INTENT_DENIAL_CODE_BY_STATUS[intent_mapping.status]
+
+
+def _intent_denial_cause(intent_mapping: IntentMappingOutput | None) -> str | None:
+    if intent_mapping is None or intent_mapping.status == "mapped":
+        return None
+    return _INTENT_DENIAL_CAUSE_BY_STATUS[intent_mapping.status]
+
+
+def _intent_denial_reason(intent_mapping: IntentMappingOutput | None) -> str | None:
+    if intent_mapping is None or intent_mapping.status == "mapped":
+        return None
+    reason = (intent_mapping.clarification or "").strip()
+    if not reason:
+        reason = _DEFAULT_INTENT_DENIAL_REASON_BY_STATUS[intent_mapping.status]
+    if (
+        _RAW_WORKSTATION_PATH_PATTERN.search(reason)
+        or _CREDENTIAL_MARKER_PATTERN.search(reason)
+    ):
+        return _DEFAULT_INTENT_DENIAL_REASON_BY_STATUS[intent_mapping.status]
+    if len(reason) > _MAX_DENIAL_REASON_LENGTH:
+        suffix = "..."
+        max_prefix = max(1, _MAX_DENIAL_REASON_LENGTH - len(suffix))
+        return f"{reason[:max_prefix].rstrip()}{suffix}"
+    return reason
 
 
 class PreviewSubmissionRequest(BaseModel):
@@ -411,6 +453,11 @@ def _build_preview_lifecycle_audit_events(
             primary_deny_code=(
                 _primary_guard_deny_code(guard_evaluation)
                 if event_type == "guard_evaluated"
+                else _intent_denial_code(intent_mapping)
+                if (
+                    event_type == "generation_requested"
+                    and intent_blocked_candidate_state is not None
+                )
                 else None
             ),
             denial_cause=(
@@ -418,11 +465,21 @@ def _build_preview_lifecycle_audit_events(
                 if event_type == "guard_evaluated"
                 and guard_evaluation is not None
                 and guard_evaluation.decision != "allow"
+                else _intent_denial_cause(intent_mapping)
+                if (
+                    event_type == "generation_requested"
+                    and intent_blocked_candidate_state is not None
+                )
                 else None
             ),
             denial_reason=(
                 _sanitized_guard_denial_reason(guard_evaluation)
                 if event_type == "guard_evaluated"
+                else _intent_denial_reason(intent_mapping)
+                if (
+                    event_type == "generation_requested"
+                    and intent_blocked_candidate_state is not None
+                )
                 else None
             ),
             intent_mapping=(
@@ -1727,6 +1784,18 @@ def submit_preview_request(
     )
     primary_deny_code = _primary_guard_deny_code(guard_evaluation)
     denial_reason = _sanitized_guard_denial_reason(guard_evaluation)
+    if intent_blocked_candidate_state is not None:
+        primary_deny_code = _intent_denial_code(intent_mapping)
+        denial_reason = _intent_denial_reason(intent_mapping)
+    evaluation_state = (
+        _intent_denial_cause(intent_mapping)
+        if intent_blocked_candidate_state is not None
+        else "pending"
+        if guard_evaluation is None
+        else "allowed"
+        if guard_evaluation.decision == "allow"
+        else "blocked"
+    )
 
     return PreviewSubmissionResponse(
         request=RequestRecord(
@@ -1756,15 +1825,7 @@ def submit_preview_request(
         audit=audit,
         evaluation=EvaluationRecord(
             source_id=resolved_source.source_id,
-            state=(
-                intent_blocked_candidate_state
-                if intent_blocked_candidate_state is not None
-                else "pending"
-                if guard_evaluation is None
-                else "allowed"
-                if guard_evaluation.decision == "allow"
-                else "blocked"
-            ),
+            state=evaluation_state,
             primary_deny_code=primary_deny_code,
             denial_reason=denial_reason,
         ),

--- a/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
+++ b/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
@@ -55,9 +55,9 @@
     ]
   },
   "authoring_summary": {
-    "fixture_count": 14,
-    "estimated_authoring_minutes": 165,
-    "estimated_review_minutes": 100,
+    "fixture_count": 16,
+    "estimated_authoring_minutes": 187,
+    "estimated_review_minutes": 112,
     "domain_expert_review_fixture_ids": [
       "gavsf-004-refund-inclusion-ambiguity",
       "gavsf-005-calendar-vs-fiscal-quarter-ambiguity",
@@ -68,7 +68,7 @@
     "review_notes": [
       "Positive fixtures capture known result shapes for the approved fiscal-quarter spend contract.",
       "Clarification fixtures preserve refund, calendar-versus-fiscal quarter, approval-timing, vendor-normalization, and top-N tie ambiguities instead of allowing speculative SQL.",
-      "Unsupported and unsafe fixtures prove the fixture set keeps unapproved spend and mutations outside the governed answer boundary.",
+      "Unsupported and unsafe fixtures prove the fixture set keeps unapproved spend, unapproved metrics, unapproved dimensions, and mutations outside the governed answer boundary.",
       "Adversarial fixtures carry reviewer-readable denial reasons for source confusion, prompt injection, ignore-policy attempts, sensitive columns, mutations, and unbounded broad requests."
     ]
   },
@@ -287,6 +287,101 @@
       "expected_correctness_level": "deny_required",
       "expected_failure_mode": "unsupported_answer_denial_required",
       "human_authoring_minutes": 13,
+      "domain_expert_review_required": false
+    },
+    {
+      "metadata": {
+        "scenario_id": "gavsf-015-unapproved-revenue-metric-denied",
+        "source_id": "business-postgres-source",
+        "schema_snapshot_version": 9,
+        "semantic_contract_version": "governed_answer_assurance.v1"
+      },
+      "question": "What is revenue by region?",
+      "case_type": "unsupported_answer",
+      "source_binding": {
+        "source_id": "business-postgres-source",
+        "schema": "finance",
+        "table": "approved_vendor_spend"
+      },
+      "expected_intent": "The user asks for revenue and region concepts that are not approved by the vendor spend semantic contract.",
+      "expected_semantic_mapping": {
+        "metric": "revenue",
+        "dimensions": [
+          "region"
+        ],
+        "filters": []
+      },
+      "acceptable_sql_shape": {
+        "must_not_execute": true,
+        "required_denial": "Reject revenue and region until an approved semantic contract explicitly defines those concepts.",
+        "must_not_reference": [
+          "revenue",
+          "region",
+          "inferred finance tables"
+        ]
+      },
+      "expected_result_shape": {
+        "response_type": "deny",
+        "must_name_missing_prerequisites": [
+          "approved revenue metric",
+          "approved region dimension"
+        ]
+      },
+      "forbidden_answer_claims": [
+        "Do not infer revenue from approved vendor spend.",
+        "Do not invent a region dimension from source-adjacent metadata."
+      ],
+      "expected_correctness_level": "deny_required",
+      "expected_failure_mode": "unsupported_answer_denial_required",
+      "human_authoring_minutes": 11,
+      "domain_expert_review_required": false
+    },
+    {
+      "metadata": {
+        "scenario_id": "gavsf-016-unapproved-department-dimension-denied",
+        "source_id": "business-postgres-source",
+        "schema_snapshot_version": 9,
+        "semantic_contract_version": "governed_answer_assurance.v1"
+      },
+      "question": "Summarize approved vendor spend by department.",
+      "case_type": "unsupported_answer",
+      "source_binding": {
+        "source_id": "business-postgres-source",
+        "schema": "finance",
+        "table": "approved_vendor_spend"
+      },
+      "expected_intent": "The user asks to group an approved metric by a department dimension that is not approved by the semantic contract.",
+      "expected_semantic_mapping": {
+        "metric": "sum_approved_vendor_spend",
+        "dimensions": [
+          "department"
+        ],
+        "filters": [
+          "approved_spend_only"
+        ]
+      },
+      "acceptable_sql_shape": {
+        "must_not_execute": true,
+        "required_denial": "Reject department grouping until the semantic contract approves a department dimension for approved vendor spend.",
+        "must_not_reference": [
+          "department",
+          "cost_center",
+          "inferred organization hierarchy"
+        ]
+      },
+      "expected_result_shape": {
+        "response_type": "deny",
+        "must_name_missing_prerequisites": [
+          "approved department dimension"
+        ]
+      },
+      "forbidden_answer_claims": [
+        "Do not infer department from vendor names.",
+        "Do not group approved spend by an unapproved organization field."
+      ],
+      "expected_correctness_level": "deny_required",
+      "expected_failure_mode": "unsupported_answer_denial_required",
+      "human_authoring_minutes": 11,
       "domain_expert_review_required": false
     },
     {

--- a/backend/tests/test_adapter_credential_isolation.py
+++ b/backend/tests/test_adapter_credential_isolation.py
@@ -51,6 +51,7 @@ def test_build_sql_generation_adapter_request_uses_only_adapter_safe_fields() ->
             "filters": [],
             "ranking_behavior_id": None,
             "clarification": None,
+            "unsupported_concepts": None,
         },
         "source": {
             "source_id": "sap-approved-spend",

--- a/backend/tests/test_adapter_single_source_validation.py
+++ b/backend/tests/test_adapter_single_source_validation.py
@@ -45,6 +45,7 @@ def test_adapter_request_accepts_single_source_context_fragments() -> None:
             "filters": [],
             "ranking_behavior_id": None,
             "clarification": None,
+            "unsupported_concepts": None,
         },
         "source": {
             "source_id": "sap-approved-spend",

--- a/backend/tests/test_governed_answer_fixtures.py
+++ b/backend/tests/test_governed_answer_fixtures.py
@@ -124,7 +124,7 @@ def test_governed_answer_vendor_spend_fixture_set_is_schema_valid() -> None:
     assert fixture_set["source_profile"]["execution_policy_version"] == 3
 
     fixtures = fixture_set["fixtures"]
-    assert 5 <= len(fixtures) <= 14
+    assert 5 <= len(fixtures) <= 16
     assert fixture_set["authoring_summary"]["fixture_count"] == len(fixtures)
     fixture_ids = {fixture["metadata"]["scenario_id"] for fixture in fixtures}
     assert len(fixture_ids) == len(fixtures)
@@ -215,6 +215,8 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
         "gavsf-007-approval-timing-ambiguity",
         "gavsf-008-vendor-name-normalization-ambiguity",
         "gavsf-009-top-n-tie-handling-ambiguity",
+        "gavsf-015-unapproved-revenue-metric-denied",
+        "gavsf-016-unapproved-department-dimension-denied",
     }
     assert required_scenario_ids <= fixtures_by_id.keys()
 
@@ -290,6 +292,17 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
     assert "unapproved vendor spend" in " ".join(
         approval_distinction["expected_result_shape"]["must_name_missing_prerequisites"]
     )
+
+    unsupported_revenue = fixtures_by_id["gavsf-015-unapproved-revenue-metric-denied"]
+    unsupported_department = fixtures_by_id[
+        "gavsf-016-unapproved-department-dimension-denied"
+    ]
+    for unsupported_fixture in (unsupported_revenue, unsupported_department):
+        assert unsupported_fixture["case_type"] == "unsupported_answer"
+        assert unsupported_fixture["expected_failure_mode"] == (
+            "unsupported_answer_denial_required"
+        )
+        assert unsupported_fixture["acceptable_sql_shape"]["must_not_execute"] is True
 
     refund_ambiguity = fixtures_by_id["gavsf-004-refund-inclusion-ambiguity"]
     quarter_ambiguity = fixtures_by_id[

--- a/backend/tests/test_intent_mapping.py
+++ b/backend/tests/test_intent_mapping.py
@@ -297,4 +297,37 @@ def test_intent_mapping_fails_closed_when_no_approved_vendor_mapping_matches(
     assert mapping.dimensions == []
     assert mapping.filters == []
     assert mapping.clarification is not None
-    assert "does not match" in mapping.clarification
+    if mapping.unsupported_concepts:
+        assert "not approved" in mapping.clarification
+    else:
+        assert "does not match" in mapping.clarification
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "expected_unsupported_concepts"),
+    [
+        (
+            "gavsf-015-unapproved-revenue-metric-denied",
+            ["metric:revenue", "dimension:region"],
+        ),
+        (
+            "gavsf-016-unapproved-department-dimension-denied",
+            ["dimension:department"],
+        ),
+    ],
+)
+def test_intent_mapping_records_unsupported_metric_and_dimension_concepts(
+    scenario_id: str,
+    expected_unsupported_concepts: list[str],
+) -> None:
+    mapping = map_question_intent(
+        _fixture_question_by_scenario_id(scenario_id),
+        semantic_contract_version="approved_vendor_spend.v1",
+    )
+
+    assert mapping.status == "unsupported"
+    assert mapping.metric is None
+    assert mapping.dimensions == []
+    assert mapping.filters == []
+    assert mapping.unsupported_concepts == expected_unsupported_concepts
+    assert mapping.clarification is not None

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -186,6 +186,24 @@ def _load_governed_answer_fixture_by_case(case_type: str) -> dict[str, object]:
     return matching[0]
 
 
+def _load_governed_answer_fixture_by_scenario_id(
+    scenario_id: str,
+) -> dict[str, object]:
+    fixture_path = (
+        Path(__file__).parent
+        / "fixtures"
+        / "governed_answer_vendor_spend_fixtures.json"
+    )
+    fixture_set = json.loads(fixture_path.read_text(encoding="utf-8"))
+    matching = [
+        fixture
+        for fixture in fixture_set["fixtures"]
+        if fixture["metadata"]["scenario_id"] == scenario_id
+    ]
+    assert matching, f"Expected Epic AA fixture for scenario_id={scenario_id}"
+    return matching[0]
+
+
 class _FailingHTTPPreviewAdapter:
     def generate_sql(self, request):
         raise SQLGenerationAdapterConfigurationError(
@@ -474,6 +492,7 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
             "filters": ["approved_spend_only"],
             "ranking_behavior_id": "top_approved_vendors_by_quarterly_spend",
             "clarification": None,
+            "unsupported_concepts": None,
         }
         assert adapter_payload["source"] == {
             "source_id": "sap-approved-spend",
@@ -724,6 +743,144 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             "source_id": "sap-approved-spend",
             "lifecycle_state": "blocked",
         }
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "expected_unsupported_concepts"),
+    [
+        (
+            "gavsf-015-unapproved-revenue-metric-denied",
+            ["metric:revenue", "dimension:region"],
+        ),
+        (
+            "gavsf-016-unapproved-department-dimension-denied",
+            ["dimension:department"],
+        ),
+    ],
+)
+def test_http_preview_unsupported_business_concepts_have_distinct_failure_surface(
+    monkeypatch,
+    scenario_id: str,
+    expected_unsupported_concepts: list[str],
+) -> None:
+    fixture = _load_governed_answer_fixture_by_scenario_id(scenario_id)
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    monkeypatch.setenv(
+        "SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        "postgresql://safequery_exec:secret@business-postgres-source:5432/business",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+    adapter = _RecordingHTTPPreviewAdapter()
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: adapter,
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(
+            session,
+            connection_reference="env:SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL",
+        )
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": fixture["question"],
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 200
+        response_payload = response.json()
+        assert adapter.adapter_request is None
+        assert response_payload["candidate"]["candidate_sql"] is None
+        assert response_payload["candidate"]["state"] == "blocked"
+        assert response_payload["candidate"]["primary_deny_code"] == (
+            "DENY_UNSUPPORTED_INTENT"
+        )
+        assert "not approved" in response_payload["candidate"]["denial_reason"]
+        assert response_payload["evaluation"] == {
+            "source_id": "sap-approved-spend",
+            "state": "unsupported_intent",
+            "primary_deny_code": "DENY_UNSUPPORTED_INTENT",
+            "denial_reason": response_payload["candidate"]["denial_reason"],
+        }
+        assert response_payload["candidate"]["intent_mapping"][
+            "unsupported_concepts"
+        ] == expected_unsupported_concepts
+        assert [event["event_type"] for event in response_payload["audit"]["events"]] == [
+            "query_submitted",
+            "generation_requested",
+        ]
+        unsupported_event = response_payload["audit"]["events"][1]
+        assert unsupported_event["primary_deny_code"] == "DENY_UNSUPPORTED_INTENT"
+        assert unsupported_event["denial_cause"] == "unsupported_intent"
+        assert unsupported_event["denial_reason"] == response_payload["candidate"][
+            "denial_reason"
+        ]
+        assert unsupported_event["intent_mapping"]["unsupported_concepts"] == (
+            expected_unsupported_concepts
+        )
+        assert "generation_completed" not in {
+            event["event_type"] for event in response_payload["audit"]["events"]
+        }
+        assert "guard_evaluated" not in {
+            event["event_type"] for event in response_payload["audit"]["events"]
+        }
+
+        persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_events = (
+            session.execute(
+                select(PreviewAuditEvent).order_by(PreviewAuditEvent.lifecycle_order)
+            )
+            .scalars()
+            .all()
+        )
+        assert persisted_candidate.candidate_sql is None
+        assert persisted_candidate.candidate_state == "blocked"
+        assert persisted_candidate.guard_status == "pending"
+        assert persisted_events[-1].event_type == "generation_requested"
+        assert persisted_events[-1].primary_deny_code == "DENY_UNSUPPORTED_INTENT"
+        assert persisted_events[-1].denial_cause == "unsupported_intent"
+        assert persisted_events[-1].audit_payload["intent_mapping"][
+            "unsupported_concepts"
+        ] == expected_unsupported_concepts
     finally:
         session.close()
         engine.dispose()

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -59,6 +59,7 @@ def test_sql_generation_adapter_request_is_source_aware_and_single_source() -> N
             "filters": [],
             "ranking_behavior_id": None,
             "clarification": None,
+            "unsupported_concepts": None,
         },
         "source": {
             "source_id": "sap-approved-spend",


### PR DESCRIPTION
## Summary
- fail closed before SQL generation when requested metric or dimension concepts are not approved by the semantic contract
- add distinct unsupported/ambiguous intent deny code, cause, reason, and audit payload surface separate from SQL Guard denial
- add negative governed-answer fixtures and API coverage for unsupported revenue/region and department requests

## Verification
- PYTHONPATH=. python3 -m pytest tests/test_intent_mapping.py tests/test_preview_persistence.py tests/test_governed_answer_fixtures.py tests/test_sql_generation_adapter_request.py tests/test_adapter_credential_isolation.py tests/test_adapter_single_source_validation.py -q

Closes #442