### PR TITLE
[Y-2] Generate business-readable answer plan

### DIFF
--- a/backend/app/features/review_llm/__init__.py
+++ b/backend/app/features/review_llm/__init__.py
@@ -1,5 +1,12 @@
 """Review LLM critique-only adapter contracts."""
 
+from app.features.review_llm.answer_plan import (
+    AnswerPlanCandidateSummary,
+    AnswerPlanGuardSummary,
+    AnswerPlanPayload,
+    AnswerPlanSemanticEvidence,
+    build_answer_plan_from_review,
+)
 from app.features.review_llm.schema import (
     ReviewLLMAdapterDiagnostics,
     ReviewLLMAdapterOutput,
@@ -8,8 +15,13 @@ from app.features.review_llm.schema import (
 )
 
 __all__ = [
+    "AnswerPlanCandidateSummary",
+    "AnswerPlanGuardSummary",
+    "AnswerPlanPayload",
+    "AnswerPlanSemanticEvidence",
     "ReviewLLMAdapterDiagnostics",
     "ReviewLLMAdapterOutput",
     "ReviewLLMAdapterOutputError",
+    "build_answer_plan_from_review",
     "parse_review_llm_adapter_output",
 ]

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -33,7 +33,10 @@ _REDACTED = "[redacted]"
 _SOURCE_IDENTIFIER_ADAPTER = TypeAdapter(SourceIdentifier)
 _SUPPORTED_SOURCE_FAMILIES = frozenset(("mssql", "postgresql"))
 _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
+    re.compile(
+        r"(?i)\b[a-z][a-z0-9+.-]*://"
+        r"(?:(?=[^\"'\r\n;,}]*@)[^\"'\r\n;,}]+|[^\s\"']+)"
+    ),
     re.compile(
         r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=\s*"
         r"(?:\{[^}]*\}|\"[^\"]*\"|'[^']*'|[^;,\"'}]+)"
@@ -42,7 +45,7 @@ _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"(?i)(?<![a-z0-9])[\"']?(?:access[_-]?token|refresh[_-]?token|"
         r"id[_-]?token|token|secret|password|passwd|pwd|credential|"
         r"client[_-]?secret|api[_-]?key|private[_-]?key)(?:\\*[\"'])?\s*[:=]\s*"
-        r"(?:\\*[\"'][^\"']*(?:\\*[\"'])|\{[^}]*\}|[^;,\"'}]+)"
+        r"(?:\\*\"(?:\\.|[^\"\\])*\\*\"|\\*'(?:\\.|[^'\\])*\\*'|\{[^}]*\}|[^;,}]+)"
     ),
     re.compile(r"(?i)\b(?:basic|bearer)\s+[a-z0-9._~+/=-]+"),
     re.compile(
@@ -166,7 +169,9 @@ def _build_semantic_evidence(
     return AnswerPlanSemanticEvidence(
         contract_version=_optional_sanitized_string(safe_mapping.get("contract_version")),
         mapping_id=_optional_sanitized_string(safe_mapping.get("mapping_id")),
-        classification=_optional_sanitized_string(safe_mapping.get("classification")),
+        classification=_normalized_classification_or_none(
+            safe_mapping.get("classification")
+        ),
         metric=_optional_sanitized_string(safe_mapping.get("metric")),
         dimensions=_sanitize_string_items(safe_mapping.get("dimensions")),
         filters=_sanitize_string_items(safe_mapping.get("filters")),
@@ -271,10 +276,15 @@ def _build_risks(
     semantic_evidence: AnswerPlanSemanticEvidence,
 ) -> tuple[str, ...]:
     risks = list(_sanitize_text_items(review.risk_flags))
-    if semantic_evidence.classification in {"ambiguous", "unsupported"}:
+    classification = (
+        semantic_evidence.classification.casefold()
+        if semantic_evidence.classification
+        else None
+    )
+    if classification in {"ambiguous", "unsupported"}:
         risks.append(
             "Semantic mapping is "
-            f"{semantic_evidence.classification}; do not present the plan as a final answer."
+            f"{classification}; do not present the plan as a final answer."
         )
     if review.status == "blocked":
         risks.append("Review output is blocked and must not be used as an answer.")
@@ -306,7 +316,9 @@ def _sanitize_string_items(value: object) -> tuple[str, ...]:
         return ()
     if isinstance(value, str):
         return _sanitize_text_items((value,))
-    if not isinstance(value, Iterable):
+    if isinstance(value, Mapping):
+        return ()
+    if not isinstance(value, (list, tuple, set, frozenset)):
         return ()
 
     items = tuple(value)
@@ -337,14 +349,19 @@ def _optional_sanitized_string(value: object) -> str | None:
     return sanitized
 
 
+def _normalized_classification_or_none(value: object) -> str | None:
+    sanitized = _optional_sanitized_string(value)
+    if sanitized is None:
+        return None
+    return sanitized.casefold()
+
+
 def _positive_int_or_none(value: object) -> int | None:
     if value is None:
         return None
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
+    if isinstance(value, bool) or not isinstance(value, int):
         return None
-    return parsed if parsed > 0 else None
+    return value if value > 0 else None
 
 
 def _guard_decision_or_none(value: object) -> Optional[Literal["allow", "reject"]]:

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -27,12 +27,15 @@ _SOURCE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 _SUPPORTED_SOURCE_FAMILIES = frozenset(("mssql", "postgresql"))
 _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
-    re.compile(r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=[^;\s\"']+"),
+    re.compile(
+        r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=\s*"
+        r"(?:\{[^}]*\}|\"[^\"]*\"|'[^']*'|[^;,\r\n\"'}]+)"
+    ),
     re.compile(
         r"(?i)(?<![a-z0-9])[\"']?(?:access[_-]?token|refresh[_-]?token|"
         r"id[_-]?token|token|secret|password|passwd|pwd|credential|"
         r"client[_-]?secret|api[_-]?key|private[_-]?key)[\"']?\s*[:=]\s*"
-        r"(?:[\"'][^\"']*[\"']|[^;,\s\"'}]+)"
+        r"(?:[\"'][^\"']*[\"']|\{[^}]*\}|[^;,\r\n\"'}]+)"
     ),
     re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/-]+"),
     re.compile(
@@ -171,9 +174,7 @@ def _build_candidate_summary(
         candidate_id=_optional_sanitized_string(safe_metadata.get("candidate_id")),
         source_id=_source_identifier_or_none(safe_metadata.get("source_id")),
         source_family=_source_family_or_none(safe_metadata.get("source_family")),
-        selected_columns=_sanitize_text_items(
-            _as_iterable(safe_metadata.get("selected_columns"))
-        ),
+        selected_columns=_sanitize_string_items(safe_metadata.get("selected_columns")),
         row_limit=_positive_int_or_none(safe_metadata.get("row_limit")),
     )
 
@@ -291,6 +292,20 @@ def _filter_safe_mapping(payload: Mapping[str, object]) -> dict[str, object]:
 
 def _sanitize_text_items(values: Iterable[object]) -> tuple[str, ...]:
     return _dedupe(_sanitize_text(value) for value in values if value is not None)
+
+
+def _sanitize_string_items(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return _sanitize_text_items((value,))
+    if not isinstance(value, Iterable):
+        return ()
+
+    items = tuple(value)
+    if not all(isinstance(item, str) for item in items):
+        return ()
+    return _sanitize_text_items(items)
 
 
 def _sanitize_text(value: object) -> str:

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -4,7 +4,14 @@ from collections.abc import Iterable, Mapping
 import re
 from typing import Any, Literal, Optional, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PositiveInt
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveInt,
+    TypeAdapter,
+    ValidationError,
+)
 
 from app.features.audit.event_model import (
     NonEmptyTrimmedString,
@@ -23,7 +30,7 @@ _MODEL_CONFIG = ConfigDict(
     populate_by_name=True,
 )
 _REDACTED = "[redacted]"
-_SOURCE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_SOURCE_IDENTIFIER_ADAPTER = TypeAdapter(SourceIdentifier)
 _SUPPORTED_SOURCE_FAMILIES = frozenset(("mssql", "postgresql"))
 _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
@@ -34,10 +41,10 @@ _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
         r"(?i)(?<![a-z0-9])[\"']?(?:access[_-]?token|refresh[_-]?token|"
         r"id[_-]?token|token|secret|password|passwd|pwd|credential|"
-        r"client[_-]?secret|api[_-]?key|private[_-]?key)[\"']?\s*[:=]\s*"
-        r"(?:[\"'][^\"']*[\"']|\{[^}]*\}|[^;,\r\n\"'}]+)"
+        r"client[_-]?secret|api[_-]?key|private[_-]?key)(?:\\?[\"'])?\s*[:=]\s*"
+        r"(?:\\?[\"'][^\"'\r\n]*(?:\\?[\"'])|\{[^}]*\}|[^;,\r\n\"'}]+)"
     ),
-    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/-]+"),
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+"),
     re.compile(
         r"(?i)(?<![a-z0-9])(?:password|passwd|pwd|secret|token|credential|"
         r"client[_ -]?secret|api[_ -]?key|private[_ -]?key)(?![a-z0-9])"
@@ -351,10 +358,11 @@ def _source_identifier_or_none(value: object) -> SourceIdentifier | None:
         return None
     if not isinstance(value, str):
         return None
-    normalized = str(value).strip()
-    if _SOURCE_IDENTIFIER_PATTERN.fullmatch(normalized):
-        return cast(SourceIdentifier, normalized)
-    return None
+    normalized = value.strip()
+    try:
+        return cast(SourceIdentifier, _SOURCE_IDENTIFIER_ADAPTER.validate_python(normalized))
+    except ValidationError:
+        return None
 
 
 def _source_family_or_none(value: object) -> str | None:

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -161,8 +161,8 @@ def _build_semantic_evidence(
         mapping_id=_optional_sanitized_string(safe_mapping.get("mapping_id")),
         classification=_optional_sanitized_string(safe_mapping.get("classification")),
         metric=_optional_sanitized_string(safe_mapping.get("metric")),
-        dimensions=_sanitize_text_items(_as_iterable(safe_mapping.get("dimensions"))),
-        filters=_sanitize_text_items(_as_iterable(safe_mapping.get("filters"))),
+        dimensions=_sanitize_string_items(safe_mapping.get("dimensions")),
+        filters=_sanitize_string_items(safe_mapping.get("filters")),
     )
 
 
@@ -305,6 +305,8 @@ def _sanitize_string_items(value: object) -> tuple[str, ...]:
     items = tuple(value)
     if not all(isinstance(item, str) for item in items):
         return ()
+    if isinstance(value, (set, frozenset)):
+        items = tuple(sorted(items))
     return _sanitize_text_items(items)
 
 
@@ -318,18 +320,10 @@ def _sanitize_text(value: object) -> str:
 def _optional_sanitized_string(value: object) -> str | None:
     if value is None:
         return None
+    if not isinstance(value, str):
+        return None
     sanitized = _sanitize_text(value)
     return sanitized or None
-
-
-def _as_iterable(value: object) -> Iterable[object]:
-    if value is None:
-        return ()
-    if isinstance(value, str):
-        return (value,)
-    if isinstance(value, Iterable):
-        return value
-    return (value,)
 
 
 def _positive_int_or_none(value: object) -> int | None:
@@ -350,6 +344,8 @@ def _guard_decision_or_none(value: object) -> Optional[Literal["allow", "reject"
 
 def _source_identifier_or_none(value: object) -> SourceIdentifier | None:
     if value is None:
+        return None
+    if not isinstance(value, str):
         return None
     normalized = str(value).strip()
     if _SOURCE_IDENTIFIER_PATTERN.fullmatch(normalized):

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -44,8 +44,7 @@ _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"client[_-]?secret|api[_-]?key|private[_-]?key)(?:\\*[\"'])?\s*[:=]\s*"
         r"(?:\\*[\"'][^\"']*(?:\\*[\"'])|\{[^}]*\}|[^;,\"'}]+)"
     ),
-    re.compile(r"(?i)\bbasic\s+[a-z0-9._~+/=-]+"),
-    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+"),
+    re.compile(r"(?i)\b(?:basic|bearer)\s+[a-z0-9._~+/=-]+"),
     re.compile(
         r"(?i)(?<![a-z0-9])(?:password|passwd|pwd|secret|token|credential|"
         r"client[_ -]?secret|api[_ -]?key|private[_ -]?key)(?![a-z0-9])"

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -36,14 +36,15 @@ _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
     re.compile(
         r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=\s*"
-        r"(?:\{[^}]*\}|\"[^\"]*\"|'[^']*'|[^;,\r\n\"'}]+)"
+        r"(?:\{[^}]*\}|\"[^\"]*\"|'[^']*'|[^;,\"'}]+)"
     ),
     re.compile(
         r"(?i)(?<![a-z0-9])[\"']?(?:access[_-]?token|refresh[_-]?token|"
         r"id[_-]?token|token|secret|password|passwd|pwd|credential|"
-        r"client[_-]?secret|api[_-]?key|private[_-]?key)(?:\\?[\"'])?\s*[:=]\s*"
-        r"(?:\\?[\"'][^\"'\r\n]*(?:\\?[\"'])|\{[^}]*\}|[^;,\r\n\"'}]+)"
+        r"client[_-]?secret|api[_-]?key|private[_-]?key)(?:\\*[\"'])?\s*[:=]\s*"
+        r"(?:\\*[\"'][^\"']*(?:\\*[\"'])|\{[^}]*\}|[^;,\"'}]+)"
     ),
+    re.compile(r"(?i)\bbasic\s+[a-z0-9._~+/=-]+"),
     re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]+"),
     re.compile(
         r"(?i)(?<![a-z0-9])(?:password|passwd|pwd|secret|token|credential|"

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -35,11 +35,12 @@ _SUPPORTED_SOURCE_FAMILIES = frozenset(("mssql", "postgresql"))
 _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
         r"(?i)\b[a-z][a-z0-9+.-]*://"
-        r"(?:(?=[^\"'\r\n;,}]*@)[^\"'\r\n;,}]+|[^\s\"']+)"
+        r"(?:(?=(?:\\+[\"']|\\.|[^\"'\r\n;,}])*@)"
+        r"(?:\\+[\"']|\\.|[^\"'\r\n;,}])+|[^\s\"']+)"
     ),
     re.compile(
         r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=\s*"
-        r"(?:\{[^}]*\}|\"[^\"]*\"|'[^']*'|[^;,\"'}]+)"
+        r"(?:\{[^}]*\}|\"(?:\\+\"|\\.|[^\"\\])*\"|'(?:\\+'|\\.|[^'\\])*'|[^;,\"'}]+)"
     ),
     re.compile(
         r"(?i)(?<![a-z0-9])[\"']?(?:access[_-]?token|refresh[_-]?token|"
@@ -47,7 +48,10 @@ _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"client[_-]?secret|api[_-]?key|private[_-]?key)(?:\\*[\"'])?\s*[:=]\s*"
         r"(?:\\*\"(?:\\.|[^\"\\])*\\*\"|\\*'(?:\\.|[^'\\])*\\*'|\{[^}]*\}|[^;,}]+)"
     ),
-    re.compile(r"(?i)\b(?:basic|bearer)\s+[a-z0-9._~+/=-]+"),
+    re.compile(
+        r"(?i)\b(?:basic|bearer)\s+"
+        r"(?:\"(?:\\+\"|\\.|[^\"\\])*\"|'(?:\\+'|\\.|[^'\\])*'|[^\s;,}]+)"
+    ),
     re.compile(
         r"(?i)(?<![a-z0-9])(?:password|passwd|pwd|secret|token|credential|"
         r"client[_ -]?secret|api[_ -]?key|private[_ -]?key)(?![a-z0-9])"

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 import re
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, cast
 
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt
 
@@ -24,13 +24,15 @@ _MODEL_CONFIG = ConfigDict(
     populate_by_name=True,
 )
 _REDACTED = "[redacted]"
+_SUPPORTED_SOURCE_FAMILIES: frozenset[SourceFamily] = frozenset(("mssql", "postgresql"))
 _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
     re.compile(r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=[^;\s\"']+"),
     re.compile(
-        r"(?i)\b(?:access[_-]?token|refresh[_-]?token|id[_-]?token|token|"
-        r"secret|password|passwd|pwd|credential|client[_-]?secret|api[_-]?key|"
-        r"private[_-]?key)\s*[:=]\s*[^;\s\"']+"
+        r"(?i)(?<![a-z0-9])[\"']?(?:access[_-]?token|refresh[_-]?token|"
+        r"id[_-]?token|token|secret|password|passwd|pwd|credential|"
+        r"client[_-]?secret|api[_-]?key|private[_-]?key)[\"']?\s*[:=]\s*"
+        r"(?:[\"'][^\"']*[\"']|[^;,\s\"'}]+)"
     ),
     re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/-]+"),
     re.compile(
@@ -168,7 +170,7 @@ def _build_candidate_summary(
     return AnswerPlanCandidateSummary(
         candidate_id=_optional_sanitized_string(safe_metadata.get("candidate_id")),
         source_id=_optional_sanitized_string(safe_metadata.get("source_id")),
-        source_family=_optional_sanitized_string(safe_metadata.get("source_family")),
+        source_family=_source_family_or_none(safe_metadata.get("source_family")),
         selected_columns=_sanitize_text_items(
             _as_iterable(safe_metadata.get("selected_columns"))
         ),
@@ -328,6 +330,13 @@ def _positive_int_or_none(value: object) -> int | None:
 def _guard_decision_or_none(value: object) -> Optional[Literal["allow", "reject"]]:
     if value in {"allow", "reject"}:
         return value
+    return None
+
+
+def _source_family_or_none(value: object) -> SourceFamily | None:
+    sanitized = _optional_sanitized_string(value)
+    if sanitized in _SUPPORTED_SOURCE_FAMILIES:
+        return cast(SourceFamily, sanitized)
     return None
 
 

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -311,7 +311,9 @@ def _sanitize_string_items(value: object) -> tuple[str, ...]:
 
 
 def _sanitize_text(value: object) -> str:
-    sanitized = str(value).strip()
+    if not isinstance(value, str):
+        return ""
+    sanitized = value.strip()
     for pattern in _SECRET_VALUE_PATTERNS:
         sanitized = pattern.sub(_REDACTED, sanitized)
     return sanitized
@@ -323,7 +325,9 @@ def _optional_sanitized_string(value: object) -> str | None:
     if not isinstance(value, str):
         return None
     sanitized = _sanitize_text(value)
-    return sanitized or None
+    if not sanitized:
+        return None
+    return sanitized
 
 
 def _positive_int_or_none(value: object) -> int | None:

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt
 
 from app.features.audit.event_model import (
     NonEmptyTrimmedString,
-    SourceFamily,
     SourceIdentifier,
     to_camel,
 )
@@ -24,7 +23,8 @@ _MODEL_CONFIG = ConfigDict(
     populate_by_name=True,
 )
 _REDACTED = "[redacted]"
-_SUPPORTED_SOURCE_FAMILIES: frozenset[SourceFamily] = frozenset(("mssql", "postgresql"))
+_SOURCE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_SUPPORTED_SOURCE_FAMILIES = frozenset(("mssql", "postgresql"))
 _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
     re.compile(r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=[^;\s\"']+"),
@@ -75,7 +75,7 @@ class AnswerPlanCandidateSummary(BaseModel):
 
     candidate_id: Optional[NonEmptyTrimmedString] = None
     source_id: Optional[SourceIdentifier] = None
-    source_family: Optional[SourceFamily] = None
+    source_family: Optional[NonEmptyTrimmedString] = None
     selected_columns: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
     row_limit: Optional[PositiveInt] = None
 
@@ -169,7 +169,7 @@ def _build_candidate_summary(
     safe_metadata = _filter_safe_mapping(candidate_metadata)
     return AnswerPlanCandidateSummary(
         candidate_id=_optional_sanitized_string(safe_metadata.get("candidate_id")),
-        source_id=_optional_sanitized_string(safe_metadata.get("source_id")),
+        source_id=_source_identifier_or_none(safe_metadata.get("source_id")),
         source_family=_source_family_or_none(safe_metadata.get("source_family")),
         selected_columns=_sanitize_text_items(
             _as_iterable(safe_metadata.get("selected_columns"))
@@ -333,10 +333,19 @@ def _guard_decision_or_none(value: object) -> Optional[Literal["allow", "reject"
     return None
 
 
-def _source_family_or_none(value: object) -> SourceFamily | None:
+def _source_identifier_or_none(value: object) -> SourceIdentifier | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if _SOURCE_IDENTIFIER_PATTERN.fullmatch(normalized):
+        return cast(SourceIdentifier, normalized)
+    return None
+
+
+def _source_family_or_none(value: object) -> str | None:
     sanitized = _optional_sanitized_string(value)
     if sanitized in _SUPPORTED_SOURCE_FAMILIES:
-        return cast(SourceFamily, sanitized)
+        return sanitized
     return None
 
 

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+import re
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt
+
+from app.features.audit.event_model import (
+    NonEmptyTrimmedString,
+    SourceFamily,
+    SourceIdentifier,
+    to_camel,
+)
+from app.features.review_llm.schema import ReviewLLMAdapterOutput
+
+
+ANSWER_PLAN_CONTRACT_VERSION = "answer_plan.v1"
+
+_MODEL_CONFIG = ConfigDict(
+    alias_generator=to_camel,
+    extra="forbid",
+    frozen=True,
+    populate_by_name=True,
+)
+_REDACTED = "[redacted]"
+_SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"']+"),
+    re.compile(r"(?i)\b(?:driver|server|database|uid|pwd|password)\s*=[^;\s\"']+"),
+    re.compile(
+        r"(?i)\b(?:access[_-]?token|refresh[_-]?token|id[_-]?token|token|"
+        r"secret|password|passwd|pwd|credential|client[_-]?secret|api[_-]?key|"
+        r"private[_-]?key)\s*[:=]\s*[^;\s\"']+"
+    ),
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/-]+"),
+    re.compile(
+        r"(?i)(?<![a-z0-9])(?:password|passwd|pwd|secret|token|credential|"
+        r"client[_ -]?secret|api[_ -]?key|private[_ -]?key)(?![a-z0-9])"
+    ),
+)
+_UNSAFE_INPUT_KEYS = frozenset(
+    {
+        "connection",
+        "connection_reference",
+        "connection_string",
+        "connection_strings",
+        "credentials",
+        "raw_result_set",
+        "raw_result_sets",
+        "raw_rows",
+        "raw_sql",
+        "result_rows",
+        "scratchpad",
+        "hidden_prompt",
+        "system_prompt",
+    }
+)
+
+
+class AnswerPlanSemanticEvidence(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    contract_version: Optional[NonEmptyTrimmedString] = None
+    mapping_id: Optional[NonEmptyTrimmedString] = None
+    classification: Optional[NonEmptyTrimmedString] = None
+    metric: Optional[NonEmptyTrimmedString] = None
+    dimensions: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    filters: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+
+
+class AnswerPlanCandidateSummary(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    candidate_id: Optional[NonEmptyTrimmedString] = None
+    source_id: Optional[SourceIdentifier] = None
+    source_family: Optional[SourceFamily] = None
+    selected_columns: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    row_limit: Optional[PositiveInt] = None
+
+
+class AnswerPlanGuardSummary(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    guard_decision: Optional[Literal["allow", "reject"]] = None
+    guard_version: Optional[NonEmptyTrimmedString] = None
+    primary_deny_code: Optional[NonEmptyTrimmedString] = None
+    denial_reason: Optional[NonEmptyTrimmedString] = None
+
+
+class AnswerPlanPayload(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    contract_version: Literal[ANSWER_PLAN_CONTRACT_VERSION] = ANSWER_PLAN_CONTRACT_VERSION
+    question: NonEmptyTrimmedString
+    narrative: NonEmptyTrimmedString
+    steps: tuple[NonEmptyTrimmedString, ...]
+    assumptions: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    risks: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    clarifications: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    semantic_evidence: tuple[AnswerPlanSemanticEvidence, ...] = Field(
+        default_factory=tuple
+    )
+    candidate_summary: AnswerPlanCandidateSummary = Field(
+        default_factory=AnswerPlanCandidateSummary
+    )
+    guard_summary: AnswerPlanGuardSummary = Field(default_factory=AnswerPlanGuardSummary)
+    advisory_only: Literal[True] = True
+    can_authorize_execution: Literal[False] = False
+
+    def to_wire_payload(self) -> dict[str, object]:
+        return self.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+def build_answer_plan_from_review(
+    *,
+    question: str,
+    review: ReviewLLMAdapterOutput,
+    semantic_mapping: Mapping[str, object],
+    candidate_metadata: Mapping[str, object],
+    guard_metadata: Mapping[str, object],
+) -> AnswerPlanPayload:
+    semantic_evidence = _build_semantic_evidence(semantic_mapping)
+    candidate_summary = _build_candidate_summary(candidate_metadata)
+    guard_summary = _build_guard_summary(guard_metadata)
+    risks = _build_risks(review=review, semantic_evidence=semantic_evidence)
+    clarifications = _sanitize_text_items(review.clarifying_questions)
+    assumptions = _sanitize_text_items(review.assumptions)
+
+    return AnswerPlanPayload(
+        question=_sanitize_text(question),
+        narrative=_build_narrative(
+            review=review,
+            semantic_evidence=semantic_evidence,
+        ),
+        steps=_build_steps(
+            review=review,
+            candidate_summary=candidate_summary,
+        ),
+        assumptions=assumptions,
+        risks=risks,
+        clarifications=clarifications,
+        semantic_evidence=(semantic_evidence,),
+        candidate_summary=candidate_summary,
+        guard_summary=guard_summary,
+        advisory_only=True,
+        can_authorize_execution=False,
+    )
+
+
+def _build_semantic_evidence(
+    semantic_mapping: Mapping[str, object],
+) -> AnswerPlanSemanticEvidence:
+    safe_mapping = _filter_safe_mapping(semantic_mapping)
+    return AnswerPlanSemanticEvidence(
+        contract_version=_optional_sanitized_string(safe_mapping.get("contract_version")),
+        mapping_id=_optional_sanitized_string(safe_mapping.get("mapping_id")),
+        classification=_optional_sanitized_string(safe_mapping.get("classification")),
+        metric=_optional_sanitized_string(safe_mapping.get("metric")),
+        dimensions=_sanitize_text_items(_as_iterable(safe_mapping.get("dimensions"))),
+        filters=_sanitize_text_items(_as_iterable(safe_mapping.get("filters"))),
+    )
+
+
+def _build_candidate_summary(
+    candidate_metadata: Mapping[str, object],
+) -> AnswerPlanCandidateSummary:
+    safe_metadata = _filter_safe_mapping(candidate_metadata)
+    return AnswerPlanCandidateSummary(
+        candidate_id=_optional_sanitized_string(safe_metadata.get("candidate_id")),
+        source_id=_optional_sanitized_string(safe_metadata.get("source_id")),
+        source_family=_optional_sanitized_string(safe_metadata.get("source_family")),
+        selected_columns=_sanitize_text_items(
+            _as_iterable(safe_metadata.get("selected_columns"))
+        ),
+        row_limit=_positive_int_or_none(safe_metadata.get("row_limit")),
+    )
+
+
+def _build_guard_summary(guard_metadata: Mapping[str, object]) -> AnswerPlanGuardSummary:
+    safe_metadata = _filter_safe_mapping(guard_metadata)
+    return AnswerPlanGuardSummary(
+        guard_decision=_guard_decision_or_none(safe_metadata.get("guard_decision")),
+        guard_version=_optional_sanitized_string(safe_metadata.get("guard_version")),
+        primary_deny_code=_optional_sanitized_string(
+            safe_metadata.get("primary_deny_code")
+        ),
+        denial_reason=_optional_sanitized_string(safe_metadata.get("denial_reason")),
+    )
+
+
+def _build_narrative(
+    *,
+    review: ReviewLLMAdapterOutput,
+    semantic_evidence: AnswerPlanSemanticEvidence,
+) -> str:
+    narrative = (
+        "The candidate is intended to "
+        f"{_sentence_fragment(_sanitize_text(review.intent_summary))}."
+    )
+    if review.dimensions or review.metrics or review.filters:
+        clauses = []
+        if review.dimensions:
+            clauses.append(
+                "group the answer by "
+                + _join_business_items(_sanitize_text_items(review.dimensions))
+            )
+        if review.metrics:
+            clauses.append(
+                "use "
+                + _join_business_items(_sanitize_text_items(review.metrics))
+                + " as the measure"
+            )
+        if review.filters:
+            clauses.append(
+                "apply " + _join_business_items(_sanitize_text_items(review.filters))
+            )
+        narrative += " It should " + _join_clauses(clauses) + "."
+
+    evidence_label = _semantic_evidence_label(semantic_evidence)
+    if evidence_label is not None:
+        narrative += f" Semantic contract evidence: {evidence_label}."
+
+    return narrative
+
+
+def _build_steps(
+    *,
+    review: ReviewLLMAdapterOutput,
+    candidate_summary: AnswerPlanCandidateSummary,
+) -> tuple[str, ...]:
+    steps = []
+    if candidate_summary.candidate_id and candidate_summary.source_id:
+        steps.append(
+            "Answer the question using candidate "
+            f"{candidate_summary.candidate_id} for source {candidate_summary.source_id}."
+        )
+    elif candidate_summary.candidate_id:
+        steps.append(f"Answer the question using candidate {candidate_summary.candidate_id}.")
+
+    metrics = _sanitize_text_items(review.metrics)
+    if metrics:
+        steps.append(f"Use the approved business metric {_join_business_items(metrics)}.")
+
+    dimensions = _sanitize_text_items(review.dimensions)
+    if dimensions:
+        steps.append(f"Group or label the answer by {_join_business_items(dimensions)}.")
+
+    filters = _sanitize_text_items(review.filters)
+    if filters:
+        steps.append(f"Apply the business filter {_join_business_items(filters)}.")
+
+    steps.append(
+        "Keep the output at plan level; do not summarize result rows in this step."
+    )
+    return tuple(steps)
+
+
+def _build_risks(
+    *,
+    review: ReviewLLMAdapterOutput,
+    semantic_evidence: AnswerPlanSemanticEvidence,
+) -> tuple[str, ...]:
+    risks = list(_sanitize_text_items(review.risk_flags))
+    if semantic_evidence.classification in {"ambiguous", "unsupported"}:
+        risks.append(
+            "Semantic mapping is "
+            f"{semantic_evidence.classification}; do not present the plan as a final answer."
+        )
+    if review.status == "blocked":
+        risks.append("Review output is blocked and must not be used as an answer.")
+    return _dedupe(risks)
+
+
+def _semantic_evidence_label(
+    semantic_evidence: AnswerPlanSemanticEvidence,
+) -> str | None:
+    if semantic_evidence.contract_version and semantic_evidence.mapping_id:
+        return f"{semantic_evidence.contract_version} / {semantic_evidence.mapping_id}"
+    return semantic_evidence.contract_version or semantic_evidence.mapping_id
+
+
+def _filter_safe_mapping(payload: Mapping[str, object]) -> dict[str, object]:
+    return {
+        str(key): value
+        for key, value in payload.items()
+        if str(key).casefold() not in _UNSAFE_INPUT_KEYS
+    }
+
+
+def _sanitize_text_items(values: Iterable[object]) -> tuple[str, ...]:
+    return _dedupe(_sanitize_text(value) for value in values if value is not None)
+
+
+def _sanitize_text(value: object) -> str:
+    sanitized = str(value).strip()
+    for pattern in _SECRET_VALUE_PATTERNS:
+        sanitized = pattern.sub(_REDACTED, sanitized)
+    return sanitized
+
+
+def _optional_sanitized_string(value: object) -> str | None:
+    if value is None:
+        return None
+    sanitized = _sanitize_text(value)
+    return sanitized or None
+
+
+def _as_iterable(value: object) -> Iterable[object]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Iterable):
+        return value
+    return (value,)
+
+
+def _positive_int_or_none(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _guard_decision_or_none(value: object) -> Optional[Literal["allow", "reject"]]:
+    if value in {"allow", "reject"}:
+        return value
+    return None
+
+
+def _sentence_fragment(value: str) -> str:
+    value = value.rstrip(".")
+    if not value:
+        return value
+    return value[0].lower() + value[1:]
+
+
+def _join_business_items(values: Iterable[str]) -> str:
+    items = tuple(values)
+    if len(items) <= 1:
+        return "".join(items)
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return ", ".join(items[:-1]) + f", and {items[-1]}"
+
+
+def _join_clauses(values: Iterable[str]) -> str:
+    clauses = tuple(values)
+    if len(clauses) <= 1:
+        return "".join(clauses)
+    return ", ".join(clauses[:-1]) + f", and {clauses[-1]}"
+
+
+def _dedupe(values: Iterable[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    deduped = []
+    for value in values:
+        normalized = value.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return tuple(deduped)

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -258,7 +258,7 @@ def test_answer_plan_redacts_escaped_quoted_secret_values() -> None:
     review = parse_review_llm_adapter_output(_review_payload())
 
     plan = build_answer_plan_from_review(
-        question=r'Inspect {\"password\":\"hunter2\"} safely.',
+        question=r'Inspect {\\"password\\":\\"hunter2\\"} safely.',
         review=review,
         semantic_mapping={
             "contract_version": "approved_vendor_spend.v1",
@@ -267,7 +267,7 @@ def test_answer_plan_redacts_escaped_quoted_secret_values() -> None:
         candidate_metadata={"candidate_id": "candidate-123"},
         guard_metadata={
             "guard_decision": "reject",
-            "denial_reason": r'Driver returned {\"token\":\"raw-token\"}.',
+            "denial_reason": r'Driver returned {\\"token\\":\\"raw-token\\"}.',
         },
     )
 
@@ -275,6 +275,54 @@ def test_answer_plan_redacts_escaped_quoted_secret_values() -> None:
 
     assert "hunter2" not in serialized
     assert "raw-token" not in serialized
+
+
+def test_answer_plan_redacts_multiline_key_value_secret_values() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Use password=northwind\nsouthwind safely.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": "Driver failed with token: redwood\ncedar; retry later",
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "northwind" not in serialized
+    assert "southwind" not in serialized
+    assert "redwood" not in serialized
+    assert "cedar" not in serialized
+
+
+def test_answer_plan_redacts_basic_auth_credentials() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Retry with Basic dXNlcjpwYXNzLXNlY3JldA== safely.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": "Authorization failed for Basic YXBpOnNlY3JldA==",
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "dxnlcjpwyxnzlxnly3jlda" not in serialized
+    assert "yxbponnly3jlda" not in serialized
 
 
 def test_answer_plan_redacts_full_bearer_token_with_equals() -> None:

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -279,3 +279,93 @@ def test_answer_plan_rejects_non_string_selected_columns() -> None:
     serialized = json.dumps(candidate_summary, sort_keys=True).lower()
     assert "alice" not in serialized
     assert "999.00" not in serialized
+
+
+def test_answer_plan_rejects_non_string_semantic_evidence_items() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+            "dimensions": [{"customer": "alice", "amount": "999.00"}],
+            "filters": ["approved_spend_only", {"token": "raw-token"}],
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    semantic_evidence = plan.to_wire_payload()["semanticEvidence"][0]
+    assert semantic_evidence["dimensions"] == []
+    assert semantic_evidence["filters"] == []
+    serialized = json.dumps(semantic_evidence, sort_keys=True).lower()
+    assert "alice" not in serialized
+    assert "999.00" not in serialized
+    assert "raw-token" not in serialized
+
+
+def test_answer_plan_orders_unordered_string_metadata_deterministically() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+            "dimensions": {"vendor_name", "fiscal_quarter"},
+            "filters": frozenset(("approved_spend_only", "current_quarter")),
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "selected_columns": {"approved_spend", "vendor_name"},
+        },
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    semantic_evidence = plan.to_wire_payload()["semanticEvidence"][0]
+    candidate_summary = plan.to_wire_payload()["candidateSummary"]
+    assert semantic_evidence["dimensions"] == ["fiscal_quarter", "vendor_name"]
+    assert semantic_evidence["filters"] == ["approved_spend_only", "current_quarter"]
+    assert candidate_summary["selectedColumns"] == ["approved_spend", "vendor_name"]
+
+
+def test_answer_plan_rejects_non_string_scalar_metadata() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": {"customer": "alice", "amount": "999.00"},
+            "mapping_id": {"mapping": "customer-row"},
+            "classification": "supported",
+            "metric": {"token": "raw-token"},
+        },
+        candidate_metadata={
+            "candidate_id": {"customer": "alice", "amount": "999.00"},
+            "source_id": {"source": "business-postgres-source"},
+        },
+        guard_metadata={
+            "guard_decision": "allow",
+            "guard_version": {"version": "row-like-object"},
+            "denial_reason": {"password": "hunter2"},
+        },
+    )
+
+    wire_payload = plan.to_wire_payload()
+    assert wire_payload["semanticEvidence"][0] == {
+        "classification": "supported",
+        "dimensions": [],
+        "filters": [],
+    }
+    assert wire_payload["candidateSummary"]["selectedColumns"] == []
+    assert wire_payload["guardSummary"] == {"guardDecision": "allow"}
+    serialized = json.dumps(wire_payload, sort_keys=True).lower()
+    assert "alice" not in serialized
+    assert "999.00" not in serialized
+    assert "customer-row" not in serialized
+    assert "raw-token" not in serialized
+    assert "hunter2" not in serialized

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -140,7 +140,7 @@ def test_answer_plan_redacts_secret_like_prompt_and_output_context() -> None:
     review = parse_review_llm_adapter_output(_review_payload())
 
     plan = build_answer_plan_from_review(
-        question="Use token=raw-secret-token to show vendor spend.",
+        question='Use token=raw-secret-token and {"password":"quoted-secret"} to show vendor spend.',
         review=review,
         semantic_mapping={
             "contract_version": "approved_vendor_spend.v1",
@@ -156,13 +156,15 @@ def test_answer_plan_redacts_secret_like_prompt_and_output_context() -> None:
         },
         guard_metadata={
             "guard_decision": "reject",
-            "denial_reason": "Driver failed with password=hunter2",
+            "denial_reason": "Driver failed with {'token': 'quoted-token'} and password=hunter2",
         },
     )
 
     serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
 
     assert "raw-secret-token" not in serialized
+    assert "quoted-secret" not in serialized
+    assert "quoted-token" not in serialized
     assert "secret-value" not in serialized
     assert "hunter2" not in serialized
     assert "vendor_secret" not in serialized
@@ -172,3 +174,27 @@ def test_answer_plan_redacts_secret_like_prompt_and_output_context() -> None:
     assert "scratchpad" not in serialized
     assert "connection_string" not in serialized
     assert "canAuthorizeExecution" not in plan.model_dump()
+
+
+def test_answer_plan_omits_unknown_source_family_without_failing() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "source_id": "business-mysql-source",
+            "source_family": "mysql",
+        },
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    candidate_summary = plan.to_wire_payload()["candidateSummary"]
+    assert candidate_summary["candidateId"] == "candidate-123"
+    assert candidate_summary["sourceId"] == "business-mysql-source"
+    assert "sourceFamily" not in candidate_summary

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -198,3 +198,26 @@ def test_answer_plan_omits_unknown_source_family_without_failing() -> None:
     assert candidate_summary["candidateId"] == "candidate-123"
     assert candidate_summary["sourceId"] == "business-mysql-source"
     assert "sourceFamily" not in candidate_summary
+
+
+def test_answer_plan_preserves_valid_source_id_with_secret_keyword() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Show quarterly spend for the configured source.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "source_id": "secret-source",
+            "source_family": "mysql",
+        },
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    candidate_summary = plan.to_wire_payload()["candidateSummary"]
+    assert candidate_summary["sourceId"] == "secret-source"
+    assert "sourceFamily" not in candidate_summary

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -258,7 +258,7 @@ def test_answer_plan_redacts_escaped_quoted_secret_values() -> None:
     review = parse_review_llm_adapter_output(_review_payload())
 
     plan = build_answer_plan_from_review(
-        question=r'Inspect {\\"password\\":\\"hunter2\\"} safely.',
+        question=r'Inspect {\\"password\\":\\"hunter2\\"} safely, then use token="alpha \"beta\" gamma".',
         review=review,
         semantic_mapping={
             "contract_version": "approved_vendor_spend.v1",
@@ -275,6 +275,35 @@ def test_answer_plan_redacts_escaped_quoted_secret_values() -> None:
 
     assert "hunter2" not in serialized
     assert "raw-token" not in serialized
+    assert "alpha" not in serialized
+    assert "beta" not in serialized
+    assert "gamma" not in serialized
+
+
+def test_answer_plan_redacts_quoted_credential_uri_with_spaces() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question='Use connection="postgresql://reader:multi word password@db/business" safely.',
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": 'Driver failed for "mssql://reader:space secret@warehouse/finance"',
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "postgresql://reader:multi word password@db/business" not in serialized
+    assert "mssql://reader:space secret@warehouse/finance" not in serialized
+    assert "multi word password" not in serialized
+    assert "space secret" not in serialized
+    assert "warehouse" not in serialized
 
 
 def test_answer_plan_redacts_multiline_key_value_secret_values() -> None:
@@ -401,6 +430,37 @@ def test_answer_plan_rejects_non_string_semantic_evidence_items() -> None:
     assert "raw-token" not in serialized
 
 
+def test_answer_plan_rejects_mapping_metadata_for_string_lists() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+            "dimensions": {"customer": "alice", "amount": "999.00"},
+            "filters": {"token": "raw-token"},
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "selected_columns": {"customer": "alice", "amount": "999.00"},
+        },
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    wire_payload = plan.to_wire_payload()
+    assert wire_payload["semanticEvidence"][0]["dimensions"] == []
+    assert wire_payload["semanticEvidence"][0]["filters"] == []
+    assert wire_payload["candidateSummary"]["selectedColumns"] == []
+    serialized = json.dumps(wire_payload, sort_keys=True).lower()
+    assert "customer" not in serialized
+    assert "amount" not in serialized
+    assert "alice" not in serialized
+    assert "999.00" not in serialized
+    assert "raw-token" not in serialized
+
+
 def test_answer_plan_orders_unordered_string_metadata_deterministically() -> None:
     review = parse_review_llm_adapter_output(_review_payload())
 
@@ -486,3 +546,45 @@ def test_answer_plan_rejects_overlong_source_id_without_failing() -> None:
     candidate_summary = plan.to_wire_payload()["candidateSummary"]
     assert candidate_summary["candidateId"] == "candidate-123"
     assert "sourceId" not in candidate_summary
+
+
+def test_answer_plan_rejects_lossy_row_limit_coercions() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    for row_limit in ("50", 50.8, True):
+        plan = build_answer_plan_from_review(
+            question="Which approved vendors had the highest quarterly spend?",
+            review=review,
+            semantic_mapping={
+                "contract_version": "approved_vendor_spend.v1",
+                "classification": "supported",
+            },
+            candidate_metadata={
+                "candidate_id": "candidate-123",
+                "row_limit": row_limit,
+            },
+            guard_metadata={"guard_decision": "allow"},
+        )
+
+        assert "rowLimit" not in plan.to_wire_payload()["candidateSummary"]
+
+
+def test_answer_plan_normalizes_semantic_classification_before_risk_check() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Show quarterly spend net of refunds.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": " Unsupported ",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    assert (
+        "Semantic mapping is unsupported; do not present the plan as a final answer."
+        in plan.risks
+    )
+    assert plan.semantic_evidence[0].classification == "unsupported"

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -173,7 +173,9 @@ def test_answer_plan_redacts_secret_like_prompt_and_output_context() -> None:
     assert "token" not in serialized
     assert "scratchpad" not in serialized
     assert "connection_string" not in serialized
-    assert "canAuthorizeExecution" not in plan.model_dump()
+    wire_payload = plan.to_wire_payload()
+    assert wire_payload["advisoryOnly"] is True
+    assert wire_payload["canAuthorizeExecution"] is False
 
 
 def test_answer_plan_omits_unknown_source_family_without_failing() -> None:
@@ -221,3 +223,59 @@ def test_answer_plan_preserves_valid_source_id_with_secret_keyword() -> None:
     candidate_summary = plan.to_wire_payload()["candidateSummary"]
     assert candidate_summary["sourceId"] == "secret-source"
     assert "sourceFamily" not in candidate_summary
+
+
+def test_answer_plan_redacts_spaced_secret_values_and_dsn_attributes() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Use token: alpha beta gamma",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": (
+                "ODBC failed with Pwd={correct horse battery staple};"
+                "Server=finance warehouse host;Password=multi word phrase"
+            ),
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "alpha beta gamma" not in serialized
+    assert "correct horse battery staple" not in serialized
+    assert "horse battery" not in serialized
+    assert "finance warehouse host" not in serialized
+    assert "multi word phrase" not in serialized
+
+
+def test_answer_plan_rejects_non_string_selected_columns() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "selected_columns": [
+                {"customer": "alice", "amount": "999.00"},
+                "approved_spend",
+            ],
+        },
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    candidate_summary = plan.to_wire_payload()["candidateSummary"]
+    assert candidate_summary["selectedColumns"] == []
+    serialized = json.dumps(candidate_summary, sort_keys=True).lower()
+    assert "alice" not in serialized
+    assert "999.00" not in serialized

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -354,6 +354,54 @@ def test_answer_plan_redacts_basic_auth_credentials() -> None:
     assert "yxbponnly3jlda" not in serialized
 
 
+def test_answer_plan_redacts_basic_auth_credentials_with_colon_payload() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Retry with Authorization: Basic user:password safely.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": "Authorization failed for Basic api:multi-word-password",
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "user:password" not in serialized
+    assert ":password" not in serialized
+    assert "api:multi-word-password" not in serialized
+    assert "multi-word-password" not in serialized
+
+
+def test_answer_plan_redacts_quoted_basic_and_bearer_credentials() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question='Retry with Authorization: Bearer "abc.def" safely.',
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": 'Authorization failed for Basic "dXNlcjpwYXNz"',
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "abc.def" not in serialized
+    assert "dxnlcjpwyxnz" not in serialized
+
+
 def test_answer_plan_redacts_full_bearer_token_with_equals() -> None:
     review = parse_review_llm_adapter_output(_review_payload())
 
@@ -376,6 +424,57 @@ def test_answer_plan_redacts_full_bearer_token_with_equals() -> None:
     assert "abc=def" not in serialized
     assert "opaque-token==" not in serialized
     assert "=def" not in serialized
+
+
+def test_answer_plan_redacts_uri_credentials_with_escaped_quotes() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question=r'Use postgresql://user:abc\\"def@host/db safely.',
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": r'Driver failed for mssql://reader:north\\"wind@warehouse/finance',
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "abc" not in serialized
+    assert "def@host" not in serialized
+    assert "north" not in serialized
+    assert "wind@warehouse" not in serialized
+    assert "warehouse/finance" not in serialized
+
+
+def test_answer_plan_redacts_dsn_password_values_with_escaped_quotes() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question=r'Use Password="abc\\"def" safely.',
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": r"ODBC failed with Pwd='cedar\\'redwood'; retry later",
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "abc" not in serialized
+    assert "def" not in serialized
+    assert "cedar" not in serialized
+    assert "redwood" not in serialized
 
 
 def test_answer_plan_rejects_non_string_selected_columns() -> None:

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -254,6 +254,53 @@ def test_answer_plan_redacts_spaced_secret_values_and_dsn_attributes() -> None:
     assert "multi word phrase" not in serialized
 
 
+def test_answer_plan_redacts_escaped_quoted_secret_values() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question=r'Inspect {\"password\":\"hunter2\"} safely.',
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": r'Driver returned {\"token\":\"raw-token\"}.',
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "hunter2" not in serialized
+    assert "raw-token" not in serialized
+
+
+def test_answer_plan_redacts_full_bearer_token_with_equals() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Use Bearer abc=def safely.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": "Authorization failed for Bearer opaque-token==",
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "abc=def" not in serialized
+    assert "opaque-token==" not in serialized
+    assert "=def" not in serialized
+
+
 def test_answer_plan_rejects_non_string_selected_columns() -> None:
     review = parse_review_llm_adapter_output(_review_payload())
 
@@ -369,3 +416,25 @@ def test_answer_plan_rejects_non_string_scalar_metadata() -> None:
     assert "customer-row" not in serialized
     assert "raw-token" not in serialized
     assert "hunter2" not in serialized
+
+
+def test_answer_plan_rejects_overlong_source_id_without_failing() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "source_id": "a" * 300,
+        },
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    candidate_summary = plan.to_wire_payload()["candidateSummary"]
+    assert candidate_summary["candidateId"] == "candidate-123"
+    assert "sourceId" not in candidate_summary

--- a/backend/tests/test_review_llm_answer_plan.py
+++ b/backend/tests/test_review_llm_answer_plan.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+
+from app.features.review_llm import (
+    build_answer_plan_from_review,
+    parse_review_llm_adapter_output,
+)
+
+
+def _review_payload() -> dict[str, object]:
+    return {
+        "status": "ready",
+        "confidence": "high",
+        "intent_summary": "Compare approved vendor spend by fiscal quarter.",
+        "data_used": ["approved_vendor_spend semantic contract v1"],
+        "metrics": ["Approved vendor spend"],
+        "dimensions": ["Vendor", "Fiscal quarter"],
+        "filters": ["Approved spend only"],
+        "assumptions": ["Quarter means fiscal quarter."],
+        "risk_flags": [],
+        "clarifying_questions": [],
+        "diagnostics": {
+            "adapter_version": "review_llm_contract.v1",
+            "model": "contract-test",
+            "raw_output_excerpt": "postgresql://reader:secret-value@db/business",
+        },
+    }
+
+
+def test_answer_plan_turns_candidate_review_into_business_readable_snapshot() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Which approved vendors had the highest quarterly spend?",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "mapping_id": "show_top_approved_vendors_by_quarterly_spend",
+            "classification": "supported",
+            "metric": "sum_approved_vendor_spend",
+            "dimensions": ["vendor_name", "fiscal_quarter"],
+            "filters": ["approved_spend_only"],
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "source_id": "business-postgres-source",
+            "source_family": "postgresql",
+            "selected_columns": ["vendor_name", "fiscal_quarter", "approved_spend"],
+            "row_limit": 100,
+            "raw_sql": "SELECT vendor_secret FROM finance.approved_vendor_spend",
+            "result_rows": [{"vendor_secret": "sk-live-should-not-leak"}],
+        },
+        guard_metadata={
+            "guard_decision": "allow",
+            "guard_version": "postgresql-guard-v1",
+        },
+    )
+
+    assert plan.to_wire_payload() == {
+        "contractVersion": "answer_plan.v1",
+        "question": "Which approved vendors had the highest quarterly spend?",
+        "narrative": (
+            "The candidate is intended to compare approved vendor spend by fiscal "
+            "quarter. It should group the answer by Vendor and Fiscal quarter, "
+            "use Approved vendor spend as the measure, and apply Approved spend "
+            "only. Semantic contract evidence: approved_vendor_spend.v1 / "
+            "show_top_approved_vendors_by_quarterly_spend."
+        ),
+        "steps": [
+            "Answer the question using candidate candidate-123 for source business-postgres-source.",
+            "Use the approved business metric Approved vendor spend.",
+            "Group or label the answer by Vendor and Fiscal quarter.",
+            "Apply the business filter Approved spend only.",
+            "Keep the output at plan level; do not summarize result rows in this step.",
+        ],
+        "assumptions": ["Quarter means fiscal quarter."],
+        "risks": [],
+        "clarifications": [],
+        "semanticEvidence": [
+            {
+                "contractVersion": "approved_vendor_spend.v1",
+                "mappingId": "show_top_approved_vendors_by_quarterly_spend",
+                "classification": "supported",
+                "metric": "sum_approved_vendor_spend",
+                "dimensions": ["vendor_name", "fiscal_quarter"],
+                "filters": ["approved_spend_only"],
+            }
+        ],
+        "candidateSummary": {
+            "candidateId": "candidate-123",
+            "sourceId": "business-postgres-source",
+            "sourceFamily": "postgresql",
+            "selectedColumns": ["vendor_name", "fiscal_quarter", "approved_spend"],
+            "rowLimit": 100,
+        },
+        "guardSummary": {
+            "guardDecision": "allow",
+            "guardVersion": "postgresql-guard-v1",
+        },
+        "advisoryOnly": True,
+        "canAuthorizeExecution": False,
+    }
+
+
+def test_answer_plan_lists_unsupported_assumptions_as_risks_or_clarifications() -> None:
+    review = parse_review_llm_adapter_output(
+        {
+            **_review_payload(),
+            "status": "needs_clarification",
+            "confidence": "medium",
+            "assumptions": ["Refunds are excluded, but the contract does not prove it."],
+            "risk_flags": ["Refund handling is unsupported by the semantic mapping."],
+            "clarifying_questions": ["Should refunded spend be excluded?"],
+        }
+    )
+
+    plan = build_answer_plan_from_review(
+        question="Show quarterly spend net of refunds.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "ambiguous",
+            "ambiguity_rule_refs": ["spend_definition"],
+        },
+        candidate_metadata={"candidate_id": "candidate-123"},
+        guard_metadata={"guard_decision": "allow"},
+    )
+
+    assert "Refund handling is unsupported by the semantic mapping." in plan.risks
+    assert (
+        "Semantic mapping is ambiguous; do not present the plan as a final answer."
+        in plan.risks
+    )
+    assert plan.clarifications == ("Should refunded spend be excluded?",)
+    assert plan.can_authorize_execution is False
+
+
+def test_answer_plan_redacts_secret_like_prompt_and_output_context() -> None:
+    review = parse_review_llm_adapter_output(_review_payload())
+
+    plan = build_answer_plan_from_review(
+        question="Use token=raw-secret-token to show vendor spend.",
+        review=review,
+        semantic_mapping={
+            "contract_version": "approved_vendor_spend.v1",
+            "classification": "supported",
+            "metric": "sum_approved_vendor_spend",
+        },
+        candidate_metadata={
+            "candidate_id": "candidate-123",
+            "source_id": "business-postgres-source",
+            "selected_columns": ["vendor_secret", "approved_spend"],
+            "connection_string": "postgresql://reader:secret-value@db/business",
+            "scratchpad": "hidden chain of thought with password=hunter2",
+        },
+        guard_metadata={
+            "guard_decision": "reject",
+            "denial_reason": "Driver failed with password=hunter2",
+        },
+    )
+
+    serialized = json.dumps(plan.to_wire_payload(), sort_keys=True).lower()
+
+    assert "raw-secret-token" not in serialized
+    assert "secret-value" not in serialized
+    assert "hunter2" not in serialized
+    assert "vendor_secret" not in serialized
+    assert "password" not in serialized
+    assert "secret" not in serialized
+    assert "token" not in serialized
+    assert "scratchpad" not in serialized
+    assert "connection_string" not in serialized
+    assert "canAuthorizeExecution" not in plan.model_dump()


### PR DESCRIPTION
## Summary
- Add deterministic Review LLM answer-plan payloads for candidate review output, semantic mapping evidence, candidate metadata, and guard metadata.
- Keep answer plans advisory-only with no execution authority, no result-row summarization, and secret-safe redaction of prompt/output metadata.
- Add focused fixture/snapshot-style tests for readable plans, unsupported assumptions, and secret-safe output.

## Verification
- cd backend && python3 -m pytest tests/test_review_llm_answer_plan.py
- cd backend && python3 -m pytest tests/test_review_llm_adapter_contract.py tests/test_review_llm_answer_plan.py
- cd backend && python3 -m pytest tests/test_semantic_contract_schema.py tests/test_governed_answer_fixtures.py
- cd backend && python3 -m pytest
- git diff --check

Closes #455