### PR TITLE
[Z-2] Add deterministic MVP answer summaries

### DIFF
--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -1014,6 +1014,7 @@ def execute_candidate_sql(
     runtime_safety_state: ExecutionRuntimeSafetyState | None = None,
     audit_context: ExecutionAuditContext | None = None,
     result_validation_contract: ResultValidationContract | None = None,
+    answer_summary_assumptions: tuple[str, ...] = (),
 ) -> ExecutionResult:
     if result_validation_contract is not None:
         _require_result_validation_linkage_before_execution(
@@ -1159,6 +1160,8 @@ def execute_candidate_sql(
             validation=result_validation,
             source_id=selection.source_id,
             source_family=selection.source_family,
+            assumptions=answer_summary_assumptions,
+            truncation_reason=metadata.truncation_reason,
         )
         metadata = metadata.model_copy(update={"answer_summary": answer_summary})
 

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -25,6 +25,10 @@ from app.features.execution.connector_selection import (
     ExecutionConnectorSelectionError,
     select_execution_connector,
 )
+from app.features.mvp_answer_summary import (
+    MVPAnswerSummary,
+    generate_mvp_answer_summary,
+)
 from app.features.result_validation import (
     ResultValidationContract,
     ResultValidationMetadata,
@@ -113,6 +117,7 @@ class ExecutionResultMetadata(BaseModel):
     result_truncated: bool
     truncation_reason: Optional[NonEmptyTrimmedString] = None
     result_validation: Optional[ResultValidationOutcome] = None
+    answer_summary: Optional[MVPAnswerSummary] = None
 
 
 class ExecutionResult(BaseModel):
@@ -1149,6 +1154,13 @@ def execute_candidate_sql(
                 canonical_sql=candidate.canonical_sql,
                 audit_context=audit_context,
             )
+        answer_summary = generate_mvp_answer_summary(
+            rows=result_rows,
+            validation=result_validation,
+            source_id=selection.source_id,
+            source_family=selection.source_family,
+        )
+        metadata = metadata.model_copy(update={"answer_summary": answer_summary})
 
     result = ExecutionResult(
         source_id=selection.source_id,

--- a/backend/app/features/mvp_answer_summary.py
+++ b/backend/app/features/mvp_answer_summary.py
@@ -28,6 +28,8 @@ _MODEL_CONFIG = ConfigDict(
     populate_by_name=True,
 )
 _MAX_SUMMARY_ROWS = 5
+_MAX_CELL_TEXT_CHARS = 160
+_TRUNCATED_CELL_SUFFIX = "... [truncated]"
 _VENDOR_COLUMN = "vendor_name"
 _QUARTER_COLUMN = "fiscal_quarter"
 _SPEND_COLUMNS = ("approved_spend", "approved_amount")
@@ -215,12 +217,12 @@ def _spend_value(row: Mapping[str, Any]) -> object:
 def _vendor_spend_intro(*, total_row_count: int, displayed_row_count: int) -> str:
     if displayed_row_count < total_row_count:
         return (
-            "Top approved vendor spend from "
+            "Approved vendor spend rows from "
             f"{_returned_row_count_text(total_row_count)}; "
             f"showing {_display_row_count_text(displayed_row_count)}: "
         )
     return (
-        "Top approved vendor spend from "
+        "Approved vendor spend rows from "
         f"{_returned_row_count_text(total_row_count)}: "
     )
 
@@ -278,7 +280,7 @@ def _redaction_sentence(status: ResultRedactionStatus) -> str:
 def _row_text(value: object, fallback: str) -> str:
     if value is None:
         return fallback
-    return _safe_text(str(value)) or fallback
+    return _bounded_text(_safe_text(str(value))) or fallback
 
 
 def _spend_text(value: object) -> str:
@@ -296,6 +298,13 @@ def _safe_text_items(values: tuple[str, ...]) -> tuple[str, ...]:
 def _safe_text(value: str) -> str:
     safe_values = sanitize_review_llm_surface_text_items((value,))
     return safe_values[0] if safe_values else ""
+
+
+def _bounded_text(value: str) -> str:
+    if len(value) <= _MAX_CELL_TEXT_CHARS:
+        return value
+    prefix_length = _MAX_CELL_TEXT_CHARS - len(_TRUNCATED_CELL_SUFFIX)
+    return value[:prefix_length].rstrip() + _TRUNCATED_CELL_SUFFIX
 
 
 def _trim_terminal_period(value: str) -> str:

--- a/backend/app/features/mvp_answer_summary.py
+++ b/backend/app/features/mvp_answer_summary.py
@@ -30,6 +30,7 @@ _MODEL_CONFIG = ConfigDict(
 _MAX_SUMMARY_ROWS = 5
 _MAX_CELL_TEXT_CHARS = 160
 _TRUNCATED_CELL_SUFFIX = "... [truncated]"
+_UNNAMED_COLUMN_LABEL = "unnamed column"
 _VENDOR_COLUMN = "vendor_name"
 _QUARTER_COLUMN = "fiscal_quarter"
 _SPEND_COLUMNS = ("approved_spend", "approved_amount")
@@ -188,7 +189,7 @@ def _generic_row_summary(
     row_entries = []
     for index, row in enumerate(rows, start=1):
         cells = [
-            f"{column}={_row_text(row.get(column), 'unavailable')}"
+            f"{_column_label(column)}={_row_text(row.get(column), 'unavailable')}"
             for column in observed_columns
         ]
         row_entries.append(f"{index}. " + ", ".join(cells))
@@ -287,12 +288,15 @@ def _spend_text(value: object) -> str:
     if isinstance(value, bool):
         return "unavailable"
     if isinstance(value, (Decimal, int, float)):
-        return str(value)
+        return _bounded_text(str(value))
     return _row_text(value, "unavailable")
 
 
 def _safe_text_items(values: tuple[str, ...]) -> tuple[str, ...]:
-    return sanitize_review_llm_surface_text_items(values)
+    return tuple(
+        _bounded_text(value)
+        for value in sanitize_review_llm_surface_text_items(values)
+    )
 
 
 def _safe_text(value: str) -> str:
@@ -305,6 +309,10 @@ def _bounded_text(value: str) -> str:
         return value
     prefix_length = _MAX_CELL_TEXT_CHARS - len(_TRUNCATED_CELL_SUFFIX)
     return value[:prefix_length].rstrip() + _TRUNCATED_CELL_SUFFIX
+
+
+def _column_label(value: str) -> str:
+    return _bounded_text(_safe_text(value)) or _UNNAMED_COLUMN_LABEL
 
 
 def _trim_terminal_period(value: str) -> str:

--- a/backend/app/features/mvp_answer_summary.py
+++ b/backend/app/features/mvp_answer_summary.py
@@ -72,6 +72,7 @@ def generate_mvp_answer_summary(
     source_id: str,
     source_family: str | None = None,
     assumptions: tuple[str, ...] = (),
+    truncation_reason: str | None = None,
     freeform_llm_answer: str | None = None,
 ) -> MVPAnswerSummary:
     del freeform_llm_answer
@@ -97,6 +98,7 @@ def generate_mvp_answer_summary(
         assumptions=safe_assumptions,
         validation=validation,
         truncation_status=truncation_status,
+        truncation_reason=truncation_reason,
         redaction_status=redaction_status,
     )
     return MVPAnswerSummary(
@@ -119,6 +121,7 @@ def _answer_text(
     assumptions: tuple[str, ...],
     validation: ResultValidationOutcome,
     truncation_status: MVPAnswerTruncationStatus,
+    truncation_reason: str | None,
     redaction_status: ResultRedactionStatus,
 ) -> str:
     segments = [
@@ -130,7 +133,7 @@ def _answer_text(
         _source_sentence(source),
         _assumptions_sentence(assumptions),
         _validation_sentence(validation),
-        _truncation_sentence(truncation_status),
+        _truncation_sentence(truncation_status, truncation_reason),
         _redaction_sentence(redaction_status),
     ]
     return " ".join(segment for segment in segments if segment)
@@ -255,10 +258,17 @@ def _validation_sentence(validation: ResultValidationOutcome) -> str:
     )
 
 
-def _truncation_sentence(status: MVPAnswerTruncationStatus) -> str:
-    if status == "truncated":
+def _truncation_sentence(
+    status: MVPAnswerTruncationStatus,
+    reason: str | None,
+) -> str:
+    if status != "truncated":
+        return "Truncation: not truncated."
+    if reason == "row_limit":
         return "Truncation: truncated by returned-row limits."
-    return "Truncation: not truncated."
+    if reason == "payload_limit":
+        return "Truncation: truncated by payload limits."
+    return "Truncation: truncated."
 
 
 def _redaction_sentence(status: ResultRedactionStatus) -> str:

--- a/backend/app/features/mvp_answer_summary.py
+++ b/backend/app/features/mvp_answer_summary.py
@@ -83,14 +83,15 @@ def generate_mvp_answer_summary(
         semantic_contract_version=validation.semantic_contract_version,
         candidate_id=validation.candidate_id,
     )
-    rows_used = min(len(rows), _MAX_SUMMARY_ROWS)
+    display_rows = rows[:_MAX_SUMMARY_ROWS]
+    rows_used = len(display_rows)
     truncation_status: MVPAnswerTruncationStatus = (
         "truncated" if validation.evidence.result_truncated else "not_truncated"
     )
     redaction_status = validation.evidence.redaction_status
 
     answer_text = _answer_text(
-        rows=rows[:_MAX_SUMMARY_ROWS],
+        rows=display_rows,
         total_row_count=validation.evidence.row_count,
         source=source,
         assumptions=safe_assumptions,
@@ -158,7 +159,10 @@ def _row_summary(
         spend = _spend_text(_spend_value(row))
         row_entries.append(f"{index}. {vendor} ({quarter}) - {spend}")
     return (
-        f"Top approved vendor spend from {_returned_row_count_text(total_row_count)}: "
+        _vendor_spend_intro(
+            total_row_count=total_row_count,
+            displayed_row_count=len(rows),
+        )
         + "; ".join(row_entries)
         + "."
     )
@@ -203,6 +207,19 @@ def _spend_value(row: Mapping[str, Any]) -> object:
         if column in row:
             return row.get(column)
     return None
+
+
+def _vendor_spend_intro(*, total_row_count: int, displayed_row_count: int) -> str:
+    if displayed_row_count < total_row_count:
+        return (
+            "Top approved vendor spend from "
+            f"{_returned_row_count_text(total_row_count)}; "
+            f"showing {_display_row_count_text(displayed_row_count)}: "
+        )
+    return (
+        "Top approved vendor spend from "
+        f"{_returned_row_count_text(total_row_count)}: "
+    )
 
 
 def _returned_row_count_text(count: int) -> str:

--- a/backend/app/features/mvp_answer_summary.py
+++ b/backend/app/features/mvp_answer_summary.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt
+
+from app.features.audit.event_model import (
+    NonEmptyTrimmedString,
+    SourceFamily,
+    SourceIdentifier,
+    to_camel,
+)
+from app.features.result_validation import (
+    ResultRedactionStatus,
+    ResultValidationOutcome,
+    ResultValidationReason,
+    ResultValidationStatus,
+)
+from app.features.review_llm.answer_plan import sanitize_review_llm_surface_text_items
+
+MVP_ANSWER_SUMMARY_CONTRACT_VERSION = "mvp_answer_summary.v1"
+_MODEL_CONFIG = ConfigDict(
+    alias_generator=to_camel,
+    extra="forbid",
+    frozen=True,
+    populate_by_name=True,
+)
+_MAX_SUMMARY_ROWS = 5
+_VENDOR_COLUMN = "vendor_name"
+_QUARTER_COLUMN = "fiscal_quarter"
+_SPEND_COLUMN = "approved_spend"
+
+MVPAnswerTruncationStatus = Literal["not_truncated", "truncated"]
+
+
+class MVPAnswerSource(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    source_id: SourceIdentifier
+    source_family: Optional[SourceFamily] = None
+    semantic_contract_version: NonEmptyTrimmedString
+    candidate_id: NonEmptyTrimmedString
+
+
+class MVPAnswerSummary(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    contract_version: Literal[MVP_ANSWER_SUMMARY_CONTRACT_VERSION] = (
+        MVP_ANSWER_SUMMARY_CONTRACT_VERSION
+    )
+    answer_text: NonEmptyTrimmedString
+    source: MVPAnswerSource
+    assumptions: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
+    validation_status: ResultValidationStatus
+    validation_reason_codes: tuple[ResultValidationReason, ...] = Field(
+        default_factory=tuple
+    )
+    truncation_status: MVPAnswerTruncationStatus
+    redaction_status: ResultRedactionStatus
+    rows_used: NonNegativeInt
+
+    def to_wire_payload(self) -> dict[str, object]:
+        return self.model_dump(mode="json", by_alias=True)
+
+
+def generate_mvp_answer_summary(
+    *,
+    rows: list[dict[str, Any]],
+    validation: ResultValidationOutcome,
+    source_id: str,
+    source_family: str | None = None,
+    assumptions: tuple[str, ...] = (),
+    freeform_llm_answer: str | None = None,
+) -> MVPAnswerSummary:
+    del freeform_llm_answer
+
+    safe_assumptions = _safe_text_items(assumptions)
+    source = MVPAnswerSource(
+        source_id=source_id,
+        source_family=source_family,
+        semantic_contract_version=validation.semantic_contract_version,
+        candidate_id=validation.candidate_id,
+    )
+    rows_used = min(len(rows), _MAX_SUMMARY_ROWS)
+    truncation_status: MVPAnswerTruncationStatus = (
+        "truncated" if validation.evidence.result_truncated else "not_truncated"
+    )
+    redaction_status = validation.evidence.redaction_status
+
+    answer_text = _answer_text(
+        rows=rows[:_MAX_SUMMARY_ROWS],
+        source=source,
+        assumptions=safe_assumptions,
+        validation=validation,
+        truncation_status=truncation_status,
+        redaction_status=redaction_status,
+    )
+    return MVPAnswerSummary(
+        answer_text=answer_text,
+        source=source,
+        assumptions=safe_assumptions,
+        validation_status=validation.status,
+        validation_reason_codes=validation.reason_codes,
+        truncation_status=truncation_status,
+        redaction_status=redaction_status,
+        rows_used=rows_used,
+    )
+
+
+def _answer_text(
+    *,
+    rows: list[Mapping[str, Any]],
+    source: MVPAnswerSource,
+    assumptions: tuple[str, ...],
+    validation: ResultValidationOutcome,
+    truncation_status: MVPAnswerTruncationStatus,
+    redaction_status: ResultRedactionStatus,
+) -> str:
+    segments = [
+        _row_summary(rows),
+        _source_sentence(source),
+        _assumptions_sentence(assumptions),
+        _validation_sentence(validation),
+        _truncation_sentence(truncation_status),
+        _redaction_sentence(redaction_status),
+    ]
+    return " ".join(segment for segment in segments if segment)
+
+
+def _row_summary(rows: list[Mapping[str, Any]]) -> str:
+    if not rows:
+        return "No rows were returned, so no vendor spend ranking is available."
+
+    row_entries = []
+    for index, row in enumerate(rows, start=1):
+        vendor = _row_text(row.get(_VENDOR_COLUMN), "unknown vendor")
+        quarter = _row_text(row.get(_QUARTER_COLUMN), "unspecified period")
+        spend = _spend_text(row.get(_SPEND_COLUMN))
+        row_entries.append(f"{index}. {vendor} ({quarter}) - {spend}")
+    return (
+        f"Top approved vendor spend from {len(rows)} returned rows: "
+        + "; ".join(row_entries)
+        + "."
+    )
+
+
+def _source_sentence(source: MVPAnswerSource) -> str:
+    if source.source_family is None:
+        return f"Source: {source.source_id}."
+    return f"Source: {source.source_id} ({source.source_family})."
+
+
+def _assumptions_sentence(assumptions: tuple[str, ...]) -> str:
+    if not assumptions:
+        return "Assumptions: none."
+    return "Assumptions: " + "; ".join(
+        _trim_terminal_period(assumption) for assumption in assumptions
+    ) + "."
+
+
+def _validation_sentence(validation: ResultValidationOutcome) -> str:
+    if not validation.reason_codes:
+        return f"Validation: {validation.status}."
+    return (
+        f"Validation: {validation.status} "
+        f"({', '.join(validation.reason_codes)})."
+    )
+
+
+def _truncation_sentence(status: MVPAnswerTruncationStatus) -> str:
+    if status == "truncated":
+        return "Truncation: truncated by returned-row limits."
+    return "Truncation: not truncated."
+
+
+def _redaction_sentence(status: ResultRedactionStatus) -> str:
+    return "Redaction: " + status.replace("_", " ") + "."
+
+
+def _row_text(value: object, fallback: str) -> str:
+    if value is None:
+        return fallback
+    return _safe_text(str(value)) or fallback
+
+
+def _spend_text(value: object) -> str:
+    if isinstance(value, bool):
+        return "unavailable"
+    if isinstance(value, (Decimal, int, float)):
+        return str(value)
+    return _row_text(value, "unavailable")
+
+
+def _safe_text_items(values: tuple[str, ...]) -> tuple[str, ...]:
+    return sanitize_review_llm_surface_text_items(values)
+
+
+def _safe_text(value: str) -> str:
+    safe_values = sanitize_review_llm_surface_text_items((value,))
+    return safe_values[0] if safe_values else ""
+
+
+def _trim_terminal_period(value: str) -> str:
+    return value.rstrip(".")

--- a/backend/app/features/mvp_answer_summary.py
+++ b/backend/app/features/mvp_answer_summary.py
@@ -30,7 +30,7 @@ _MODEL_CONFIG = ConfigDict(
 _MAX_SUMMARY_ROWS = 5
 _VENDOR_COLUMN = "vendor_name"
 _QUARTER_COLUMN = "fiscal_quarter"
-_SPEND_COLUMN = "approved_spend"
+_SPEND_COLUMNS = ("approved_spend", "approved_amount")
 
 MVPAnswerTruncationStatus = Literal["not_truncated", "truncated"]
 
@@ -91,6 +91,7 @@ def generate_mvp_answer_summary(
 
     answer_text = _answer_text(
         rows=rows[:_MAX_SUMMARY_ROWS],
+        total_row_count=validation.evidence.row_count,
         source=source,
         assumptions=safe_assumptions,
         validation=validation,
@@ -112,6 +113,7 @@ def generate_mvp_answer_summary(
 def _answer_text(
     *,
     rows: list[Mapping[str, Any]],
+    total_row_count: int,
     source: MVPAnswerSource,
     assumptions: tuple[str, ...],
     validation: ResultValidationOutcome,
@@ -119,7 +121,11 @@ def _answer_text(
     redaction_status: ResultRedactionStatus,
 ) -> str:
     segments = [
-        _row_summary(rows),
+        _row_summary(
+            rows=rows,
+            total_row_count=total_row_count,
+            observed_columns=validation.evidence.observed_columns,
+        ),
         _source_sentence(source),
         _assumptions_sentence(assumptions),
         _validation_sentence(validation),
@@ -129,21 +135,84 @@ def _answer_text(
     return " ".join(segment for segment in segments if segment)
 
 
-def _row_summary(rows: list[Mapping[str, Any]]) -> str:
+def _row_summary(
+    *,
+    rows: list[Mapping[str, Any]],
+    total_row_count: int,
+    observed_columns: tuple[str, ...],
+) -> str:
     if not rows:
         return "No rows were returned, so no vendor spend ranking is available."
+
+    if not _has_vendor_spend_shape(observed_columns):
+        return _generic_row_summary(
+            rows=rows,
+            total_row_count=total_row_count,
+            observed_columns=observed_columns,
+        )
 
     row_entries = []
     for index, row in enumerate(rows, start=1):
         vendor = _row_text(row.get(_VENDOR_COLUMN), "unknown vendor")
         quarter = _row_text(row.get(_QUARTER_COLUMN), "unspecified period")
-        spend = _spend_text(row.get(_SPEND_COLUMN))
+        spend = _spend_text(_spend_value(row))
         row_entries.append(f"{index}. {vendor} ({quarter}) - {spend}")
     return (
-        f"Top approved vendor spend from {len(rows)} returned rows: "
+        f"Top approved vendor spend from {_returned_row_count_text(total_row_count)}: "
         + "; ".join(row_entries)
         + "."
     )
+
+
+def _generic_row_summary(
+    *,
+    rows: list[Mapping[str, Any]],
+    total_row_count: int,
+    observed_columns: tuple[str, ...],
+) -> str:
+    if not observed_columns:
+        return (
+            f"Returned {_display_row_count_text(total_row_count)}; "
+            "no displayable columns are available."
+        )
+
+    row_entries = []
+    for index, row in enumerate(rows, start=1):
+        cells = [
+            f"{column}={_row_text(row.get(column), 'unavailable')}"
+            for column in observed_columns
+        ]
+        row_entries.append(f"{index}. " + ", ".join(cells))
+    return (
+        f"Returned {_display_row_count_text(total_row_count)}; "
+        f"showing {_display_row_count_text(len(rows))}: "
+        + "; ".join(row_entries)
+        + "."
+    )
+
+
+def _has_vendor_spend_shape(observed_columns: tuple[str, ...]) -> bool:
+    observed = set(observed_columns)
+    return _VENDOR_COLUMN in observed and any(
+        column in observed for column in _SPEND_COLUMNS
+    )
+
+
+def _spend_value(row: Mapping[str, Any]) -> object:
+    for column in _SPEND_COLUMNS:
+        if column in row:
+            return row.get(column)
+    return None
+
+
+def _returned_row_count_text(count: int) -> str:
+    noun = "row" if count == 1 else "rows"
+    return f"{count} returned {noun}"
+
+
+def _display_row_count_text(count: int) -> str:
+    noun = "row" if count == 1 else "rows"
+    return f"{count} {noun}"
 
 
 def _source_sentence(source: MVPAnswerSource) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -874,6 +874,7 @@ def create_app() -> FastAPI:
                 http_request
             )
             result_validation_contract: ResultValidationContract | None = None
+            answer_summary_assumptions: tuple[str, ...] = ()
 
             def prepare_execution(
                 revalidation_result: CandidateLifecycleRevalidationResult,
@@ -882,6 +883,7 @@ def create_app() -> FastAPI:
                 nonlocal selection
                 nonlocal cancellation_probe
                 nonlocal result_validation_contract
+                nonlocal answer_summary_assumptions
                 approved_sql = revalidation_result.approved_sql
                 if approved_sql is None:
                     raise api_error(
@@ -961,6 +963,7 @@ def create_app() -> FastAPI:
                 selection = prepared_selection
                 cancellation_probe = prepared_cancellation_probe
                 result_validation_contract = prepared_result_validation_contract
+                answer_summary_assumptions = revalidation_result.review_assumptions
 
             revalidate_authoritative_candidate_approval(
                 session=session,
@@ -1012,6 +1015,7 @@ def create_app() -> FastAPI:
                 runtime_safety_state=runtime_safety_state,
                 audit_context=execution_audit_context,
                 result_validation_contract=result_validation_contract,
+                answer_summary_assumptions=answer_summary_assumptions,
             )
         except CandidateLifecycleRevalidationError as exc:
             if exc.audit_event is not None:

--- a/backend/app/services/candidate_lifecycle.py
+++ b/backend/app/services/candidate_lifecycle.py
@@ -97,6 +97,7 @@ class CandidateLifecycleRevalidationResult(BaseModel):
     state: Literal["execution_eligible"]
     source: SourceBoundCandidateMetadata
     approved_sql: Optional[str] = None
+    review_assumptions: tuple[str, ...] = ()
 
 
 class CandidateLifecycleRevalidationError(PermissionError):
@@ -542,12 +543,12 @@ def _approved_sql_from_approval(
     return approval.approved_sql
 
 
-def _deny_if_review_blocks_execution(
+def _review_decision_allowed_for_execution(
     *,
     session: Session,
     approval: PreviewCandidateApproval,
     audit_context: CandidateLifecycleAuditContext | None,
-) -> None:
+) -> PreviewReviewDecision | None:
     review_decision = session.scalar(
         select(PreviewReviewDecision).where(
             PreviewReviewDecision.preview_candidate_id == approval.preview_candidate_id
@@ -568,6 +569,7 @@ def _deny_if_review_blocks_execution(
             approval=approval,
             audit_context=audit_context,
         )
+    return review_decision
 
 
 def revalidate_authoritative_candidate_approval(
@@ -654,7 +656,7 @@ def revalidate_authoritative_candidate_approval(
         approval,
         audit_context=audit_context,
     )
-    _deny_if_review_blocks_execution(
+    review_decision = _review_decision_allowed_for_execution(
         session=session,
         approval=approval,
         audit_context=audit_context,
@@ -671,7 +673,15 @@ def revalidate_authoritative_candidate_approval(
         selected_source_id=selected_source_id,
         audit_context=audit_context,
     )
-    result = result.model_copy(update={"approved_sql": approved_sql})
+    review_assumptions = (
+        tuple(review_decision.assumptions) if review_decision is not None else ()
+    )
+    result = result.model_copy(
+        update={
+            "approved_sql": approved_sql,
+            "review_assumptions": review_assumptions,
+        }
+    )
     if before_mark_executed is not None:
         before_mark_executed(result)
     if mark_executed:

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -351,15 +351,15 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
 
     def test_execute_candidate_api_attaches_result_validation_metadata(self) -> None:
         def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
-            return [{"vendor_name": "Acme"}]
+            return [{"vendor_name": "Acme", "approved_spend": 1200}]
 
         app_session = create_test_application_session(build_dev_authenticated_subject())
         response = self._client(
             query_runner,
             result_validation_contract=ResultValidationContract(
                 semantic_contract_version="approved_vendor_spend.v1",
-                expected_columns=("vendor_name",),
-                required_columns=("vendor_name",),
+                expected_columns=("vendor_name", "approved_spend"),
+                required_columns=("vendor_name", "approved_spend"),
             ),
         ).post(
             "/candidates/candidate-123/execute",
@@ -381,8 +381,22 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             validation["execution_run_id"],
             response.json()["metadata"]["execution_run_id"],
         )
-        self.assertEqual(validation["evidence"]["expected_columns"], ["vendor_name"])
+        self.assertEqual(
+            validation["evidence"]["expected_columns"],
+            ["vendor_name", "approved_spend"],
+        )
         self.assertEqual(validation["evidence"]["row_count"], 1)
+        answer_summary = response.json()["metadata"]["answer_summary"]
+        self.assertEqual(answer_summary["contract_version"], "mvp_answer_summary.v1")
+        self.assertEqual(answer_summary["validation_status"], "pass")
+        self.assertEqual(answer_summary["truncation_status"], "not_truncated")
+        self.assertEqual(answer_summary["redaction_status"], "not_required")
+        self.assertEqual(answer_summary["rows_used"], 1)
+        self.assertIn(
+            "Top approved vendor spend from 1 returned rows: "
+            "1. Acme (unspecified period) - 1200.",
+            answer_summary["answer_text"],
+        )
 
     def test_execute_candidate_api_redacts_sensitive_columns_before_result_rows(
         self,

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -398,7 +398,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(answer_summary["redaction_status"], "not_required")
         self.assertEqual(answer_summary["rows_used"], 1)
         self.assertIn(
-            "Top approved vendor spend from 1 returned row: "
+            "Approved vendor spend rows from 1 returned row: "
             "1. Acme (unspecified period) - 1200.",
             answer_summary["answer_text"],
         )

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -393,7 +393,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(answer_summary["redaction_status"], "not_required")
         self.assertEqual(answer_summary["rows_used"], 1)
         self.assertIn(
-            "Top approved vendor spend from 1 returned rows: "
+            "Top approved vendor spend from 1 returned row: "
             "1. Acme (unspecified period) - 1200.",
             answer_summary["answer_text"],
         )

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -440,6 +440,41 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             answer_summary["answer_text"],
         )
 
+    def test_execute_candidate_api_bounds_review_assumptions_in_answer_summary(
+        self,
+    ) -> None:
+        long_assumption = "Rows are sorted by " + ("approved spend " * 40)
+        self._seed_review_decision("ready", assumptions=[long_assumption])
+
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            return [{"vendor_name": "Acme", "approved_spend": 1200}]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name", "approved_spend"),
+                required_columns=("vendor_name", "approved_spend"),
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        answer_summary = response.json()["metadata"]["answer_summary"]
+        self.assertNotIn(long_assumption, answer_summary["answer_text"])
+        displayed_assumption = answer_summary["assumptions"][0]
+        self.assertTrue(displayed_assumption.endswith("... [truncated]"))
+        self.assertEqual(len(displayed_assumption), 160)
+        self.assertIn(
+            f"Assumptions: {displayed_assumption}.",
+            answer_summary["answer_text"],
+        )
+
     def test_execute_candidate_api_redacts_sensitive_columns_before_result_rows(
         self,
     ) -> None:

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -220,7 +220,12 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         )
         self.session.commit()
 
-    def _seed_review_decision(self, review_status: str) -> None:
+    def _seed_review_decision(
+        self,
+        review_status: str,
+        *,
+        assumptions: list[str] | None = None,
+    ) -> None:
         candidate = (
             self.session.query(PreviewCandidate)
             .filter_by(candidate_id="candidate-123")
@@ -281,7 +286,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
                 review_contract_version="review_llm_adapter_output.v1",
                 review_status=review_status,
                 review_confidence="high",
-                assumptions=[],
+                assumptions=list(assumptions or []),
                 risk_flags=[],
                 clarifying_questions=[],
                 review_payload={"status": review_status},
@@ -398,6 +403,43 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             answer_summary["answer_text"],
         )
 
+    def test_execute_candidate_api_attaches_review_assumptions_to_answer_summary(
+        self,
+    ) -> None:
+        self._seed_review_decision(
+            "ready",
+            assumptions=["Rows are sorted by approved spend descending."],
+        )
+
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            return [{"vendor_name": "Acme", "approved_spend": 1200}]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name", "approved_spend"),
+                required_columns=("vendor_name", "approved_spend"),
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        answer_summary = response.json()["metadata"]["answer_summary"]
+        self.assertEqual(
+            answer_summary["assumptions"],
+            ["Rows are sorted by approved spend descending."],
+        )
+        self.assertIn(
+            "Assumptions: Rows are sorted by approved spend descending.",
+            answer_summary["answer_text"],
+        )
+
     def test_execute_candidate_api_redacts_sensitive_columns_before_result_rows(
         self,
     ) -> None:
@@ -492,6 +534,41 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertIs(payload["metadata"]["result_truncated"], False)
         self.assertNotIn("truncation_reason", payload["metadata"])
         self.assertNotIn("private-note-", response.text)
+
+    def test_execute_candidate_api_summary_preserves_payload_truncation_reason(
+        self,
+    ) -> None:
+        def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
+            return [
+                {
+                    "vendor_name": f"Vendor {index} " + ("x" * 4096),
+                    "approved_spend": index,
+                }
+                for index in range(200)
+            ]
+
+        app_session = create_test_application_session(build_dev_authenticated_subject())
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name", "approved_spend"),
+                required_columns=("vendor_name", "approved_spend"),
+            ),
+        ).post(
+            "/candidates/candidate-123/execute",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+            json={"selected_source_id": "demo-business-postgres"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIs(payload["metadata"]["result_truncated"], True)
+        self.assertEqual(payload["metadata"]["truncation_reason"], "payload_limit")
+        answer_text = payload["metadata"]["answer_summary"]["answer_text"]
+        self.assertIn("Truncation: truncated by payload limits.", answer_text)
+        self.assertNotIn("truncated by returned-row limits", answer_text)
 
     def test_execute_candidate_api_validates_returned_rows_after_redaction_and_capping(
         self,

--- a/backend/tests/test_mvp_answer_summary.py
+++ b/backend/tests/test_mvp_answer_summary.py
@@ -421,3 +421,87 @@ def test_mvp_answer_summary_bounds_large_row_values() -> None:
     )[0]
     assert displayed_vendor.endswith("... [truncated]")
     assert len(displayed_vendor) == 160
+
+
+def test_mvp_answer_summary_bounds_large_numeric_spend_values() -> None:
+    long_amount = int("9" * 400)
+    rows = [{"vendor_name": "Acme", "approved_spend": long_amount}]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert str(long_amount) not in summary.answer_text
+    displayed_amount = summary.answer_text.split(
+        " (unspecified period) - ",
+        maxsplit=1,
+    )[1].split(". Source:", maxsplit=1)[0]
+    assert displayed_amount.endswith("... [truncated]")
+    assert len(displayed_amount) == 160
+
+
+def test_mvp_answer_summary_bounds_large_assumptions() -> None:
+    long_assumption = "Rows are ordered by " + ("approved spend " * 40)
+    rows = [{"vendor_name": "Acme", "approved_spend": 1200}]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+        assumptions=(long_assumption,),
+    )
+
+    assert long_assumption not in summary.answer_text
+    displayed_assumption = summary.assumptions[0]
+    assert displayed_assumption.endswith("... [truncated]")
+    assert len(displayed_assumption) == 160
+    assert f"Assumptions: {displayed_assumption}." in summary.answer_text
+
+
+def test_mvp_answer_summary_bounds_generic_column_names() -> None:
+    long_column = "column_" + ("alias_" * 80)
+    rows = [{long_column: "East", "vendor_count": 3}]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1),
+        contract=ResultValidationContract(
+            expected_columns=(long_column, "vendor_count"),
+            required_columns=(long_column, "vendor_count"),
+            aggregate_columns=("vendor_count",),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert long_column not in summary.answer_text
+    displayed_column = summary.answer_text.split("1. ", maxsplit=1)[1].split(
+        "=East",
+        maxsplit=1,
+    )[0]
+    assert displayed_column.endswith("... [truncated]")
+    assert len(displayed_column) == 160

--- a/backend/tests/test_mvp_answer_summary.py
+++ b/backend/tests/test_mvp_answer_summary.py
@@ -79,6 +79,97 @@ def test_mvp_answer_summary_uses_only_returned_rows_and_metadata() -> None:
     assert "fastest-growing" not in summary.answer_text
 
 
+def test_mvp_answer_summary_uses_mssql_approved_amount_spend_column() -> None:
+    rows = [
+        {"vendor_name": "Acme", "approved_amount": 1200},
+        {"vendor_name": "Beta", "approved_amount": 900},
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=2),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_amount"),
+            required_columns=("vendor_name", "approved_amount"),
+            aggregate_columns=("approved_amount",),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-mssql-source",
+        source_family="mssql",
+    )
+
+    assert summary.answer_text.startswith(
+        "Top approved vendor spend from 2 returned rows: "
+        "1. Acme (unspecified period) - 1200; "
+        "2. Beta (unspecified period) - 900."
+    )
+    assert "unavailable" not in summary.answer_text
+
+
+def test_mvp_answer_summary_preserves_total_row_count_when_display_is_capped() -> None:
+    rows = [
+        {"vendor_name": f"Vendor {index}", "approved_spend": index}
+        for index in range(1, 7)
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=6),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+            aggregate_columns=("approved_spend",),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert summary.rows_used == 5
+    assert "Top approved vendor spend from 6 returned rows:" in summary.answer_text
+    assert "from 5 returned rows" not in summary.answer_text
+    assert "Vendor 5" in summary.answer_text
+    assert "Vendor 6" not in summary.answer_text
+
+
+def test_mvp_answer_summary_uses_neutral_template_for_aggregate_rows() -> None:
+    rows = [
+        {"region": "East", "vendor_count": 3},
+        {"region": "West", "vendor_count": 2},
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=2),
+        contract=ResultValidationContract(
+            expected_columns=("region", "vendor_count"),
+            required_columns=("region", "vendor_count"),
+            aggregate_columns=("vendor_count",),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert summary.answer_text.startswith(
+        "Returned 2 rows; showing 2 rows: "
+        "1. region=East, vendor_count=3; "
+        "2. region=West, vendor_count=2."
+    )
+    assert "Top approved vendor spend" not in summary.answer_text
+    assert "unknown vendor" not in summary.answer_text
+    assert "unavailable" not in summary.answer_text
+
+
 def test_mvp_answer_summary_reports_no_rows_without_claiming_a_ranking() -> None:
     rows: list[dict[str, object]] = []
     validation = validate_execution_result(

--- a/backend/tests/test_mvp_answer_summary.py
+++ b/backend/tests/test_mvp_answer_summary.py
@@ -55,7 +55,7 @@ def test_mvp_answer_summary_uses_only_returned_rows_and_metadata() -> None:
     assert summary.to_wire_payload() == {
         "contractVersion": "mvp_answer_summary.v1",
         "answerText": (
-            "Top approved vendor spend from 2 returned rows: "
+            "Approved vendor spend rows from 2 returned rows: "
             "1. Acme (FY26-Q1) - 1200; 2. Beta (FY26-Q1) - 900. "
             "Source: business-postgres-source (postgresql). "
             "Assumptions: Rows are sorted by approved spend descending. "
@@ -102,7 +102,7 @@ def test_mvp_answer_summary_uses_mssql_approved_amount_spend_column() -> None:
     )
 
     assert summary.answer_text.startswith(
-        "Top approved vendor spend from 2 returned rows: "
+        "Approved vendor spend rows from 2 returned rows: "
         "1. Acme (unspecified period) - 1200; "
         "2. Beta (unspecified period) - 900."
     )
@@ -133,7 +133,7 @@ def test_mvp_answer_summary_preserves_total_row_count_when_display_is_capped() -
 
     assert summary.rows_used == 5
     assert (
-        "Top approved vendor spend from 6 returned rows; showing 5 rows:"
+        "Approved vendor spend rows from 6 returned rows; showing 5 rows:"
         in summary.answer_text
     )
     assert "from 5 returned rows" not in summary.answer_text
@@ -200,6 +200,36 @@ def test_mvp_answer_summary_reports_no_rows_without_claiming_a_ranking() -> None
     assert summary.rows_used == 0
     assert summary.validation_status == "fail"
     assert summary.validation_reason_codes == ("missing_expected_columns",)
+
+
+def test_mvp_answer_summary_does_not_claim_vendor_rows_are_top_ranked() -> None:
+    rows = [
+        {"vendor_name": "Acme", "approved_spend": 900},
+        {"vendor_name": "Beta", "approved_spend": 1200},
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=2),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert summary.answer_text.startswith(
+        "Approved vendor spend rows from 2 returned rows: "
+        "1. Acme (unspecified period) - 900; "
+        "2. Beta (unspecified period) - 1200."
+    )
+    assert "Top approved vendor spend" not in summary.answer_text
+    assert "ranking" not in summary.answer_text
 
 
 def test_mvp_answer_summary_surfaces_truncation_and_validation_warnings() -> None:
@@ -363,3 +393,31 @@ def test_mvp_answer_summary_redacts_secret_and_path_like_row_values() -> None:
     assert "hidden value" not in serialized
     assert unsafe_home_path not in serialized
     assert "[redacted]" in serialized
+
+
+def test_mvp_answer_summary_bounds_large_row_values() -> None:
+    long_note = "A" * 400
+    rows = [{"vendor_name": long_note, "approved_spend": 1200}]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert long_note not in summary.answer_text
+    displayed_vendor = summary.answer_text.split("1. ", maxsplit=1)[1].split(
+        " (unspecified period) - ",
+        maxsplit=1,
+    )[0]
+    assert displayed_vendor.endswith("... [truncated]")
+    assert len(displayed_vendor) == 160

--- a/backend/tests/test_mvp_answer_summary.py
+++ b/backend/tests/test_mvp_answer_summary.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.features.mvp_answer_summary import generate_mvp_answer_summary
+from app.features.result_validation import (
+    ResultValidationContract,
+    ResultValidationMetadata,
+    validate_execution_result,
+)
+
+
+def _metadata(
+    *,
+    row_count: int,
+    row_limit: int = 200,
+    result_truncated: bool = False,
+) -> ResultValidationMetadata:
+    return ResultValidationMetadata(
+        semantic_contract_version="approved_vendor_spend.v1",
+        candidate_id="candidate-123",
+        execution_run_id=uuid4(),
+        row_count=row_count,
+        row_limit=row_limit,
+        result_truncated=result_truncated,
+    )
+
+
+def test_mvp_answer_summary_uses_only_returned_rows_and_metadata() -> None:
+    rows = [
+        {"vendor_name": "Acme", "fiscal_quarter": "FY26-Q1", "approved_spend": 1200},
+        {"vendor_name": "Beta", "fiscal_quarter": "FY26-Q1", "approved_spend": 900},
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=2),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "fiscal_quarter", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+            aggregate_columns=("approved_spend",),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+        assumptions=("Rows are sorted by approved spend descending.",),
+        freeform_llm_answer=(
+            "Gamma was the fastest-growing vendor and should be prioritized."
+        ),
+    )
+
+    assert summary.to_wire_payload() == {
+        "contractVersion": "mvp_answer_summary.v1",
+        "answerText": (
+            "Top approved vendor spend from 2 returned rows: "
+            "1. Acme (FY26-Q1) - 1200; 2. Beta (FY26-Q1) - 900. "
+            "Source: business-postgres-source (postgresql). "
+            "Assumptions: Rows are sorted by approved spend descending. "
+            "Validation: pass. Truncation: not truncated. "
+            "Redaction: not required."
+        ),
+        "source": {
+            "sourceId": "business-postgres-source",
+            "sourceFamily": "postgresql",
+            "semanticContractVersion": "approved_vendor_spend.v1",
+            "candidateId": "candidate-123",
+        },
+        "assumptions": ["Rows are sorted by approved spend descending."],
+        "validationStatus": "pass",
+        "validationReasonCodes": [],
+        "truncationStatus": "not_truncated",
+        "redactionStatus": "not_required",
+        "rowsUsed": 2,
+    }
+    assert "Gamma" not in summary.answer_text
+    assert "fastest-growing" not in summary.answer_text
+
+
+def test_mvp_answer_summary_reports_no_rows_without_claiming_a_ranking() -> None:
+    rows: list[dict[str, object]] = []
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=0),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            minimum_row_count=0,
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert summary.answer_text == (
+        "No rows were returned, so no vendor spend ranking is available. "
+        "Source: business-postgres-source (postgresql). "
+        "Assumptions: none. Validation: fail (missing_expected_columns). "
+        "Truncation: not truncated. Redaction: not required."
+    )
+    assert summary.rows_used == 0
+    assert summary.validation_status == "fail"
+    assert summary.validation_reason_codes == ("missing_expected_columns",)
+
+
+def test_mvp_answer_summary_surfaces_truncation_and_validation_warnings() -> None:
+    rows = [
+        {"vendor_name": "Acme", "approved_spend": None},
+        {"vendor_name": "Beta", "approved_spend": 9_999_999},
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=2, row_limit=2, result_truncated=True),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+            warn_on_null_columns=("approved_spend",),
+            outlier_columns=("approved_spend",),
+            outlier_numeric_max=1_000_000,
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert summary.validation_status == "warn"
+    assert summary.validation_reason_codes == (
+        "result_truncated",
+        "null_values_present",
+        "outlier_values_present",
+    )
+    assert summary.truncation_status == "truncated"
+    assert "Validation: warn (result_truncated, null_values_present, outlier_values_present)." in (
+        summary.answer_text
+    )
+    assert "Truncation: truncated by returned-row limits." in summary.answer_text
+
+
+def test_mvp_answer_summary_reports_redaction_without_exposing_redacted_inputs() -> None:
+    raw_rows = [
+        {
+            "vendor_name": "Acme",
+            "vendor_email": "buyer@example.test",
+            "approved_spend": 1200,
+        }
+    ]
+    contract = ResultValidationContract(
+        expected_columns=("vendor_name", "approved_spend"),
+        required_columns=("vendor_name", "approved_spend"),
+        redaction_required=True,
+        column_sensitivity={
+            "vendor_name": "public",
+            "vendor_email": "sensitive",
+            "approved_spend": "public",
+        },
+    )
+    rows = [
+        {
+            column: value
+            for column, value in row.items()
+            if column != "vendor_email"
+        }
+        for row in raw_rows
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1),
+        contract=contract,
+        redaction_source_rows=raw_rows,
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert summary.redaction_status == "applied"
+    assert "Redaction: applied." in summary.answer_text
+    assert "buyer@example.test" not in summary.answer_text
+    assert "vendor_email" not in summary.answer_text
+
+
+def test_mvp_answer_summary_redacts_secret_and_path_like_row_values() -> None:
+    unsafe_home_path = "~" + "/workspace/private"
+    rows = [
+        {
+            "vendor_name": "token=raw-secret-token",
+            "fiscal_quarter": unsafe_home_path,
+            "approved_spend": 1200,
+        }
+    ]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "fiscal_quarter", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+        assumptions=("Use credential=hidden value from the run note.",),
+    )
+
+    serialized = str(summary.to_wire_payload()).lower()
+    assert "raw-secret-token" not in serialized
+    assert "hidden value" not in serialized
+    assert unsafe_home_path not in serialized
+    assert "[redacted]" in serialized

--- a/backend/tests/test_mvp_answer_summary.py
+++ b/backend/tests/test_mvp_answer_summary.py
@@ -224,6 +224,7 @@ def test_mvp_answer_summary_surfaces_truncation_and_validation_warnings() -> Non
         validation=validation,
         source_id="business-postgres-source",
         source_family="postgresql",
+        truncation_reason="row_limit",
     )
 
     assert summary.validation_status == "warn"
@@ -237,6 +238,52 @@ def test_mvp_answer_summary_surfaces_truncation_and_validation_warnings() -> Non
         summary.answer_text
     )
     assert "Truncation: truncated by returned-row limits." in summary.answer_text
+
+
+def test_mvp_answer_summary_uses_payload_truncation_reason_when_available() -> None:
+    rows = [{"vendor_name": "Acme", "approved_spend": 1200}]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1, result_truncated=True),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+        truncation_reason="payload_limit",
+    )
+
+    assert "Truncation: truncated by payload limits." in summary.answer_text
+    assert "returned-row limits" not in summary.answer_text
+
+
+def test_mvp_answer_summary_uses_neutral_truncation_when_reason_is_unknown() -> None:
+    rows = [{"vendor_name": "Acme", "approved_spend": 1200}]
+    validation = validate_execution_result(
+        rows=rows,
+        metadata=_metadata(row_count=1, result_truncated=True),
+        contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("vendor_name", "approved_spend"),
+        ),
+    )
+
+    summary = generate_mvp_answer_summary(
+        rows=rows,
+        validation=validation,
+        source_id="business-postgres-source",
+        source_family="postgresql",
+    )
+
+    assert "Truncation: truncated." in summary.answer_text
+    assert "returned-row limits" not in summary.answer_text
+    assert "payload limits" not in summary.answer_text
 
 
 def test_mvp_answer_summary_reports_redaction_without_exposing_redacted_inputs() -> None:

--- a/backend/tests/test_mvp_answer_summary.py
+++ b/backend/tests/test_mvp_answer_summary.py
@@ -132,7 +132,10 @@ def test_mvp_answer_summary_preserves_total_row_count_when_display_is_capped() -
     )
 
     assert summary.rows_used == 5
-    assert "Top approved vendor spend from 6 returned rows:" in summary.answer_text
+    assert (
+        "Top approved vendor spend from 6 returned rows; showing 5 rows:"
+        in summary.answer_text
+    )
     assert "from 5 returned rows" not in summary.answer_text
     assert "Vendor 5" in summary.answer_text
     assert "Vendor 6" not in summary.answer_text


### PR DESCRIPTION
## Summary
- add deterministic MVP answer summary payloads for approved vendor spend rows
- derive answer text only from returned rows, source metadata, assumptions, validation, truncation, and redaction metadata
- attach the summary to successful execute responses after result validation passes

## Verification
- python3 -m pytest tests/test_result_validation_contract.py tests/test_execution_runtime_controls.py tests/test_candidate_execute_api.py tests/test_mvp_answer_summary.py -q
- python3 -m pytest tests/test_check_repository_hygiene.py -q

Closes #477