### PR TITLE
[Y-4] Persist review decision evidence

### DIFF
--- a/backend/alembic/versions/0012_review_decision_persistence.py
+++ b/backend/alembic/versions/0012_review_decision_persistence.py
@@ -1,0 +1,105 @@
+"""Persist Review LLM decision evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0012_review_decision_persistence"
+down_revision: str | None = "0011_semantic_contract_preview_version"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "preview_review_decisions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("review_decision_id", sa.String(length=255), nullable=False),
+        sa.Column("preview_candidate_id", sa.Uuid(), nullable=False),
+        sa.Column("candidate_id", sa.String(length=255), nullable=False),
+        sa.Column("request_id", sa.String(length=255), nullable=False),
+        sa.Column("audit_event_id", sa.Uuid(), nullable=False),
+        sa.Column("registered_source_id", sa.Uuid(), nullable=False),
+        sa.Column("source_id", sa.String(length=255), nullable=False),
+        sa.Column("source_family", sa.String(length=64), nullable=False),
+        sa.Column("source_flavor", sa.String(length=64), nullable=True),
+        sa.Column("dataset_contract_version", sa.Integer(), nullable=False),
+        sa.Column("semantic_contract_version", sa.String(length=255), nullable=True),
+        sa.Column("schema_snapshot_version", sa.Integer(), nullable=False),
+        sa.Column("review_contract_version", sa.String(length=255), nullable=False),
+        sa.Column("review_status", sa.String(length=64), nullable=False),
+        sa.Column("review_confidence", sa.String(length=32), nullable=False),
+        sa.Column("assumptions", sa.JSON(), nullable=False),
+        sa.Column("risk_flags", sa.JSON(), nullable=False),
+        sa.Column("clarifying_questions", sa.JSON(), nullable=False),
+        sa.Column("review_payload", sa.JSON(), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "preview_candidate_id",
+                "candidate_id",
+                "request_id",
+                "registered_source_id",
+                "source_id",
+                "source_family",
+                "dataset_contract_version",
+                "schema_snapshot_version",
+            ],
+            [
+                "preview_candidates.id",
+                "preview_candidates.candidate_id",
+                "preview_candidates.request_id",
+                "preview_candidates.registered_source_id",
+                "preview_candidates.source_id",
+                "preview_candidates.source_family",
+                "preview_candidates.dataset_contract_version",
+                "preview_candidates.schema_snapshot_version",
+            ],
+            name=op.f("fk_preview_review_decisions_preview_candidate_identity"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["audit_event_id"],
+            ["preview_audit_events.event_id"],
+            name=op.f("fk_preview_review_decisions_audit_event_id_preview_audit_events"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["registered_source_id"],
+            ["registered_sources.id"],
+            name=op.f(
+                "fk_preview_review_decisions_registered_source_id_registered_sources"
+            ),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_preview_review_decisions")),
+        sa.UniqueConstraint(
+            "review_decision_id",
+            name=op.f("uq_preview_review_decisions_review_decision_id"),
+        ),
+        sa.UniqueConstraint(
+            "preview_candidate_id",
+            name=op.f("uq_preview_review_decisions_preview_candidate_id"),
+        ),
+        sa.UniqueConstraint(
+            "candidate_id",
+            name=op.f("uq_preview_review_decisions_candidate_id"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("preview_review_decisions")

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -3,6 +3,7 @@ from app.db.models.preview import (
     PreviewAuditEvent,
     PreviewCandidate,
     PreviewCandidateApproval,
+    PreviewReviewDecision,
     PreviewRequest,
 )
 from app.db.models.retrieval_corpus import RetrievalCorpusAsset
@@ -15,6 +16,7 @@ __all__ = [
     "PreviewAuditEvent",
     "PreviewCandidate",
     "PreviewCandidateApproval",
+    "PreviewReviewDecision",
     "PreviewRequest",
     "RegisteredSource",
     "RetrievalCorpusAsset",

--- a/backend/app/db/models/preview.py
+++ b/backend/app/db/models/preview.py
@@ -341,3 +341,88 @@ class PreviewAuditEvent(Base):
         nullable=False,
         server_default=func.now(),
     )
+
+
+class PreviewReviewDecision(Base):
+    __tablename__ = "preview_review_decisions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            (
+                "preview_candidate_id",
+                "candidate_id",
+                "request_id",
+                "registered_source_id",
+                "source_id",
+                "source_family",
+                "dataset_contract_version",
+                "schema_snapshot_version",
+            ),
+            (
+                "preview_candidates.id",
+                "preview_candidates.candidate_id",
+                "preview_candidates.request_id",
+                "preview_candidates.registered_source_id",
+                "preview_candidates.source_id",
+                "preview_candidates.source_family",
+                "preview_candidates.dataset_contract_version",
+                "preview_candidates.schema_snapshot_version",
+            ),
+            name="fk_preview_review_decisions_preview_candidate_identity",
+        ),
+        UniqueConstraint("review_decision_id"),
+        UniqueConstraint("preview_candidate_id"),
+        UniqueConstraint("candidate_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    review_decision_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    preview_candidate_id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        nullable=False,
+    )
+    candidate_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    request_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    audit_event_id: Mapped[uuid.UUID] = mapped_column(
+        SqlAlchemyUuid,
+        ForeignKey("preview_audit_events.event_id"),
+        nullable=False,
+    )
+    registered_source_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("registered_sources.id"),
+        nullable=False,
+    )
+    source_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_family: Mapped[str] = mapped_column(String(64), nullable=False)
+    source_flavor: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    dataset_contract_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    semantic_contract_version: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+    schema_snapshot_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    review_contract_version: Mapped[str] = mapped_column(String(255), nullable=False)
+    review_status: Mapped[str] = mapped_column(String(64), nullable=False)
+    review_confidence: Mapped[str] = mapped_column(String(32), nullable=False)
+    assumptions: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    risk_flags: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    clarifying_questions: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    review_payload: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/app/features/review_llm/__init__.py
+++ b/backend/app/features/review_llm/__init__.py
@@ -6,6 +6,7 @@ from app.features.review_llm.answer_plan import (
     AnswerPlanPayload,
     AnswerPlanSemanticEvidence,
     build_answer_plan_from_review,
+    sanitize_review_llm_surface_text_items,
 )
 from app.features.review_llm.schema import (
     ReviewLLMAdapterDiagnostics,
@@ -24,4 +25,5 @@ __all__ = [
     "ReviewLLMAdapterOutputError",
     "build_answer_plan_from_review",
     "parse_review_llm_adapter_output",
+    "sanitize_review_llm_surface_text_items",
 ]

--- a/backend/app/features/review_llm/answer_plan.py
+++ b/backend/app/features/review_llm/answer_plan.py
@@ -57,6 +57,14 @@ _SECRET_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
         r"client[_ -]?secret|api[_ -]?key|private[_ -]?key)(?![a-z0-9])"
     ),
 )
+_RAW_WORKSTATION_PATH_PATTERN = re.compile(
+    r"(?i)(?:"
+    r"(?:^|(?<=[\s'\"(=]))/(?:[^/\s:;,'\")]+/)+[^\s:;,'\")]*"
+    r"|[a-z]:[\\/](?:[^\\/\s:;,'\")]+[\\/])*[^\\/\s:;,'\")]+"
+    r"|\\\\[^\\\s/:;,'\")]+\\[^\\\s:;,'\")]+(?:\\[^\\\s:;,'\")]+)*"
+    r"|(?<!\S)~[\\/][^\s:;,'\")]+"
+    r")"
+)
 _UNSAFE_INPUT_KEYS = frozenset(
     {
         "connection",
@@ -164,6 +172,10 @@ def build_answer_plan_from_review(
         advisory_only=True,
         can_authorize_execution=False,
     )
+
+
+def sanitize_review_llm_surface_text_items(values: Iterable[object]) -> tuple[str, ...]:
+    return _sanitize_text_items(values)
 
 
 def _build_semantic_evidence(
@@ -339,6 +351,7 @@ def _sanitize_text(value: object) -> str:
     sanitized = value.strip()
     for pattern in _SECRET_VALUE_PATTERNS:
         sanitized = pattern.sub(_REDACTED, sanitized)
+    sanitized = _RAW_WORKSTATION_PATH_PATTERN.sub(_REDACTED, sanitized)
     return sanitized
 
 

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -12,6 +12,7 @@ from app.db.models.preview import (
     PreviewAuditEvent,
     PreviewCandidate,
     PreviewCandidateApproval,
+    PreviewReviewDecision,
     PreviewRequest,
 )
 from app.db.models.schema_snapshot import SchemaSnapshot
@@ -105,6 +106,28 @@ class OperatorWorkflowHistoryItem(BaseModel):
     candidate_attempts: list["OperatorWorkflowCandidateAttemptSummary"] = Field(
         default_factory=list,
         serialization_alias="candidateAttempts",
+    )
+    review_evidence: list["OperatorWorkflowReviewEvidence"] = Field(
+        default_factory=list,
+        serialization_alias="reviewEvidence",
+    )
+
+
+class OperatorWorkflowReviewEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    review_decision_id: str = Field(serialization_alias="reviewDecisionId")
+    review_status: str = Field(serialization_alias="reviewStatus")
+    review_contract_version: str = Field(serialization_alias="reviewContractVersion")
+    audit_event_id: str = Field(serialization_alias="auditEventId")
+    assumptions: list[str] = Field(default_factory=list)
+    risk_flags: list[str] = Field(
+        default_factory=list,
+        serialization_alias="riskFlags",
+    )
+    clarifying_questions: list[str] = Field(
+        default_factory=list,
+        serialization_alias="clarifyingQuestions",
     )
 
 
@@ -457,6 +480,41 @@ def _read_payload_items(value: object) -> list[dict[str, object]]:
     return [item for item in value if isinstance(item, dict)]
 
 
+def _read_text_items(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]
+
+
+def _review_evidence_summary(
+    review: PreviewReviewDecision,
+) -> OperatorWorkflowReviewEvidence:
+    return OperatorWorkflowReviewEvidence(
+        review_decision_id=review.review_decision_id,
+        review_status=review.review_status,
+        review_contract_version=review.review_contract_version,
+        audit_event_id=str(review.audit_event_id),
+        assumptions=_read_text_items(review.assumptions),
+        risk_flags=_read_text_items(review.risk_flags),
+        clarifying_questions=_read_text_items(review.clarifying_questions),
+    )
+
+
+def _review_evidence_by_candidate_id(
+    reviews: list[PreviewReviewDecision],
+) -> dict[str, list[OperatorWorkflowReviewEvidence]]:
+    evidence_by_candidate: dict[str, list[OperatorWorkflowReviewEvidence]] = {}
+    for review in sorted(
+        reviews,
+        key=lambda item: (_as_utc_datetime(item.occurred_at), item.review_decision_id),
+        reverse=True,
+    ):
+        evidence_by_candidate.setdefault(review.candidate_id, []).append(
+            _review_evidence_summary(review)
+        )
+    return evidence_by_candidate
+
+
 def _execution_run_id_for_event(event: PreviewAuditEvent) -> str:
     for item in _read_payload_items(event.audit_payload.get("executed_evidence")):
         if (
@@ -748,6 +806,7 @@ def _build_operator_history(
     requests = session.execute(select(PreviewRequest)).scalars().all()
     candidates = session.execute(select(PreviewCandidate)).scalars().all()
     approvals = session.execute(select(PreviewCandidateApproval)).scalars().all()
+    review_decisions = session.execute(select(PreviewReviewDecision)).scalars().all()
     audit_events = (
         session.execute(
             select(PreviewAuditEvent).order_by(
@@ -775,6 +834,7 @@ def _build_operator_history(
         for candidate in candidates
         if candidate.candidate_id in candidate_attempts
     }
+    review_evidence = _review_evidence_by_candidate_id(review_decisions)
 
     history: list[OperatorWorkflowHistoryItem] = []
     for event, run_state in _terminal_run_events(audit_events):
@@ -798,6 +858,11 @@ def _build_operator_history(
                 retrieved_citations=_retrieved_citations_for_event(event),
                 candidate_attempts=(
                     candidate_attempts.get(event.candidate_id, [])
+                    if event.candidate_id is not None
+                    else []
+                ),
+                review_evidence=(
+                    review_evidence.get(event.candidate_id, [])
                     if event.candidate_id is not None
                     else []
                 ),
@@ -841,6 +906,7 @@ def _build_operator_history(
                     source_id=candidate.revised_from_source_id,
                 ),
                 candidate_attempts=candidate_attempts.get(candidate.candidate_id, []),
+                review_evidence=review_evidence.get(candidate.candidate_id, []),
             )
         )
 

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -481,7 +481,7 @@ def _read_payload_items(value: object) -> list[dict[str, object]]:
     return [item for item in value if isinstance(item, dict)]
 
 
-def _read_text_items(value: object) -> list[str]:
+def _read_sanitized_review_text_items(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return list(sanitize_review_llm_surface_text_items(value))
@@ -495,9 +495,9 @@ def _review_evidence_summary(
         review_status=review.review_status,
         review_contract_version=review.review_contract_version,
         audit_event_id=str(review.audit_event_id),
-        assumptions=_read_text_items(review.assumptions),
-        risk_flags=_read_text_items(review.risk_flags),
-        clarifying_questions=_read_text_items(review.clarifying_questions),
+        assumptions=_read_sanitized_review_text_items(review.assumptions),
+        risk_flags=_read_sanitized_review_text_items(review.risk_flags),
+        clarifying_questions=_read_sanitized_review_text_items(review.clarifying_questions),
     )
 
 

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -18,6 +18,7 @@ from app.db.models.preview import (
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
 from app.features.auth.governance_bindings import normalize_governance_binding
+from app.features.review_llm import sanitize_review_llm_surface_text_items
 from app.services.source_registry import effective_source_activation_posture
 
 
@@ -483,7 +484,7 @@ def _read_payload_items(value: object) -> list[dict[str, object]]:
 def _read_text_items(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
-    return [item for item in value if isinstance(item, str) and item.strip()]
+    return list(sanitize_review_llm_surface_text_items(value))
 
 
 def _review_evidence_summary(

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -484,7 +484,10 @@ def _read_payload_items(value: object) -> list[dict[str, object]]:
 def _read_sanitized_review_text_items(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
-    return list(sanitize_review_llm_surface_text_items(value))
+    sanitized: list[str] = []
+    for item in value:
+        sanitized.extend(sanitize_review_llm_surface_text_items((item,)))
+    return sanitized
 
 
 def _review_evidence_summary(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -15,6 +15,7 @@ from app.db.models.preview import (
     PreviewAuditEvent,
     PreviewCandidate,
     PreviewCandidateApproval,
+    PreviewReviewDecision,
     PreviewRequest,
 )
 from app.db.models.schema_snapshot import SchemaSnapshot
@@ -31,6 +32,7 @@ from app.features.guard import (
     evaluate_postgresql_sql_guard,
 )
 from app.features.operator_history.payloads import GuardStatus
+from app.features.review_llm.schema import ReviewLLMAdapterOutput
 from app.services.candidate_lifecycle import (
     CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY,
     CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY,
@@ -1027,6 +1029,110 @@ def persist_execution_audit_events(
         session.rollback()
         raise PreviewSubmissionContractError(
             "Execution audit events could not be persisted consistently."
+        ) from exc
+
+
+def persist_review_decision(
+    session: Session,
+    *,
+    candidate_id: str,
+    review: ReviewLLMAdapterOutput,
+    audit_event_id: UUID,
+    occurred_at: datetime,
+) -> str:
+    try:
+        preview_candidate = session.execute(
+            select(PreviewCandidate).where(
+                PreviewCandidate.candidate_id == candidate_id
+            )
+        ).scalar_one_or_none()
+        if preview_candidate is None:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision cannot be persisted without a bound preview candidate.",
+            )
+
+        assert preview_candidate is not None
+        preview_request = session.get(
+            PreviewRequest,
+            preview_candidate.preview_request_id,
+        )
+        if preview_request is None:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision cannot be persisted without a bound preview request.",
+            )
+
+        assert preview_request is not None
+        audit_event = session.execute(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.event_id == audit_event_id
+            )
+        ).scalar_one_or_none()
+        if audit_event is None:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision cannot be persisted without an audit event anchor.",
+            )
+        assert audit_event is not None
+        if audit_event.request_id != preview_candidate.request_id:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision audit anchor must stay bound to the preview request.",
+            )
+        if audit_event.candidate_id != preview_candidate.candidate_id:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision audit anchor must stay bound to the preview candidate.",
+            )
+        if audit_event.source_id != preview_candidate.source_id:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision audit anchor must stay bound to the preview source.",
+            )
+
+        existing = session.execute(
+            select(PreviewReviewDecision).where(
+                PreviewReviewDecision.candidate_id == preview_candidate.candidate_id
+            )
+        ).scalar_one_or_none()
+        review_decision_id = f"review-{preview_candidate.candidate_id}"
+        if existing is None:
+            existing = PreviewReviewDecision(
+                review_decision_id=review_decision_id,
+                candidate_id=preview_candidate.candidate_id,
+                preview_candidate_id=preview_candidate.id,
+            )
+            session.add(existing)
+        elif existing.preview_candidate_id != preview_candidate.id:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision cannot be rebound to a different preview candidate.",
+            )
+
+        existing.request_id = preview_candidate.request_id
+        existing.audit_event_id = audit_event.event_id
+        existing.registered_source_id = preview_candidate.registered_source_id
+        existing.source_id = preview_candidate.source_id
+        existing.source_family = preview_candidate.source_family
+        existing.source_flavor = preview_candidate.source_flavor
+        existing.dataset_contract_version = preview_candidate.dataset_contract_version
+        existing.semantic_contract_version = preview_candidate.semantic_contract_version
+        existing.schema_snapshot_version = preview_candidate.schema_snapshot_version
+        existing.review_contract_version = review.contract_version
+        existing.review_status = review.status
+        existing.review_confidence = review.confidence
+        existing.assumptions = list(review.assumptions)
+        existing.risk_flags = list(review.risk_flags)
+        existing.clarifying_questions = list(review.clarifying_questions)
+        existing.review_payload = review.to_wire_payload()
+        existing.occurred_at = occurred_at
+        session.commit()
+        return review_decision_id
+    except IntegrityError as exc:
+        session.rollback()
+        raise PreviewSubmissionContractError(
+            "Review decision could not be persisted consistently."
         ) from exc
 
 

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1110,6 +1110,11 @@ def persist_review_decision(
                 "Review decision cannot be persisted without an audit event anchor.",
             )
         assert audit_event is not None
+        if audit_event.event_type != "guard_evaluated":
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision requires a guard audit event anchor.",
+            )
         if audit_event.request_id != preview_candidate.request_id:
             _raise_preview_persistence_contract_error(
                 session,

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -952,6 +952,32 @@ def _persist_preview_audit_events(
         )
 
 
+def _bind_preview_candidate_to_audit_events(
+    audit_events: list[SourceAwareAuditEvent],
+    *,
+    candidate_id: str,
+    candidate_owner_subject: str,
+) -> None:
+    for index, event in enumerate(audit_events):
+        if event.event_type not in {"generation_completed", "guard_evaluated"}:
+            continue
+        if event.query_candidate_id is not None:
+            if event.query_candidate_id != candidate_id:
+                raise PreviewSubmissionContractError(
+                    "Preview audit events must stay bound to the preview candidate."
+                )
+            continue
+
+        audit_events[index] = event.model_copy(
+            update={
+                "query_candidate_id": candidate_id,
+                "candidate_owner_subject": (
+                    event.candidate_owner_subject or candidate_owner_subject
+                ),
+            }
+        )
+
+
 def _next_audit_lifecycle_order(
     session: Session,
     *,
@@ -1287,6 +1313,11 @@ def _persist_preview_submission_records(
     subject_id = authenticated_subject.normalized_subject_id()
     governance_bindings = _joined_governance_bindings(
         sorted(authenticated_subject.normalized_governance_bindings())
+    )
+    _bind_preview_candidate_to_audit_events(
+        audit_events,
+        candidate_id=candidate_id,
+        candidate_owner_subject=subject_id,
     )
     if revision_record is not None and (
         request_id == revision_record.request_id

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -102,6 +102,8 @@ _DEFAULT_INTENT_DENIAL_REASON_BY_STATUS = {
     "ambiguous": "The requested business concept requires clarification before SQL generation.",
     "unsupported": "The requested business concept is not approved for the selected semantic contract.",
 }
+_REVIEW_DECISION_ID_PREFIX = "review-"
+_MAX_REVIEW_DECISION_ID_LENGTH = 255
 
 
 def _resolve_sql_guard_controls(source_family: str) -> tuple[str, Any]:
@@ -112,6 +114,13 @@ def _resolve_sql_guard_controls(source_family: str) -> tuple[str, Any]:
             f"Unsupported source family '{source_family}' cannot be guarded."
         )
     return guard_version, evaluator
+
+
+def _review_decision_id_for_candidate(preview_candidate: PreviewCandidate) -> str:
+    candidate_scoped_id = f"{_REVIEW_DECISION_ID_PREFIX}{preview_candidate.candidate_id}"
+    if len(candidate_scoped_id) <= _MAX_REVIEW_DECISION_ID_LENGTH:
+        return candidate_scoped_id
+    return f"{_REVIEW_DECISION_ID_PREFIX}{preview_candidate.id}"
 
 
 def _sanitized_guard_denial_reason(
@@ -1096,7 +1105,7 @@ def persist_review_decision(
                 PreviewReviewDecision.candidate_id == preview_candidate.candidate_id
             )
         ).scalar_one_or_none()
-        review_decision_id = f"review-{preview_candidate.candidate_id}"
+        review_decision_id = _review_decision_id_for_candidate(preview_candidate)
         if existing is None:
             existing = PreviewReviewDecision(
                 review_decision_id=review_decision_id,
@@ -1109,6 +1118,8 @@ def persist_review_decision(
                 session,
                 "Review decision cannot be rebound to a different preview candidate.",
             )
+        else:
+            review_decision_id = existing.review_decision_id
 
         existing.request_id = preview_candidate.request_id
         existing.audit_event_id = audit_event.event_id

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -1094,6 +1094,11 @@ def persist_review_decision(
                 session,
                 "Review decision audit anchor must stay bound to the preview candidate.",
             )
+        if audit_event.preview_candidate_id != preview_candidate.id:
+            _raise_preview_persistence_contract_error(
+                session,
+                "Review decision audit anchor must stay bound to the preview candidate.",
+            )
         if audit_event.source_id != preview_candidate.source_id:
             _raise_preview_persistence_contract_error(
                 session,
@@ -1153,6 +1158,22 @@ def _raise_preview_persistence_contract_error(
 ) -> None:
     session.rollback()
     raise PreviewSubmissionContractError(message)
+
+
+def _review_decision_audit_event_id(
+    audit_events: list[SourceAwareAuditEvent],
+    *,
+    candidate_id: str,
+) -> UUID:
+    for event in reversed(audit_events):
+        if (
+            event.event_type == "guard_evaluated"
+            and event.query_candidate_id == candidate_id
+        ):
+            return event.event_id
+    raise PreviewSubmissionContractError(
+        "Review decision requires a bound guard audit event anchor."
+    )
 
 
 def _persist_candidate_approval_record(
@@ -1779,6 +1800,7 @@ def submit_preview_request(
     candidate_sql: str | None = None
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None
     guard_evaluation: SQLGuardEvaluation | None = None
+    review_decision: ReviewLLMAdapterOutput | None = None
     guard_status: GuardStatus = PREVIEW_PENDING_GUARD_STATUS
     candidate_state = "preview_ready"
     request_state = "previewed"
@@ -1813,6 +1835,7 @@ def submit_preview_request(
                     intent_mapping=intent_mapping,
                 )
                 adapter_response = sql_generation_adapter.generate_sql(adapter_request)
+                review_decision = adapter_response.review_decision
                 candidate_sql = normalize_adapter_generated_sql(
                     adapter_response.candidate_sql
                 )
@@ -1906,6 +1929,21 @@ def submit_preview_request(
         candidate_state=candidate_state,
         guard_status=guard_status,
     )
+    if review_decision is not None:
+        persist_review_decision(
+            session,
+            candidate_id=candidate_id,
+            review=review_decision,
+            audit_event_id=_review_decision_audit_event_id(
+                audit.events,
+                candidate_id=candidate_id,
+            ),
+            occurred_at=(
+                audit_context.occurred_at
+                if audit_context is not None
+                else datetime.now(timezone.utc)
+            ),
+        )
     primary_deny_code = _primary_guard_deny_code(guard_evaluation)
     denial_reason = _sanitized_guard_denial_reason(guard_evaluation)
     if intent_blocked_candidate_state is not None:

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -20,7 +20,11 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from app.core.config import SQLGenerationProvider, SQLGenerationSettings
-from app.features.review_llm.schema import ReviewLLMAdapterOutput
+from app.features.review_llm.schema import (
+    ReviewLLMAdapterOutput,
+    ReviewLLMAdapterOutputError,
+    parse_review_llm_adapter_output,
+)
 from app.services.intent_mapping import IntentMappingOutput
 from app.services.generation_context import PreparedGenerationContext
 
@@ -184,7 +188,20 @@ def _require_adapter_response_has_no_execution_material(
                 f"{provider_label} SQL generation runtime returned forbidden "
                 f"adapter boundary material '{forbidden_key}'."
             ),
-        )
+            )
+
+
+def _parse_optional_review_decision(value: object) -> ReviewLLMAdapterOutput | None:
+    if value is None:
+        return None
+    if isinstance(value, ReviewLLMAdapterOutput):
+        return value
+    if not isinstance(value, (str, bytes, bytearray, Mapping)):
+        return None
+    try:
+        return parse_review_llm_adapter_output(value)
+    except ReviewLLMAdapterOutputError:
+        return None
 
 
 class SQLGenerationAdapter(Protocol):
@@ -311,7 +328,9 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
             provider="local_llm",
             adapter_version=self.adapter_version,
             model=model,
-            review_decision=decoded.get("review_decision"),
+            review_decision=_parse_optional_review_decision(
+                decoded.get("review_decision")
+            ),
         )
 
     def _generate_vanna_sql(
@@ -440,7 +459,9 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
             provider="vanna",
             adapter_version=self.adapter_version,
             model=model,
-            review_decision=decoded.get("review_decision"),
+            review_decision=_parse_optional_review_decision(
+                decoded.get("review_decision")
+            ),
         )
 
 

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -20,6 +20,7 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from app.core.config import SQLGenerationProvider, SQLGenerationSettings
+from app.features.review_llm.schema import ReviewLLMAdapterOutput
 from app.services.intent_mapping import IntentMappingOutput
 from app.services.generation_context import PreparedGenerationContext
 
@@ -102,6 +103,7 @@ class SQLGenerationAdapterResponse(BaseModel):
     provider: SQLGenerationProvider
     adapter_version: NonEmptyTrimmedString
     model: Optional[NonEmptyTrimmedString] = None
+    review_decision: Optional[ReviewLLMAdapterOutput] = None
 
 
 class SQLGenerationAdapterRunMetadata(BaseModel):
@@ -309,6 +311,7 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
             provider="local_llm",
             adapter_version=self.adapter_version,
             model=model,
+            review_decision=decoded.get("review_decision"),
         )
 
     def _generate_vanna_sql(
@@ -437,6 +440,7 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
             provider="vanna",
             adapter_version=self.adapter_version,
             model=model,
+            review_decision=decoded.get("review_decision"),
         )
 
 

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -36,6 +36,9 @@ from app.services.sql_generation_adapter import SQLGenerationAdapterResponse
 
 
 class _PreviewAdapter:
+    def __init__(self, review_decision=None):
+        self.review_decision = review_decision
+
     def generate_sql(self, request):
         return SQLGenerationAdapterResponse(
             candidate_sql=(
@@ -44,6 +47,7 @@ class _PreviewAdapter:
             provider="local_llm",
             adapter_version="test.adapter.v1",
             model="safequery-test-sql",
+            review_decision=self.review_decision,
         )
 
 
@@ -372,6 +376,62 @@ def test_review_decision_id_stays_within_column_length_for_long_candidate_id() -
         session.close()
 
 
+def test_preview_submission_persists_adapter_review_decision() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        review = parse_review_llm_adapter_output(_review_payload())
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                query_candidate_id="preview-candidate-457",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(review_decision=review),
+        )
+
+        persisted_review = session.scalar(select(PreviewReviewDecision))
+        guard_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.candidate_id == response.candidate.candidate_id,
+                PreviewAuditEvent.event_type == "guard_evaluated",
+            )
+        )
+        assert persisted_review is not None
+        assert guard_event is not None
+        assert persisted_review.candidate_id == response.candidate.candidate_id
+        assert persisted_review.audit_event_id == guard_event.event_id
+        assert persisted_review.review_status == "needs_clarification"
+
+        candidate_history = next(
+            item
+            for item in get_operator_workflow_snapshot(session).history
+            if item.item_type == "candidate"
+            and item.record_id == response.candidate.candidate_id
+        )
+        assert [item.review_status for item in candidate_history.review_evidence] == [
+            "needs_clarification"
+        ]
+    finally:
+        session.close()
+
+
 def test_review_decision_rejects_unbound_audit_anchor_without_partial_write() -> None:
     session = _session()
     try:
@@ -399,13 +459,19 @@ def test_review_decision_rejects_unbound_audit_anchor_without_partial_write() ->
             ),
             sql_generation_adapter=_PreviewAdapter(),
         )
+        preview_candidate = session.scalar(
+            select(PreviewCandidate).where(
+                PreviewCandidate.candidate_id == response.candidate.candidate_id
+            )
+        )
+        assert preview_candidate is not None
         unbound_event = PreviewAuditEvent(
             event_id=uuid4(),
             lifecycle_order=99,
-            preview_request_id=uuid4(),
+            preview_request_id=preview_candidate.preview_request_id,
             preview_candidate_id=None,
             request_id=response.request.request_id,
-            candidate_id="different-candidate",
+            candidate_id=response.candidate.candidate_id,
             event_type="guard_evaluated",
             occurred_at=datetime(2026, 1, 2, 3, 4, 59, tzinfo=timezone.utc),
             correlation_id="preview-request-457-correlation",

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -320,6 +320,94 @@ def test_operator_review_evidence_sanitizes_llm_text_before_payload_exposure() -
         session.close()
 
 
+def test_operator_review_evidence_preserves_duplicate_sanitized_items() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                query_candidate_id="preview-candidate-457",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+        )
+        audit_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.candidate_id == response.candidate.candidate_id,
+                PreviewAuditEvent.event_type == "guard_evaluated",
+            )
+        )
+        assert audit_event is not None
+
+        payload = _review_payload()
+        payload["assumptions"] = ["Shared interpretation.", "Shared interpretation."]
+        payload["risk_flags"] = [
+            "Credential token=raw-review-token; continue.",
+            "Credential token=raw-review-token; continue.",
+        ]
+        payload["clarifying_questions"] = [
+            "Retry with Bearer opaque-review-token; then ask?",
+            "Retry with Bearer opaque-review-token; then ask?",
+        ]
+        review = parse_review_llm_adapter_output(payload)
+
+        persist_review_decision(
+            session,
+            candidate_id=response.candidate.candidate_id,
+            review=review,
+            audit_event_id=audit_event.event_id,
+            occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+        )
+
+        persisted_review = session.scalar(select(PreviewReviewDecision))
+        assert persisted_review is not None
+        assert persisted_review.assumptions == [
+            "Shared interpretation.",
+            "Shared interpretation.",
+        ]
+
+        candidate_history = next(
+            item
+            for item in get_operator_workflow_snapshot(session).history
+            if item.item_type == "candidate"
+            and item.record_id == response.candidate.candidate_id
+        )
+        operator_payload = candidate_history.review_evidence[0].model_dump(
+            mode="json", by_alias=True
+        )
+
+        assert operator_payload["assumptions"] == [
+            "Shared interpretation.",
+            "Shared interpretation.",
+        ]
+        assert operator_payload["riskFlags"] == [
+            "[redacted] [redacted]; continue.",
+            "[redacted] [redacted]; continue.",
+        ]
+        assert operator_payload["clarifyingQuestions"] == [
+            "Retry with [redacted]; then ask?",
+            "Retry with [redacted]; then ask?",
+        ]
+    finally:
+        session.close()
+
+
 def test_review_decision_id_stays_within_column_length_for_long_candidate_id() -> None:
     session = _session()
     try:
@@ -428,6 +516,59 @@ def test_preview_submission_persists_adapter_review_decision() -> None:
         assert [item.review_status for item in candidate_history.review_evidence] == [
             "needs_clarification"
         ]
+    finally:
+        session.close()
+
+
+def test_preview_submission_persists_review_decision_with_generated_candidate_id() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        review = parse_review_llm_adapter_output(_review_payload())
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(review_decision=review),
+        )
+
+        persisted_review = session.scalar(select(PreviewReviewDecision))
+        preview_candidate = session.scalar(
+            select(PreviewCandidate).where(
+                PreviewCandidate.candidate_id == response.candidate.candidate_id
+            )
+        )
+        guard_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.candidate_id == response.candidate.candidate_id,
+                PreviewAuditEvent.event_type == "guard_evaluated",
+            )
+        )
+        assert persisted_review is not None
+        assert preview_candidate is not None
+        assert guard_event is not None
+        assert response.candidate.candidate_id != "preview-candidate-457"
+        assert persisted_review.candidate_id == response.candidate.candidate_id
+        assert persisted_review.preview_candidate_id == preview_candidate.id
+        assert persisted_review.audit_event_id == guard_event.event_id
+        assert guard_event.preview_candidate_id == preview_candidate.id
+        assert guard_event.candidate_id == response.candidate.candidate_id
     finally:
         session.close()
 

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.db.models.dataset_contract import (
+    DatasetContract,
+    DatasetContractDataset,
+    DatasetContractDatasetKind,
+)
+from app.db.models.preview import (
+    PreviewAuditEvent,
+    PreviewCandidate,
+    PreviewReviewDecision,
+)
+from app.db.models.schema_snapshot import SchemaSnapshot, SchemaSnapshotReviewStatus
+from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.auth.context import AuthenticatedSubject
+from app.features.review_llm import parse_review_llm_adapter_output
+from app.services.operator_workflow import get_operator_workflow_snapshot
+from app.services.request_preview import (
+    PreviewAuditContext,
+    PreviewSubmissionContractError,
+    PreviewSubmissionRequest,
+    persist_review_decision,
+    submit_preview_request,
+)
+from app.services.sql_generation_adapter import SQLGenerationAdapterResponse
+
+
+class _PreviewAdapter:
+    def generate_sql(self, request):
+        return SQLGenerationAdapterResponse(
+            candidate_sql=(
+                "SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50"
+            ),
+            provider="local_llm",
+            adapter_version="test.adapter.v1",
+            model="safequery-test-sql",
+        )
+
+
+def _session() -> Session:
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _seed_source(session: Session) -> None:
+    source = RegisteredSource(
+        id=uuid4(),
+        source_id="sap-approved-spend",
+        display_label="SAP spend cube / approved_vendor_spend",
+        source_family="postgresql",
+        source_flavor="warehouse",
+        activation_posture=SourceActivationPosture.ACTIVE,
+        connector_profile_id=None,
+        dialect_profile_id=None,
+        dataset_contract_id=None,
+        schema_snapshot_id=None,
+        execution_policy_id=None,
+        connection_reference="vault:sap-approved-spend",
+    )
+    session.add(source)
+    session.flush()
+
+    snapshot = SchemaSnapshot(
+        id=uuid4(),
+        registered_source_id=source.id,
+        snapshot_version=1,
+        review_status=SchemaSnapshotReviewStatus.APPROVED,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    session.add(snapshot)
+    session.flush()
+
+    contract = DatasetContract(
+        id=uuid4(),
+        registered_source_id=source.id,
+        schema_snapshot_id=snapshot.id,
+        contract_version=1,
+        semantic_contract_version="approved_vendor_spend.v1",
+        display_name="SAP spend cube contract",
+        owner_binding="group:finance-analysts",
+        security_review_binding=None,
+        exception_policy_binding=None,
+    )
+    session.add(contract)
+    session.flush()
+    session.add(
+        DatasetContractDataset(
+            id=uuid4(),
+            dataset_contract_id=contract.id,
+            schema_name="finance",
+            dataset_name="approved_vendor_spend",
+            dataset_kind=DatasetContractDatasetKind.TABLE,
+        )
+    )
+
+    source.dataset_contract_id = contract.id
+    source.schema_snapshot_id = snapshot.id
+    session.commit()
+
+
+def _review_payload() -> dict[str, object]:
+    return {
+        "contract_version": "review_llm_adapter_output.v1",
+        "status": "needs_clarification",
+        "confidence": "medium",
+        "intent_summary": "compare approved vendor spend by vendor",
+        "data_used": ["approved vendor spend"],
+        "metrics": ["net spend"],
+        "dimensions": ["vendor"],
+        "filters": ["current quarter"],
+        "assumptions": ["Vendor means normalized vendor_id."],
+        "risk_flags": ["Vendor names may be sensitive."],
+        "clarifying_questions": ["Should inactive vendors be included?"],
+        "diagnostics": {
+            "adapter_version": "review-adapter.v1",
+            "model": "safequery-review-test",
+            "provider": "local",
+            "prompt_version": "review-prompt.v1",
+            "response_id": "review-response-457",
+            "raw_output_excerpt": "Should inactive vendors be included?",
+        },
+    }
+
+
+def test_review_decision_is_persisted_with_schema_version_and_operator_evidence() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                query_candidate_id="preview-candidate-457",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+        )
+        audit_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.candidate_id == response.candidate.candidate_id,
+                PreviewAuditEvent.event_type == "guard_evaluated",
+            )
+        )
+        assert audit_event is not None
+
+        review = parse_review_llm_adapter_output(_review_payload())
+        persist_review_decision(
+            session,
+            candidate_id=response.candidate.candidate_id,
+            review=review,
+            audit_event_id=audit_event.event_id,
+            occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+        )
+
+        persisted_review = session.scalar(select(PreviewReviewDecision))
+        assert persisted_review is not None
+        assert persisted_review.review_decision_id == (
+            "review-preview-candidate-457"
+        )
+        assert persisted_review.request_id == response.request.request_id
+        assert persisted_review.candidate_id == response.candidate.candidate_id
+        assert persisted_review.audit_event_id == audit_event.event_id
+        assert persisted_review.review_contract_version == (
+            "review_llm_adapter_output.v1"
+        )
+        assert persisted_review.review_status == "needs_clarification"
+        assert persisted_review.assumptions == ["Vendor means normalized vendor_id."]
+        assert persisted_review.risk_flags == ["Vendor names may be sensitive."]
+        assert persisted_review.clarifying_questions == [
+            "Should inactive vendors be included?"
+        ]
+        assert (
+            persisted_review.review_payload["diagnostics"]["rawOutputExcerpt"]
+            == "Should inactive vendors be included?"
+        )
+
+        candidate_history = next(
+            item
+            for item in get_operator_workflow_snapshot(session).history
+            if item.item_type == "candidate"
+            and item.record_id == response.candidate.candidate_id
+        )
+        assert len(candidate_history.review_evidence) == 1
+        assert candidate_history.review_evidence[0].model_dump(
+            mode="json", by_alias=True
+        ) == {
+            "reviewDecisionId": "review-preview-candidate-457",
+            "reviewStatus": "needs_clarification",
+            "reviewContractVersion": "review_llm_adapter_output.v1",
+            "auditEventId": str(audit_event.event_id),
+            "assumptions": ["Vendor means normalized vendor_id."],
+            "riskFlags": ["Vendor names may be sensitive."],
+            "clarifyingQuestions": ["Should inactive vendors be included?"],
+        }
+    finally:
+        session.close()
+
+
+def test_review_decision_rejects_unbound_audit_anchor_without_partial_write() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                query_candidate_id="preview-candidate-457",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+        )
+        unbound_event = PreviewAuditEvent(
+            event_id=uuid4(),
+            lifecycle_order=99,
+            preview_request_id=uuid4(),
+            preview_candidate_id=None,
+            request_id=response.request.request_id,
+            candidate_id="different-candidate",
+            event_type="guard_evaluated",
+            occurred_at=datetime(2026, 1, 2, 3, 4, 59, tzinfo=timezone.utc),
+            correlation_id="preview-request-457-correlation",
+            authenticated_subject_id="user:alice",
+            session_id="preview-request-457-session",
+            source_id=response.request.source_id,
+            source_family=response.candidate.source_family,
+            source_flavor=response.candidate.source_flavor,
+            dataset_contract_version=response.candidate.dataset_contract_version,
+            semantic_contract_version=response.candidate.semantic_contract_version,
+            schema_snapshot_version=response.candidate.schema_snapshot_version,
+            candidate_state="preview_ready",
+            audit_payload={"event_type": "guard_evaluated"},
+        )
+        session.add(unbound_event)
+        session.commit()
+
+        with pytest.raises(
+            PreviewSubmissionContractError,
+            match="audit anchor must stay bound to the preview candidate",
+        ):
+            persist_review_decision(
+                session,
+                candidate_id=response.candidate.candidate_id,
+                review=parse_review_llm_adapter_output(_review_payload()),
+                audit_event_id=unbound_event.event_id,
+                occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+            )
+
+        assert session.scalars(select(PreviewReviewDecision)).all() == []
+    finally:
+        session.close()

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -645,3 +645,55 @@ def test_review_decision_rejects_unbound_audit_anchor_without_partial_write() ->
         assert session.scalars(select(PreviewReviewDecision)).all() == []
     finally:
         session.close()
+
+
+def test_review_decision_rejects_non_guard_audit_anchor_without_partial_write() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                query_candidate_id="preview-candidate-457",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+        )
+        generation_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.candidate_id == response.candidate.candidate_id,
+                PreviewAuditEvent.event_type == "generation_completed",
+            )
+        )
+        assert generation_event is not None
+
+        with pytest.raises(
+            PreviewSubmissionContractError,
+            match="requires a guard audit event anchor",
+        ):
+            persist_review_decision(
+                session,
+                candidate_id=response.candidate.candidate_id,
+                review=parse_review_llm_adapter_output(_review_payload()),
+                audit_event_id=generation_event.event_id,
+                occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+            )
+
+        assert session.scalars(select(PreviewReviewDecision)).all() == []
+    finally:
+        session.close()

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import json
 from uuid import uuid4
 
 import pytest
@@ -220,6 +221,153 @@ def test_review_decision_is_persisted_with_schema_version_and_operator_evidence(
             "riskFlags": ["Vendor names may be sensitive."],
             "clarifyingQuestions": ["Should inactive vendors be included?"],
         }
+    finally:
+        session.close()
+
+
+def test_operator_review_evidence_sanitizes_llm_text_before_payload_exposure() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                query_candidate_id="preview-candidate-457",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+        )
+        audit_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.candidate_id == response.candidate.candidate_id,
+                PreviewAuditEvent.event_type == "guard_evaluated",
+            )
+        )
+        assert audit_event is not None
+
+        unsafe_path = "/" + "/".join(["Users", "example", "review-secret.txt"])
+        payload = _review_payload()
+        payload["assumptions"] = ["Credential token=raw-review-token; continue."]
+        payload["risk_flags"] = [f"Review diagnostics referenced {unsafe_path}."]
+        payload["clarifying_questions"] = [
+            "Retry with Bearer opaque-review-token; then ask?"
+        ]
+        review = parse_review_llm_adapter_output(payload)
+
+        persist_review_decision(
+            session,
+            candidate_id=response.candidate.candidate_id,
+            review=review,
+            audit_event_id=audit_event.event_id,
+            occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+        )
+
+        persisted_review = session.scalar(select(PreviewReviewDecision))
+        assert persisted_review is not None
+        assert persisted_review.assumptions == [
+            "Credential token=raw-review-token; continue."
+        ]
+        assert persisted_review.risk_flags == [
+            f"Review diagnostics referenced {unsafe_path}."
+        ]
+        assert persisted_review.clarifying_questions == [
+            "Retry with Bearer opaque-review-token; then ask?"
+        ]
+
+        candidate_history = next(
+            item
+            for item in get_operator_workflow_snapshot(session).history
+            if item.item_type == "candidate"
+            and item.record_id == response.candidate.candidate_id
+        )
+        operator_payload = candidate_history.review_evidence[0].model_dump(
+            mode="json", by_alias=True
+        )
+        serialized = json.dumps(operator_payload, sort_keys=True)
+
+        assert operator_payload["assumptions"] == [
+            "[redacted] [redacted]; continue."
+        ]
+        assert operator_payload["riskFlags"] == [
+            "Review diagnostics referenced [redacted]"
+        ]
+        assert operator_payload["clarifyingQuestions"] == [
+            "Retry with [redacted]; then ask?"
+        ]
+        assert "raw-review-token" not in serialized
+        assert "opaque-review-token" not in serialized
+        assert unsafe_path not in serialized
+    finally:
+        session.close()
+
+
+def test_review_decision_id_stays_within_column_length_for_long_candidate_id() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        long_candidate_id = "candidate-" + ("x" * 245)
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-457",
+                correlation_id="preview-request-457-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-457-session",
+                query_candidate_id=long_candidate_id,
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+        )
+        audit_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.candidate_id == response.candidate.candidate_id,
+                PreviewAuditEvent.event_type == "guard_evaluated",
+            )
+        )
+        assert audit_event is not None
+
+        review = parse_review_llm_adapter_output(_review_payload())
+        review_decision_id = persist_review_decision(
+            session,
+            candidate_id=response.candidate.candidate_id,
+            review=review,
+            audit_event_id=audit_event.event_id,
+            occurred_at=datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc),
+        )
+
+        persisted_review = session.scalar(select(PreviewReviewDecision))
+        assert persisted_review is not None
+        assert response.candidate.candidate_id == long_candidate_id
+        assert len(f"review-{long_candidate_id}") > 255
+        assert review_decision_id == persisted_review.review_decision_id
+        assert review_decision_id == f"review-{persisted_review.preview_candidate_id}"
+        assert len(review_decision_id) <= 255
     finally:
         session.close()
 

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -349,6 +349,21 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
                         "select vendor_id from approved_vendor_spend limit 50"
                     ),
                     "model": "safequery-local-sql",
+                    "review_decision": {
+                        "contract_version": "review_llm_adapter_output.v1",
+                        "status": "needs_clarification",
+                        "confidence": "medium",
+                        "intent_summary": "show approved vendors",
+                        "assumptions": ["Vendor means normalized vendor_id."],
+                        "risk_flags": ["Vendor names may be sensitive."],
+                        "clarifying_questions": [
+                            "Should inactive vendors be included?"
+                        ],
+                        "diagnostics": {
+                            "adapter_version": "review-adapter.v1",
+                            "model": "safequery-review-test",
+                        },
+                    },
                 }
             ).encode("utf-8")
 
@@ -363,12 +378,15 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
 
     response = adapter.generate_sql(request)
 
-    assert response.model_dump(exclude_none=True) == {
+    assert response.model_dump(exclude={"review_decision"}, exclude_none=True) == {
         "candidate_sql": "select vendor_id from approved_vendor_spend limit 50",
         "provider": "local_llm",
         "adapter_version": "local_llm.v1",
         "model": "safequery-local-sql",
     }
+    assert response.review_decision is not None
+    assert response.review_decision.status == "needs_clarification"
+    assert response.review_decision.risk_flags == ["Vendor names may be sensitive."]
     assert [call[0] for call in calls] == [
         "http://local-llm:8080/generate-sql",
         "http://local-llm:8080/generate-sql",

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -397,6 +397,70 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
     assert "credentials" not in json.dumps(calls[0][2])
 
 
+def test_local_llm_generation_ignores_malformed_review_decision(monkeypatch) -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "local_llm",
+            "local_llm_base_url": "http://local-llm:8080",
+            "retry_count": 0,
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_80_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+        ),
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "candidate_sql": (
+                        "select vendor_id from approved_vendor_spend limit 50"
+                    ),
+                    "review_decision": {
+                        "status": "ready",
+                        "confidence": "low",
+                    },
+                }
+            ).encode("utf-8")
+
+    monkeypatch.setattr(
+        adapter_module,
+        "urlopen",
+        lambda request, timeout=None: Response(),
+    )
+
+    response = adapter.generate_sql(request)
+
+    assert (
+        response.candidate_sql
+        == "select vendor_id from approved_vendor_spend limit 50"
+    )
+    assert response.review_decision is None
+
+
 def test_local_llm_generation_retries_malformed_json_response(monkeypatch) -> None:
     adapter = resolve_sql_generation_adapter(
         {
@@ -631,6 +695,75 @@ def test_vanna_generation_uses_curated_context_and_bounded_request(
     }
     assert "credentials" not in json.dumps(seen["body"])
     assert "execution_result" not in json.dumps(response.model_dump())
+
+
+def test_vanna_generation_ignores_malformed_review_decision(monkeypatch) -> None:
+    adapter = resolve_sql_generation_adapter(
+        {
+            "provider": "vanna",
+            "vanna_base_url": "http://vanna:8084",
+            "retry_count": 0,
+        }
+    )
+    request = SQLGenerationAdapterRequest(
+        request_id="req_82_preview",
+        question="Show approved vendors",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+            datasets=[
+                {
+                    "schema_name": "finance",
+                    "dataset_name": "approved_vendor_spend",
+                    "dataset_kind": "table",
+                },
+            ],
+        ),
+    )
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "sql": "select vendor_id from approved_vendor_spend limit 50",
+                    "review_decision": {
+                        "contract_version": "review_llm_adapter_output.v1",
+                        "status": "unknown",
+                    },
+                }
+            ).encode("utf-8")
+
+    monkeypatch.setattr(
+        adapter_module,
+        "urlopen",
+        lambda request, timeout=None: Response(),
+    )
+
+    response = adapter.generate_sql(request)
+
+    assert (
+        response.candidate_sql
+        == "select vendor_id from approved_vendor_spend limit 50"
+    )
+    assert response.review_decision is None
 
 
 def test_vanna_generation_fails_closed_for_execution_material_response(

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -2077,6 +2077,20 @@ describe("HomePage", () => {
                         localPath: unsafeLocalPath
                       }
                     ],
+                    reviewEvidence: [
+                      {
+                        auditEventId: "00000000-0000-4000-8000-000000000012",
+                        assumptions: [
+                          "Vendor means normalized vendor_id.",
+                          "Inactive vendors stay excluded."
+                        ],
+                        clarifyingQuestions: ["Should inactive vendors be included?"],
+                        reviewContractVersion: "review_llm_adapter_output.v1",
+                        reviewDecisionId: "review-candidate-selected",
+                        reviewStatus: "needs_clarification",
+                        riskFlags: ["Duplicate risk label", "Duplicate risk label"]
+                      }
+                    ],
                     resultTruncated: false,
                     rowCount: 12,
                     runState: "completed",
@@ -2120,6 +2134,16 @@ describe("HomePage", () => {
     expect(screen.getByLabelText(/retrieved citation context/i)).toHaveTextContent(
       "advisory_context"
     );
+    expect(screen.getByLabelText(/review evidence/i)).toHaveTextContent(
+      "Vendor means normalized vendor_id."
+    );
+    expect(screen.getByLabelText(/review evidence/i)).toHaveTextContent(
+      "Inactive vendors stay excluded."
+    );
+    expect(screen.getByLabelText(/review evidence/i)).toHaveTextContent(
+      "Should inactive vendors be included?"
+    );
+    expect(screen.getAllByText("Duplicate risk label")).toHaveLength(2);
     const evidencePanel = screen.getByRole("heading", {
       name: /operator evidence context/i
     }).closest("section");

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -11,6 +11,7 @@ import type {
   OperatorWorkflowExecutedEvidence,
   OperatorHistoryItem,
   OperatorWorkflowRevisionContext,
+  OperatorWorkflowReviewEvidence,
   OperatorWorkflowRetrievedCitation,
   OperatorWorkflowSnapshot,
   SourceOption
@@ -163,6 +164,7 @@ type AuthoritativeCandidatePreview = {
   executedEvidence: OperatorWorkflowExecutedEvidence[];
   guardStatus: string;
   requestId?: string;
+  reviewEvidence: OperatorWorkflowReviewEvidence[];
   retrievedCitations: OperatorWorkflowRetrievedCitation[];
   sourceId: string;
   sourceLabel?: string;
@@ -175,6 +177,7 @@ type AuthoritativeRunContext = {
   lifecycleState: string;
   lifecycleTimestamp: string;
   primaryDenyCode?: string | null;
+  reviewEvidence: OperatorWorkflowReviewEvidence[];
   retrievedCitations: OperatorWorkflowRetrievedCitation[];
   resultTruncated?: boolean | null;
   resultRows?: ResultRow[];
@@ -1087,6 +1090,7 @@ function findAuthoritativeCandidatePreview(
     executedEvidence: candidate.executedEvidence,
     guardStatus: candidate.guardStatus ?? "pending",
     requestId: candidate.requestId ?? undefined,
+    reviewEvidence: candidate.reviewEvidence,
     retrievedCitations: candidate.retrievedCitations,
     sourceId: candidate.sourceId,
     sourceLabel: candidate.sourceLabel
@@ -1120,6 +1124,7 @@ function findAuthoritativeRunContext(
     lifecycleState: run.lifecycleState,
     lifecycleTimestamp: run.occurredAt,
     primaryDenyCode: run.primaryDenyCode,
+    reviewEvidence: run.reviewEvidence,
     retrievedCitations: run.retrievedCitations,
     resultTruncated: run.resultTruncated,
     rowCount: run.rowCount,
@@ -1687,6 +1692,7 @@ function renderAuditEvidencePanel(
   auditEvents: OperatorWorkflowAuditEvent[],
   executedEvidence: OperatorWorkflowExecutedEvidence[],
   retrievedCitations: OperatorWorkflowRetrievedCitation[],
+  reviewEvidence: OperatorWorkflowReviewEvidence[],
   history: OperatorHistoryItem[],
   question: string
 ) {
@@ -1738,7 +1744,8 @@ function renderAuditEvidencePanel(
 
       {auditEvents.length === 0 &&
       executedEvidence.length === 0 &&
-      retrievedCitations.length === 0 ? (
+      retrievedCitations.length === 0 &&
+      reviewEvidence.length === 0 ? (
         <div className="placeholder-block">
           <p className="placeholder-title">No audit evidence selected</p>
           <p>Open a history row with persisted audit context to inspect lifecycle evidence.</p>
@@ -1798,6 +1805,26 @@ function renderAuditEvidencePanel(
               <span>{citation.assetId}</span>
               <span>{citation.authority}</span>
               <span>Cannot authorize execution: {String(citation.canAuthorizeExecution)}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {reviewEvidence.length > 0 ? (
+        <div className="evidence-list" aria-label="review evidence">
+          {reviewEvidence.map((review) => (
+            <div className="evidence-item" key={review.reviewDecisionId}>
+              <span className="meta-label">Review evidence</span>
+              <strong>{review.reviewStatus}</strong>
+              <span>{review.reviewDecisionId}</span>
+              <span>{review.reviewContractVersion}</span>
+              <span>Audit event {review.auditEventId}</span>
+              {review.riskFlags.map((risk) => (
+                <span key={`risk:${risk}`}>{risk}</span>
+              ))}
+              {review.clarifyingQuestions.map((question) => (
+                <span key={`clarifying:${question}`}>{question}</span>
+              ))}
             </div>
           ))}
         </div>
@@ -2180,6 +2207,8 @@ export function QueryWorkflowShell({
     historyRunContext?.executedEvidence ?? candidatePreview?.executedEvidence ?? [];
   const selectedRetrievedCitations =
     historyRunContext?.retrievedCitations ?? candidatePreview?.retrievedCitations ?? [];
+  const selectedReviewEvidence =
+    historyRunContext?.reviewEvidence ?? candidatePreview?.reviewEvidence ?? [];
   const firstRunGuidance = getFirstRunGuidance(operatorWorkflow);
   const operatorRecoveryGuidance = getOperatorRecoveryGuidance(
     normalizedState,
@@ -2344,6 +2373,7 @@ export function QueryWorkflowShell({
           executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
+          reviewEvidence: [],
           retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
@@ -2370,6 +2400,7 @@ export function QueryWorkflowShell({
           executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
+          reviewEvidence: [],
           retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
@@ -2395,6 +2426,7 @@ export function QueryWorkflowShell({
           executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
+          reviewEvidence: [],
           retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
@@ -2429,6 +2461,7 @@ export function QueryWorkflowShell({
         executedEvidence: [],
         guardStatus: result.guardStatus,
         requestId: result.requestId,
+        reviewEvidence: [],
         retrievedCitations: [],
         sourceId: result.sourceId,
         sourceLabel: selectedSource.displayLabel
@@ -2495,6 +2528,7 @@ export function QueryWorkflowShell({
             executedEvidence: [],
             lifecycleState: "canceled",
             lifecycleTimestamp: new Date().toISOString(),
+            reviewEvidence: candidatePreview.reviewEvidence,
             retrievedCitations: [],
             runIdentity: candidatePreview.candidateId,
             runState: "canceled",
@@ -2553,6 +2587,7 @@ export function QueryWorkflowShell({
         executedEvidence: result.executedEvidence,
         lifecycleState: nextState,
         lifecycleTimestamp: new Date().toISOString(),
+        reviewEvidence: candidatePreview.reviewEvidence,
         retrievedCitations: [],
         resultTruncated: result.resultTruncated,
         resultRows: result.rows,
@@ -3034,6 +3069,7 @@ export function QueryWorkflowShell({
             selectedAuditEvents,
             selectedExecutedEvidence,
             selectedRetrievedCitations,
+            selectedReviewEvidence,
             operatorWorkflow.history,
             submittedQuestion
           )}

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1819,11 +1819,14 @@ function renderAuditEvidencePanel(
               <span>{review.reviewDecisionId}</span>
               <span>{review.reviewContractVersion}</span>
               <span>Audit event {review.auditEventId}</span>
-              {review.riskFlags.map((risk) => (
-                <span key={`risk:${risk}`}>{risk}</span>
+              {review.assumptions.map((assumption, index) => (
+                <span key={`${review.reviewDecisionId}:assumption:${index}`}>{assumption}</span>
               ))}
-              {review.clarifyingQuestions.map((question) => (
-                <span key={`clarifying:${question}`}>{question}</span>
+              {review.riskFlags.map((risk, index) => (
+                <span key={`${review.reviewDecisionId}:risk:${index}`}>{risk}</span>
+              ))}
+              {review.clarifyingQuestions.map((question, index) => (
+                <span key={`${review.reviewDecisionId}:clarifying:${index}`}>{question}</span>
               ))}
             </div>
           ))}

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -86,6 +86,16 @@ export type OperatorWorkflowRetrievedCitation = {
   sourceFlavor: string | null;
 };
 
+export type OperatorWorkflowReviewEvidence = {
+  auditEventId: string;
+  assumptions: string[];
+  clarifyingQuestions: string[];
+  reviewContractVersion: string;
+  reviewDecisionId: string;
+  reviewStatus: string;
+  riskFlags: string[];
+};
+
 export type OperatorWorkflowRevisionContext = {
   candidateId?: string | null;
   requestId?: string | null;
@@ -106,6 +116,7 @@ export type OperatorHistoryItem = {
   occurredAt: string;
   primaryDenyCode?: string | null;
   recordId: string;
+  reviewEvidence: OperatorWorkflowReviewEvidence[];
   requestId?: string | null;
   semanticContractVersion?: string | null;
   resultTruncated?: boolean | null;
@@ -341,6 +352,55 @@ function parseRetrievedCitation(value: unknown): OperatorWorkflowRetrievedCitati
   };
 }
 
+function readStringArray(value: unknown): string[] | null {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const strings = value.filter((item): item is string => {
+    return typeof item === "string" && item.trim().length > 0;
+  });
+  return strings.length === value.length ? strings : null;
+}
+
+function parseReviewEvidence(value: unknown): OperatorWorkflowReviewEvidence | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const auditEventId = readOptionalString(value.auditEventId);
+  const reviewContractVersion = readOptionalString(value.reviewContractVersion);
+  const reviewDecisionId = readOptionalString(value.reviewDecisionId);
+  const reviewStatus = readOptionalString(value.reviewStatus);
+  const assumptions = readStringArray(value.assumptions);
+  const clarifyingQuestions = readStringArray(value.clarifyingQuestions);
+  const riskFlags = readStringArray(value.riskFlags);
+
+  if (
+    !auditEventId ||
+    !reviewContractVersion ||
+    !reviewDecisionId ||
+    !reviewStatus ||
+    assumptions === null ||
+    clarifyingQuestions === null ||
+    riskFlags === null
+  ) {
+    return null;
+  }
+
+  return {
+    auditEventId,
+    assumptions,
+    clarifyingQuestions,
+    reviewContractVersion,
+    reviewDecisionId,
+    reviewStatus,
+    riskFlags
+  };
+}
+
 function parseRevisionContext(value: unknown): OperatorWorkflowRevisionContext | null {
   if (value === undefined || value === null) {
     return null;
@@ -437,6 +497,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   const candidateAttempts = parseArray(value.candidateAttempts, parseCandidateAttempt);
   const executedEvidence = parseArray(value.executedEvidence, parseExecutedEvidence);
   const retrievedCitations = parseArray(value.retrievedCitations, parseRetrievedCitation);
+  const reviewEvidence = parseArray(value.reviewEvidence, parseReviewEvidence);
   const revisionContext = parseRevisionContext(value.revisionContext);
   const analystResponse =
     value.analystResponse === undefined || value.analystResponse === null
@@ -454,7 +515,8 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     auditEvents === null ||
     candidateAttempts === null ||
     executedEvidence === null ||
-    retrievedCitations === null
+    retrievedCitations === null ||
+    reviewEvidence === null
   ) {
     return null;
   }
@@ -472,6 +534,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     occurredAt,
     primaryDenyCode: readOptionalString(value.primaryDenyCode) ?? null,
     recordId,
+    reviewEvidence,
     requestId: readOptionalString(value.requestId) ?? null,
     semanticContractVersion: readOptionalString(value.semanticContractVersion) ?? null,
     resultTruncated:


### PR DESCRIPTION
## Summary
- add durable preview review decision records with schema/version, status, assumptions, risk flags, clarifying questions, and audit anchor linkage
- expose redacted review evidence through the operator workflow payload and frontend evidence panel
- add focused persistence/operator payload regressions, including fail-closed audit-anchor validation

## Verification
- uv run --with pytest --with httpx --with sqlalchemy --with pydantic --with pydantic-settings --with fastapi --with 'psycopg[binary]' --with alembic pytest tests/test_review_decision_persistence.py tests/test_operator_workflow_history.py tests/test_preview_persistence.py tests/test_source_foundation_smoke.py -q
- npx tsc --noEmit

## Known follow-up
- npm test currently has 3 revision-flow smoke failures where the test mock hangs after /auth/dev/session before /requests/preview is called.