### PR TITLE
[Y-3] Detect ambiguous questions and ask for clarification

### DIFF
--- a/backend/app/features/operator_history/payloads.py
+++ b/backend/app/features/operator_history/payloads.py
@@ -13,10 +13,18 @@ from app.features.audit.event_model import (
     SourceIdentifier,
 )
 
-RequestState = Literal["drafting", "submitted", "previewed", "blocked", "superseded"]
+RequestState = Literal[
+    "drafting",
+    "submitted",
+    "previewed",
+    "clarification_required",
+    "blocked",
+    "superseded",
+]
 CandidateState = Literal[
     "pending_generation",
     "preview_ready",
+    "clarification_required",
     "blocked",
     "expired",
     "invalidated",

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -554,6 +554,8 @@ def _intent_blocked_candidate_state(
 ) -> str | None:
     if intent_mapping is None or intent_mapping.status == "mapped":
         return None
+    if intent_mapping.status == "ambiguous":
+        return "clarification_required"
     return "blocked"
 
 
@@ -754,6 +756,7 @@ def _resolve_revision_record(
             )
         if request.request_state not in {
             "blocked",
+            "clarification_required",
             "preview_denied",
             "preview_generation_failed",
             "preview_malformed",
@@ -794,7 +797,11 @@ def _resolve_revision_record(
             raise PreviewSubmissionContractError(
                 "Revision context lifecycle_state does not match candidate_state."
             )
-        if candidate.candidate_state not in {"blocked", "preview_ready"}:
+        if candidate.candidate_state not in {
+            "blocked",
+            "clarification_required",
+            "preview_ready",
+        }:
             raise PreviewSubmissionContractError(
                 "Preview candidate state is not eligible for revision."
             )
@@ -1673,8 +1680,8 @@ def submit_preview_request(
             intent_mapping
         )
         if intent_blocked_candidate_state is not None:
-            candidate_state = "blocked"
-            request_state = "blocked"
+            candidate_state = intent_blocked_candidate_state
+            request_state = intent_blocked_candidate_state
         else:
             try:
                 prepared_context = prepare_generation_context(

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -274,8 +274,8 @@ def test_http_preview_submission_persists_request_and_candidate_records() -> Non
         assert response_payload["candidate"]["guard_status"] == "pending"
         assert response_payload["candidate"]["candidate_sql"] is None
 
-        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_approval = session.execute(
             select(PreviewCandidateApproval)
         ).scalar_one()
@@ -659,9 +659,19 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
 
         assert response.status_code == 200
         response_payload = response.json()
+        expected_candidate_state = (
+            "clarification_required"
+            if expected_status == "ambiguous"
+            else "blocked"
+        )
         assert adapter.adapter_request is None
         assert response_payload["candidate"]["candidate_sql"] is None
-        assert response_payload["candidate"]["state"] == "blocked"
+        assert response_payload["candidate"]["state"] == expected_candidate_state
+        assert response_payload["candidate"]["primary_deny_code"] == (
+            "DENY_AMBIGUOUS_INTENT"
+            if expected_status == "ambiguous"
+            else "DENY_UNSUPPORTED_INTENT"
+        )
         assert response_payload["candidate"]["intent_mapping"]["status"] == (
             expected_status
         )
@@ -671,6 +681,13 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             else None
         )
         assert response_payload["candidate"]["intent_mapping"]["clarification"] is not None
+        assert "/Users/" not in response_payload["candidate"]["denial_reason"]
+        assert "secret" not in response_payload["candidate"]["denial_reason"].lower()
+        assert response_payload["evaluation"]["state"] == (
+            "ambiguous_intent"
+            if expected_status == "ambiguous"
+            else "unsupported_intent"
+        )
         assert [event["event_type"] for event in response_payload["audit"]["events"]] == [
             "query_submitted",
             "generation_requested",
@@ -685,9 +702,13 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             expected_status
         )
         assert response_payload["audit"]["events"][1]["candidate_state"] == (
-            "blocked"
+            expected_candidate_state
+        )
+        assert response_payload["audit"]["events"][1]["primary_deny_code"] == (
+            response_payload["candidate"]["primary_deny_code"]
         )
 
+        persisted_request = session.execute(select(PreviewRequest)).scalar_one()
         persisted_candidate = session.execute(select(PreviewCandidate)).scalar_one()
         persisted_approval = session.execute(
             select(PreviewCandidateApproval)
@@ -699,8 +720,9 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             .scalars()
             .all()
         )
+        assert persisted_request.request_state == expected_candidate_state
         assert persisted_candidate.candidate_sql is None
-        assert persisted_candidate.candidate_state == "blocked"
+        assert persisted_candidate.candidate_state == expected_candidate_state
         assert persisted_candidate.guard_status == "pending"
         assert persisted_approval.approval_state == "invalidated"
         assert [event.event_type for event in persisted_events] == [
@@ -711,7 +733,7 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             event.event_type for event in persisted_events
         }
         assert "guard_evaluated" not in {event.event_type for event in persisted_events}
-        assert persisted_events[-1].candidate_state == "blocked"
+        assert persisted_events[-1].candidate_state == expected_candidate_state
         assert persisted_events[-1].audit_payload["intent_mapping"]["status"] == (
             expected_status
         )
@@ -727,7 +749,7 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
                     "item_type": "candidate",
                     "request_id": response_payload["request"]["request_id"],
                     "candidate_id": response_payload["candidate"]["candidate_id"],
-                    "lifecycle_state": "blocked",
+                    "lifecycle_state": expected_candidate_state,
                 },
             },
         )
@@ -741,7 +763,7 @@ def test_http_preview_intent_mapping_blocks_before_sql_generation_for_non_mapped
             "candidate_id": response_payload["candidate"]["candidate_id"],
             "run_id": None,
             "source_id": "sap-approved-spend",
-            "lifecycle_state": "blocked",
+            "lifecycle_state": expected_candidate_state,
         }
     finally:
         session.close()

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -243,6 +243,17 @@ describe("HomePage", () => {
                     sourceLabel: "SAP spend cube / approved_vendor_spend"
                   },
                   {
+                    guardStatus: "pending",
+                    itemType: "candidate",
+                    label: "Ambiguous candidate",
+                    lifecycleState: "clarification_required",
+                    occurredAt: "2026-04-21T14:25:00Z",
+                    recordId: "candidate-clarification-123",
+                    requestId: "request-clarification-123",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
+                  {
                     itemType: "run",
                     label: "Failed run",
                     lifecycleState: "failed",
@@ -266,12 +277,23 @@ describe("HomePage", () => {
 
     const history = screen.getByLabelText(/operator history/i);
     const deniedCandidateLink = within(history).getByRole("link", { name: /blocked candidate/i });
+    const ambiguousCandidateLink = within(history).getByRole("link", {
+      name: /ambiguous candidate/i
+    });
     const failedRunLink = within(history).getByRole("link", { name: /failed run/i });
 
     expect(deniedCandidateLink).toHaveAttribute("href", expect.stringContaining("state=review_denied"));
     expect(deniedCandidateLink).toHaveAttribute(
       "href",
       expect.stringContaining("history_record_id=candidate-123")
+    );
+    expect(ambiguousCandidateLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("state=review_denied")
+    );
+    expect(ambiguousCandidateLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("history_record_id=candidate-clarification-123")
     );
     expect(failedRunLink).toHaveAttribute("href", expect.stringContaining("state=failed"));
     expect(failedRunLink).toHaveAttribute("href", expect.stringContaining("history_record_id=run-123"));

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -963,6 +963,11 @@ describe("HomePage", () => {
         requestState: "submitted"
       },
       {
+        candidateState: "clarification_required",
+        expectedCopy: /clarification required/i,
+        requestState: "submitted"
+      },
+      {
         candidateState: "denied",
         expectedCopy: /preview denied/i,
         requestState: "blocked"

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -112,7 +112,7 @@ type PreviewSubmissionStatus =
       candidateState: string;
       requestState: string;
       sourceId: string;
-      status: "denied" | "pending";
+      status: "clarification_required" | "denied" | "pending";
     }
   | {
       code: string;
@@ -838,6 +838,13 @@ function isDeniedPreviewState(result: PreviewSubmissionResult): boolean {
   );
 }
 
+function isClarificationRequiredPreviewState(result: PreviewSubmissionResult): boolean {
+  const requestState = result.requestState.toLowerCase();
+  const candidateState = result.candidateState.toLowerCase();
+
+  return requestState === "clarification_required" || candidateState === "clarification_required";
+}
+
 function isReadyPreviewState(result: PreviewSubmissionResult): boolean {
   return result.candidateState.toLowerCase() === "preview_ready";
 }
@@ -1231,6 +1238,7 @@ function isRevisableRequestLifecycleState(lifecycleState: string): boolean {
   const normalizedLifecycleState = lifecycleState.toLowerCase();
   return (
     normalizedLifecycleState === "blocked" ||
+    normalizedLifecycleState === "clarification_required" ||
     normalizedLifecycleState === "preview_denied" ||
     normalizedLifecycleState === "preview_generation_failed" ||
     normalizedLifecycleState === "preview_malformed" ||
@@ -2322,6 +2330,32 @@ export function QueryWorkflowShell({
         return;
       }
 
+      if (isClarificationRequiredPreviewState(result)) {
+        setSubmittedQuestion(submittedQuestionText);
+        setSubmittedSourceId(result.sourceId);
+        setSubmittedState("review_denied");
+        setRevisionDraft(result.revisionContext ?? revisionDraft);
+        setSubmittedCandidatePreview({
+          auditEvents: [],
+          candidateId: result.candidateId,
+          candidateSql: result.candidateSql,
+          candidateState: result.candidateState,
+          executedEvidence: [],
+          guardStatus: result.guardStatus,
+          requestId: result.requestId,
+          retrievedCitations: [],
+          sourceId: result.sourceId,
+          sourceLabel: selectedSource.displayLabel
+        });
+        setPreviewSubmission({
+          candidateState: result.candidateState,
+          requestState: result.requestState,
+          sourceId: result.sourceId,
+          status: "clarification_required"
+        });
+        return;
+      }
+
       if (isDeniedPreviewState(result)) {
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
@@ -2762,6 +2796,16 @@ export function QueryWorkflowShell({
                     Request state {previewSubmission.requestState}; candidate state{" "}
                     {previewSubmission.candidateState}. The shell stays in query review until SQL
                     preview is ready.
+                  </p>
+                </div>
+              ) : null}
+              {previewSubmission.status === "clarification_required" ? (
+                <div className="state-callout state-callout-warning" role="status">
+                  <p className="state-callout-title">Clarification required</p>
+                  <p>
+                    Request state {previewSubmission.requestState}; candidate state{" "}
+                    {previewSubmission.candidateState}. Answer the clarifying question before SQL
+                    generation can continue.
                   </p>
                 </div>
               ) : null}

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -966,6 +966,7 @@ function historyItemToState(item: OperatorHistoryItem): CanonicalWorkflowState {
     if (
       lifecycleState === "review_denied" ||
       lifecycleState === "blocked" ||
+      lifecycleState === "clarification_required" ||
       lifecycleState === "preview_denied" ||
       lifecycleState === "preview_generation_failed" ||
       lifecycleState === "preview_malformed" ||


### PR DESCRIPTION
## Summary
- map ambiguous preview intent to a distinct clarification_required lifecycle state
- keep unsupported intent and guard-denied previews on blocked paths
- surface clarification-required preview submissions distinctly in the operator shell

## Verification
- cd backend && uv run --with pytest --with httpx pytest tests/test_intent_mapping.py tests/test_preview_persistence.py -q
- cd frontend && npm test -- page.test.tsx

Closes #456