### PR TITLE
[Z-7] Enforce result PII redaction before summaries

### DIFF
--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -1108,8 +1108,12 @@ def execute_candidate_sql(
             audit_context=audit_context,
         ) from exc
 
+    rows_for_payload_limits = redact_execution_result_rows(
+        rows=rows,
+        contract=result_validation_contract,
+    )
     capped_rows, metadata = _cap_rows(
-        rows,
+        rows_for_payload_limits,
         runtime_controls=runtime_controls,
         candidate_source=candidate.source,
         audit_context=audit_context,
@@ -1119,8 +1123,13 @@ def execute_candidate_sql(
         assert candidate.source.semantic_contract_version is not None
         assert metadata.candidate_id is not None
         assert metadata.execution_run_id is not None
+        validation_rows = (
+            rows
+            if result_validation_contract.redaction_required
+            else capped_rows
+        )
         result_validation = validate_execution_result(
-            rows=capped_rows,
+            rows=validation_rows,
             metadata=ResultValidationMetadata(
                 semantic_contract_version=candidate.source.semantic_contract_version,
                 candidate_id=metadata.candidate_id,
@@ -1139,10 +1148,6 @@ def execute_candidate_sql(
                 canonical_sql=candidate.canonical_sql,
                 audit_context=audit_context,
             )
-        result_rows = redact_execution_result_rows(
-            rows=capped_rows,
-            contract=result_validation_contract,
-        )
 
     result = ExecutionResult(
         source_id=selection.source_id,

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -29,6 +29,7 @@ from app.features.result_validation import (
     ResultValidationContract,
     ResultValidationMetadata,
     ResultValidationOutcome,
+    redact_execution_result_rows,
     validate_execution_result,
 )
 from app.features.guard.deny_taxonomy import (
@@ -1113,6 +1114,7 @@ def execute_candidate_sql(
         candidate_source=candidate.source,
         audit_context=audit_context,
     )
+    result_rows = capped_rows
     if result_validation_contract is not None:
         assert candidate.source.semantic_contract_version is not None
         assert metadata.candidate_id is not None
@@ -1137,12 +1139,16 @@ def execute_candidate_sql(
                 canonical_sql=candidate.canonical_sql,
                 audit_context=audit_context,
             )
+        result_rows = redact_execution_result_rows(
+            rows=capped_rows,
+            contract=result_validation_contract,
+        )
 
     result = ExecutionResult(
         source_id=selection.source_id,
         connector_id=selection.connector_id,
         ownership=selection.ownership,
-        rows=capped_rows,
+        rows=result_rows,
         metadata=metadata,
     )
     result._audit_events = _build_execution_audit_events(

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -1123,13 +1123,13 @@ def execute_candidate_sql(
         assert candidate.source.semantic_contract_version is not None
         assert metadata.candidate_id is not None
         assert metadata.execution_run_id is not None
-        validation_rows = (
-            rows
+        redaction_source_rows = (
+            rows[: len(capped_rows)]
             if result_validation_contract.redaction_required
-            else capped_rows
+            else None
         )
         result_validation = validate_execution_result(
-            rows=validation_rows,
+            rows=capped_rows,
             metadata=ResultValidationMetadata(
                 semantic_contract_version=candidate.source.semantic_contract_version,
                 candidate_id=metadata.candidate_id,
@@ -1139,6 +1139,7 @@ def execute_candidate_sql(
                 result_truncated=metadata.result_truncated,
             ),
             contract=result_validation_contract,
+            redaction_source_rows=redaction_source_rows,
         )
         metadata = metadata.model_copy(update={"result_validation": result_validation})
         if not result_validation.answer_generation_allowed:

--- a/backend/app/features/result_validation.py
+++ b/backend/app/features/result_validation.py
@@ -123,13 +123,10 @@ def validate_execution_result(
         observed_columns=redaction_observed_columns,
         contract=contract,
     )
-    contract_observed_columns = (
-        observed_columns
-        if redaction_source_rows is not None and contract.redaction_required
-        else _contract_observed_columns_after_redaction(
-            observed_columns=observed_columns,
-            contract=contract,
-        )
+    contract_observed_columns = _contract_observed_columns_for_validation(
+        returned_observed_columns=observed_columns,
+        redaction_source_rows=redaction_source_rows,
+        contract=contract,
     )
     observed_set = set(contract_observed_columns)
     missing_expected_columns = tuple(
@@ -285,6 +282,20 @@ def _redaction_evidence(
     if unclassified_columns:
         return "fail", redacted_columns, unclassified_columns
     return "applied", redacted_columns, ()
+
+
+def _contract_observed_columns_for_validation(
+    *,
+    returned_observed_columns: tuple[str, ...],
+    redaction_source_rows: list[dict[str, Any]] | None,
+    contract: ResultValidationContract,
+) -> tuple[str, ...]:
+    if contract.redaction_required and redaction_source_rows is not None:
+        return returned_observed_columns
+    return _contract_observed_columns_after_redaction(
+        observed_columns=returned_observed_columns,
+        contract=contract,
+    )
 
 
 def _contract_observed_columns_after_redaction(

--- a/backend/app/features/result_validation.py
+++ b/backend/app/features/result_validation.py
@@ -123,9 +123,8 @@ def validate_execution_result(
         observed_columns=redaction_observed_columns,
         contract=contract,
     )
-    contract_observed_columns = _contract_observed_columns_for_validation(
-        returned_observed_columns=observed_columns,
-        redaction_source_rows=redaction_source_rows,
+    contract_observed_columns = _contract_observed_columns_after_redaction(
+        observed_columns=observed_columns,
         contract=contract,
     )
     observed_set = set(contract_observed_columns)
@@ -282,20 +281,6 @@ def _redaction_evidence(
     if unclassified_columns:
         return "fail", redacted_columns, unclassified_columns
     return "applied", redacted_columns, ()
-
-
-def _contract_observed_columns_for_validation(
-    *,
-    returned_observed_columns: tuple[str, ...],
-    redaction_source_rows: list[dict[str, Any]] | None,
-    contract: ResultValidationContract,
-) -> tuple[str, ...]:
-    if contract.redaction_required and redaction_source_rows is not None:
-        return returned_observed_columns
-    return _contract_observed_columns_after_redaction(
-        observed_columns=returned_observed_columns,
-        contract=contract,
-    )
 
 
 def _contract_observed_columns_after_redaction(

--- a/backend/app/features/result_validation.py
+++ b/backend/app/features/result_validation.py
@@ -117,7 +117,11 @@ def validate_execution_result(
         observed_columns=observed_columns,
         contract=contract,
     )
-    observed_set = set(observed_columns)
+    contract_observed_columns = _contract_observed_columns_after_redaction(
+        observed_columns=observed_columns,
+        contract=contract,
+    )
+    observed_set = set(contract_observed_columns)
     missing_expected_columns = tuple(
         column for column in expected_columns if column not in observed_set
     )
@@ -137,7 +141,7 @@ def validate_execution_result(
     aggregation_shape = _aggregation_shape(
         rows=rows,
         expected_columns=expected_columns,
-        observed_columns=observed_columns,
+        observed_columns=contract_observed_columns,
         aggregate_columns=contract.aggregate_columns,
     )
 
@@ -271,6 +275,20 @@ def _redaction_evidence(
     if unclassified_columns:
         return "fail", redacted_columns, unclassified_columns
     return "applied", redacted_columns, ()
+
+
+def _contract_observed_columns_after_redaction(
+    *,
+    observed_columns: tuple[str, ...],
+    contract: ResultValidationContract,
+) -> tuple[str, ...]:
+    if not contract.redaction_required or contract.column_sensitivity is None:
+        return observed_columns
+    return tuple(
+        column
+        for column in observed_columns
+        if contract.column_sensitivity.get(column) != "sensitive"
+    )
 
 
 def _columns_with_nulls(

--- a/backend/app/features/result_validation.py
+++ b/backend/app/features/result_validation.py
@@ -109,17 +109,27 @@ def validate_execution_result(
     rows: list[dict[str, Any]],
     metadata: ResultValidationMetadata,
     contract: ResultValidationContract,
+    redaction_source_rows: list[dict[str, Any]] | None = None,
 ) -> ResultValidationOutcome:
     expected_columns = _unique_ordered(contract.expected_columns)
     required_columns = _unique_ordered(contract.required_columns)
     observed_columns = _observed_columns(rows)
+    redaction_observed_columns = (
+        _observed_columns(redaction_source_rows)
+        if redaction_source_rows is not None
+        else observed_columns
+    )
     redaction_status, redacted_columns, unclassified_columns = _redaction_evidence(
-        observed_columns=observed_columns,
+        observed_columns=redaction_observed_columns,
         contract=contract,
     )
-    contract_observed_columns = _contract_observed_columns_after_redaction(
-        observed_columns=observed_columns,
-        contract=contract,
+    contract_observed_columns = (
+        observed_columns
+        if redaction_source_rows is not None and contract.redaction_required
+        else _contract_observed_columns_after_redaction(
+            observed_columns=observed_columns,
+            contract=contract,
+        )
     )
     observed_set = set(contract_observed_columns)
     missing_expected_columns = tuple(

--- a/backend/app/features/result_validation.py
+++ b/backend/app/features/result_validation.py
@@ -12,6 +12,7 @@ ResultValidationStatus = Literal["pass", "warn", "fail"]
 ResultValidationReason = Literal[
     "missing_expected_columns",
     "missing_required_columns",
+    "column_sensitivity_metadata_missing",
     "no_rows",
     "under_minimum_rows",
     "row_count_mismatch",
@@ -20,6 +21,8 @@ ResultValidationReason = Literal[
     "outlier_values_present",
     "aggregation_shape_mismatch",
 ]
+ColumnSensitivity = Literal["public", "sensitive"]
+ResultRedactionStatus = Literal["not_required", "applied", "fail"]
 
 
 class ResultValidationContract(BaseModel):
@@ -35,6 +38,8 @@ class ResultValidationContract(BaseModel):
     outlier_numeric_min: Optional[float] = None
     outlier_numeric_max: Optional[float] = None
     aggregate_columns: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    redaction_required: bool = False
+    column_sensitivity: Optional[dict[NonEmptyTrimmedString, ColumnSensitivity]] = None
 
 
 class ResultValidationMetadata(BaseModel):
@@ -68,6 +73,9 @@ class ResultValidationEvidence(BaseModel):
     )
     null_columns: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
     outlier_columns: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    redaction_status: ResultRedactionStatus = "not_required"
+    redacted_columns: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    unclassified_columns: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
 
 
 class ResultValidationOutcome(BaseModel):
@@ -105,6 +113,10 @@ def validate_execution_result(
     expected_columns = _unique_ordered(contract.expected_columns)
     required_columns = _unique_ordered(contract.required_columns)
     observed_columns = _observed_columns(rows)
+    redaction_status, redacted_columns, unclassified_columns = _redaction_evidence(
+        observed_columns=observed_columns,
+        contract=contract,
+    )
     observed_set = set(observed_columns)
     missing_expected_columns = tuple(
         column for column in expected_columns if column not in observed_set
@@ -130,6 +142,8 @@ def validate_execution_result(
     )
 
     reason_codes: list[ResultValidationReason] = []
+    if unclassified_columns:
+        reason_codes.append("column_sensitivity_metadata_missing")
     if missing_expected_columns:
         reason_codes.append("missing_expected_columns")
     if missing_required_columns:
@@ -156,6 +170,7 @@ def validate_execution_result(
         reason_codes.append("aggregation_shape_mismatch")
 
     fail_reasons = {
+        "column_sensitivity_metadata_missing",
         "missing_expected_columns",
         "missing_required_columns",
         "no_rows",
@@ -183,6 +198,9 @@ def validate_execution_result(
         aggregation_shape=aggregation_shape,
         null_columns=null_columns,
         outlier_columns=outlier_columns,
+        redaction_status=redaction_status,
+        redacted_columns=redacted_columns,
+        unclassified_columns=unclassified_columns,
     )
     return ResultValidationOutcome(
         status=status,
@@ -194,6 +212,31 @@ def validate_execution_result(
     )
 
 
+def redact_execution_result_rows(
+    *,
+    rows: list[dict[str, Any]],
+    contract: ResultValidationContract | None,
+) -> list[dict[str, Any]]:
+    if contract is None or not contract.redaction_required:
+        return rows
+    sensitivity = contract.column_sensitivity or {}
+    redacted_columns = {
+        column
+        for column, classification in sensitivity.items()
+        if classification == "sensitive"
+    }
+    if not redacted_columns:
+        return rows
+    return [
+        {
+            column: value
+            for column, value in row.items()
+            if column not in redacted_columns
+        }
+        for row in rows
+    ]
+
+
 def _unique_ordered(values: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(values))
 
@@ -203,6 +246,31 @@ def _observed_columns(rows: list[dict[str, Any]]) -> tuple[str, ...]:
     for row in rows:
         columns.update(str(column) for column in row)
     return tuple(sorted(columns))
+
+
+def _redaction_evidence(
+    *,
+    observed_columns: tuple[str, ...],
+    contract: ResultValidationContract,
+) -> tuple[ResultRedactionStatus, tuple[str, ...], tuple[str, ...]]:
+    if not contract.redaction_required:
+        return "not_required", (), ()
+
+    sensitivity = contract.column_sensitivity
+    if sensitivity is None:
+        return "fail", (), observed_columns
+
+    unclassified_columns = tuple(
+        column for column in observed_columns if column not in sensitivity
+    )
+    redacted_columns = tuple(
+        column
+        for column in observed_columns
+        if sensitivity.get(column) == "sensitive"
+    )
+    if unclassified_columns:
+        return "fail", redacted_columns, unclassified_columns
+    return "applied", redacted_columns, ()
 
 
 def _columns_with_nulls(

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -384,6 +384,97 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(validation["evidence"]["expected_columns"], ["vendor_name"])
         self.assertEqual(validation["evidence"]["row_count"], 1)
 
+    def test_execute_candidate_api_redacts_sensitive_columns_before_result_rows(
+        self,
+    ) -> None:
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            return [
+                {
+                    "vendor_name": "Acme",
+                    "vendor_email": "buyer@example.test",
+                    "approved_spend": 1200,
+                }
+            ]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name", "approved_spend"),
+                required_columns=("vendor_name", "approved_spend"),
+                redaction_required=True,
+                column_sensitivity={
+                    "vendor_name": "public",
+                    "vendor_email": "sensitive",
+                    "approved_spend": "public",
+                },
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["rows"],
+            [{"vendor_name": "Acme", "approved_spend": 1200}],
+        )
+        self.assertNotIn("buyer@example.test", response.text)
+        validation = payload["metadata"]["result_validation"]
+        self.assertEqual(validation["status"], "pass")
+        self.assertEqual(validation["evidence"]["redaction_status"], "applied")
+        self.assertEqual(validation["evidence"]["redacted_columns"], ["vendor_email"])
+        self.assertEqual(validation["evidence"]["unclassified_columns"], [])
+
+    def test_execute_candidate_api_fails_closed_when_redaction_metadata_is_missing(
+        self,
+    ) -> None:
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            return [
+                {
+                    "vendor_name": "Acme",
+                    "vendor_email": "buyer@example.test",
+                    "approved_spend": 1200,
+                }
+            ]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name", "approved_spend"),
+                required_columns=("vendor_name", "approved_spend"),
+                redaction_required=True,
+                column_sensitivity={
+                    "vendor_name": "public",
+                    "approved_spend": "public",
+                },
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_denied")
+        self.assertNotIn("buyer@example.test", response.text)
+        self.assertEqual(
+            payload["audit"]["events"][-1]["primary_deny_code"],
+            "DENY_RESULT_VALIDATION_FAILED",
+        )
+        self.assertEqual(
+            payload["audit"]["events"][-1]["denial_reason"],
+            "column_sensitivity_metadata_missing",
+        )
+
     def test_execute_candidate_api_selects_validation_contract_by_semantic_version(
         self,
     ) -> None:

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -479,6 +479,63 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertNotIn("truncation_reason", payload["metadata"])
         self.assertNotIn("private-note-", response.text)
 
+    def test_execute_candidate_api_validates_returned_rows_after_redaction_and_capping(
+        self,
+    ) -> None:
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            rows: list[dict[str, object]] = [
+                {
+                    "vendor_name": f"Vendor {index}",
+                    "approved_spend": index,
+                    "analyst_note": f"private-note-{index}",
+                }
+                for index in range(200)
+            ]
+            rows.append(
+                {
+                    "vendor_name": "Vendor 0",
+                    "approved_spend": 999,
+                    "analyst_note": "excluded-private-note",
+                }
+            )
+            return rows
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name", "approved_spend"),
+                required_columns=("vendor_name", "approved_spend"),
+                aggregate_columns=("approved_spend",),
+                redaction_required=True,
+                column_sensitivity={
+                    "vendor_name": "public",
+                    "approved_spend": "public",
+                    "analyst_note": "sensitive",
+                },
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["metadata"]["row_count"], 200)
+        self.assertIs(payload["metadata"]["result_truncated"], True)
+        self.assertEqual(payload["metadata"]["truncation_reason"], "row_limit")
+        self.assertNotIn("private-note-", response.text)
+        self.assertNotIn("excluded-private-note", response.text)
+        validation = payload["metadata"]["result_validation"]
+        self.assertEqual(validation["status"], "warn")
+        self.assertEqual(validation["reason_codes"], ["result_truncated"])
+        self.assertEqual(validation["evidence"]["aggregation_shape"], "valid")
+        self.assertEqual(validation["evidence"]["redaction_status"], "applied")
+        self.assertEqual(validation["evidence"]["redacted_columns"], ["analyst_note"])
+
     def test_execute_candidate_api_fails_closed_when_redaction_metadata_is_missing(
         self,
     ) -> None:

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -430,6 +430,55 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(validation["evidence"]["redacted_columns"], ["vendor_email"])
         self.assertEqual(validation["evidence"]["unclassified_columns"], [])
 
+    def test_execute_candidate_api_applies_payload_limit_after_redaction(
+        self,
+    ) -> None:
+        sensitive_note = "private-note-" + ("x" * 70_000)
+
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            return [
+                {
+                    "vendor_name": "Acme",
+                    "analyst_note": sensitive_note,
+                },
+                {
+                    "vendor_name": "Beta",
+                    "analyst_note": sensitive_note,
+                },
+            ]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name",),
+                required_columns=("vendor_name",),
+                redaction_required=True,
+                column_sensitivity={
+                    "vendor_name": "public",
+                    "analyst_note": "sensitive",
+                },
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            payload["rows"],
+            [{"vendor_name": "Acme"}, {"vendor_name": "Beta"}],
+        )
+        self.assertEqual(payload["metadata"]["row_count"], 2)
+        self.assertLess(payload["metadata"]["payload_bytes"], 64 * 1024)
+        self.assertIs(payload["metadata"]["result_truncated"], False)
+        self.assertNotIn("truncation_reason", payload["metadata"])
+        self.assertNotIn("private-note-", response.text)
+
     def test_execute_candidate_api_fails_closed_when_redaction_metadata_is_missing(
         self,
     ) -> None:

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -581,6 +581,54 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             "column_sensitivity_metadata_missing",
         )
 
+    def test_execute_candidate_api_blocks_when_required_column_is_redacted(
+        self,
+    ) -> None:
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            return [
+                {
+                    "vendor_name": "Acme",
+                    "vendor_email": "buyer@example.test",
+                    "approved_spend": 1200,
+                }
+            ]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name", "vendor_email", "approved_spend"),
+                required_columns=("vendor_name", "vendor_email", "approved_spend"),
+                redaction_required=True,
+                column_sensitivity={
+                    "vendor_name": "public",
+                    "vendor_email": "sensitive",
+                    "approved_spend": "public",
+                },
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "execution_denied")
+        self.assertNotIn("buyer@example.test", response.text)
+        self.assertEqual(
+            payload["audit"]["events"][-1]["primary_deny_code"],
+            "DENY_RESULT_VALIDATION_FAILED",
+        )
+        self.assertEqual(
+            payload["audit"]["events"][-1]["denial_reason"],
+            "missing_expected_columns,missing_required_columns",
+        )
+        self.assertEqual(payload["audit"]["events"][-1]["execution_row_count"], 1)
+        self.assertIs(payload["audit"]["events"][-1]["result_truncated"], False)
+
     def test_execute_candidate_api_selects_validation_contract_by_semantic_version(
         self,
     ) -> None:

--- a/backend/tests/test_result_validation_contract.py
+++ b/backend/tests/test_result_validation_contract.py
@@ -200,6 +200,46 @@ def test_result_validation_fails_when_redaction_removes_required_columns() -> No
     assert validation.evidence.missing_required_columns == ("vendor_email",)
 
 
+def test_result_validation_fails_when_returned_rows_removed_required_sensitive_columns() -> None:
+    raw_rows = [
+        {
+            "vendor_name": "Acme",
+            "vendor_email": "buyer@example.test",
+            "approved_spend": 1200,
+        }
+    ]
+    contract = ResultValidationContract(
+        expected_columns=("vendor_name", "vendor_email", "approved_spend"),
+        required_columns=("vendor_name", "vendor_email", "approved_spend"),
+        redaction_required=True,
+        column_sensitivity={
+            "vendor_name": "public",
+            "vendor_email": "sensitive",
+            "approved_spend": "public",
+        },
+    )
+    returned_rows = redact_execution_result_rows(rows=raw_rows, contract=contract)
+
+    validation = validate_execution_result(
+        rows=returned_rows,
+        metadata=_metadata(),
+        contract=contract,
+        redaction_source_rows=raw_rows,
+    )
+
+    assert validation.status == "fail"
+    assert validation.reason_codes == (
+        "missing_expected_columns",
+        "missing_required_columns",
+    )
+    assert validation.evidence.observed_columns == ("approved_spend", "vendor_name")
+    assert validation.evidence.redaction_status == "applied"
+    assert validation.evidence.redacted_columns == ("vendor_email",)
+    assert validation.evidence.unclassified_columns == ()
+    assert validation.evidence.missing_expected_columns == ("vendor_email",)
+    assert validation.evidence.missing_required_columns == ("vendor_email",)
+
+
 def test_result_redaction_removes_sensitive_columns_without_mutating_source_rows() -> None:
     rows = [
         {

--- a/backend/tests/test_result_validation_contract.py
+++ b/backend/tests/test_result_validation_contract.py
@@ -9,6 +9,7 @@ from app.features.result_validation import (
     ResultValidationContract,
     ResultValidationError,
     ResultValidationMetadata,
+    redact_execution_result_rows,
     validate_execution_result,
 )
 
@@ -103,6 +104,93 @@ def test_result_validation_warns_on_decimal_outliers() -> None:
     assert validation.status == "warn"
     assert validation.reason_codes == ("outlier_values_present",)
     assert validation.evidence.outlier_columns == ("approved_spend",)
+
+
+def test_result_validation_reports_applied_redaction_policy() -> None:
+    validation = validate_execution_result(
+        rows=[
+            {
+                "vendor_name": "Acme",
+                "vendor_email": "buyer@example.test",
+                "approved_spend": 1200,
+            }
+        ],
+        metadata=_metadata(),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+            redaction_required=True,
+            column_sensitivity={
+                "vendor_name": "public",
+                "vendor_email": "sensitive",
+                "approved_spend": "public",
+            },
+        ),
+    )
+
+    assert validation.status == "pass"
+    assert validation.evidence.redaction_status == "applied"
+    assert validation.evidence.redacted_columns == ("vendor_email",)
+    assert validation.evidence.unclassified_columns == ()
+
+
+def test_result_validation_fails_closed_when_redaction_metadata_is_missing() -> None:
+    validation = validate_execution_result(
+        rows=[
+            {
+                "vendor_name": "Acme",
+                "vendor_email": "buyer@example.test",
+                "approved_spend": 1200,
+            }
+        ],
+        metadata=_metadata(),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+            redaction_required=True,
+            column_sensitivity={
+                "vendor_name": "public",
+                "approved_spend": "public",
+            },
+        ),
+    )
+
+    assert validation.status == "fail"
+    assert validation.reason_codes == ("column_sensitivity_metadata_missing",)
+    assert validation.evidence.redaction_status == "fail"
+    assert validation.evidence.redacted_columns == ()
+    assert validation.evidence.unclassified_columns == ("vendor_email",)
+    with pytest.raises(
+        ResultValidationError,
+        match="column_sensitivity_metadata_missing",
+    ):
+        validation.require_answer_generation_allowed()
+
+
+def test_result_redaction_removes_sensitive_columns_without_mutating_source_rows() -> None:
+    rows = [
+        {
+            "vendor_name": "Acme",
+            "vendor_email": "buyer@example.test",
+            "approved_spend": 1200,
+        }
+    ]
+
+    redacted = redact_execution_result_rows(
+        rows=rows,
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            redaction_required=True,
+            column_sensitivity={
+                "vendor_name": "public",
+                "vendor_email": "sensitive",
+                "approved_spend": "public",
+            },
+        ),
+    )
+
+    assert redacted == [{"vendor_name": "Acme", "approved_spend": 1200}]
+    assert rows[0]["vendor_email"] == "buyer@example.test"
 
 
 def test_result_validation_reports_under_minimum_rows_separately_from_no_rows() -> None:

--- a/backend/tests/test_result_validation_contract.py
+++ b/backend/tests/test_result_validation_contract.py
@@ -240,6 +240,42 @@ def test_result_validation_fails_when_returned_rows_removed_required_sensitive_c
     assert validation.evidence.missing_required_columns == ("vendor_email",)
 
 
+def test_result_validation_fails_when_raw_rows_still_include_required_sensitive_columns() -> None:
+    rows = [
+        {
+            "vendor_name": "Acme",
+            "vendor_email": "buyer@example.test",
+            "approved_spend": 1200,
+        }
+    ]
+
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "vendor_email", "approved_spend"),
+            required_columns=("vendor_name", "vendor_email", "approved_spend"),
+            redaction_required=True,
+            column_sensitivity={
+                "vendor_name": "public",
+                "vendor_email": "sensitive",
+                "approved_spend": "public",
+            },
+        ),
+        redaction_source_rows=rows,
+    )
+
+    assert validation.status == "fail"
+    assert validation.reason_codes == (
+        "missing_expected_columns",
+        "missing_required_columns",
+    )
+    assert validation.evidence.redaction_status == "applied"
+    assert validation.evidence.redacted_columns == ("vendor_email",)
+    assert validation.evidence.missing_expected_columns == ("vendor_email",)
+    assert validation.evidence.missing_required_columns == ("vendor_email",)
+
+
 def test_result_redaction_removes_sensitive_columns_without_mutating_source_rows() -> None:
     rows = [
         {

--- a/backend/tests/test_result_validation_contract.py
+++ b/backend/tests/test_result_validation_contract.py
@@ -167,6 +167,39 @@ def test_result_validation_fails_closed_when_redaction_metadata_is_missing() -> 
         validation.require_answer_generation_allowed()
 
 
+def test_result_validation_fails_when_redaction_removes_required_columns() -> None:
+    validation = validate_execution_result(
+        rows=[
+            {
+                "vendor_name": "Acme",
+                "vendor_email": "buyer@example.test",
+                "approved_spend": 1200,
+            }
+        ],
+        metadata=_metadata(),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "vendor_email", "approved_spend"),
+            required_columns=("vendor_name", "vendor_email", "approved_spend"),
+            redaction_required=True,
+            column_sensitivity={
+                "vendor_name": "public",
+                "vendor_email": "sensitive",
+                "approved_spend": "public",
+            },
+        ),
+    )
+
+    assert validation.status == "fail"
+    assert validation.reason_codes == (
+        "missing_expected_columns",
+        "missing_required_columns",
+    )
+    assert validation.evidence.redaction_status == "applied"
+    assert validation.evidence.redacted_columns == ("vendor_email",)
+    assert validation.evidence.missing_expected_columns == ("vendor_email",)
+    assert validation.evidence.missing_required_columns == ("vendor_email",)
+
+
 def test_result_redaction_removes_sensitive_columns_without_mutating_source_rows() -> None:
     rows = [
         {


### PR DESCRIPTION
## Summary
- add contract-owned result column sensitivity metadata and redaction evidence
- redact sensitive columns from execute response rows after validation and before any result-summary consumer can use them
- fail closed when redaction is required but observed columns lack sensitivity metadata

## Verification
- cd backend && python3 -m pytest tests/test_result_validation_contract.py tests/test_candidate_execute_api.py
- python3 -m pytest tests/test_check_repository_hygiene.py
- rtk git diff --check

Closes #476