### PR TITLE
[Y-1] Add review LLM adapter contract

### DIFF
--- a/backend/app/features/review_llm/__init__.py
+++ b/backend/app/features/review_llm/__init__.py
@@ -1,0 +1,15 @@
+"""Review LLM critique-only adapter contracts."""
+
+from app.features.review_llm.schema import (
+    ReviewLLMAdapterDiagnostics,
+    ReviewLLMAdapterOutput,
+    ReviewLLMAdapterOutputError,
+    parse_review_llm_adapter_output,
+)
+
+__all__ = [
+    "ReviewLLMAdapterDiagnostics",
+    "ReviewLLMAdapterOutput",
+    "ReviewLLMAdapterOutputError",
+    "parse_review_llm_adapter_output",
+]

--- a/backend/app/features/review_llm/schema.py
+++ b/backend/app/features/review_llm/schema.py
@@ -99,7 +99,7 @@ def parse_review_llm_adapter_output(
 
     try:
         return ReviewLLMAdapterOutput.model_validate(decoded)
-    except ValidationError as exc:
+    except (RecursionError, ValidationError) as exc:
         raise ReviewLLMAdapterOutputError(
             f"Review LLM adapter output is malformed: {exc}"
         ) from exc
@@ -113,7 +113,12 @@ def _decode_review_llm_output(
 
     try:
         decoded = json.loads(output)
-    except (TypeError, json.JSONDecodeError) as exc:
+    except (
+        RecursionError,
+        TypeError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as exc:
         raise ReviewLLMAdapterOutputError(
             "Review LLM adapter output is malformed: expected a JSON object."
         ) from exc
@@ -127,22 +132,35 @@ def _decode_review_llm_output(
 
 
 def _find_execution_authority_key(value: object) -> str | None:
-    if isinstance(value, Mapping):
-        for key, nested_value in value.items():
-            normalized_key = str(key).strip()
-            snake_key = "".join(
-                f"_{character.lower()}" if character.isupper() else character
-                for character in normalized_key
-            ).strip("_")
-            if snake_key.casefold() in _EXECUTION_AUTHORITY_KEYS:
-                return str(key)
-            nested_match = _find_execution_authority_key(nested_value)
-            if nested_match is not None:
-                return nested_match
-    elif isinstance(value, list):
-        for item in value:
-            nested_match = _find_execution_authority_key(item)
-            if nested_match is not None:
-                return nested_match
+    stack = [value]
+    seen_container_ids: set[int] = set()
+
+    while stack:
+        current_value = stack.pop()
+        if isinstance(current_value, Mapping):
+            container_id = id(current_value)
+            if container_id in seen_container_ids:
+                continue
+            seen_container_ids.add(container_id)
+
+            for key, nested_value in current_value.items():
+                normalized_key = str(key).strip()
+                snake_key = "".join(
+                    f"_{character.lower()}" if character.isupper() else character
+                    for character in normalized_key
+                ).strip("_")
+                if snake_key.casefold() in _EXECUTION_AUTHORITY_KEYS:
+                    return str(key)
+                if isinstance(nested_value, (Mapping, list)):
+                    stack.append(nested_value)
+        elif isinstance(current_value, list):
+            container_id = id(current_value)
+            if container_id in seen_container_ids:
+                continue
+            seen_container_ids.add(container_id)
+
+            for item in current_value:
+                if isinstance(item, (Mapping, list)):
+                    stack.append(item)
 
     return None

--- a/backend/app/features/review_llm/schema.py
+++ b/backend/app/features/review_llm/schema.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from app.features.audit.event_model import NonEmptyTrimmedString, to_camel
+
+
+ReviewLLMStatus = Literal["ready", "needs_clarification", "blocked"]
+ReviewLLMConfidence = Literal["low", "medium", "high", "unknown"]
+
+REVIEW_LLM_CONTRACT_VERSION = "review_llm_adapter_output.v1"
+
+_REVIEW_LLM_MODEL_CONFIG = ConfigDict(
+    alias_generator=to_camel,
+    extra="forbid",
+    frozen=True,
+    populate_by_name=True,
+)
+
+_EXECUTION_AUTHORITY_KEYS = frozenset(
+    {
+        "approval_status",
+        "approved_for_execution",
+        "authorize_execution",
+        "authorized_for_execution",
+        "can_authorize_execution",
+        "can_execute",
+        "execute",
+        "execution_approved",
+        "execution_authority",
+        "execution_authorized",
+        "execution_decision",
+        "execution_permission",
+        "is_executable",
+        "query_candidate_id",
+        "run_query",
+        "sql_execution_approved",
+    }
+)
+
+
+class ReviewLLMAdapterOutputError(ValueError):
+    """Raised when review LLM output cannot satisfy the critique-only contract."""
+
+
+class ReviewLLMAdapterDiagnostics(BaseModel):
+    model_config = _REVIEW_LLM_MODEL_CONFIG
+
+    adapter_version: NonEmptyTrimmedString
+    model: Optional[NonEmptyTrimmedString] = None
+    provider: Optional[NonEmptyTrimmedString] = None
+    prompt_version: Optional[NonEmptyTrimmedString] = None
+    response_id: Optional[NonEmptyTrimmedString] = None
+    raw_output_excerpt: Optional[NonEmptyTrimmedString] = None
+
+
+class ReviewLLMAdapterOutput(BaseModel):
+    model_config = _REVIEW_LLM_MODEL_CONFIG
+
+    contract_version: Literal[REVIEW_LLM_CONTRACT_VERSION] = REVIEW_LLM_CONTRACT_VERSION
+    status: ReviewLLMStatus
+    confidence: ReviewLLMConfidence = "unknown"
+    intent_summary: NonEmptyTrimmedString
+    data_used: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    metrics: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    dimensions: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    filters: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    assumptions: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    risk_flags: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    clarifying_questions: list[NonEmptyTrimmedString] = Field(default_factory=list)
+    diagnostics: ReviewLLMAdapterDiagnostics
+
+    def to_wire_payload(self) -> dict[str, object]:
+        return self.model_dump(mode="json", by_alias=True)
+
+    @model_validator(mode="after")
+    def validate_confidence_status(self) -> "ReviewLLMAdapterOutput":
+        if self.confidence == "low" and self.status == "ready":
+            raise ValueError(
+                "Low confidence review output must use needs_clarification or blocked status."
+            )
+        return self
+
+
+def parse_review_llm_adapter_output(
+    output: str | bytes | bytearray | Mapping[str, object],
+) -> ReviewLLMAdapterOutput:
+    decoded = _decode_review_llm_output(output)
+    forbidden_key = _find_execution_authority_key(decoded)
+    if forbidden_key is not None:
+        raise ReviewLLMAdapterOutputError(
+            "Review LLM output cannot carry execution authority field "
+            f"'{forbidden_key}'."
+        )
+
+    try:
+        return ReviewLLMAdapterOutput.model_validate(decoded)
+    except ValidationError as exc:
+        raise ReviewLLMAdapterOutputError(
+            f"Review LLM adapter output is malformed: {exc}"
+        ) from exc
+
+
+def _decode_review_llm_output(
+    output: str | bytes | bytearray | Mapping[str, object],
+) -> Mapping[str, object]:
+    if isinstance(output, Mapping):
+        return output
+
+    try:
+        decoded = json.loads(output)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ReviewLLMAdapterOutputError(
+            "Review LLM adapter output is malformed: expected a JSON object."
+        ) from exc
+
+    if not isinstance(decoded, Mapping):
+        raise ReviewLLMAdapterOutputError(
+            "Review LLM adapter output is malformed: expected a JSON object."
+        )
+
+    return decoded
+
+
+def _find_execution_authority_key(value: object) -> str | None:
+    if isinstance(value, Mapping):
+        for key, nested_value in value.items():
+            normalized_key = str(key).strip()
+            snake_key = "".join(
+                f"_{character.lower()}" if character.isupper() else character
+                for character in normalized_key
+            ).strip("_")
+            if snake_key.casefold() in _EXECUTION_AUTHORITY_KEYS:
+                return str(key)
+            nested_match = _find_execution_authority_key(nested_value)
+            if nested_match is not None:
+                return nested_match
+    elif isinstance(value, list):
+        for item in value:
+            nested_match = _find_execution_authority_key(item)
+            if nested_match is not None:
+                return nested_match
+
+    return None

--- a/backend/tests/test_review_llm_adapter_contract.py
+++ b/backend/tests/test_review_llm_adapter_contract.py
@@ -48,6 +48,12 @@ def test_review_llm_adapter_rejects_malformed_output() -> None:
         parse_review_llm_adapter_output(json.dumps({"status": "ready"}))
 
 
+@pytest.mark.parametrize("payload", [b"\xff", bytearray(b"\xff")])
+def test_review_llm_adapter_rejects_invalid_utf8_bytes(payload: bytes | bytearray) -> None:
+    with pytest.raises(ReviewLLMAdapterOutputError, match="malformed"):
+        parse_review_llm_adapter_output(payload)
+
+
 @pytest.mark.parametrize(
     "field_name",
     [
@@ -59,6 +65,17 @@ def test_review_llm_adapter_rejects_malformed_output() -> None:
 )
 def test_review_llm_adapter_rejects_execution_authorizing_fields(field_name: str) -> None:
     payload = {**_ready_payload(), field_name: True}
+
+    with pytest.raises(ReviewLLMAdapterOutputError, match="execution authority"):
+        parse_review_llm_adapter_output(payload)
+
+
+def test_review_llm_adapter_rejects_deep_execution_authority_without_recursion_error() -> None:
+    nested: dict[str, object] = {"execution_authorized": True}
+    for _ in range(1500):
+        nested = {"wrap": [nested]}
+
+    payload = {**_ready_payload(), "untrusted_context": nested}
 
     with pytest.raises(ReviewLLMAdapterOutputError, match="execution authority"):
         parse_review_llm_adapter_output(payload)

--- a/backend/tests/test_review_llm_adapter_contract.py
+++ b/backend/tests/test_review_llm_adapter_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.features.review_llm.schema import (
+    ReviewLLMAdapterOutput,
+    ReviewLLMAdapterOutputError,
+    parse_review_llm_adapter_output,
+)
+
+
+def _ready_payload() -> dict[str, object]:
+    return {
+        "status": "ready",
+        "confidence": "high",
+        "intent_summary": "Compare approved vendor spend by quarter.",
+        "data_used": ["approved_vendor_spend semantic contract v2"],
+        "metrics": ["total_spend"],
+        "dimensions": ["vendor_id", "calendar_quarter"],
+        "filters": ["approval_status = approved"],
+        "assumptions": ["Quarter means calendar quarter."],
+        "risk_flags": [],
+        "clarifying_questions": [],
+        "diagnostics": {
+            "adapter_version": "review_llm_contract.v1",
+            "model": "contract-test",
+            "raw_output_excerpt": "No execution authority requested.",
+        },
+    }
+
+
+def test_review_llm_adapter_output_has_serializable_explicit_status() -> None:
+    output = ReviewLLMAdapterOutput.model_validate(_ready_payload())
+
+    assert output.status == "ready"
+    assert output.to_wire_payload()["status"] == "ready"
+    assert "canAuthorizeExecution" not in output.to_wire_payload()
+    assert "executionAuthorized" not in output.to_wire_payload()
+
+
+def test_review_llm_adapter_rejects_malformed_output() -> None:
+    with pytest.raises(ReviewLLMAdapterOutputError, match="malformed"):
+        parse_review_llm_adapter_output("{not-json")
+
+    with pytest.raises(ReviewLLMAdapterOutputError, match="malformed"):
+        parse_review_llm_adapter_output(json.dumps({"status": "ready"}))
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "can_authorize_execution",
+        "execution_authorized",
+        "approved_for_execution",
+        "approval_status",
+    ],
+)
+def test_review_llm_adapter_rejects_execution_authorizing_fields(field_name: str) -> None:
+    payload = {**_ready_payload(), field_name: True}
+
+    with pytest.raises(ReviewLLMAdapterOutputError, match="execution authority"):
+        parse_review_llm_adapter_output(payload)
+
+
+@pytest.mark.parametrize("status", ["needs_clarification", "blocked"])
+def test_review_llm_adapter_allows_low_confidence_only_when_not_ready(status: str) -> None:
+    payload = {
+        **_ready_payload(),
+        "status": status,
+        "confidence": "low",
+        "clarifying_questions": ["Which fiscal calendar should be used?"],
+    }
+
+    output = parse_review_llm_adapter_output(payload)
+
+    assert output.status == status
+    assert output.confidence == "low"
+
+
+def test_review_llm_adapter_rejects_low_confidence_ready_state() -> None:
+    payload = {**_ready_payload(), "confidence": "low"}
+
+    with pytest.raises(ReviewLLMAdapterOutputError, match="Low confidence"):
+        parse_review_llm_adapter_output(payload)

--- a/docs/01_READING_ORDER.md
+++ b/docs/01_READING_ORDER.md
@@ -66,43 +66,45 @@ This reading order is intended to help new contributors understand SafeQuery fro
     Review why MLflow is used for tracing, evaluation, and model-lifecycle support without becoming the trusted control plane in the current baseline.
 25. [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md)
     Review how the current source-aware baseline adds governed search and analyst-style capabilities without moving trust boundaries out of the application.
-26. [design/evaluation-harness.md](./design/evaluation-harness.md)
+26. [design/review-llm-adapter-contract.md](./design/review-llm-adapter-contract.md)
+    Review the critique-only structured output boundary before implementing Review LLM parser, adapter, or reviewer diagnostic surfaces.
+27. [design/evaluation-harness.md](./design/evaluation-harness.md)
     Use this to understand how NL2SQL quality should be measured safely in the current source-aware baseline.
-27. [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md)
+28. [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md)
     Use this as the 2-source core path pilot-readiness checklist after the source-aware implementation slices are complete.
-28. [pilot-deployment-profile.md](./pilot-deployment-profile.md)
+29. [pilot-deployment-profile.md](./pilot-deployment-profile.md)
     Use this to classify local/pilot environment values as required, optional, or forbidden before startup, doctor checks, exports, or support bundles.
-29. [pilot-operations-runbook.md](./pilot-operations-runbook.md)
+30. [pilot-operations-runbook.md](./pilot-operations-runbook.md)
     Use this to classify normal, degraded, maintenance, incident, and recovery posture during limited pilot operation without treating UI, LLM, adapter, MLflow, Search, Analyst, or external evidence as authoritative.
 
 ### 5. Approved Follow-on Direction
 
-30. [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md)
+31. [adr/ADR-0011-target-source-registry-and-single-source-execution-model.md](./adr/ADR-0011-target-source-registry-and-single-source-execution-model.md)
     Read first in this section to understand how SafeQuery expands beyond one hard-coded business source while keeping request, candidate, and execution paths single-source.
-31. [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md)
+32. [adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md](./adr/ADR-0012-multi-dialect-connector-and-guard-profile-strategy.md)
     Review how source families, flavors, connector profiles, and guard profiles are separated so future onboarding does not redesign the control plane.
-32. [design/target-source-registry.md](./design/target-source-registry.md)
+33. [design/target-source-registry.md](./design/target-source-registry.md)
     Use this to understand the concrete registry model, source lifecycle expectations, and application PostgreSQL separation guardrails.
-33. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
+34. [design/dialect-capability-matrix.md](./design/dialect-capability-matrix.md)
     Review the family and flavor rollout matrix before planning connector, guard, or evaluation work for additional sources.
-34. [design/dialect-guard-readiness-checklists.md](./design/dialect-guard-readiness-checklists.md)
+35. [design/dialect-guard-readiness-checklists.md](./design/dialect-guard-readiness-checklists.md)
     Use this as the review checklist for guard readiness evidence before any planned MySQL, MariaDB, Aurora, or Oracle source can be considered for connector activation.
-35. [design/source-family-activation-selection.md](./design/source-family-activation-selection.md)
+36. [design/source-family-activation-selection.md](./design/source-family-activation-selection.md)
     Read this after the activation criteria and guard checklists to see the Epic V recommendation for the first future source flavor that should advance toward active implementation planning.
-36. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
+37. [adr/ADR-0013-operator-workflow-and-ui-foundation.md](./adr/ADR-0013-operator-workflow-and-ui-foundation.md)
     Read this to understand why the product shell is workflow-first and why the Epic A shell remains a developer state demo.
-37. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
+38. [adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md](./adr/ADR-0014-ui-implementation-stack-and-oss-adoption-boundaries.md)
     Review how SafeQuery may borrow OSS ergonomics without turning the product into a generic chat shell or moving trust boundaries.
-38. [adr/ADR-0015-semantic-contract-and-sql-guard-responsibility.md](./adr/ADR-0015-semantic-contract-and-sql-guard-responsibility.md)
+39. [adr/ADR-0015-semantic-contract-and-sql-guard-responsibility.md](./adr/ADR-0015-semantic-contract-and-sql-guard-responsibility.md)
     Read this before implementing Semantic Contract schema, mapping, or persistence so business-intent authorization stays separate from executable SQL safety.
-39. [implementation-roadmap.md](./implementation-roadmap.md)
+40. [implementation-roadmap.md](./implementation-roadmap.md)
     Finish this section with the current implementation sequence so roadmap work stays aligned with the reviewed docs direction.
 
 ### 6. Local Setup and Threat Review
 
-40. [local-development.md](./local-development.md)
+41. [local-development.md](./local-development.md)
     Use this once the document set is clear so local startup follows the reviewed topology and role split.
-41. [security/threat-model.md](./security/threat-model.md)
+42. [security/threat-model.md](./security/threat-model.md)
     Finish with the threat model and residual risks for the current source-aware and UX-foundation baseline before pilot readiness review.
 
 ## Source Hierarchy

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ If documents drift, do not silently let lower-level docs override upstream inten
 
 - [adr/ADR-0010-mlflow-observability-and-evaluation-plane.md](./adr/ADR-0010-mlflow-observability-and-evaluation-plane.md): MLflow as observability, evaluation, and model-lifecycle plane within the current baseline
 - [design/search-and-analyst-capabilities.md](./design/search-and-analyst-capabilities.md): governed semantic retrieval and analyst-style orchestration in the current source-aware baseline
+- [design/review-llm-adapter-contract.md](./design/review-llm-adapter-contract.md): critique-only structured output contract for Review LLM adapter output
 - [design/evaluation-harness.md](./design/evaluation-harness.md): evaluation goals, datasets, and scoring for the current baseline
 - [pilot-safety-verification-checklist.md](./pilot-safety-verification-checklist.md): pilot-readiness verification checklist for the completed 2-source core path
 - [pilot-deployment-profile.md](./pilot-deployment-profile.md): pilot deployment assumptions and environment contract for safe local/pilot operation

--- a/docs/design/review-llm-adapter-contract.md
+++ b/docs/design/review-llm-adapter-contract.md
@@ -1,0 +1,70 @@
+# Review LLM Adapter Contract
+
+## Purpose
+
+The Review LLM adapter is a critique-only boundary for structured review of an
+operator request or generated answer context. It can summarize intent, identify
+the data it used, list metrics, dimensions, filters, assumptions, risks, and
+clarifying questions, and return reviewer-facing diagnostics.
+
+The adapter output is not an authorization source. It must not approve SQL,
+mint or select a candidate, bypass SQL Guard, approve execution, or replace the
+backend-owned preview and execute lifecycle.
+
+## Structured Output
+
+The backend accepts one structured object with these fields:
+
+- `contractVersion`: fixed to `review_llm_adapter_output.v1`
+- `status`: one of `ready`, `needs_clarification`, or `blocked`
+- `confidence`: one of `low`, `medium`, `high`, or `unknown`
+- `intentSummary`: concise reviewer-facing intent summary
+- `dataUsed`: context references or reviewed evidence labels
+- `metrics`: reviewed metric names
+- `dimensions`: reviewed grouping or entity dimensions
+- `filters`: reviewed filter constraints
+- `assumptions`: assumptions the reviewer should inspect
+- `riskFlags`: risks that keep the output advisory
+- `clarifyingQuestions`: questions for the operator or reviewer
+- `diagnostics`: adapter version, model/provider metadata, prompt version,
+  response identifier, and optional raw output excerpt
+
+The contract deliberately has no `canAuthorizeExecution`,
+`executionAuthorized`, `approvalStatus`, `queryCandidateId`, or equivalent
+execution-authorizing field. If such a field appears anywhere in the adapter
+output, the parser rejects the output before it can reach a reviewer surface.
+
+## Status Semantics
+
+`ready` means the critique output is structurally complete enough for reviewer
+inspection. It does not mean the candidate is approved or executable.
+
+`needs_clarification` means the adapter found missing or ambiguous inputs and
+the caller should ask one or more clarifying questions before relying on the
+critique.
+
+`blocked` means the adapter found a critique boundary problem or risk that
+requires a real prerequisite outside the Review LLM output.
+
+Low confidence cannot be returned with `ready`; it must be represented as
+`needs_clarification` or `blocked`.
+
+## Malformed Output Handling
+
+The parser accepts a JSON object or already-decoded mapping and validates it
+against the structured schema. Invalid JSON, non-object JSON, missing required
+fields, unsupported statuses, blank strings, unknown fields, and execution
+authority fields are rejected as malformed adapter output.
+
+Malformed output must fail closed. The caller may surface a controlled review
+diagnostic, but it must not infer readiness, candidate approval, or execution
+permission from partial output.
+
+## Boundary Rules
+
+- The Review LLM can critique and summarize; it cannot authorize.
+- SQL Guard and backend candidate lifecycle remain the enforcement boundary.
+- Preview and execute requests still require backend-owned source, subject,
+  candidate, guard, TTL, replay, and entitlement checks.
+- Reviewer-facing diagnostics are advisory evidence, not durable lifecycle
+  truth.

--- a/tests/test_review_llm_adapter_contract_docs.py
+++ b/tests/test_review_llm_adapter_contract_docs.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_DOC = REPO_ROOT / "docs" / "design" / "review-llm-adapter-contract.md"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+READING_ORDER = REPO_ROOT / "docs" / "01_READING_ORDER.md"
+
+
+def test_review_llm_adapter_contract_documents_critique_only_boundary() -> None:
+    content = CONTRACT_DOC.read_text(encoding="utf-8")
+    normalized = " ".join(content.split())
+
+    for phrase in [
+        "critique-only boundary",
+        "not an authorization source",
+        "must not approve SQL",
+        "Low confidence cannot be returned with `ready`",
+        "Malformed output must fail closed",
+        "SQL Guard and backend candidate lifecycle remain the enforcement boundary",
+    ]:
+        assert phrase in normalized
+
+    for forbidden_field in [
+        "canAuthorizeExecution",
+        "executionAuthorized",
+        "approvalStatus",
+        "queryCandidateId",
+    ]:
+        assert forbidden_field in content
+
+
+def test_review_llm_adapter_contract_is_listed_in_docs_entrypoints() -> None:
+    docs_readme = DOCS_README.read_text(encoding="utf-8")
+    reading_order = READING_ORDER.read_text(encoding="utf-8")
+
+    assert "design/review-llm-adapter-contract.md" in docs_readme
+    assert "design/review-llm-adapter-contract.md" in reading_order


### PR DESCRIPTION
## Summary
- Adds a critique-only Review LLM structured output schema and parser.
- Rejects malformed output, low-confidence ready states, and execution-authorizing fields.
- Documents the Review LLM adapter boundary and links it from the docs entrypoints.

## Verification
- python3 -m pytest tests/test_review_llm_adapter_contract.py -q (from backend/)
- python3 -m pytest tests/test_sql_generation_adapter_request.py tests/test_analyst_response_schema.py tests/test_review_llm_adapter_contract.py -q (from backend/)
- python3 -m pytest tests/test_review_llm_adapter_contract_docs.py -q
- python3 -m pytest tests/test_runtime_flow_rate_limit_docs.py tests/test_review_llm_adapter_contract_docs.py -q
- python3 -m pytest tests -q (from backend/)

Closes #454