### PR TITLE
[Y-F3] Make backend pytest verification reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         working-directory: backend
         run: |
           python -m pytest \
+            tests/test_backend_packaging.py \
             tests/test_review_llm_adapter_contract.py \
             tests/test_review_llm_answer_plan.py \
             tests/test_review_llm_adapter_request.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: backend
         run: |
           python -m pip install --upgrade pip
-          python -m pip install . pytest httpx
+          python -m pip install ".[test]"
 
       - name: Provision backend example environment
         if: ${{ hashFiles('backend/pyproject.toml') != '' }}

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Source-foundation smoke verification:
 
 ```bash
 cd backend
+python3 -m pip install -e ".[test]"
 python3 -m pytest tests/test_source_foundation_smoke.py
 ```
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -96,5 +96,24 @@ The startup log now also emits:
 Focused source-foundation smoke verification:
 
 ```bash
-PYTHONPATH=backend python3 -m pytest backend/tests/test_source_foundation_smoke.py
+cd backend
+python3 -m pip install -e ".[test]"
+python3 -m pytest tests/test_source_foundation_smoke.py
+```
+
+Review LLM safety verification uses the same backend test extra:
+
+```bash
+cd backend
+python3 -m pip install -e ".[test]"
+python3 -m pytest \
+  tests/test_review_llm_adapter_contract.py \
+  tests/test_review_llm_answer_plan.py \
+  tests/test_review_llm_adapter_request.py \
+  tests/test_review_llm_calibration_fixtures.py \
+  tests/test_review_decision_persistence.py \
+  tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_blocked_without_consuming_approval \
+  tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_needs_clarification_without_consuming_approval \
+  tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_review_ready_does_not_override_guard_denied \
+  tests/test_preview_persistence.py::test_http_preview_review_adapter_failure_uses_registered_error_code
 ```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,5 +18,11 @@ dependencies = [
   "uvicorn[standard]>=0.34,<1.0"
 ]
 
+[project.optional-dependencies]
+test = [
+  "httpx>=0.28,<1.0",
+  "pytest>=8.0,<9.0"
+]
+
 [tool.setuptools.packages.find]
 include = ["app*"]

--- a/backend/tests/test_backend_packaging.py
+++ b/backend/tests/test_backend_packaging.py
@@ -1,0 +1,42 @@
+import re
+import unittest
+from importlib.metadata import metadata, requires
+
+
+def _dependency_names(requirements: list[str]) -> set[str]:
+    names: set[str] = set()
+    for requirement in requirements:
+        match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
+        if match:
+            names.add(match.group(1).lower().replace("_", "-"))
+    return names
+
+
+class BackendPackagingTestCase(unittest.TestCase):
+    def test_test_extra_declares_pytest_dependencies_without_runtime_bloat(
+        self,
+    ) -> None:
+        package_metadata = metadata("safequery-backend")
+        provided_extras = set(package_metadata.get_all("Provides-Extra") or [])
+
+        self.assertIn("test", provided_extras)
+
+        package_requirements = list(requires("safequery-backend") or [])
+        test_requirements = [
+            requirement
+            for requirement in package_requirements
+            if "extra == 'test'" in requirement or 'extra == "test"' in requirement
+        ]
+        runtime_requirements = [
+            requirement
+            for requirement in package_requirements
+            if "extra ==" not in requirement
+        ]
+
+        test_dependency_names = _dependency_names(test_requirements)
+        runtime_dependency_names = _dependency_names(runtime_requirements)
+
+        self.assertIn("pytest", test_dependency_names)
+        self.assertIn("httpx", test_dependency_names)
+        self.assertNotIn("pytest", runtime_dependency_names)
+        self.assertNotIn("httpx", runtime_dependency_names)

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -294,6 +294,7 @@ startup behavior before moving on to deeper source-aware work:
 ```bash
 bash tests/smoke/test-local-topology-roles.sh
 cd backend
+python3 -m pip install -e ".[test]"
 python3 -m pytest tests/test_application_postgres_guard.py
 python3 -m pytest tests/test_source_foundation_smoke.py
 bash tests/smoke/test-compose-operator-workflow-source-selector.sh
@@ -378,6 +379,31 @@ Backend install check:
 ```bash
 cp backend/.env.example backend/.env
 python3 -m pip install -e backend
+```
+
+Backend test dependency install check:
+
+```bash
+cd backend
+python3 -m pip install -e ".[test]"
+python3 -m pytest tests/test_review_llm_adapter_contract.py
+```
+
+Review LLM safety verification uses that same install path:
+
+```bash
+cd backend
+python3 -m pip install -e ".[test]"
+python3 -m pytest \
+  tests/test_review_llm_adapter_contract.py \
+  tests/test_review_llm_answer_plan.py \
+  tests/test_review_llm_adapter_request.py \
+  tests/test_review_llm_calibration_fixtures.py \
+  tests/test_review_decision_persistence.py \
+  tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_blocked_without_consuming_approval \
+  tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_needs_clarification_without_consuming_approval \
+  tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_review_ready_does_not_override_guard_denied \
+  tests/test_preview_persistence.py::test_http_preview_review_adapter_failure_uses_registered_error_code
 ```
 
 The backend settings loader accepts `.env` and `../.env`, which keeps the repo


### PR DESCRIPTION
## Summary
- Add a backend `test` extra for pytest/httpx so Review LLM backend tests have a repo-owned install path.
- Switch backend CI from ad hoc `pytest httpx` installation to `python -m pip install ".[test]"`.
- Document the backend test-extra setup and Review LLM focused suite, with a packaging regression test that keeps pytest/httpx out of runtime requirements.

Closes #471

## Verification
- Reproduced pre-fix fresh runtime-only failure: `/private/tmp/safequery-issue-471-runtime/bin/python: No module named pytest`
- `/tmp/safequery-issue-471-runtime-post/bin/python -m pip install ./backend`; `(cd backend && /tmp/safequery-issue-471-runtime-post/bin/python -c "from app.main import app; print(app.title)")`
- `/tmp/safequery-issue-471-runtime-post/bin/python -c "import importlib.util; raise SystemExit(0 if importlib.util.find_spec('pytest') is None else 1)"`
- `(cd backend && /tmp/safequery-issue-471-test/bin/python -m pytest tests/test_backend_packaging.py tests/test_review_llm_adapter_contract.py)`
- `(cd backend && /tmp/safequery-issue-471-test/bin/python -m pytest tests/test_review_llm_adapter_contract.py tests/test_review_llm_answer_plan.py tests/test_review_llm_adapter_request.py tests/test_review_llm_calibration_fixtures.py tests/test_review_decision_persistence.py tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_blocked_without_consuming_approval tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_rejects_review_needs_clarification_without_consuming_approval tests/test_candidate_execute_api.py::CandidateExecuteApiTestCase::test_execute_candidate_api_review_ready_does_not_override_guard_denied tests/test_preview_persistence.py::test_http_preview_review_adapter_failure_uses_registered_error_code)`
- `bash tests/smoke/test-local-startup-docs.sh`
- `python3 scripts/ci/check_repository_hygiene.py`
- `git diff --check`