### PR TITLE
[Y-F1] Surface Review LLM blocking outcomes in preview

### DIFF
--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -37,6 +37,7 @@ from app.features.review_llm.adapter import (
     ReviewLLMAdapterConfigurationError,
     build_review_llm_adapter_request,
 )
+from app.features.review_llm.answer_plan import sanitize_review_llm_surface_text_items
 from app.features.review_llm.schema import ReviewLLMAdapterOutput
 from app.services.candidate_lifecycle import (
     CURRENT_CONNECTOR_PROFILE_VERSION_BY_SOURCE_FAMILY,
@@ -237,6 +238,17 @@ class CandidateRecord(BaseModel):
     denial_reason: Optional[str] = None
     intent_mapping: Optional[IntentMappingOutput] = None
     revision_context: Optional["RevisionRecord"] = None
+    review_evidence: list["ReviewEvidenceRecord"] = Field(default_factory=list)
+
+
+class ReviewEvidenceRecord(BaseModel):
+    review_decision_id: str
+    review_status: str
+    review_contract_version: str
+    audit_event_id: str
+    assumptions: list[str] = Field(default_factory=list)
+    risk_flags: list[str] = Field(default_factory=list)
+    clarifying_questions: list[str] = Field(default_factory=list)
 
 
 class RevisionRecord(BaseModel):
@@ -1188,6 +1200,49 @@ def persist_review_decision(
         ) from exc
 
 
+def _review_blocking_candidate_state(review: ReviewLLMAdapterOutput) -> str | None:
+    if review.status == "blocked":
+        return "blocked"
+    if review.status == "needs_clarification":
+        return "clarification_required"
+    return None
+
+
+def _review_deny_code(review: ReviewLLMAdapterOutput) -> str | None:
+    if review.status == "blocked":
+        return "review_blocked"
+    if review.status == "needs_clarification":
+        return "review_needs_clarification"
+    return None
+
+
+def _review_denial_reason(review: ReviewLLMAdapterOutput) -> str | None:
+    if review.status == "blocked":
+        return "Review LLM blocked this candidate before execution."
+    if review.status == "needs_clarification":
+        return "Review LLM requires clarification before execution."
+    return None
+
+
+def _review_evidence_record(
+    *,
+    review_decision_id: str,
+    review: ReviewLLMAdapterOutput,
+    audit_event_id: UUID,
+) -> ReviewEvidenceRecord:
+    return ReviewEvidenceRecord(
+        review_decision_id=review_decision_id,
+        review_status=review.status,
+        review_contract_version=review.contract_version,
+        audit_event_id=str(audit_event_id),
+        assumptions=sanitize_review_llm_surface_text_items(review.assumptions),
+        risk_flags=sanitize_review_llm_surface_text_items(review.risk_flags),
+        clarifying_questions=sanitize_review_llm_surface_text_items(
+            review.clarifying_questions
+        ),
+    )
+
+
 def _raise_preview_persistence_contract_error(
     session: Session,
     message: str,
@@ -1903,6 +1958,15 @@ def submit_preview_request(
                         candidate_sql=candidate_sql,
                     )
                     review_decision = review_llm_adapter.review_sql(review_request)
+                    review_blocking_state = _review_blocking_candidate_state(
+                        review_decision
+                    )
+                    if (
+                        review_blocking_state is not None
+                        and guard_evaluation.decision == "allow"
+                    ):
+                        candidate_state = review_blocking_state
+                        request_state = review_blocking_state
             except (
                 GenerationContextPreparationError,
                 SQLGenerationAdapterConfigurationError,
@@ -1988,29 +2052,47 @@ def submit_preview_request(
         candidate_state=candidate_state,
         guard_status=guard_status,
     )
+    review_evidence: list[ReviewEvidenceRecord] = []
     if review_decision is not None:
-        persist_review_decision(
+        review_audit_event_id = _review_decision_audit_event_id(
+            audit.events,
+            candidate_id=candidate_id,
+        )
+        review_decision_id = persist_review_decision(
             session,
             candidate_id=candidate_id,
             review=review_decision,
-            audit_event_id=_review_decision_audit_event_id(
-                audit.events,
-                candidate_id=candidate_id,
-            ),
+            audit_event_id=review_audit_event_id,
             occurred_at=(
                 audit_context.occurred_at
                 if audit_context is not None
                 else datetime.now(timezone.utc)
             ),
         )
+        review_evidence = [
+            _review_evidence_record(
+                review_decision_id=review_decision_id,
+                review=review_decision,
+                audit_event_id=review_audit_event_id,
+            )
+        ]
     primary_deny_code = _primary_guard_deny_code(guard_evaluation)
     denial_reason = _sanitized_guard_denial_reason(guard_evaluation)
     if intent_blocked_candidate_state is not None:
         primary_deny_code = _intent_denial_code(intent_mapping)
         denial_reason = _intent_denial_reason(intent_mapping)
+    elif review_decision is not None and candidate_state in {
+        "blocked",
+        "clarification_required",
+    }:
+        primary_deny_code = _review_deny_code(review_decision)
+        denial_reason = _review_denial_reason(review_decision)
     evaluation_state = (
         _intent_denial_cause(intent_mapping)
         if intent_blocked_candidate_state is not None
+        else candidate_state
+        if review_decision is not None
+        and candidate_state in {"blocked", "clarification_required"}
         else "pending"
         if guard_evaluation is None
         else "allowed"
@@ -2024,7 +2106,7 @@ def submit_preview_request(
             request_id=request_id,
             source_id=resolved_source.source_id,
             semantic_contract_version=dataset_contract.semantic_contract_version,
-            state="submitted",
+            state=request_state,
             revision_context=revision_record,
         ),
         candidate=CandidateRecord(
@@ -2042,6 +2124,7 @@ def submit_preview_request(
             denial_reason=denial_reason,
             intent_mapping=intent_mapping,
             revision_context=revision_record,
+            review_evidence=review_evidence,
         ),
         audit=audit,
         evaluation=EvaluationRecord(

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -31,6 +31,10 @@ from app.features.guard import (
     evaluate_mssql_sql_guard,
     evaluate_postgresql_sql_guard,
 )
+from app.features.guard.deny_taxonomy import (
+    DENY_REVIEW_BLOCKED,
+    DENY_REVIEW_NEEDS_CLARIFICATION,
+)
 from app.features.operator_history.payloads import GuardStatus
 from app.features.review_llm.adapter import (
     ReviewLLMAdapter,
@@ -353,6 +357,8 @@ def _build_preview_lifecycle_audit_events(
     candidate_sql: str | None = None,
     intent_mapping: IntentMappingOutput | None = None,
     intent_blocked_candidate_state: str | None = None,
+    review_decision: ReviewLLMAdapterOutput | None = None,
+    review_blocking_candidate_state: str | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
         return []
@@ -364,6 +370,13 @@ def _build_preview_lifecycle_audit_events(
     )
 
     for event_type in event_types:
+        review_denial_applies = (
+            event_type == "guard_evaluated"
+            and guard_evaluation is not None
+            and guard_evaluation.decision == "allow"
+            and review_decision is not None
+            and review_blocking_candidate_state is not None
+        )
         execution_policy_version = (
             CURRENT_EXECUTION_POLICY_VERSION_BY_SOURCE_FAMILY.get(
                 resolved_source.source_family
@@ -471,7 +484,9 @@ def _build_preview_lifecycle_audit_events(
                     and intent_blocked_candidate_state is not None
                 )
                 else (
-                    "preview_ready"
+                    review_blocking_candidate_state
+                    if review_denial_applies
+                    else "preview_ready"
                     if guard_evaluation is None or guard_evaluation.decision == "allow"
                     else "blocked"
                 )
@@ -479,7 +494,9 @@ def _build_preview_lifecycle_audit_events(
                 else None
             ),
             primary_deny_code=(
-                _primary_guard_deny_code(guard_evaluation)
+                _review_deny_code(review_decision)
+                if review_denial_applies
+                else _primary_guard_deny_code(guard_evaluation)
                 if event_type == "guard_evaluated"
                 else _intent_denial_code(intent_mapping)
                 if (
@@ -489,10 +506,14 @@ def _build_preview_lifecycle_audit_events(
                 else None
             ),
             denial_cause=(
-                "guard_rejected"
-                if event_type == "guard_evaluated"
-                and guard_evaluation is not None
-                and guard_evaluation.decision != "allow"
+                _review_denial_cause(review_decision)
+                if review_denial_applies
+                else "guard_rejected"
+                if (
+                    event_type == "guard_evaluated"
+                    and guard_evaluation is not None
+                    and guard_evaluation.decision != "allow"
+                )
                 else _intent_denial_cause(intent_mapping)
                 if (
                     event_type == "generation_requested"
@@ -501,7 +522,9 @@ def _build_preview_lifecycle_audit_events(
                 else None
             ),
             denial_reason=(
-                _sanitized_guard_denial_reason(guard_evaluation)
+                _review_denial_reason(review_decision)
+                if review_denial_applies
+                else _sanitized_guard_denial_reason(guard_evaluation)
                 if event_type == "guard_evaluated"
                 else _intent_denial_reason(intent_mapping)
                 if (
@@ -1210,13 +1233,25 @@ def _review_blocking_candidate_state(review: ReviewLLMAdapterOutput) -> str | No
 
 def _review_deny_code(review: ReviewLLMAdapterOutput) -> str | None:
     if review.status == "blocked":
+        return DENY_REVIEW_BLOCKED
+    if review.status == "needs_clarification":
+        return DENY_REVIEW_NEEDS_CLARIFICATION
+    return None
+
+
+def _review_denial_cause(review: ReviewLLMAdapterOutput | None) -> str | None:
+    if review is None:
+        return None
+    if review.status == "blocked":
         return "review_blocked"
     if review.status == "needs_clarification":
         return "review_needs_clarification"
     return None
 
 
-def _review_denial_reason(review: ReviewLLMAdapterOutput) -> str | None:
+def _review_denial_reason(review: ReviewLLMAdapterOutput | None) -> str | None:
+    if review is None:
+        return None
     if review.status == "blocked":
         return "Review LLM blocked this candidate before execution."
     if review.status == "needs_clarification":
@@ -1898,6 +1933,7 @@ def submit_preview_request(
     adapter_metadata: SQLGenerationAdapterRunMetadata | None = None
     guard_evaluation: SQLGuardEvaluation | None = None
     review_decision: ReviewLLMAdapterOutput | None = None
+    review_blocking_state: str | None = None
     guard_status: GuardStatus = PREVIEW_PENDING_GUARD_STATUS
     candidate_state = "preview_ready"
     request_state = "previewed"
@@ -2030,8 +2066,15 @@ def submit_preview_request(
             guard_evaluation=guard_evaluation,
             candidate_sql=candidate_sql,
             intent_mapping=intent_mapping,
+            review_decision=review_decision,
+            review_blocking_candidate_state=review_blocking_state,
         )
 
+    review_denial_applied = (
+        review_blocking_state is not None
+        and guard_evaluation is not None
+        and guard_evaluation.decision == "allow"
+    )
     audit = AuditRecord(
         source_id=resolved_source.source_id,
         state="recorded",
@@ -2081,10 +2124,7 @@ def submit_preview_request(
     if intent_blocked_candidate_state is not None:
         primary_deny_code = _intent_denial_code(intent_mapping)
         denial_reason = _intent_denial_reason(intent_mapping)
-    elif review_decision is not None and candidate_state in {
-        "blocked",
-        "clarification_required",
-    }:
+    elif review_decision is not None and review_denial_applied:
         primary_deny_code = _review_deny_code(review_decision)
         denial_reason = _review_denial_reason(review_decision)
     evaluation_state = (

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -147,6 +147,115 @@ def _review_payload() -> dict[str, object]:
     }
 
 
+def test_preview_response_exposes_blocked_review_evidence_before_execute() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        review_payload = _review_payload()
+        review_payload["status"] = "blocked"
+        review_payload["assumptions"] = ["Uses approved vendor spend only."]
+        review_payload["risk_flags"] = [
+            "Review found unbounded spend exposure.",
+            "postgresql://user:secret@example.test/db",
+        ]
+        review_payload["clarifying_questions"] = []
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-468-blocked",
+                correlation_id="preview-request-468-blocked-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-468-blocked-session",
+                query_candidate_id="preview-candidate-468-blocked",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+            review_llm_adapter=_ReviewAdapter(
+                parse_review_llm_adapter_output(review_payload)
+            ),
+        )
+
+        payload = response.model_dump(mode="json")
+        assert payload["request"]["state"] == "blocked"
+        assert payload["candidate"]["state"] == "blocked"
+        review_evidence = payload["candidate"]["review_evidence"]
+        assert len(review_evidence) == 1
+        assert review_evidence == [
+            {
+                "review_decision_id": "review-preview-candidate-468-blocked",
+                "review_status": "blocked",
+                "review_contract_version": "review_llm_adapter_output.v1",
+                "audit_event_id": review_evidence[0]["audit_event_id"],
+                "assumptions": ["Uses approved vendor spend only."],
+                "risk_flags": [
+                    "Review found unbounded spend exposure.",
+                    "[redacted]",
+                ],
+                "clarifying_questions": [],
+            }
+        ]
+        assert "postgresql://" not in json.dumps(review_evidence)
+    finally:
+        session.close()
+
+
+def test_preview_response_exposes_review_clarifying_questions_before_execute() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-468-clarify",
+                correlation_id="preview-request-468-clarify-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-468-clarify-session",
+                query_candidate_id="preview-candidate-468-clarify",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(),
+            review_llm_adapter=_ReviewAdapter(
+                parse_review_llm_adapter_output(_review_payload())
+            ),
+        )
+
+        payload = response.model_dump(mode="json")
+        assert payload["request"]["state"] == "clarification_required"
+        assert payload["candidate"]["state"] == "clarification_required"
+        assert payload["candidate"]["review_evidence"][0]["review_status"] == (
+            "needs_clarification"
+        )
+        assert payload["candidate"]["review_evidence"][0]["clarifying_questions"] == [
+            "Should inactive vendors be included?"
+        ]
+    finally:
+        session.close()
+
+
 def test_review_decision_is_persisted_with_schema_version_and_operator_evidence() -> None:
     session = _session()
     try:

--- a/backend/tests/test_review_decision_persistence.py
+++ b/backend/tests/test_review_decision_persistence.py
@@ -36,11 +36,15 @@ from app.services.sql_generation_adapter import SQLGenerationAdapterResponse
 
 
 class _PreviewAdapter:
+    def __init__(
+        self,
+        candidate_sql: str = "SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50",
+    ) -> None:
+        self.candidate_sql = candidate_sql
+
     def generate_sql(self, request):
         return SQLGenerationAdapterResponse(
-            candidate_sql=(
-                "SELECT vendor_id FROM finance.approved_vendor_spend LIMIT 50"
-            ),
+            candidate_sql=self.candidate_sql,
             provider="local_llm",
             adapter_version="test.adapter.v1",
             model="safequery-test-sql",
@@ -190,6 +194,8 @@ def test_preview_response_exposes_blocked_review_evidence_before_execute() -> No
         payload = response.model_dump(mode="json")
         assert payload["request"]["state"] == "blocked"
         assert payload["candidate"]["state"] == "blocked"
+        assert payload["candidate"]["primary_deny_code"] == "DENY_REVIEW_BLOCKED"
+        assert payload["evaluation"]["primary_deny_code"] == "DENY_REVIEW_BLOCKED"
         review_evidence = payload["candidate"]["review_evidence"]
         assert len(review_evidence) == 1
         assert review_evidence == [
@@ -207,6 +213,24 @@ def test_preview_response_exposes_blocked_review_evidence_before_execute() -> No
             }
         ]
         assert "postgresql://" not in json.dumps(review_evidence)
+        persisted_guard_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.event_type == "guard_evaluated"
+            )
+        )
+        assert persisted_guard_event is not None
+        assert persisted_guard_event.candidate_state == "blocked"
+        assert persisted_guard_event.primary_deny_code == "DENY_REVIEW_BLOCKED"
+        assert persisted_guard_event.denial_cause == "review_blocked"
+        assert persisted_guard_event.audit_payload["guard_decision"] == "allow"
+        assert (
+            persisted_guard_event.audit_payload["primary_deny_code"]
+            == "DENY_REVIEW_BLOCKED"
+        )
+        assert (
+            persisted_guard_event.audit_payload["denial_reason"]
+            == "Review LLM blocked this candidate before execution."
+        )
     finally:
         session.close()
 
@@ -246,12 +270,89 @@ def test_preview_response_exposes_review_clarifying_questions_before_execute() -
         payload = response.model_dump(mode="json")
         assert payload["request"]["state"] == "clarification_required"
         assert payload["candidate"]["state"] == "clarification_required"
+        assert payload["candidate"]["primary_deny_code"] == (
+            "DENY_REVIEW_NEEDS_CLARIFICATION"
+        )
+        assert payload["evaluation"]["primary_deny_code"] == (
+            "DENY_REVIEW_NEEDS_CLARIFICATION"
+        )
         assert payload["candidate"]["review_evidence"][0]["review_status"] == (
             "needs_clarification"
         )
         assert payload["candidate"]["review_evidence"][0]["clarifying_questions"] == [
             "Should inactive vendors be included?"
         ]
+        persisted_guard_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.event_type == "guard_evaluated"
+            )
+        )
+        assert persisted_guard_event is not None
+        assert persisted_guard_event.candidate_state == "clarification_required"
+        assert (
+            persisted_guard_event.primary_deny_code
+            == "DENY_REVIEW_NEEDS_CLARIFICATION"
+        )
+        assert persisted_guard_event.denial_cause == "review_needs_clarification"
+        assert persisted_guard_event.audit_payload["guard_decision"] == "allow"
+    finally:
+        session.close()
+
+
+def test_review_denial_does_not_override_guard_rejection_primary_code() -> None:
+    session = _session()
+    try:
+        _seed_source(session)
+        subject = AuthenticatedSubject(
+            subject_id="user:alice",
+            governance_bindings=frozenset({"group:finance-analysts"}),
+        )
+        review_payload = _review_payload()
+        review_payload["status"] = "blocked"
+        review_payload["clarifying_questions"] = []
+
+        response = submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Compare approved vendor spend by vendor this quarter.",
+                source_id="sap-approved-spend",
+            ),
+            authenticated_subject=subject,
+            session=session,
+            audit_context=PreviewAuditContext(
+                occurred_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+                request_id="preview-request-468-guard-denied",
+                correlation_id="preview-request-468-guard-denied-correlation",
+                user_subject="user:alice",
+                session_id="preview-request-468-guard-denied-session",
+                query_candidate_id="preview-candidate-468-guard-denied",
+                candidate_owner_subject="user:alice",
+                auth_source="test-helper",
+            ),
+            sql_generation_adapter=_PreviewAdapter(
+                "DELETE FROM finance.approved_vendor_spend"
+            ),
+            review_llm_adapter=_ReviewAdapter(
+                parse_review_llm_adapter_output(review_payload)
+            ),
+        )
+
+        payload = response.model_dump(mode="json")
+        assert payload["request"]["state"] == "blocked"
+        assert payload["candidate"]["state"] == "blocked"
+        assert payload["candidate"]["primary_deny_code"] == "DENY_WRITE_OPERATION"
+        assert payload["evaluation"]["primary_deny_code"] == "DENY_WRITE_OPERATION"
+        assert payload["candidate"]["review_evidence"][0]["review_status"] == "blocked"
+
+        persisted_guard_event = session.scalar(
+            select(PreviewAuditEvent).where(
+                PreviewAuditEvent.event_type == "guard_evaluated"
+            )
+        )
+        assert persisted_guard_event is not None
+        assert persisted_guard_event.candidate_state == "blocked"
+        assert persisted_guard_event.primary_deny_code == "DENY_WRITE_OPERATION"
+        assert persisted_guard_event.denial_cause == "guard_rejected"
+        assert persisted_guard_event.audit_payload["guard_decision"] == "reject"
     finally:
         session.close()
 

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1640,6 +1640,48 @@ describe("HomePage", () => {
         }
       },
       {
+        expectedCopy: /malformed_preview_response/i,
+        response: {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [],
+                source_id: "sap-approved-spend",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-review-malformed",
+                candidate_sql: null,
+                dataset_contract_version: 1,
+                guard_status: "allow",
+                review_evidence: [
+                  {
+                    audit_event_id: "00000000-0000-4000-8000-000000000468",
+                    review_contract_version: "review_llm_adapter_output.v1",
+                    review_status: "blocked"
+                  }
+                ],
+                schema_snapshot_version: 1,
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                state: "blocked"
+              },
+              evaluation: {
+                source_id: "sap-approved-spend",
+                state: "blocked"
+              },
+              request: {
+                question: "Show approved vendors by quarterly spend",
+                request_id: "request-review-malformed",
+                source_id: "sap-approved-spend",
+                state: "blocked"
+              }
+            })
+        }
+      },
+      {
         expectedCopy: /preview_submission_unavailable/i,
         response: {
           ok: false,

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -982,17 +982,30 @@ describe("HomePage", () => {
       {
         candidateState: "pending_generation",
         expectedCopy: /preview generation pending/i,
-        requestState: "submitted"
+        requestState: "submitted",
+        reviewEvidence: []
       },
       {
         candidateState: "clarification_required",
         expectedCopy: /clarification required/i,
-        requestState: "submitted"
+        requestState: "clarification_required",
+        reviewEvidence: [
+          {
+            audit_event_id: "00000000-0000-4000-8000-000000000468",
+            assumptions: ["Vendor means normalized vendor_id."],
+            clarifying_questions: ["Should inactive vendors be included?"],
+            review_contract_version: "review_llm_adapter_output.v1",
+            review_decision_id: "review-candidate-clarification-required",
+            review_status: "needs_clarification",
+            risk_flags: ["Inactive vendor handling is ambiguous."]
+          }
+        ]
       },
       {
         candidateState: "denied",
         expectedCopy: /preview denied/i,
-        requestState: "blocked"
+        requestState: "blocked",
+        reviewEvidence: []
       }
     ] as const;
 
@@ -1028,6 +1041,7 @@ describe("HomePage", () => {
                   source_family: "postgresql",
                   source_flavor: "warehouse",
                   source_id: "sap-approved-spend",
+                  review_evidence: stateCase.reviewEvidence ?? [],
                   state: stateCase.candidateState
                 },
                 evaluation: {
@@ -1061,6 +1075,14 @@ describe("HomePage", () => {
       expect(await screen.findByText(stateCase.expectedCopy)).toBeInTheDocument();
       expect(screen.queryByText(/preview request accepted/i)).not.toBeInTheDocument();
       expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
+      if (stateCase.candidateState === "clarification_required") {
+        expect(screen.getByLabelText(/review evidence/i)).toHaveTextContent(
+          "Should inactive vendors be included?"
+        );
+        expect(screen.getByLabelText(/review evidence/i)).toHaveTextContent(
+          "needs_clarification"
+        );
+      }
     }
   });
 

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -772,14 +772,27 @@ function parsePreviewSubmissionResult(
   const guardStatus = readRequiredString(value.candidate.guard_status);
   const requestState = readRequiredString(value.request.state);
   const candidateState = readRequiredString(value.candidate.state);
-  const reviewEvidenceValue = Array.isArray(value.candidate.review_evidence)
+  const hasSnakeReviewEvidence = Object.prototype.hasOwnProperty.call(
+    value.candidate,
+    "review_evidence"
+  );
+  const hasCamelReviewEvidence = Object.prototype.hasOwnProperty.call(
+    value.candidate,
+    "reviewEvidence"
+  );
+  const reviewEvidenceValue = hasSnakeReviewEvidence
     ? value.candidate.review_evidence
-    : Array.isArray(value.candidate.reviewEvidence)
+    : hasCamelReviewEvidence
       ? value.candidate.reviewEvidence
       : [];
-  const reviewEvidence = reviewEvidenceValue
-    .map(parsePreviewReviewEvidence)
-    .filter((item): item is OperatorWorkflowReviewEvidence => item !== null);
+  if (!Array.isArray(reviewEvidenceValue)) {
+    return null;
+  }
+  const parsedReviewEvidence = reviewEvidenceValue.map(parsePreviewReviewEvidence);
+  if (parsedReviewEvidence.some((item) => item === null)) {
+    return null;
+  }
+  const reviewEvidence = parsedReviewEvidence as OperatorWorkflowReviewEvidence[];
 
   if (
     !requestId ||

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -152,6 +152,7 @@ type PreviewSubmissionResult = {
   guardStatus: string;
   requestId: string;
   requestState: string;
+  reviewEvidence: OperatorWorkflowReviewEvidence[];
   revisionContext: RevisionDraftContext | null;
   sourceId: string;
 };
@@ -543,6 +544,67 @@ function readOptionalNonNegativeInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
+function readStringArray(value: unknown): string[] | null {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const strings = value.filter((item): item is string => {
+    return typeof item === "string" && item.trim().length > 0;
+  });
+  return strings.length === value.length ? strings : null;
+}
+
+function parsePreviewReviewEvidence(value: unknown): OperatorWorkflowReviewEvidence | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const auditEventId =
+    readOptionalString(value.audit_event_id) ?? readOptionalString(value.auditEventId);
+  const reviewContractVersion =
+    readOptionalString(value.review_contract_version) ??
+    readOptionalString(value.reviewContractVersion);
+  const reviewDecisionId =
+    readOptionalString(value.review_decision_id) ?? readOptionalString(value.reviewDecisionId);
+  const reviewStatus =
+    readOptionalString(value.review_status) ?? readOptionalString(value.reviewStatus);
+  const assumptions = readStringArray(value.assumptions);
+  const clarifyingQuestions =
+    value.clarifying_questions === undefined
+      ? readStringArray(value.clarifyingQuestions)
+      : readStringArray(value.clarifying_questions);
+  const riskFlags =
+    value.risk_flags === undefined
+      ? readStringArray(value.riskFlags)
+      : readStringArray(value.risk_flags);
+
+  if (
+    !auditEventId ||
+    !reviewContractVersion ||
+    !reviewDecisionId ||
+    !reviewStatus ||
+    assumptions === null ||
+    clarifyingQuestions === null ||
+    riskFlags === null
+  ) {
+    return null;
+  }
+
+  return {
+    auditEventId,
+    assumptions,
+    clarifyingQuestions,
+    reviewContractVersion,
+    reviewDecisionId,
+    reviewStatus,
+    riskFlags
+  };
+}
+
 function parseExecuteAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
   if (!isObject(value)) {
     return null;
@@ -710,6 +772,14 @@ function parsePreviewSubmissionResult(
   const guardStatus = readRequiredString(value.candidate.guard_status);
   const requestState = readRequiredString(value.request.state);
   const candidateState = readRequiredString(value.candidate.state);
+  const reviewEvidenceValue = Array.isArray(value.candidate.review_evidence)
+    ? value.candidate.review_evidence
+    : Array.isArray(value.candidate.reviewEvidence)
+      ? value.candidate.reviewEvidence
+      : [];
+  const reviewEvidence = reviewEvidenceValue
+    .map(parsePreviewReviewEvidence)
+    .filter((item): item is OperatorWorkflowReviewEvidence => item !== null);
 
   if (
     !requestId ||
@@ -730,6 +800,7 @@ function parsePreviewSubmissionResult(
     guardStatus,
     requestId,
     requestState,
+    reviewEvidence,
     revisionContext:
       parsePreviewRevisionContext(value.request.revision_context, expectedSourceId) ??
       parsePreviewRevisionContext(value.candidate.revision_context, expectedSourceId),
@@ -845,7 +916,12 @@ function isClarificationRequiredPreviewState(result: PreviewSubmissionResult): b
   const requestState = result.requestState.toLowerCase();
   const candidateState = result.candidateState.toLowerCase();
 
-  return requestState === "clarification_required" || candidateState === "clarification_required";
+  return (
+    requestState === "clarification_required" ||
+    requestState === "needs_clarification" ||
+    candidateState === "clarification_required" ||
+    candidateState === "needs_clarification"
+  );
 }
 
 function isReadyPreviewState(result: PreviewSubmissionResult): boolean {
@@ -2376,7 +2452,7 @@ export function QueryWorkflowShell({
           executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
-          reviewEvidence: [],
+          reviewEvidence: result.reviewEvidence,
           retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
@@ -2403,7 +2479,7 @@ export function QueryWorkflowShell({
           executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
-          reviewEvidence: [],
+          reviewEvidence: result.reviewEvidence,
           retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
@@ -2429,7 +2505,7 @@ export function QueryWorkflowShell({
           executedEvidence: [],
           guardStatus: result.guardStatus,
           requestId: result.requestId,
-          reviewEvidence: [],
+          reviewEvidence: result.reviewEvidence,
           retrievedCitations: [],
           sourceId: result.sourceId,
           sourceLabel: selectedSource.displayLabel
@@ -2464,7 +2540,7 @@ export function QueryWorkflowShell({
         executedEvidence: [],
         guardStatus: result.guardStatus,
         requestId: result.requestId,
-        reviewEvidence: [],
+        reviewEvidence: result.reviewEvidence,
         retrievedCitations: [],
         sourceId: result.sourceId,
         sourceLabel: selectedSource.displayLabel


### PR DESCRIPTION
## Summary
- expose sanitized Review LLM evidence on preview candidate responses
- map Review LLM `blocked` and `needs_clarification` outcomes to non-ready preview states before execute
- preserve execute-time Review LLM denial coverage and keep ready non-authoritative
- render preview-time review evidence in the operator UI instead of replacing it with an empty array

## Verification
- `cd backend && python3 -m pytest tests/test_review_decision_persistence.py tests/test_preview_persistence.py::test_http_preview_review_adapter_failure_uses_registered_error_code -q`
- `cd backend && python3 -m pytest tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_blocked_without_consuming_approval tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_needs_clarification_without_consuming_approval tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_review_ready_does_not_override_guard_denied -q`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && ./node_modules/.bin/vitest run app/page.test.tsx -t "maps authoritative preview API states" --reporter=default`

Closes #468