### PR TITLE
[Y-7] Separate review LLM from SQL generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ SAFEQUERY_ENVIRONMENT=development
 # placeholders so application persistence values are never repurposed by guess.
 # SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me-for-local-source-topology@business-postgres-source:5432/business
 # SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:business-mssql-source,1433;Database=business;Uid=sa;Pwd=ChangeMeDevOnly_123;Encrypt=no;TrustServerCertificate=yes
+# Optional SQL generation runtime. Keep generation and review settings separate.
+# SAFEQUERY_SQL_GENERATION_PROVIDER=local_llm
+# SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL=http://sql-generation-llm:8080
+# SAFEQUERY_SQL_GENERATION_LOCAL_LLM_MODEL=safequery-generator
+# Optional Review LLM critique runtime. This can point at a different model.
+# SAFEQUERY_REVIEW_LLM_PROVIDER=local_llm
+# SAFEQUERY_REVIEW_LLM_LOCAL_LLM_BASE_URL=http://review-llm:8090
+# SAFEQUERY_REVIEW_LLM_LOCAL_LLM_MODEL=safequery-reviewer
 SAFEQUERY_CORS_ORIGINS=http://localhost:3000
 
 # Frontend application settings

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Optional values with reviewed defaults in code or compose:
 - `BUSINESS_MSSQL_SOURCE_SA_PASSWORD`
 - `SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL`
 - `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING`
+- `SAFEQUERY_SQL_GENERATION_PROVIDER`
+- `SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL`
+- `SAFEQUERY_SQL_GENERATION_LOCAL_LLM_MODEL`
+- `SAFEQUERY_SQL_GENERATION_VANNA_BASE_URL`
+- `SAFEQUERY_SQL_GENERATION_VANNA_MODEL`
+- `SAFEQUERY_REVIEW_LLM_PROVIDER`
+- `SAFEQUERY_REVIEW_LLM_LOCAL_LLM_BASE_URL`
+- `SAFEQUERY_REVIEW_LLM_LOCAL_LLM_MODEL`
 
 Keep the local roles distinct from the start:
 
@@ -126,6 +134,9 @@ Keep the local roles distinct from the start:
 - business MSSQL source uses
   `SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING` and the
   `business-mssql-source` service for source-specific connector work
+- SQL generation uses `SAFEQUERY_SQL_GENERATION_*` settings, while optional
+  Review LLM critique uses `SAFEQUERY_REVIEW_LLM_*` settings so reviewer
+  model/runtime changes do not alter generation configuration
 
 This role split does not make the application database a business target.
 The backend image packages `pyodbc` and Microsoft ODBC Driver 18 for SQL

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,4 +5,11 @@ SAFEQUERY_ENVIRONMENT=development
 # Keep business-source credentials separate from the application database URL.
 # SAFEQUERY_BUSINESS_POSTGRES_SOURCE_URL=postgresql://source_reader:change-me@127.0.0.1:5432/business
 # SAFEQUERY_BUSINESS_MSSQL_SOURCE_CONNECTION_STRING=Driver={ODBC Driver 18 for SQL Server};Server=tcp:127.0.0.1,1433;Database=business;Uid=source_reader;Pwd=change-me;Encrypt=yes;TrustServerCertificate=no
+# Keep optional review critique settings separate from generation settings.
+# SAFEQUERY_SQL_GENERATION_PROVIDER=local_llm
+# SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL=http://127.0.0.1:8080
+# SAFEQUERY_SQL_GENERATION_LOCAL_LLM_MODEL=safequery-generator
+# SAFEQUERY_REVIEW_LLM_PROVIDER=local_llm
+# SAFEQUERY_REVIEW_LLM_LOCAL_LLM_BASE_URL=http://127.0.0.1:8090
+# SAFEQUERY_REVIEW_LLM_LOCAL_LLM_MODEL=safequery-reviewer
 SAFEQUERY_CORS_ORIGINS=http://localhost:3000

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -38,6 +38,7 @@ class ProductionIdentityBridgeSettings(BaseModel):
 
 
 SQLGenerationProvider = Literal["disabled", "local_llm", "vanna"]
+ReviewLLMProvider = Literal["disabled", "local_llm"]
 
 _PLACEHOLDER_CREDENTIAL_VALUES = frozenset(
     {
@@ -80,6 +81,17 @@ class SQLGenerationSettings(BaseModel):
     circuit_breaker_failure_threshold: int = Field(default=3, ge=1, le=10)
 
 
+class ReviewLLMSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: ReviewLLMProvider = "disabled"
+    local_llm_base_url: Optional[AnyHttpUrl] = None
+    local_llm_model: Optional[str] = None
+    timeout_seconds: int = Field(default=30, ge=1, le=300)
+    retry_count: int = Field(default=1, ge=0, le=3)
+    circuit_breaker_failure_threshold: int = Field(default=3, ge=1, le=10)
+
+
 class SourceRoleTelemetry(BaseModel):
     application_postgres_persistence: Literal["configured"] = "configured"
     business_postgres_source_generation: Literal["configured", "unconfigured"]
@@ -117,6 +129,16 @@ class Settings(BaseSettings):
         ge=1,
         le=10,
     )
+    review_llm_provider: ReviewLLMProvider = "disabled"
+    review_llm_local_llm_base_url: Optional[AnyHttpUrl] = None
+    review_llm_local_llm_model: Optional[str] = None
+    review_llm_timeout_seconds: int = Field(default=30, ge=1, le=300)
+    review_llm_retry_count: int = Field(default=1, ge=0, le=3)
+    review_llm_circuit_breaker_failure_threshold: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+    )
     cors_origins: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["http://localhost:3000"]
     )
@@ -141,6 +163,7 @@ class Settings(BaseSettings):
     @field_validator(
         "sql_generation_local_llm_model",
         "sql_generation_vanna_model",
+        "review_llm_local_llm_model",
         mode="before",
     )
     @classmethod
@@ -332,6 +355,15 @@ class Settings(BaseSettings):
                 "when SAFEQUERY_SQL_GENERATION_PROVIDER=vanna."
             )
 
+        if (
+            self.review_llm_provider == "local_llm"
+            and self.review_llm_local_llm_base_url is None
+        ):
+            raise ValueError(
+                "SAFEQUERY_REVIEW_LLM_LOCAL_LLM_BASE_URL must be configured "
+                "when SAFEQUERY_REVIEW_LLM_PROVIDER=local_llm."
+            )
+
         return self
 
     @property
@@ -409,6 +441,19 @@ class Settings(BaseSettings):
             retry_count=self.sql_generation_retry_count,
             circuit_breaker_failure_threshold=(
                 self.sql_generation_circuit_breaker_failure_threshold
+            ),
+        )
+
+    @property
+    def review_llm(self) -> ReviewLLMSettings:
+        return ReviewLLMSettings(
+            provider=self.review_llm_provider,
+            local_llm_base_url=self.review_llm_local_llm_base_url,
+            local_llm_model=self.review_llm_local_llm_model,
+            timeout_seconds=self.review_llm_timeout_seconds,
+            retry_count=self.review_llm_retry_count,
+            circuit_breaker_failure_threshold=(
+                self.review_llm_circuit_breaker_failure_threshold
             ),
         )
 

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -24,6 +24,7 @@ _SAFE_API_ERROR_CODES = frozenset(
         "operator_read_forbidden",
         "preview_guard_malformed",
         "preview_generation_failed",
+        "preview_review_failed",
         "preview_source_malformed",
         "preview_source_unavailable",
         "request_context_unavailable",

--- a/backend/app/features/review_llm/__init__.py
+++ b/backend/app/features/review_llm/__init__.py
@@ -1,5 +1,17 @@
 """Review LLM critique-only adapter contracts."""
 
+from app.features.review_llm.adapter import (
+    REVIEW_LLM_PROMPT_VERSION,
+    ConfiguredReviewLLMAdapter,
+    ReviewLLMAdapter,
+    ReviewLLMAdapterConfigurationError,
+    ReviewLLMAdapterRequest,
+    ReviewLLMGenerationSummary,
+    ReviewLLMPromptMessages,
+    build_review_llm_adapter_request,
+    build_review_llm_prompt_messages,
+    resolve_review_llm_adapter,
+)
 from app.features.review_llm.answer_plan import (
     AnswerPlanCandidateSummary,
     AnswerPlanGuardSummary,
@@ -20,10 +32,20 @@ __all__ = [
     "AnswerPlanGuardSummary",
     "AnswerPlanPayload",
     "AnswerPlanSemanticEvidence",
+    "ConfiguredReviewLLMAdapter",
+    "REVIEW_LLM_PROMPT_VERSION",
+    "ReviewLLMAdapter",
+    "ReviewLLMAdapterConfigurationError",
     "ReviewLLMAdapterDiagnostics",
     "ReviewLLMAdapterOutput",
     "ReviewLLMAdapterOutputError",
+    "ReviewLLMAdapterRequest",
+    "ReviewLLMGenerationSummary",
+    "ReviewLLMPromptMessages",
     "build_answer_plan_from_review",
+    "build_review_llm_adapter_request",
+    "build_review_llm_prompt_messages",
     "parse_review_llm_adapter_output",
+    "resolve_review_llm_adapter",
     "sanitize_review_llm_surface_text_items",
 ]

--- a/backend/app/features/review_llm/adapter.py
+++ b/backend/app/features/review_llm/adapter.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from typing import Optional, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationError,
+)
+
+from app.core.config import ReviewLLMProvider, ReviewLLMSettings
+from app.features.review_llm.schema import (
+    ReviewLLMAdapterOutput,
+    ReviewLLMAdapterOutputError,
+    parse_review_llm_adapter_output,
+)
+from app.services.sql_generation_adapter import (
+    NonEmptyTrimmedString,
+    SQLGenerationAdapterRequest,
+    SQLGenerationAdapterResponse,
+    SQLGenerationAdapterRunMetadata,
+)
+
+
+REVIEW_LLM_PROMPT_VERSION = "review_llm_critique_request.v1"
+
+
+class ReviewLLMAdapterConfigurationError(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ReviewLLMGenerationSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    adapter_provider: NonEmptyTrimmedString
+    adapter_version: NonEmptyTrimmedString
+    adapter_model: Optional[NonEmptyTrimmedString] = None
+    generation_prompt_version: NonEmptyTrimmedString
+
+
+class ReviewLLMAdapterRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: NonEmptyTrimmedString
+    question: NonEmptyTrimmedString
+    candidate_sql: NonEmptyTrimmedString
+    source_id: NonEmptyTrimmedString
+    source_family: NonEmptyTrimmedString
+    source_flavor: Optional[NonEmptyTrimmedString] = None
+    generation: ReviewLLMGenerationSummary
+    prompt_version: NonEmptyTrimmedString = REVIEW_LLM_PROMPT_VERSION
+
+    def to_runtime_payload(self) -> dict[str, object]:
+        return self.model_dump(mode="json", exclude_none=True)
+
+
+class ReviewLLMPromptMessages(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    prompt_version: NonEmptyTrimmedString
+    system: NonEmptyTrimmedString
+    user: NonEmptyTrimmedString
+
+
+class ReviewLLMAdapter(Protocol):
+    def review_sql(self, request: ReviewLLMAdapterRequest) -> ReviewLLMAdapterOutput:
+        """Critique generated SQL from a minimized, review-only request projection."""
+
+
+class ConfiguredReviewLLMAdapter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: NonEmptyTrimmedString
+    adapter_version: NonEmptyTrimmedString
+    base_url: NonEmptyTrimmedString
+    model: Optional[NonEmptyTrimmedString] = None
+    timeout_seconds: int
+    retry_count: int
+    circuit_breaker_failure_threshold: int
+    _consecutive_failures: int = PrivateAttr(default=0)
+
+    def review_sql(self, request: ReviewLLMAdapterRequest) -> ReviewLLMAdapterOutput:
+        if self.provider == "local_llm":
+            return self._review_with_local_llm(request)
+
+        raise ReviewLLMAdapterConfigurationError(
+            "review_llm_provider_not_implemented",
+            f"Provider '{self.provider}' is configured but dispatch is not implemented.",
+        )
+
+    def _review_with_local_llm(
+        self,
+        request: ReviewLLMAdapterRequest,
+    ) -> ReviewLLMAdapterOutput:
+        if self._consecutive_failures >= self.circuit_breaker_failure_threshold:
+            raise ReviewLLMAdapterConfigurationError(
+                "review_llm_runtime_circuit_open",
+                "Review LLM runtime is unhealthy; circuit breaker is open.",
+            )
+
+        last_error: BaseException | None = None
+        for _attempt in range(self.retry_count + 1):
+            try:
+                response = self._dispatch_local_llm_review(request)
+            except (
+                HTTPError,
+                URLError,
+                TimeoutError,
+                OSError,
+                ValidationError,
+                json.JSONDecodeError,
+                ReviewLLMAdapterOutputError,
+                ReviewLLMAdapterConfigurationError,
+            ) as exc:
+                last_error = exc
+                continue
+
+            self._consecutive_failures = 0
+            return response
+
+        self._consecutive_failures += 1
+        detail = (
+            last_error.__class__.__name__
+            if last_error is not None
+            else "UnknownAdapterFailure"
+        )
+        raise ReviewLLMAdapterConfigurationError(
+            "review_llm_runtime_unhealthy",
+            f"Review LLM runtime is unavailable ({detail}).",
+        )
+
+    def _dispatch_local_llm_review(
+        self,
+        request: ReviewLLMAdapterRequest,
+    ) -> ReviewLLMAdapterOutput:
+        prompt = build_review_llm_prompt_messages(request)
+        payload: dict[str, object] = {
+            "request": request.to_runtime_payload(),
+            "prompt": prompt.model_dump(mode="json"),
+        }
+        if self.model is not None:
+            payload["model"] = self.model
+
+        http_request = Request(
+            f"{self.base_url.rstrip('/')}/review-sql",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urlopen(http_request, timeout=self.timeout_seconds) as response:  # noqa: S310
+            status = getattr(response, "status", 200)
+            raw_body = response.read().decode("utf-8", errors="replace")
+
+        if status >= 400:
+            raise ReviewLLMAdapterConfigurationError(
+                "review_llm_runtime_unhealthy",
+                "Review LLM runtime returned an unhealthy response.",
+            )
+
+        decoded = json.loads(raw_body)
+        if not isinstance(decoded, Mapping):
+            raise ReviewLLMAdapterConfigurationError(
+                "review_llm_response_invalid",
+                "Review LLM runtime returned an invalid response.",
+            )
+
+        return parse_review_llm_adapter_output(decoded)
+
+
+def build_review_llm_prompt_messages(
+    request: ReviewLLMAdapterRequest,
+) -> ReviewLLMPromptMessages:
+    request_payload = json.dumps(
+        request.to_runtime_payload(),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return ReviewLLMPromptMessages(
+        prompt_version=REVIEW_LLM_PROMPT_VERSION,
+        system=(
+            "You are SafeQuery's critique-only SQL review model. Review the "
+            "candidate for uncertainty, ambiguity, missing context, unsafe "
+            "assumptions, and business-intent mismatch. Return only the "
+            "review_llm_adapter_output.v1 JSON object. Do not approve "
+            "execution, select candidates, bypass SQL Guard, or infer hidden "
+            "generation reasoning. Hidden scratchpads, chain-of-thought, "
+            "credentials, and runtime secrets are not provided."
+        ),
+        user=(
+            "Critique this minimized review input. Treat generation metadata as "
+            "diagnostic context only and keep the result advisory: "
+            f"{request_payload}"
+        ),
+    )
+
+
+def build_review_llm_adapter_request(
+    *,
+    generation_request: SQLGenerationAdapterRequest,
+    generation_response: SQLGenerationAdapterResponse,
+    generation_metadata: SQLGenerationAdapterRunMetadata,
+    candidate_sql: str,
+) -> ReviewLLMAdapterRequest:
+    return ReviewLLMAdapterRequest(
+        request_id=generation_request.request_id,
+        question=generation_request.question,
+        candidate_sql=candidate_sql,
+        source_id=generation_request.source.source_id,
+        source_family=generation_request.source.source_family,
+        source_flavor=generation_request.source.source_flavor,
+        generation=ReviewLLMGenerationSummary(
+            adapter_provider=generation_response.provider,
+            adapter_version=generation_response.adapter_version,
+            adapter_model=generation_response.model,
+            generation_prompt_version=generation_metadata.prompt_version,
+        ),
+    )
+
+
+def _settings_from_mapping(settings: Mapping[str, object]) -> ReviewLLMSettings:
+    try:
+        return ReviewLLMSettings.model_validate(settings)
+    except ValidationError as exc:
+        raise ReviewLLMAdapterConfigurationError(
+            "review_llm_settings_invalid",
+            "Review LLM adapter settings are invalid.",
+        ) from exc
+
+
+def resolve_review_llm_adapter(
+    settings: ReviewLLMSettings | Mapping[str, object],
+) -> ReviewLLMAdapter:
+    review_settings = (
+        _settings_from_mapping(settings) if isinstance(settings, Mapping) else settings
+    )
+
+    if review_settings.provider == "disabled":
+        raise ReviewLLMAdapterConfigurationError(
+            "review_llm_disabled",
+            "Review LLM is disabled; no adapter can be used for critique.",
+        )
+
+    if review_settings.provider == "local_llm":
+        if review_settings.local_llm_base_url is None:
+            raise ReviewLLMAdapterConfigurationError(
+                "review_llm_local_llm_misconfigured",
+                "Local review LLM requires a configured base URL.",
+            )
+        return ConfiguredReviewLLMAdapter(
+            provider="local_llm",
+            adapter_version="review_local_llm.v1",
+            base_url=str(review_settings.local_llm_base_url),
+            model=review_settings.local_llm_model,
+            timeout_seconds=review_settings.timeout_seconds,
+            retry_count=review_settings.retry_count,
+            circuit_breaker_failure_threshold=(
+                review_settings.circuit_breaker_failure_threshold
+            ),
+        )
+
+    raise ReviewLLMAdapterConfigurationError(
+        "review_llm_provider_unknown",
+        "Review LLM provider selection is not recognized.",
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,6 +56,7 @@ from app.features.execution import (
     preflight_execution_runtime_controls,
     select_execution_connector,
 )
+from app.features.review_llm import resolve_review_llm_adapter
 from app.services.candidate_lifecycle import (
     CandidateLifecycleAuditContext,
     CandidateLifecycleRevalidationError,
@@ -457,6 +458,11 @@ def create_app() -> FastAPI:
         if settings.sql_generation.provider == "disabled"
         else resolve_sql_generation_adapter(settings.sql_generation)
     )
+    review_llm_adapter = (
+        None
+        if settings.review_llm.provider == "disabled"
+        else resolve_review_llm_adapter(settings.review_llm)
+    )
 
     app.add_middleware(
         CORSMiddleware,
@@ -686,6 +692,7 @@ def create_app() -> FastAPI:
                 session,
                 audit_context=audit_context,
                 sql_generation_adapter=sql_generation_adapter,
+                review_llm_adapter=review_llm_adapter,
             )
         except PreviewSubmissionEntitlementError as exc:
             raise api_error(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -32,6 +32,11 @@ from app.features.guard import (
     evaluate_postgresql_sql_guard,
 )
 from app.features.operator_history.payloads import GuardStatus
+from app.features.review_llm.adapter import (
+    ReviewLLMAdapter,
+    ReviewLLMAdapterConfigurationError,
+    build_review_llm_adapter_request,
+)
 from app.features.review_llm.schema import ReviewLLMAdapterOutput
 from app.services.candidate_lifecycle import (
     CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY,
@@ -1728,6 +1733,7 @@ def submit_preview_request(
     session: Session,
     audit_context: PreviewAuditContext | None = None,
     sql_generation_adapter: SQLGenerationAdapter | None = None,
+    review_llm_adapter: ReviewLLMAdapter | None = None,
 ) -> PreviewSubmissionResponse:
     source, dataset_contract, schema_snapshot = _resolve_authoritative_source_governance(
         session,
@@ -1871,7 +1877,6 @@ def submit_preview_request(
                     intent_mapping=intent_mapping,
                 )
                 adapter_response = sql_generation_adapter.generate_sql(adapter_request)
-                review_decision = getattr(adapter_response, "review_decision", None)
                 candidate_sql = normalize_adapter_generated_sql(
                     adapter_response.candidate_sql
                 )
@@ -1890,11 +1895,32 @@ def submit_preview_request(
                     guard_status = "blocked"
                     candidate_state = "blocked"
                     request_state = "blocked"
+                if review_llm_adapter is not None:
+                    review_request = build_review_llm_adapter_request(
+                        generation_request=adapter_request,
+                        generation_response=adapter_response,
+                        generation_metadata=adapter_metadata,
+                        candidate_sql=candidate_sql,
+                    )
+                    review_decision = review_llm_adapter.review_sql(review_request)
             except (
                 GenerationContextPreparationError,
                 SQLGenerationAdapterConfigurationError,
+                ReviewLLMAdapterConfigurationError,
             ) as exc:
                 failure_code = getattr(exc, "code", "sql_generation_context_unavailable")
+                if isinstance(exc, ReviewLLMAdapterConfigurationError):
+                    public_code = "preview_review_failed"
+                    public_message = (
+                        "Review LLM critique failed before an authoritative preview "
+                        "candidate was created."
+                    )
+                else:
+                    public_code = "preview_generation_failed"
+                    public_message = (
+                        "SQL generation failed before an authoritative preview "
+                        "candidate was created."
+                    )
                 audit_events = _build_preview_generation_failed_audit_event(
                     resolved_source=resolved_source,
                     dataset_contract=dataset_contract,
@@ -1916,11 +1942,8 @@ def submit_preview_request(
                 )
                 raise PreviewSubmissionContractError(
                     str(exc),
-                    public_code="preview_generation_failed",
-                    public_message=(
-                        "SQL generation failed before an authoritative preview "
-                        "candidate was created."
-                    ),
+                    public_code=public_code,
+                    public_message=public_message,
                 ) from exc
 
     if intent_blocked_candidate_state is not None:

--- a/backend/app/services/sql_generation_adapter.py
+++ b/backend/app/services/sql_generation_adapter.py
@@ -20,11 +20,6 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from app.core.config import SQLGenerationProvider, SQLGenerationSettings
-from app.features.review_llm.schema import (
-    ReviewLLMAdapterOutput,
-    ReviewLLMAdapterOutputError,
-    parse_review_llm_adapter_output,
-)
 from app.services.intent_mapping import IntentMappingOutput
 from app.services.generation_context import PreparedGenerationContext
 
@@ -107,7 +102,6 @@ class SQLGenerationAdapterResponse(BaseModel):
     provider: SQLGenerationProvider
     adapter_version: NonEmptyTrimmedString
     model: Optional[NonEmptyTrimmedString] = None
-    review_decision: Optional[ReviewLLMAdapterOutput] = None
 
 
 class SQLGenerationAdapterRunMetadata(BaseModel):
@@ -189,19 +183,6 @@ def _require_adapter_response_has_no_execution_material(
                 f"adapter boundary material '{forbidden_key}'."
             ),
             )
-
-
-def _parse_optional_review_decision(value: object) -> ReviewLLMAdapterOutput | None:
-    if value is None:
-        return None
-    if isinstance(value, ReviewLLMAdapterOutput):
-        return value
-    if not isinstance(value, (str, bytes, bytearray, Mapping)):
-        return None
-    try:
-        return parse_review_llm_adapter_output(value)
-    except ReviewLLMAdapterOutputError:
-        return None
 
 
 class SQLGenerationAdapter(Protocol):
@@ -328,9 +309,6 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
             provider="local_llm",
             adapter_version=self.adapter_version,
             model=model,
-            review_decision=_parse_optional_review_decision(
-                decoded.get("review_decision")
-            ),
         )
 
     def _generate_vanna_sql(
@@ -459,9 +437,6 @@ class ConfiguredSQLGenerationAdapter(BaseModel):
             provider="vanna",
             adapter_version=self.adapter_version,
             model=model,
-            review_decision=_parse_optional_review_decision(
-                decoded.get("review_decision")
-            ),
         )
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -127,6 +127,37 @@ class SettingsTestCase(unittest.TestCase):
         self.assertNotIn("business_postgres_source_url", dumped)
         self.assertNotIn("business_mssql_source_connection_string", dumped)
 
+    def test_review_llm_settings_are_independent_from_sql_generation_defaults(
+        self,
+    ) -> None:
+        settings = Settings(
+            app_postgres_url="postgresql://safequery:safequery@db:5432/safequery",
+            sql_generation_provider="vanna",
+            sql_generation_vanna_base_url="http://vanna:8084",
+            sql_generation_vanna_model="warehouse-assistant",
+            review_llm_provider="local_llm",
+            review_llm_local_llm_base_url="http://review-llm:8090",
+            review_llm_local_llm_model="safequery-reviewer",
+            review_llm_timeout_seconds=13,
+            review_llm_retry_count=0,
+            review_llm_circuit_breaker_failure_threshold=2,
+            _env_file=None,
+            _env_prefix="SAFEQUERY_",
+        )
+
+        self.assertEqual(settings.sql_generation.provider, "vanna")
+        self.assertEqual(settings.sql_generation.vanna_model, "warehouse-assistant")
+        self.assertFalse(hasattr(settings.sql_generation, "review_llm_model"))
+        self.assertEqual(settings.review_llm.provider, "local_llm")
+        self.assertEqual(
+            str(settings.review_llm.local_llm_base_url),
+            "http://review-llm:8090/",
+        )
+        self.assertEqual(settings.review_llm.local_llm_model, "safequery-reviewer")
+        self.assertEqual(settings.review_llm.timeout_seconds, 13)
+        self.assertEqual(settings.review_llm.retry_count, 0)
+        self.assertEqual(settings.review_llm.circuit_breaker_failure_threshold, 2)
+
     def test_sql_generation_retry_policy_settings_are_bounded(self) -> None:
         for field, value in (
             ("sql_generation_timeout_seconds", 0),

--- a/backend/tests/test_preview_persistence.py
+++ b/backend/tests/test_preview_persistence.py
@@ -34,6 +34,7 @@ from app.features.audit.event_model import SourceAwareAuditEvent
 from app.features.auth.session import create_test_application_session
 from app.features.evaluation.harness import list_postgresql_evaluation_scenarios
 from app.features.guard import SQLGuardEvaluation, SQLGuardRejection
+from app.features.review_llm import ReviewLLMAdapterConfigurationError
 from app.services import request_preview as request_preview_service
 from app.services.request_preview import (
     PreviewAuditContext,
@@ -209,6 +210,14 @@ class _FailingHTTPPreviewAdapter:
         raise SQLGenerationAdapterConfigurationError(
             "sql_generation_runtime_unhealthy",
             "SQL generation runtime is unavailable.",
+        )
+
+
+class _FailingReviewAdapter:
+    def review_sql(self, request):
+        raise ReviewLLMAdapterConfigurationError(
+            "review_llm_runtime_unhealthy",
+            "Review LLM runtime is unavailable.",
         )
 
 
@@ -580,6 +589,85 @@ def test_http_preview_allow_path_creates_approved_candidate_and_executes(
         assert persisted_execution_event.audit_payload["semantic_contract_version"] == (
             persisted_candidate.semantic_contract_version
         )
+    finally:
+        session.close()
+        engine.dispose()
+        app.dependency_overrides.clear()
+        get_settings.cache_clear()
+
+
+def test_http_preview_review_adapter_failure_uses_registered_error_code(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:safequery@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SESSION_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_SQL_GENERATION_LOCAL_LLM_BASE_URL",
+        "http://sql-generation.example.test",
+    )
+    monkeypatch.setenv("SAFEQUERY_REVIEW_LLM_PROVIDER", "local_llm")
+    monkeypatch.setenv(
+        "SAFEQUERY_REVIEW_LLM_LOCAL_LLM_BASE_URL",
+        "http://review-llm.example.test",
+    )
+    get_settings.cache_clear()
+
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = Session(engine)
+    subject = AuthenticatedSubject(
+        subject_id="user:alice",
+        governance_bindings=frozenset({"group:finance-analysts"}),
+    )
+
+    main_module = importlib.import_module("app.main")
+    monkeypatch.setattr(
+        main_module,
+        "resolve_sql_generation_adapter",
+        lambda _: _RecordingHTTPPreviewAdapter(),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "resolve_review_llm_adapter",
+        lambda _: _FailingReviewAdapter(),
+    )
+    app = main_module.create_app()
+    app.dependency_overrides[require_authenticated_subject] = lambda: subject
+    app.dependency_overrides[require_preview_submission_session] = lambda: session
+    client = TestClient(app)
+
+    try:
+        _seed_authoritative_source_governance(session)
+        app_session = create_test_application_session(subject)
+
+        response = client.post(
+            "/requests/preview",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={
+                "question": "Show approved vendors by quarterly spend",
+                "source_id": "sap-approved-spend",
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "error": {
+                "code": "preview_review_failed",
+                "message": (
+                    "Review LLM critique failed before an authoritative preview "
+                    "candidate was created."
+                ),
+            }
+        }
     finally:
         session.close()
         engine.dispose()

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -36,9 +36,6 @@ from app.services.sql_generation_adapter import SQLGenerationAdapterResponse
 
 
 class _PreviewAdapter:
-    def __init__(self, review_decision=None):
-        self.review_decision = review_decision
-
     def generate_sql(self, request):
         return SQLGenerationAdapterResponse(
             candidate_sql=(
@@ -47,8 +44,17 @@ class _PreviewAdapter:
             provider="local_llm",
             adapter_version="test.adapter.v1",
             model="safequery-test-sql",
-            review_decision=self.review_decision,
         )
+
+
+class _ReviewAdapter:
+    def __init__(self, review_decision):
+        self.review_decision = review_decision
+        self.requests = []
+
+    def review_sql(self, request):
+        self.requests.append(request)
+        return self.review_decision
 
 
 def _session() -> Session:
@@ -491,7 +497,8 @@ def test_preview_submission_persists_adapter_review_decision() -> None:
                 candidate_owner_subject="user:alice",
                 auth_source="test-helper",
             ),
-            sql_generation_adapter=_PreviewAdapter(review_decision=review),
+            sql_generation_adapter=_PreviewAdapter(),
+            review_llm_adapter=_ReviewAdapter(review),
         )
 
         persisted_review = session.scalar(select(PreviewReviewDecision))
@@ -545,7 +552,8 @@ def test_preview_submission_persists_review_decision_with_generated_candidate_id
                 session_id="preview-request-457-session",
                 auth_source="test-helper",
             ),
-            sql_generation_adapter=_PreviewAdapter(review_decision=review),
+            sql_generation_adapter=_PreviewAdapter(),
+            review_llm_adapter=_ReviewAdapter(review),
         )
 
         persisted_review = session.scalar(select(PreviewReviewDecision))

--- a/backend/tests/test_review_llm_adapter_request.py
+++ b/backend/tests/test_review_llm_adapter_request.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+import app.features.review_llm.adapter as review_adapter_module
+from app.features.review_llm import (
+    REVIEW_LLM_PROMPT_VERSION,
+    build_review_llm_adapter_request,
+    build_review_llm_prompt_messages,
+    resolve_review_llm_adapter,
+)
+from app.services.sql_generation_adapter import (
+    SQLGenerationAdapterRequest,
+    SQLGenerationAdapterResponse,
+    SQLGenerationContextReferences,
+    SQLGenerationSourceBinding,
+    build_sql_generation_adapter_run_metadata,
+)
+
+
+def _generation_request() -> SQLGenerationAdapterRequest:
+    return SQLGenerationAdapterRequest(
+        request_id="req_460_preview",
+        question="Show approved vendors by quarterly spend.",
+        source=SQLGenerationSourceBinding(
+            source_id="sap-approved-spend",
+            source_family="postgresql",
+            source_flavor="warehouse",
+        ),
+        context=SQLGenerationContextReferences(
+            dataset_contract={
+                "context_id": "contract_finance_v1",
+                "source_id": "sap-approved-spend",
+            },
+            schema_snapshot={
+                "context_id": "snapshot_finance_v3",
+                "source_id": "sap-approved-spend",
+            },
+        ),
+    )
+
+
+def test_review_llm_request_uses_separate_prompt_boundary_and_minimized_inputs() -> None:
+    generation_request = _generation_request()
+    generation_response = SQLGenerationAdapterResponse(
+        candidate_sql="select vendor_id from approved_vendor_spend limit 50",
+        provider="vanna",
+        adapter_version="vanna.v1",
+        model="warehouse-assistant",
+    )
+    generation_metadata = build_sql_generation_adapter_run_metadata(
+        adapter_request=generation_request,
+        adapter_response=generation_response,
+        adapter_run_id="correlation-460",
+    )
+
+    review_request = build_review_llm_adapter_request(
+        generation_request=generation_request,
+        generation_response=generation_response,
+        generation_metadata=generation_metadata,
+        candidate_sql=generation_response.candidate_sql,
+    )
+    prompt = build_review_llm_prompt_messages(review_request)
+    serialized_request = json.dumps(review_request.to_runtime_payload(), sort_keys=True)
+    serialized_prompt = json.dumps(prompt.model_dump(mode="json"), sort_keys=True)
+
+    assert review_request.prompt_version == REVIEW_LLM_PROMPT_VERSION
+    assert review_request.generation.generation_prompt_version == (
+        "sql_generation_adapter_request.v1"
+    )
+    assert review_request.generation.adapter_provider == "vanna"
+    assert "prompt_fingerprint" not in serialized_request
+    assert "adapter_run_id" not in serialized_request
+    assert "credentials" not in serialized_request
+    assert "scratchpad" not in serialized_request
+    assert "chain-of-thought" not in serialized_request
+    assert "Critique" in prompt.user
+    assert "uncertainty" in prompt.system
+    assert "Do not approve execution" in prompt.system
+    assert "Hidden scratchpads, chain-of-thought, credentials" in prompt.system
+    assert "sql_generation_adapter_request.v1" in serialized_prompt
+
+
+def test_review_llm_request_rejects_generation_internals_and_credentials() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        review_adapter_module.ReviewLLMAdapterRequest.model_validate(
+            {
+                "request_id": "req_460_preview",
+                "question": "Show approved vendors.",
+                "candidate_sql": "select vendor_id from approved_vendor_spend limit 50",
+                "source_id": "sap-approved-spend",
+                "source_family": "postgresql",
+                "generation": {
+                    "adapter_provider": "vanna",
+                    "adapter_version": "vanna.v1",
+                    "generation_prompt_version": "sql_generation_adapter_request.v1",
+                },
+                "hidden_prompt": "do not expose generation scratchpad",
+                "credentials": {"password": "not-allowed"},
+            }
+        )
+
+    field_errors = {
+        (error["loc"][0], error["type"])
+        for error in exc_info.value.errors()
+    }
+    assert ("hidden_prompt", "extra_forbidden") in field_errors
+    assert ("credentials", "extra_forbidden") in field_errors
+
+
+def test_review_llm_adapter_registry_selects_independent_model(monkeypatch) -> None:
+    adapter = resolve_review_llm_adapter(
+        {
+            "provider": "local_llm",
+            "local_llm_base_url": "http://review-llm:8090",
+            "local_llm_model": "safequery-reviewer",
+            "retry_count": 0,
+            "timeout_seconds": 12,
+        }
+    )
+    generation_request = _generation_request()
+    generation_response = SQLGenerationAdapterResponse(
+        candidate_sql="select vendor_id from approved_vendor_spend limit 50",
+        provider="local_llm",
+        adapter_version="local_llm.v1",
+        model="safequery-generator",
+    )
+    review_request = build_review_llm_adapter_request(
+        generation_request=generation_request,
+        generation_response=generation_response,
+        generation_metadata=build_sql_generation_adapter_run_metadata(
+            adapter_request=generation_request,
+            adapter_response=generation_response,
+            adapter_run_id="correlation-460",
+        ),
+        candidate_sql=generation_response.candidate_sql,
+    )
+    seen: dict[str, object] = {}
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "contract_version": "review_llm_adapter_output.v1",
+                    "status": "needs_clarification",
+                    "confidence": "medium",
+                    "intent_summary": "Show approved vendors.",
+                    "risk_flags": ["The candidate needs reviewer confirmation."],
+                    "clarifying_questions": ["Should inactive vendors be included?"],
+                    "diagnostics": {
+                        "adapter_version": "review_local_llm.v1",
+                        "provider": "local_llm",
+                        "model": "safequery-reviewer",
+                        "prompt_version": REVIEW_LLM_PROMPT_VERSION,
+                    },
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(http_request, timeout=None):
+        seen["url"] = http_request.full_url
+        seen["timeout"] = timeout
+        seen["body"] = json.loads(http_request.data.decode("utf-8"))
+        return Response()
+
+    monkeypatch.setattr(review_adapter_module, "urlopen", fake_urlopen)
+
+    review = adapter.review_sql(review_request)
+
+    assert review.status == "needs_clarification"
+    assert seen["url"] == "http://review-llm:8090/review-sql"
+    assert seen["timeout"] == 12
+    assert seen["body"]["model"] == "safequery-reviewer"
+    assert seen["body"]["request"]["generation"]["adapter_model"] == (
+        "safequery-generator"
+    )
+    assert seen["body"]["prompt"]["prompt_version"] == REVIEW_LLM_PROMPT_VERSION

--- a/backend/tests/test_sql_generation_adapter_request.py
+++ b/backend/tests/test_sql_generation_adapter_request.py
@@ -169,6 +169,35 @@ def test_sql_generation_adapter_response_shape_is_typed_and_credential_free() ->
         raise AssertionError("Expected response validation to reject credentials.")
 
 
+def test_sql_generation_adapter_response_rejects_review_decision() -> None:
+    try:
+        SQLGenerationAdapterResponse.model_validate(
+            {
+                "candidate_sql": "select vendor_id from approved_vendor_spend limit 50",
+                "provider": "local_llm",
+                "adapter_version": "local_llm.v1",
+                "model": "safequery-local-sql",
+                "review_decision": {
+                    "contract_version": "review_llm_adapter_output.v1",
+                    "status": "ready",
+                    "confidence": "high",
+                    "intent_summary": "Show approved vendors.",
+                    "diagnostics": {
+                        "adapter_version": "review-adapter.v1",
+                        "model": "same-generation-model",
+                    },
+                },
+            }
+        )
+    except ValidationError as exc:
+        assert exc.errors()[0]["loc"] == ("review_decision",)
+        assert exc.errors()[0]["type"] == "extra_forbidden"
+    else:
+        raise AssertionError(
+            "Expected generation responses to reject embedded review decisions."
+        )
+
+
 def test_sql_generation_adapter_run_metadata_fingerprints_safe_request_projection() -> None:
     request = SQLGenerationAdapterRequest(
         request_id="req_79_preview",
@@ -378,15 +407,12 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
 
     response = adapter.generate_sql(request)
 
-    assert response.model_dump(exclude={"review_decision"}, exclude_none=True) == {
+    assert response.model_dump(exclude_none=True) == {
         "candidate_sql": "select vendor_id from approved_vendor_spend limit 50",
         "provider": "local_llm",
         "adapter_version": "local_llm.v1",
         "model": "safequery-local-sql",
     }
-    assert response.review_decision is not None
-    assert response.review_decision.status == "needs_clarification"
-    assert response.review_decision.risk_flags == ["Vendor names may be sensitive."]
     assert [call[0] for call in calls] == [
         "http://local-llm:8080/generate-sql",
         "http://local-llm:8080/generate-sql",
@@ -397,7 +423,7 @@ def test_local_llm_generation_retries_with_bounded_timeout(monkeypatch) -> None:
     assert "credentials" not in json.dumps(calls[0][2])
 
 
-def test_local_llm_generation_ignores_malformed_review_decision(monkeypatch) -> None:
+def test_local_llm_generation_ignores_embedded_review_decision(monkeypatch) -> None:
     adapter = resolve_sql_generation_adapter(
         {
             "provider": "local_llm",
@@ -458,7 +484,7 @@ def test_local_llm_generation_ignores_malformed_review_decision(monkeypatch) -> 
         response.candidate_sql
         == "select vendor_id from approved_vendor_spend limit 50"
     )
-    assert response.review_decision is None
+    assert "review_decision" not in response.model_dump()
 
 
 def test_local_llm_generation_retries_malformed_json_response(monkeypatch) -> None:
@@ -697,7 +723,7 @@ def test_vanna_generation_uses_curated_context_and_bounded_request(
     assert "execution_result" not in json.dumps(response.model_dump())
 
 
-def test_vanna_generation_ignores_malformed_review_decision(monkeypatch) -> None:
+def test_vanna_generation_ignores_embedded_review_decision(monkeypatch) -> None:
     adapter = resolve_sql_generation_adapter(
         {
             "provider": "vanna",
@@ -763,7 +789,7 @@ def test_vanna_generation_ignores_malformed_review_decision(monkeypatch) -> None
         response.candidate_sql
         == "select vendor_id from approved_vendor_spend limit 50"
     )
-    assert response.review_decision is None
+    assert "review_decision" not in response.model_dump()
 
 
 def test_vanna_generation_fails_closed_for_execution_material_response(

--- a/docs/design/review-llm-adapter-contract.md
+++ b/docs/design/review-llm-adapter-contract.md
@@ -11,6 +11,25 @@ The adapter output is not an authorization source. It must not approve SQL,
 mint or select a candidate, bypass SQL Guard, approve execution, or replace the
 backend-owned preview and execute lifecycle.
 
+## Generation Separation
+
+Review uses a separate prompt boundary and model configuration from SQL
+generation. `SAFEQUERY_REVIEW_LLM_*` settings select the optional review
+runtime without changing `SAFEQUERY_SQL_GENERATION_*` settings, so a deployment
+can use a different reviewer model or keep review disabled while generation is
+enabled.
+
+The review request is assembled after SQL generation from minimized application
+state: the operator question, candidate SQL, source identifiers, and generation
+diagnostics needed for reviewer context. It does not include generation
+chain-of-thought, hidden scratchpads, prompt fingerprints, adapter run IDs,
+source credentials, connection strings, result rows, or runtime secrets.
+
+This separation mitigates correlated generation and review failure by forcing a
+critique-oriented prompt and an independently configurable runtime. It does not
+eliminate correlated failure: shared training data, shared vendors, shared
+operator assumptions, or similar model families can still miss the same defect.
+
 ## Structured Output
 
 The backend accepts one structured object with these fields:
@@ -68,3 +87,5 @@ permission from partial output.
   candidate, guard, TTL, replay, and entitlement checks.
 - Reviewer-facing diagnostics are advisory evidence, not durable lifecycle
   truth.
+- Review prompts must emphasize critique, uncertainty, assumptions, and
+  boundary risks rather than approval.

--- a/docs/design/runtime-flow.md
+++ b/docs/design/runtime-flow.md
@@ -34,13 +34,26 @@ This SQL-backed path is the required Phase 1 core flow. Governed search, analyst
 
    The adapter returns candidate SQL to the application. This output is not yet trusted for execution.
 
-6. Canonicalization and bounded-SQL preparation
+6. Optional Review LLM critique
+
+   If the Review LLM is enabled, the backend sends a separate minimized review
+   request through the Review LLM adapter after generation. The review prompt
+   emphasizes critique, uncertainty, assumptions, and boundary risks. The review
+   input excludes generation chain-of-thought, hidden scratchpads, source
+   credentials, connection strings, result rows, and runtime secrets.
+
+   Review uses `SAFEQUERY_REVIEW_LLM_*` configuration, which can point to a
+   different model or runtime from `SAFEQUERY_SQL_GENERATION_*`. This separation
+   mitigates correlated failure but does not prove independence or make the
+   Review LLM authoritative.
+
+7. Canonicalization and bounded-SQL preparation
 
    Before guard evaluation, the backend canonicalizes the candidate SQL and applies any required row-bounding rewrite for the Phase 1 bounded execution contract.
 
    The SQL that is hashed, guarded, previewed, and executed is the same canonical SQL.
 
-7. SQL Guard evaluation
+8. SQL Guard evaluation
 
    The application validates candidate SQL using application-owned guardrails such as:
 
@@ -52,13 +65,13 @@ This SQL-backed path is the required Phase 1 core flow. Governed search, analyst
 
    Guard evaluation runs against the canonicalized candidate SQL prepared in the previous step.
 
-8. Candidate persistence
+9. Candidate persistence
 
    The backend computes a SQL hash for the canonical SQL, stores an opaque `query_candidate_id`, and records candidate ownership and validity metadata including owner subject, authorization snapshot, guard version, schema snapshot version, approval timestamp, approval expiration timestamp, replay limits, and invalidation fields.
 
    In the baseline lifecycle, this persistence step creates the approved execution-eligible candidate. Preview happens after approval metadata is already fixed.
 
-9. Preview response
+10. Preview response
 
    The application returns the candidate SQL and guard outcome to the frontend so the user can inspect them. In Phase 1, the preview is read-only and not editable in place.
 
@@ -66,13 +79,13 @@ This SQL-backed path is the required Phase 1 core flow. Governed search, analyst
 
    Admin and audit interfaces should default to metadata-first display and must not re-expose full result payloads unless an explicit lower-level design authorizes that behavior.
 
-10. Explicit execution request
+11. Explicit execution request
 
    If the approved candidate remains visible and unexpired, the user may explicitly trigger execution through the UI. The execution request submits the `query_candidate_id`, not raw SQL text. No silent automatic execution is assumed in the first PoC.
 
    Execute requests keep the candidate-bound source and authenticated subject checks separate from preview submission. Dedicated execute-request rate-limit and concurrency enforcement is not active in this release; it is tracked as follow-up implementation work in [implementation-roadmap.md](../implementation-roadmap.md).
 
-11. Controlled SQL execution
+12. Controlled SQL execution
 
    The backend verifies that the candidate is already approved, unexpired, non-invalidated, owned by the current authenticated subject, still allowed under current authorization policy, and still below replay limits.
 
@@ -82,11 +95,11 @@ This SQL-backed path is the required Phase 1 core flow. Governed search, analyst
 
    If allow-list state, schema snapshot policy, guard rules, role mapping, or kill-switch posture changed since approval, the backend denies execution or requires explicit revalidation rather than trusting stale approval state.
 
-12. Result delivery
+13. Result delivery
 
     The backend returns bounded results and metadata to the frontend for display. Phase 1 result handling applies row, byte, timeout, and cancellation controls.
 
-13. Final audit persistence
+14. Final audit persistence
 
     The application records guard decisions, execution decisions, execution metadata, and any error or denial outcome in PostgreSQL.
 
@@ -142,6 +155,8 @@ stateDiagram-v2
 - Single-use execution is protected by an atomic claim step before execution begins.
 - Previewed SQL is read-only in Phase 1.
 - Previewed SQL is the executable bounded canonical SQL in Phase 1.
+- Review LLM critique is advisory and uses separate prompt and runtime
+  configuration from generation.
 - The normative state vocabulary lives in [query-lifecycle-state-machine.md](./query-lifecycle-state-machine.md).
 - Execution authority always remains in the backend.
 - End users do not connect directly to SQL Server.

--- a/tests/test_review_llm_adapter_contract_docs.py
+++ b/tests/test_review_llm_adapter_contract_docs.py
@@ -18,6 +18,10 @@ def test_review_llm_adapter_contract_documents_critique_only_boundary() -> None:
         "Low confidence cannot be returned with `ready`",
         "Malformed output must fail closed",
         "SQL Guard and backend candidate lifecycle remain the enforcement boundary",
+        "Review uses a separate prompt boundary and model configuration from SQL generation",
+        "SAFEQUERY_REVIEW_LLM_*",
+        "It does not eliminate correlated failure",
+        "source credentials, connection strings, result rows, or runtime secrets",
     ]:
         assert phrase in normalized
 


### PR DESCRIPTION
## Summary
- add independent Review LLM settings and adapter resolution separate from SQL generation
- remove embedded review decisions from generation responses and route preview review through a dedicated review adapter
- add critique-oriented, minimized review prompt/input tests plus docs/env guidance on correlated-failure limits

## Verification
- cd backend && python3 -m pytest tests
- python3 -m pytest tests

Closes #460