### PR TITLE
Add review LLM calibration fixtures

### DIFF
--- a/backend/app/features/evaluation/__init__.py
+++ b/backend/app/features/evaluation/__init__.py
@@ -48,6 +48,18 @@ from app.features.evaluation.release_gate import (
     build_release_gate_assurance_report,
     reconstruct_release_gate,
 )
+from app.features.evaluation.review_llm_calibration import (
+    ReviewLLMCalibrationCategory,
+    ReviewLLMCalibrationCategoryReport,
+    ReviewLLMCalibrationEvidence,
+    ReviewLLMCalibrationFixture,
+    ReviewLLMCalibrationFixtureSet,
+    ReviewLLMCalibrationFormatStatus,
+    ReviewLLMCalibrationReport,
+    ReviewLLMCalibrationStatus,
+    build_review_llm_calibration_report,
+    validate_review_llm_calibration_fixture_set,
+)
 
 __all__ = [
     "EvaluationComparisonKey",
@@ -81,6 +93,14 @@ __all__ = [
     "ReleaseGateDiffArtifact",
     "ReleaseGateDiffScenario",
     "ReleaseGateFailure",
+    "ReviewLLMCalibrationCategory",
+    "ReviewLLMCalibrationCategoryReport",
+    "ReviewLLMCalibrationEvidence",
+    "ReviewLLMCalibrationFixture",
+    "ReviewLLMCalibrationFixtureSet",
+    "ReviewLLMCalibrationFormatStatus",
+    "ReviewLLMCalibrationReport",
+    "ReviewLLMCalibrationStatus",
     "SourceRegressionMatrixEntry",
     "compare_evaluation_outcomes",
     "build_release_gate_assurance_report",
@@ -88,6 +108,8 @@ __all__ = [
     "list_postgresql_evaluation_scenarios",
     "list_source_regression_matrix",
     "reconstruct_release_gate",
+    "build_review_llm_calibration_report",
     "score_governed_answer_consistency",
+    "validate_review_llm_calibration_fixture_set",
     "validate_governed_answer_fixture_set",
 ]

--- a/backend/app/features/evaluation/review_llm_calibration.py
+++ b/backend/app/features/evaluation/review_llm_calibration.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveInt,
+    StringConstraints,
+    model_validator,
+)
+
+
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+ReviewLLMCalibrationCategory = Literal[
+    "false_approval",
+    "false_denial",
+    "ambiguity",
+    "source_confusion",
+]
+ReviewLLMCalibrationStatus = Literal["ready", "needs_clarification", "blocked"]
+ReviewLLMCalibrationFormatStatus = Literal["review_llm_calibration.v1"]
+
+
+class ReviewLLMCalibrationEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    operator_request: NonEmptyString
+    source_context: NonEmptyString
+    candidate_summary: NonEmptyString
+    critique_output: dict[str, Any]
+
+
+class ReviewLLMCalibrationFixture(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    scenario_id: NonEmptyString
+    category: ReviewLLMCalibrationCategory
+    title: NonEmptyString
+    expected_review_status: ReviewLLMCalibrationStatus
+    expected_failure_signal: NonEmptyString
+    evidence: ReviewLLMCalibrationEvidence
+    reviewer_rationale: NonEmptyString
+
+    @model_validator(mode="after")
+    def _validate_category_status_pair(self) -> "ReviewLLMCalibrationFixture":
+        expected_status_by_category: dict[ReviewLLMCalibrationCategory, str] = {
+            "false_approval": "blocked",
+            "false_denial": "ready",
+            "ambiguity": "needs_clarification",
+            "source_confusion": "blocked",
+        }
+        expected_status = expected_status_by_category[self.category]
+        if self.expected_review_status != expected_status:
+            raise ValueError(
+                "Calibration fixture category and expected review status disagree."
+            )
+        return self
+
+
+class ReviewLLMCalibrationFixtureSet(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    fixture_set: NonEmptyString
+    purpose: NonEmptyString
+    format_status: ReviewLLMCalibrationFormatStatus
+    release_gate_authority: bool
+    authority_note: NonEmptyString
+    malformed_output_handling: Literal["excluded_parser_contract"]
+    fixtures: tuple[ReviewLLMCalibrationFixture, ...]
+
+    @model_validator(mode="after")
+    def _validate_fixture_set_contract(self) -> "ReviewLLMCalibrationFixtureSet":
+        if self.release_gate_authority is not False:
+            raise ValueError(
+                "Review LLM calibration fixtures must not grant release-gate authority."
+            )
+        if "does not make Review LLM release-gate authority" not in self.authority_note:
+            raise ValueError(
+                "Authority note must state that calibration does not make Review LLM "
+                "release-gate authority."
+            )
+        if not self.fixtures:
+            raise ValueError("Calibration fixture set must include fixtures.")
+
+        scenario_ids = [fixture.scenario_id for fixture in self.fixtures]
+        if len(set(scenario_ids)) != len(scenario_ids):
+            raise ValueError("Calibration fixture scenario ids must be unique.")
+
+        categories = {fixture.category for fixture in self.fixtures}
+        required_categories: set[ReviewLLMCalibrationCategory] = {
+            "false_approval",
+            "false_denial",
+            "ambiguity",
+            "source_confusion",
+        }
+        if not required_categories.issubset(categories):
+            raise ValueError(
+                "Calibration fixtures must include false approval, false denial, "
+                "ambiguity, and source confusion cases."
+            )
+
+        return self
+
+
+class ReviewLLMCalibrationCategoryReport(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    fixture_count: PositiveInt
+    scenario_ids: tuple[NonEmptyString, ...]
+    expected_review_statuses: tuple[ReviewLLMCalibrationStatus, ...]
+    expected_failure_signals: tuple[NonEmptyString, ...]
+
+
+class ReviewLLMCalibrationReport(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    fixture_set: NonEmptyString
+    fixture_count: PositiveInt
+    release_gate_authority: bool
+    authority_statement: NonEmptyString
+    malformed_output_handling: Literal["excluded_parser_contract"]
+    failure_categories: dict[
+        ReviewLLMCalibrationCategory,
+        ReviewLLMCalibrationCategoryReport,
+    ]
+
+
+def validate_review_llm_calibration_fixture_set(
+    fixture_set: dict[str, Any],
+) -> ReviewLLMCalibrationFixtureSet:
+    return ReviewLLMCalibrationFixtureSet.model_validate(fixture_set)
+
+
+def build_review_llm_calibration_report(
+    fixture_set: ReviewLLMCalibrationFixtureSet,
+) -> ReviewLLMCalibrationReport:
+    category_reports: dict[
+        ReviewLLMCalibrationCategory,
+        ReviewLLMCalibrationCategoryReport,
+    ] = {}
+    for category in (
+        "false_approval",
+        "false_denial",
+        "ambiguity",
+        "source_confusion",
+    ):
+        fixtures = [
+            fixture
+            for fixture in fixture_set.fixtures
+            if fixture.category == category
+        ]
+        category_reports[category] = ReviewLLMCalibrationCategoryReport(
+            fixture_count=len(fixtures),
+            scenario_ids=tuple(fixture.scenario_id for fixture in fixtures),
+            expected_review_statuses=tuple(
+                dict.fromkeys(fixture.expected_review_status for fixture in fixtures)
+            ),
+            expected_failure_signals=tuple(
+                dict.fromkeys(fixture.expected_failure_signal for fixture in fixtures)
+            ),
+        )
+
+    return ReviewLLMCalibrationReport(
+        fixture_set=fixture_set.fixture_set,
+        fixture_count=len(fixture_set.fixtures),
+        release_gate_authority=fixture_set.release_gate_authority,
+        authority_statement=fixture_set.authority_note,
+        malformed_output_handling=fixture_set.malformed_output_handling,
+        failure_categories=category_reports,
+    )

--- a/backend/tests/fixtures/review_llm_calibration_fixtures.json
+++ b/backend/tests/fixtures/review_llm_calibration_fixtures.json
@@ -1,0 +1,102 @@
+{
+  "fixture_set": "review_llm_calibration.v0",
+  "purpose": "Calibration fixtures for Review LLM critique behavior on false approvals, false denials, ambiguity, and source confusion.",
+  "format_status": "review_llm_calibration.v1",
+  "release_gate_authority": false,
+  "authority_note": "This calibration report does not make Review LLM release-gate authority unless measured coverage is separately defined and approved.",
+  "malformed_output_handling": "excluded_parser_contract",
+  "fixtures": [
+    {
+      "scenario_id": "rlcf-001-false-approval-unapproved-source",
+      "category": "false_approval",
+      "title": "Overconfident ready status for an unapproved source request",
+      "expected_review_status": "blocked",
+      "expected_failure_signal": "unapproved_source_must_not_be_treated_as_ready",
+      "evidence": {
+        "operator_request": "Compare approved vendor spend with unapproved vendor spend.",
+        "source_context": "Only business-postgres-source finance.approved_vendor_spend is governed for this fixture set.",
+        "candidate_summary": "The candidate joins finance.approved_vendor_spend to finance.unapproved_vendor_spend without an authoritative source binding for the second table.",
+        "critique_output": {
+          "status": "ready",
+          "confidence": "high",
+          "intentSummary": "Compare approved and unapproved vendor spend.",
+          "dataUsed": [
+            "approved_vendor_spend semantic contract"
+          ],
+          "riskFlags": []
+        }
+      },
+      "reviewer_rationale": "A ready critique would falsely approve an answer path that widened beyond the governed source contract."
+    },
+    {
+      "scenario_id": "rlcf-002-false-denial-approved-source",
+      "category": "false_denial",
+      "title": "Blocked status for a governed exact approved-spend query",
+      "expected_review_status": "ready",
+      "expected_failure_signal": "approved_source_query_should_not_be_denied_without_a_real_risk",
+      "evidence": {
+        "operator_request": "Show approved vendor spend by fiscal quarter.",
+        "source_context": "business-postgres-source finance.approved_vendor_spend is governed and active for fiscal-quarter spend.",
+        "candidate_summary": "The candidate selects fiscal_quarter and SUM(approved_spend) from finance.approved_vendor_spend filtered to approval_status = 'approved'.",
+        "critique_output": {
+          "status": "blocked",
+          "confidence": "medium",
+          "intentSummary": "Approved vendor spend by fiscal quarter.",
+          "dataUsed": [
+            "approved_vendor_spend semantic contract"
+          ],
+          "riskFlags": [
+            "No source was reviewed"
+          ]
+        }
+      },
+      "reviewer_rationale": "A denial here is a false denial because the source binding and fiscal-quarter semantic contract are explicit."
+    },
+    {
+      "scenario_id": "rlcf-003-ambiguity-refund-semantics",
+      "category": "ambiguity",
+      "title": "Refund treatment should request clarification",
+      "expected_review_status": "needs_clarification",
+      "expected_failure_signal": "refund_semantics_require_clarification",
+      "evidence": {
+        "operator_request": "Show net approved spend after refunds by quarter.",
+        "source_context": "The governed source includes approved_spend and refund_amount, but net-of-refunds semantics are not pre-approved.",
+        "candidate_summary": "The candidate subtracts refund_amount from approved_spend without a finance-owner semantic mapping.",
+        "critique_output": {
+          "status": "ready",
+          "confidence": "high",
+          "intentSummary": "Net approved spend by quarter.",
+          "dataUsed": [
+            "approved_vendor_spend semantic contract"
+          ],
+          "assumptions": [
+            "Refunds should be subtracted from approved spend"
+          ]
+        }
+      },
+      "reviewer_rationale": "Ambiguity calibration is separate from malformed output handling; the structured output can be valid while the critique should ask a question."
+    },
+    {
+      "scenario_id": "rlcf-004-source-confusion-application-postgres",
+      "category": "source_confusion",
+      "title": "Application PostgreSQL must not be accepted as business evidence",
+      "expected_review_status": "blocked",
+      "expected_failure_signal": "application_persistence_is_not_business_source_evidence",
+      "evidence": {
+        "operator_request": "Use the app database history to answer vendor spend.",
+        "source_context": "Application PostgreSQL stores SafeQuery control-plane records only and is not the governed business source.",
+        "candidate_summary": "The candidate cites application request history as if it were approved vendor spend evidence.",
+        "critique_output": {
+          "status": "ready",
+          "confidence": "medium",
+          "intentSummary": "Vendor spend from app database history.",
+          "dataUsed": [
+            "application-postgres-persistence request summaries"
+          ],
+          "riskFlags": []
+        }
+      },
+      "reviewer_rationale": "Source-confusion fixtures must fail closed at the review boundary rather than relying on source names or nearby metadata."
+    }
+  ]
+}

--- a/backend/tests/test_review_llm_calibration_fixtures.py
+++ b/backend/tests/test_review_llm_calibration_fixtures.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.features.evaluation import (
+    ReviewLLMCalibrationCategory,
+    build_review_llm_calibration_report,
+    validate_review_llm_calibration_fixture_set,
+)
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "review_llm_calibration_fixtures.json"
+
+
+def _load_fixture_set() -> dict[str, object]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_review_llm_calibration_fixture_set_is_schema_valid() -> None:
+    fixture_set = _load_fixture_set()
+    validated = validate_review_llm_calibration_fixture_set(fixture_set)
+
+    assert validated.fixture_set == "review_llm_calibration.v0"
+    assert validated.format_status == "review_llm_calibration.v1"
+    assert validated.release_gate_authority is False
+    assert "does not make Review LLM release-gate authority" in (
+        validated.authority_note
+    )
+
+    categories = {fixture.category for fixture in validated.fixtures}
+    assert categories == {
+        "false_approval",
+        "false_denial",
+        "ambiguity",
+        "source_confusion",
+    }
+
+    by_category = {
+        category: [
+            fixture
+            for fixture in validated.fixtures
+            if fixture.category == category
+        ]
+        for category in categories
+    }
+    assert by_category["false_approval"][0].expected_review_status == "blocked"
+    assert by_category["false_denial"][0].expected_review_status == "ready"
+    assert by_category["ambiguity"][0].expected_review_status == "needs_clarification"
+    assert by_category["source_confusion"][0].expected_review_status == "blocked"
+
+
+def test_review_llm_calibration_report_lists_failure_categories_separately() -> None:
+    fixture_set = validate_review_llm_calibration_fixture_set(_load_fixture_set())
+    report = build_review_llm_calibration_report(fixture_set)
+
+    assert report.fixture_count == len(fixture_set.fixtures)
+    assert report.release_gate_authority is False
+    assert report.authority_statement == fixture_set.authority_note
+    assert set(report.failure_categories) == {
+        "false_approval",
+        "false_denial",
+        "ambiguity",
+        "source_confusion",
+    }
+    assert report.failure_categories["false_approval"].fixture_count >= 1
+    assert report.failure_categories["false_denial"].fixture_count >= 1
+    assert report.failure_categories["ambiguity"].fixture_count >= 1
+    assert report.failure_categories["source_confusion"].fixture_count >= 1
+    assert "malformed_output" not in report.failure_categories
+    assert report.malformed_output_handling == "excluded_parser_contract"
+
+
+def test_review_llm_calibration_requires_false_approval_and_false_denial_cases() -> None:
+    fixture_set = _load_fixture_set()
+    fixture_set["fixtures"] = [
+        fixture
+        for fixture in fixture_set["fixtures"]  # type: ignore[index]
+        if fixture["category"] != "false_denial"
+    ]
+
+    with pytest.raises(ValidationError, match="false approval, false denial"):
+        validate_review_llm_calibration_fixture_set(fixture_set)
+
+
+def test_review_llm_calibration_rejects_release_gate_authority_claim() -> None:
+    fixture_set = _load_fixture_set()
+    fixture_set["release_gate_authority"] = True
+
+    with pytest.raises(ValidationError, match="must not grant release-gate authority"):
+        validate_review_llm_calibration_fixture_set(fixture_set)
+
+
+def test_review_llm_calibration_categories_are_closed() -> None:
+    assert set(ReviewLLMCalibrationCategory.__args__) == {
+        "false_approval",
+        "false_denial",
+        "ambiguity",
+        "source_confusion",
+    }


### PR DESCRIPTION
## Summary
- add Review LLM calibration fixture schema and report aggregation
- cover false approval, false denial, ambiguity, and source-confusion categories separately
- keep malformed output handling in the parser contract and state that calibration is not release-gate authority

## Verification
- cd backend && python3 -m pytest tests/test_review_llm_adapter_contract.py tests/test_review_llm_answer_plan.py tests/test_governed_answer_fixtures.py tests/test_review_llm_calibration_fixtures.py -q
- python3 -m pytest tests/test_check_repository_hygiene.py -q

Closes #459