### PR TITLE
[X-6] make connector activation gate semantic-contract-aware

### DIFF
--- a/docs/design/source-family-activation-selection.md
+++ b/docs/design/source-family-activation-selection.md
@@ -39,6 +39,10 @@ The recommendation depends on these Epic V sources:
 - `evaluation-harness.md`: requires positive, deny, malformed, metadata-only,
   schema-bound, runtime-unavailable, audit reconstruction, release-gate
   reconstruction, and operator-history coverage before activation.
+- `ADR-0015-semantic-contract-and-sql-guard-responsibility.md`: defines the
+  boundary that SQL safety does not prove business-intent correctness and that
+  semantic-contract readiness is required for Level 2 or Level 3 governed
+  answer assurance.
 
 Aurora PostgreSQL is selected for active implementation planning because it has
 the smallest safe planning distance from an existing active baseline:
@@ -50,6 +54,10 @@ the smallest safe planning distance from an existing active baseline:
   Aurora endpoint posture, TLS posture, engine version, timeout behavior,
   cancellation behavior, connector profile evidence, and flavor regression
   coverage.
+- Aurora can inherit PostgreSQL SQL Guard posture only for Level 1 SQL safety
+  until a reviewed semantic contract is bound to the source record. Without
+  semantic-contract readiness, Aurora PostgreSQL must not claim Level 2 or
+  Level 3 governed answer assurance.
 - The decision avoids treating MySQL-family or Oracle-specific dialect work as
   implicitly solved by nearby roadmap text.
 
@@ -122,6 +130,9 @@ The packet should include:
   secret reference pattern without exposing secret values
 - connector-profile and dialect-profile version plan showing exactly what is
   inherited from PostgreSQL and what is Aurora-specific
+- semantic-contract readiness summary that identifies approved mappings,
+  versioning, unsupported-intent handling, and whether the candidate is limited
+  to Level 1 SQL safety only
 - fixture manifest covering allow, deny, malformed, metadata-only,
   schema-bound, runtime-unavailable, audit reconstruction, release-gate
   reconstruction, and operator-history scenarios

--- a/docs/design/target-source-registry.md
+++ b/docs/design/target-source-registry.md
@@ -87,15 +87,22 @@ Activation states:
   hint, source label, driver name, or connection shape claims it is available.
 - `activation-candidate`: all required evidence has been assembled for review,
   but connector dispatch remains disabled until the gate is approved.
-- `active-baseline`: the backend-owned registry, connector, guard, audit,
-  evaluation, dataset, and runtime controls are approved together and covered by
-  release-gate reconstruction.
+- `active-baseline`: the backend-owned registry, connector, guard, semantic
+  contract, audit, evaluation, dataset, and runtime controls are approved
+  together and covered by release-gate reconstruction.
 
 Required readiness evidence before `active-baseline`:
 
 - Guard readiness: the family has an approved dialect profile, canonicalization
   behavior, deny catalog mapping, deny corpus, parser-failure behavior, and
   profile-version drift test. The explicit blocker is missing guard readiness.
+- Semantic-contract readiness: the family or explicitly approved flavor
+  inheritance has approved semantic mappings, forward-only contract versioning,
+  historical reconstruction behavior, unsupported-intent handling, and release
+  evidence tied to the active source record. The explicit blocker is missing
+  semantic-contract readiness. Sources without semantic contracts may claim
+  Level 1 SQL safety only; they must not claim Level 2 or Level 3 governed
+  answer assurance.
 - Runtime readiness: the family has backend-owned connector selection, driver
   availability checks, timeout handling, cancellation behavior, source
   unavailable classification, rate or concurrency limits where applicable, and
@@ -157,10 +164,10 @@ No planned or unsupported family may dispatch connector code, appear in active
 execution coverage, or be treated as runtime-capable because it appears in a
 roadmap, matrix, sample config, adapter output, analyst artifact, MLflow trace,
 or operator-facing label. `activation-candidate` is also non-executable until
-the gate is approved. If any required guard, runtime, secrets, audit,
-evaluation, dataset-contract, or row-bounds evidence is missing, malformed,
-stale, or only inferred from a non-authoritative surface, SafeQuery must reject
-activation and keep the family non-executable.
+the gate is approved. If any required guard, semantic-contract, runtime,
+secrets, audit, evaluation, dataset-contract, or row-bounds evidence is missing,
+malformed, stale, or only inferred from a non-authoritative surface, SafeQuery
+must reject activation and keep the family non-executable.
 
 Runtime and secret evidence must be family-specific before activation:
 

--- a/tests/test_source_family_activation_criteria_docs.py
+++ b/tests/test_source_family_activation_criteria_docs.py
@@ -26,6 +26,7 @@ def test_future_source_family_activation_gate_is_documented() -> None:
 
     required_categories = [
         "Guard readiness",
+        "Semantic-contract readiness",
         "Runtime readiness",
         "Secrets readiness",
         "Audit readiness",
@@ -38,6 +39,7 @@ def test_future_source_family_activation_gate_is_documented() -> None:
 
     fail_closed_blockers = [
         "missing guard readiness",
+        "missing semantic-contract readiness",
         "missing runtime readiness",
         "missing secrets readiness",
         "missing audit readiness",
@@ -50,6 +52,14 @@ def test_future_source_family_activation_gate_is_documented() -> None:
 
     assert (
         "No planned or unsupported family may dispatch connector code"
+        in normalized_activation_section
+    )
+    assert (
+        "Sources without semantic contracts may claim Level 1 SQL safety only"
+        in normalized_activation_section
+    )
+    assert (
+        "must not claim Level 2 or Level 3 governed answer assurance"
         in normalized_activation_section
     )
 

--- a/tests/test_source_family_activation_selection_docs.py
+++ b/tests/test_source_family_activation_selection_docs.py
@@ -27,8 +27,13 @@ def test_first_planning_candidate_selection_is_recorded() -> None:
         "dialect-capability-matrix.md",
         "dialect-guard-readiness-checklists.md",
         "evaluation-harness.md",
+        "ADR-0015-semantic-contract-and-sql-guard-responsibility.md",
     ]:
         assert source in content
+
+    assert "semantic-contract readiness" in normalized
+    assert "Level 1 SQL safety only" in normalized
+    assert "Level 2 or Level 3 governed answer assurance" in normalized
 
 
 def test_deferred_families_have_explicit_blockers() -> None:
@@ -93,6 +98,7 @@ def test_next_roadmap_handoff_artifact_is_defined() -> None:
         "flavor-specific runtime readiness plan",
         "backend-owned secret indirection plan",
         "fixture manifest",
+        "semantic-contract readiness summary",
         "release-gate reconstruction plan",
         "operator-history checklist",
         "must be reviewed before active connector implementation is scoped",


### PR DESCRIPTION
## Summary
- add semantic-contract readiness to the future source-family activation gate
- clarify that sources without semantic contracts can claim Level 1 SQL safety only, not Level 2 or Level 3 governed answer assurance
- link the Epic V Aurora PostgreSQL planning handoff to ADR-0015 semantic-contract readiness

## Verification
- python3 -m pytest tests/test_source_family_activation_criteria_docs.py tests/test_source_family_activation_selection_docs.py -q
- python3 -m pytest tests/test_source_family_activation_criteria_docs.py tests/test_source_family_activation_selection_docs.py tests/test_dialect_guard_readiness_checklist_docs.py tests/test_connector_threat_model_docs.py -q
- python3 -m pytest tests/test_check_repository_hygiene.py -q
- bash tests/smoke/test-semantic-contract-adr.sh

Closes #443