### PR TITLE
[Z-4] show insufficient data state instead of speculative answer (#478)

### DIFF
--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -159,3 +159,7 @@ class SourceAwareAuditEvent(BaseModel):
     candidate_state: Optional[NonEmptyTrimmedString] = None
     execution_row_count: Optional[int] = None
     result_truncated: Optional[bool] = None
+    answer_state: Optional[NonEmptyTrimmedString] = None
+    answer_text: Optional[NonEmptyTrimmedString] = None
+    insufficient_evidence_reason: Optional[NonEmptyTrimmedString] = None
+    next_action: Optional[NonEmptyTrimmedString] = None

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -1148,7 +1148,7 @@ def execute_candidate_sql(
             redaction_source_rows=redaction_source_rows,
         )
         metadata = metadata.model_copy(update={"result_validation": result_validation})
-        if not result_validation.answer_generation_allowed:
+        if "column_sensitivity_metadata_missing" in result_validation.reason_codes:
             _raise_result_validation_denial(
                 validation=result_validation,
                 candidate_source=candidate.source,

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -342,6 +342,10 @@ def _build_execution_audit_event(
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
+    answer_state: str | None = None,
+    answer_text: str | None = None,
+    insufficient_evidence_reason: str | None = None,
+    next_action: str | None = None,
     release_gate_guard_decision: Literal["allow", "reject"] | None = None,
 ) -> SourceAwareAuditEvent | None:
     if audit_context is None:
@@ -389,6 +393,10 @@ def _build_execution_audit_event(
         ),
         execution_row_count=execution_row_count,
         result_truncated=result_truncated,
+        answer_state=answer_state,
+        answer_text=answer_text,
+        insufficient_evidence_reason=insufficient_evidence_reason,
+        next_action=next_action,
     )
     if canonical_sql is not None and event_type in {
         "execution_completed",
@@ -434,6 +442,10 @@ def _build_execution_audit_events(
     candidate_state: str | None = None,
     execution_row_count: int | None = None,
     result_truncated: bool | None = None,
+    answer_state: str | None = None,
+    answer_text: str | None = None,
+    insufficient_evidence_reason: str | None = None,
+    next_action: str | None = None,
     release_gate_guard_decision: Literal["allow", "reject"] | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
@@ -467,6 +479,16 @@ def _build_execution_audit_events(
                 if event_type in {"execution_completed", "execution_denied"}
                 else None
             ),
+            answer_state=(
+                answer_state if event_type == "execution_completed" else None
+            ),
+            answer_text=answer_text if event_type == "execution_completed" else None,
+            insufficient_evidence_reason=(
+                insufficient_evidence_reason
+                if event_type == "execution_completed"
+                else None
+            ),
+            next_action=next_action if event_type == "execution_completed" else None,
             release_gate_guard_decision=(
                 release_gate_guard_decision
                 if event_type in {"execution_completed", "execution_denied"}
@@ -1125,6 +1147,7 @@ def execute_candidate_sql(
         audit_context=audit_context,
     )
     result_rows = capped_rows
+    answer_summary: MVPAnswerSummary | None = None
     if result_validation_contract is not None:
         assert candidate.source.semantic_contract_version is not None
         assert metadata.candidate_id is not None
@@ -1179,6 +1202,30 @@ def execute_candidate_sql(
         canonical_sql=candidate.canonical_sql,
         execution_row_count=metadata.row_count,
         result_truncated=metadata.result_truncated,
+        answer_state=(
+            answer_summary.answer_state
+            if answer_summary is not None
+            and answer_summary.answer_state == "insufficient_evidence"
+            else None
+        ),
+        answer_text=(
+            answer_summary.answer_text
+            if answer_summary is not None
+            and answer_summary.answer_state == "insufficient_evidence"
+            else None
+        ),
+        insufficient_evidence_reason=(
+            answer_summary.insufficient_evidence_reason
+            if answer_summary is not None
+            and answer_summary.answer_state == "insufficient_evidence"
+            else None
+        ),
+        next_action=(
+            answer_summary.next_action
+            if answer_summary is not None
+            and answer_summary.answer_state == "insufficient_evidence"
+            else None
+        ),
     )
     result._audit_event = result._audit_events[-1] if result._audit_events else None
     return result

--- a/backend/app/features/mvp_answer_summary.py
+++ b/backend/app/features/mvp_answer_summary.py
@@ -36,6 +36,19 @@ _QUARTER_COLUMN = "fiscal_quarter"
 _SPEND_COLUMNS = ("approved_spend", "approved_amount")
 
 MVPAnswerTruncationStatus = Literal["not_truncated", "truncated"]
+MVPAnswerState = Literal["answered", "insufficient_evidence"]
+MVPInsufficientEvidenceReason = Literal[
+    "no_rows",
+    "missing_columns",
+    "unsafe_truncation",
+    "blocking_validation_warnings",
+]
+MVPInsufficientEvidenceNextAction = Literal[
+    "revise_query_filters_or_source",
+    "revise_query_or_semantic_contract_columns",
+    "rerun_with_trusted_top_n_or_higher_limit",
+    "inspect_blocking_validation_warnings",
+]
 
 
 class MVPAnswerSource(BaseModel):
@@ -53,6 +66,7 @@ class MVPAnswerSummary(BaseModel):
     contract_version: Literal[MVP_ANSWER_SUMMARY_CONTRACT_VERSION] = (
         MVP_ANSWER_SUMMARY_CONTRACT_VERSION
     )
+    answer_state: MVPAnswerState = "answered"
     answer_text: NonEmptyTrimmedString
     source: MVPAnswerSource
     assumptions: tuple[NonEmptyTrimmedString, ...] = Field(default_factory=tuple)
@@ -60,12 +74,14 @@ class MVPAnswerSummary(BaseModel):
     validation_reason_codes: tuple[ResultValidationReason, ...] = Field(
         default_factory=tuple
     )
+    insufficient_evidence_reason: Optional[MVPInsufficientEvidenceReason] = None
+    next_action: Optional[MVPInsufficientEvidenceNextAction] = None
     truncation_status: MVPAnswerTruncationStatus
     redaction_status: ResultRedactionStatus
     rows_used: NonNegativeInt
 
     def to_wire_payload(self) -> dict[str, object]:
-        return self.model_dump(mode="json", by_alias=True)
+        return self.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
 def generate_mvp_answer_summary(
@@ -93,26 +109,82 @@ def generate_mvp_answer_summary(
         "truncated" if validation.evidence.result_truncated else "not_truncated"
     )
     redaction_status = validation.evidence.redaction_status
+    insufficient_evidence = _insufficient_evidence_decision(validation)
 
-    answer_text = _answer_text(
-        rows=display_rows,
-        total_row_count=validation.evidence.row_count,
-        source=source,
-        assumptions=safe_assumptions,
-        validation=validation,
-        truncation_status=truncation_status,
-        truncation_reason=truncation_reason,
-        redaction_status=redaction_status,
+    answer_text = (
+        _insufficient_evidence_answer_text(insufficient_evidence)
+        if insufficient_evidence is not None
+        else _answer_text(
+            rows=display_rows,
+            total_row_count=validation.evidence.row_count,
+            source=source,
+            assumptions=safe_assumptions,
+            validation=validation,
+            truncation_status=truncation_status,
+            truncation_reason=truncation_reason,
+            redaction_status=redaction_status,
+        )
     )
     return MVPAnswerSummary(
+        answer_state=(
+            "insufficient_evidence"
+            if insufficient_evidence is not None
+            else "answered"
+        ),
         answer_text=answer_text,
         source=source,
         assumptions=safe_assumptions,
         validation_status=validation.status,
         validation_reason_codes=validation.reason_codes,
+        insufficient_evidence_reason=(
+            insufficient_evidence[0] if insufficient_evidence is not None else None
+        ),
+        next_action=(
+            insufficient_evidence[1] if insufficient_evidence is not None else None
+        ),
         truncation_status=truncation_status,
         redaction_status=redaction_status,
         rows_used=rows_used,
+    )
+
+
+def _insufficient_evidence_decision(
+    validation: ResultValidationOutcome,
+) -> tuple[MVPInsufficientEvidenceReason, MVPInsufficientEvidenceNextAction] | None:
+    reasons = set(validation.reason_codes)
+    if "no_rows" in reasons:
+        return ("no_rows", "revise_query_filters_or_source")
+    if "missing_expected_columns" in reasons or "missing_required_columns" in reasons:
+        return ("missing_columns", "revise_query_or_semantic_contract_columns")
+    if "result_truncated" in reasons:
+        return ("unsafe_truncation", "rerun_with_trusted_top_n_or_higher_limit")
+    if validation.status != "pass":
+        return ("blocking_validation_warnings", "inspect_blocking_validation_warnings")
+    return None
+
+
+def _insufficient_evidence_answer_text(
+    decision: tuple[MVPInsufficientEvidenceReason, MVPInsufficientEvidenceNextAction],
+) -> str:
+    reason, _next_action = decision
+    if reason == "no_rows":
+        return (
+            "Insufficient evidence: no rows were returned. "
+            "Next action: revise the query filters or source selection before requesting an answer."
+        )
+    if reason == "missing_columns":
+        return (
+            "Insufficient evidence: expected result columns were missing. "
+            "Next action: revise the SQL projection or semantic contract columns before requesting an answer."
+        )
+    if reason == "unsafe_truncation":
+        return (
+            "Insufficient evidence: result was truncated before the top set could be trusted. "
+            "Next action: rerun with an authoritative ORDER BY, tighter filters, or a higher trusted limit."
+        )
+    return (
+        "Insufficient evidence: validation warnings block answer generation. "
+        "Next action: inspect the validation warnings before requesting an answer."
     )
 
 

--- a/backend/app/features/result_validation.py
+++ b/backend/app/features/result_validation.py
@@ -90,7 +90,7 @@ class ResultValidationOutcome(BaseModel):
 
     @property
     def answer_generation_allowed(self) -> bool:
-        return self.status != "fail"
+        return self.status == "pass"
 
     def require_answer_generation_allowed(self) -> None:
         if not self.answer_generation_allowed:
@@ -158,7 +158,7 @@ def validate_execution_result(
         reason_codes.append("missing_expected_columns")
     if missing_required_columns:
         reason_codes.append("missing_required_columns")
-    if metadata.row_count == 0 and metadata.row_count < contract.minimum_row_count:
+    if metadata.row_count == 0:
         reason_codes.append("no_rows")
     elif metadata.row_count < contract.minimum_row_count:
         reason_codes.append("under_minimum_rows")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -147,6 +147,10 @@ _EXECUTION_DENIAL_AUDIT_FIELDS = frozenset(
         "candidate_state",
         "execution_row_count",
         "result_truncated",
+        "answer_state",
+        "answer_text",
+        "insufficient_evidence_reason",
+        "next_action",
     }
 )
 

--- a/backend/app/services/operator_workflow.py
+++ b/backend/app/services/operator_workflow.py
@@ -88,6 +88,10 @@ class OperatorWorkflowHistoryItem(BaseModel):
     )
     row_count: Optional[int] = Field(default=None, serialization_alias="rowCount")
     run_state: Optional[str] = Field(default=None, serialization_alias="runState")
+    insufficient_evidence: Optional["OperatorWorkflowInsufficientEvidenceState"] = Field(
+        default=None,
+        serialization_alias="insufficientEvidence",
+    )
     audit_events: list["OperatorWorkflowAuditEventSummary"] = Field(
         default_factory=list,
         serialization_alias="auditEvents",
@@ -130,6 +134,19 @@ class OperatorWorkflowReviewEvidence(BaseModel):
         default_factory=list,
         serialization_alias="clarifyingQuestions",
     )
+
+
+class OperatorWorkflowInsufficientEvidenceState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    answer_text: str = Field(serialization_alias="answerText")
+    next_action: str = Field(serialization_alias="nextAction")
+    reason: Literal[
+        "no_rows",
+        "missing_columns",
+        "unsafe_truncation",
+        "blocking_validation_warnings",
+    ]
 
 
 class OperatorWorkflowCandidateAttemptSummary(BaseModel):
@@ -427,6 +444,8 @@ def _latest_candidate_events(
 
 def _run_state_for_event(event: PreviewAuditEvent) -> str | None:
     if event.event_type == "execution_completed":
+        if _insufficient_evidence_for_event(event) is not None:
+            return "insufficient_evidence"
         row_count = event.audit_payload.get("execution_row_count")
         return "empty" if row_count == 0 else "completed"
 
@@ -440,7 +459,7 @@ def _run_state_for_event(event: PreviewAuditEvent) -> str | None:
 
 
 def _run_row_count_for_event(event: PreviewAuditEvent, run_state: str) -> int | None:
-    if run_state not in {"completed", "empty"}:
+    if run_state not in {"completed", "empty", "insufficient_evidence"}:
         return None
 
     row_count = event.audit_payload.get("execution_row_count")
@@ -451,7 +470,7 @@ def _run_result_truncated_for_event(
     event: PreviewAuditEvent,
     run_state: str,
 ) -> bool | None:
-    if run_state not in {"completed", "empty"}:
+    if run_state not in {"completed", "empty", "insufficient_evidence"}:
         return None
 
     result_truncated = event.audit_payload.get("result_truncated")
@@ -472,6 +491,38 @@ def _read_non_negative_int(value: object) -> int | None:
 
 def _read_positive_int(value: object) -> int | None:
     return value if isinstance(value, int) and value > 0 else None
+
+
+def _insufficient_evidence_for_event(
+    event: PreviewAuditEvent,
+) -> OperatorWorkflowInsufficientEvidenceState | None:
+    if (
+        event.event_type != "execution_completed"
+        or event.audit_payload.get("answer_state") != "insufficient_evidence"
+    ):
+        return None
+
+    answer_text = _read_text(event.audit_payload.get("answer_text"))
+    next_action = _read_text(event.audit_payload.get("next_action"))
+    reason = event.audit_payload.get("insufficient_evidence_reason")
+    if (
+        answer_text is None
+        or next_action is None
+        or reason
+        not in {
+            "no_rows",
+            "missing_columns",
+            "unsafe_truncation",
+            "blocking_validation_warnings",
+        }
+    ):
+        return None
+
+    return OperatorWorkflowInsufficientEvidenceState(
+        answer_text=answer_text,
+        next_action=next_action,
+        reason=reason,
+    )
 
 
 def _read_payload_items(value: object) -> list[dict[str, object]]:
@@ -857,6 +908,7 @@ def _build_operator_history(
                 result_truncated=_run_result_truncated_for_event(event, run_state),
                 row_count=_run_row_count_for_event(event, run_state),
                 run_state=run_state,
+                insufficient_evidence=_insufficient_evidence_for_event(event),
                 audit_events=[_audit_event_summary(event)],
                 executed_evidence=_executed_evidence_for_event(event),
                 retrieved_citations=_retrieved_citations_for_event(event),

--- a/backend/app/services/request_preview.py
+++ b/backend/app/services/request_preview.py
@@ -764,6 +764,8 @@ def _joined_governance_bindings(bindings: list[str]) -> str | None:
 
 def _terminal_run_state(event: PreviewAuditEvent) -> str | None:
     if event.event_type == "execution_completed":
+        if event.audit_payload.get("answer_state") == "insufficient_evidence":
+            return "insufficient_evidence"
         row_count = event.audit_payload.get("execution_row_count")
         return "empty" if row_count == 0 else "completed"
     if event.event_type == "execution_denied":
@@ -887,7 +889,13 @@ def _resolve_revision_record(
             "Revision context references an unknown execution run."
         )
     run_state = _terminal_run_state(run_event)
-    if run_state not in {"completed", "empty", "failed", "execution_denied"}:
+    if run_state not in {
+        "completed",
+        "empty",
+        "insufficient_evidence",
+        "failed",
+        "execution_denied",
+    }:
         raise PreviewSubmissionContractError(
             "Execution run state is not eligible for revision."
         )

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -601,9 +601,20 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         payload = response.json()
         self.assertIs(payload["metadata"]["result_truncated"], True)
         self.assertEqual(payload["metadata"]["truncation_reason"], "payload_limit")
-        answer_text = payload["metadata"]["answer_summary"]["answer_text"]
-        self.assertIn("Truncation: truncated by payload limits.", answer_text)
-        self.assertNotIn("truncated by returned-row limits", answer_text)
+        answer_summary = payload["metadata"]["answer_summary"]
+        self.assertEqual(answer_summary["answer_state"], "insufficient_evidence")
+        self.assertEqual(
+            answer_summary["insufficient_evidence_reason"],
+            "unsafe_truncation",
+        )
+        self.assertEqual(
+            answer_summary["next_action"],
+            "rerun_with_trusted_top_n_or_higher_limit",
+        )
+        self.assertIn(
+            "result was truncated before the top set could be trusted",
+            answer_summary["answer_text"],
+        )
 
     def test_execute_candidate_api_validates_returned_rows_after_redaction_and_capping(
         self,
@@ -707,7 +718,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             "column_sensitivity_metadata_missing",
         )
 
-    def test_execute_candidate_api_blocks_when_required_column_is_redacted(
+    def test_execute_candidate_api_returns_insufficient_evidence_when_required_column_is_redacted(
         self,
     ) -> None:
         def query_runner(*, canonical_sql: str, **_: object) -> list[dict[str, object]]:
@@ -740,17 +751,25 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             json={"selected_source_id": "demo-business-postgres"},
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertEqual(payload["error"]["code"], "execution_denied")
         self.assertNotIn("buyer@example.test", response.text)
+        answer_summary = payload["metadata"]["answer_summary"]
         self.assertEqual(
-            payload["audit"]["events"][-1]["primary_deny_code"],
-            "DENY_RESULT_VALIDATION_FAILED",
+            answer_summary["answer_state"],
+            "insufficient_evidence",
         )
         self.assertEqual(
-            payload["audit"]["events"][-1]["denial_reason"],
-            "missing_expected_columns,missing_required_columns",
+            answer_summary["insufficient_evidence_reason"],
+            "missing_columns",
+        )
+        self.assertEqual(
+            answer_summary["next_action"],
+            "revise_query_or_semantic_contract_columns",
+        )
+        self.assertEqual(
+            payload["metadata"]["result_validation"]["reason_codes"],
+            ["missing_expected_columns", "missing_required_columns"],
         )
         self.assertEqual(payload["audit"]["events"][-1]["execution_row_count"], 1)
         self.assertIs(payload["audit"]["events"][-1]["result_truncated"], False)
@@ -834,7 +853,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         self.assertEqual(approval.approval_state, "approved")
         self.assertIsNone(approval.executed_at)
 
-    def test_execute_candidate_api_blocks_failed_result_validation_before_success(
+    def test_execute_candidate_api_returns_insufficient_evidence_for_missing_columns(
         self,
     ) -> None:
         calls: list[str] = []
@@ -858,25 +877,29 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             json={"selected_source_id": "demo-business-postgres"},
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertEqual(payload["error"]["code"], "execution_denied")
         self.assertEqual(
             [event["event_type"] for event in payload["audit"]["events"]],
-            ["execution_requested", "execution_started", "execution_denied"],
+            ["execution_requested", "execution_started", "execution_completed"],
+        )
+        validation = payload["metadata"]["result_validation"]
+        self.assertEqual(validation["status"], "fail")
+        self.assertEqual(
+            validation["reason_codes"],
+            ["missing_expected_columns", "missing_required_columns"],
+        )
+        answer_summary = payload["metadata"]["answer_summary"]
+        self.assertEqual(answer_summary["answer_state"], "insufficient_evidence")
+        self.assertEqual(
+            answer_summary["insufficient_evidence_reason"],
+            "missing_columns",
         )
         self.assertEqual(
-            payload["audit"]["events"][-1]["primary_deny_code"],
-            "DENY_RESULT_VALIDATION_FAILED",
+            answer_summary["next_action"],
+            "revise_query_or_semantic_contract_columns",
         )
-        self.assertEqual(
-            payload["audit"]["events"][-1]["denial_cause"],
-            "result_validation_failed",
-        )
-        self.assertEqual(
-            payload["audit"]["events"][-1]["denial_reason"],
-            "missing_expected_columns,missing_required_columns",
-        )
+        self.assertNotIn("Acme", answer_summary["answer_text"])
         self.assertEqual(payload["audit"]["events"][-1]["execution_row_count"], 1)
         self.assertIs(payload["audit"]["events"][-1]["result_truncated"], False)
         self.assertEqual(
@@ -890,7 +913,7 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
         )
         self.assertEqual(
             [event.event_type for event in persisted_events],
-            ["execution_requested", "execution_started", "execution_denied"],
+            ["execution_requested", "execution_started", "execution_completed"],
         )
         self.assertEqual(
             persisted_events[-1].audit_payload["execution_row_count"],

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -863,14 +863,15 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             return [{"vendor_name": "Acme"}]
 
         app_session = create_test_application_session(build_dev_authenticated_subject())
-        response = self._client(
+        client = self._client(
             query_runner,
             result_validation_contract=ResultValidationContract(
                 semantic_contract_version="approved_vendor_spend.v1",
                 expected_columns=("vendor_name", "approved_spend"),
                 required_columns=("approved_spend",),
             ),
-        ).post(
+        )
+        response = client.post(
             "/candidates/candidate-123/execute",
             headers=app_session.headers,
             cookies=app_session.cookies,
@@ -939,6 +940,36 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             "expected result columns were missing",
             persisted_events[-1].audit_payload["answer_text"],
         )
+
+        workflow_response = client.get(
+            "/operator/workflow",
+            headers=app_session.headers,
+            cookies=app_session.cookies,
+        )
+        self.assertEqual(workflow_response.status_code, 200)
+        workflow_payload = workflow_response.json()
+        run_history = [
+            item
+            for item in workflow_payload["history"]
+            if item["itemType"] == "run"
+            and item["recordId"] == payload["metadata"]["execution_run_id"]
+        ]
+        self.assertEqual(len(run_history), 1)
+        self.assertEqual(run_history[0]["runState"], "insufficient_evidence")
+        self.assertEqual(
+            run_history[0]["lifecycleState"],
+            "insufficient_evidence",
+        )
+        self.assertEqual(
+            run_history[0]["insufficientEvidence"],
+            {
+                "answerText": persisted_events[-1].audit_payload["answer_text"],
+                "nextAction": "revise_query_or_semantic_contract_columns",
+                "reason": "missing_columns",
+            },
+        )
+        self.assertEqual(run_history[0]["rowCount"], 1)
+        self.assertIs(run_history[0]["resultTruncated"], False)
 
     def test_execute_candidate_api_rejects_malformed_validation_contract_before_consuming_approval(
         self,

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -923,6 +923,22 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             persisted_events[-1].audit_payload["result_truncated"],
             False,
         )
+        self.assertEqual(
+            persisted_events[-1].audit_payload["answer_state"],
+            "insufficient_evidence",
+        )
+        self.assertEqual(
+            persisted_events[-1].audit_payload["insufficient_evidence_reason"],
+            "missing_columns",
+        )
+        self.assertEqual(
+            persisted_events[-1].audit_payload["next_action"],
+            "revise_query_or_semantic_contract_columns",
+        )
+        self.assertIn(
+            "expected result columns were missing",
+            persisted_events[-1].audit_payload["answer_text"],
+        )
 
     def test_execute_candidate_api_rejects_malformed_validation_contract_before_consuming_approval(
         self,

--- a/backend/tests/test_mvp_answer_summary.py
+++ b/backend/tests/test_mvp_answer_summary.py
@@ -54,6 +54,7 @@ def test_mvp_answer_summary_uses_only_returned_rows_and_metadata() -> None:
 
     assert summary.to_wire_payload() == {
         "contractVersion": "mvp_answer_summary.v1",
+        "answerState": "answered",
         "answerText": (
             "Approved vendor spend rows from 2 returned rows: "
             "1. Acme (FY26-Q1) - 1200; 2. Beta (FY26-Q1) - 900. "
@@ -192,14 +193,15 @@ def test_mvp_answer_summary_reports_no_rows_without_claiming_a_ranking() -> None
     )
 
     assert summary.answer_text == (
-        "No rows were returned, so no vendor spend ranking is available. "
-        "Source: business-postgres-source (postgresql). "
-        "Assumptions: none. Validation: fail (missing_expected_columns). "
-        "Truncation: not truncated. Redaction: not required."
+        "Insufficient evidence: no rows were returned. "
+        "Next action: revise the query filters or source selection before requesting an answer."
     )
+    assert summary.answer_state == "insufficient_evidence"
+    assert summary.insufficient_evidence_reason == "no_rows"
+    assert summary.next_action == "revise_query_filters_or_source"
     assert summary.rows_used == 0
     assert summary.validation_status == "fail"
-    assert summary.validation_reason_codes == ("missing_expected_columns",)
+    assert summary.validation_reason_codes == ("missing_expected_columns", "no_rows")
 
 
 def test_mvp_answer_summary_does_not_claim_vendor_rows_are_top_ranked() -> None:
@@ -257,6 +259,9 @@ def test_mvp_answer_summary_surfaces_truncation_and_validation_warnings() -> Non
         truncation_reason="row_limit",
     )
 
+    assert summary.answer_state == "insufficient_evidence"
+    assert summary.insufficient_evidence_reason == "unsafe_truncation"
+    assert summary.next_action == "rerun_with_trusted_top_n_or_higher_limit"
     assert summary.validation_status == "warn"
     assert summary.validation_reason_codes == (
         "result_truncated",
@@ -264,10 +269,12 @@ def test_mvp_answer_summary_surfaces_truncation_and_validation_warnings() -> Non
         "outlier_values_present",
     )
     assert summary.truncation_status == "truncated"
-    assert "Validation: warn (result_truncated, null_values_present, outlier_values_present)." in (
-        summary.answer_text
+    assert summary.answer_text == (
+        "Insufficient evidence: result was truncated before the top set could be trusted. "
+        "Next action: rerun with an authoritative ORDER BY, tighter filters, or a higher trusted limit."
     )
-    assert "Truncation: truncated by returned-row limits." in summary.answer_text
+    assert "Acme" not in summary.answer_text
+    assert "Beta" not in summary.answer_text
 
 
 def test_mvp_answer_summary_uses_payload_truncation_reason_when_available() -> None:
@@ -289,8 +296,11 @@ def test_mvp_answer_summary_uses_payload_truncation_reason_when_available() -> N
         truncation_reason="payload_limit",
     )
 
-    assert "Truncation: truncated by payload limits." in summary.answer_text
-    assert "returned-row limits" not in summary.answer_text
+    assert summary.answer_state == "insufficient_evidence"
+    assert summary.insufficient_evidence_reason == "unsafe_truncation"
+    assert summary.next_action == "rerun_with_trusted_top_n_or_higher_limit"
+    assert "result was truncated before the top set could be trusted" in summary.answer_text
+    assert "Acme" not in summary.answer_text
 
 
 def test_mvp_answer_summary_uses_neutral_truncation_when_reason_is_unknown() -> None:
@@ -311,7 +321,8 @@ def test_mvp_answer_summary_uses_neutral_truncation_when_reason_is_unknown() -> 
         source_family="postgresql",
     )
 
-    assert "Truncation: truncated." in summary.answer_text
+    assert summary.answer_state == "insufficient_evidence"
+    assert summary.insufficient_evidence_reason == "unsafe_truncation"
     assert "returned-row limits" not in summary.answer_text
     assert "payload limits" not in summary.answer_text
 

--- a/backend/tests/test_operator_workflow_history.py
+++ b/backend/tests/test_operator_workflow_history.py
@@ -232,6 +232,10 @@ def _execution_audit_event(
     retrieved_citations: list[dict[str, object]] | None = None,
     result_truncated: bool | None = None,
     row_count: int | None = None,
+    answer_state: str | None = None,
+    answer_text: str | None = None,
+    insufficient_evidence_reason: str | None = None,
+    next_action: str | None = None,
 ) -> SourceAwareAuditEvent:
     return SourceAwareAuditEvent(
         event_id=event_id,
@@ -252,6 +256,10 @@ def _execution_audit_event(
         executed_evidence=executed_evidence,
         execution_row_count=row_count,
         result_truncated=result_truncated,
+        answer_state=answer_state,
+        answer_text=answer_text,
+        insufficient_evidence_reason=insufficient_evidence_reason,
+        next_action=next_action,
     )
 
 
@@ -656,6 +664,74 @@ def test_operator_workflow_history_includes_execution_run_records() -> None:
             "resultTruncated": False,
         }
     ]
+
+
+def test_operator_workflow_history_surfaces_insufficient_evidence_run_state() -> None:
+    with _session_scope() as session:
+        _seed_authoritative_source_governance(session)
+
+        submit_preview_request(
+            PreviewSubmissionRequest(
+                question="Show approved vendors by quarterly spend",
+                source_id="sap-approved-spend",
+            ),
+            AuthenticatedSubject(
+                subject_id="user:alice",
+                governance_bindings=frozenset({"group:finance-analysts"}),
+            ),
+            session,
+            audit_context=_audit_context(
+                request_id="preview-request-234",
+                candidate_id="preview-candidate-234",
+            ),
+        )
+        persist_execution_audit_events(
+            session,
+            candidate_id="preview-candidate-234",
+            audit_events=[
+                _execution_audit_event(
+                    event_id=UUID("00000000-0000-4000-8000-000000000012"),
+                    event_type="execution_completed",
+                    occurred_at=datetime(2026, 1, 2, 3, 5, 3, tzinfo=timezone.utc),
+                    row_count=1,
+                    result_truncated=False,
+                    answer_state="insufficient_evidence",
+                    answer_text=(
+                        "Insufficient evidence: expected result columns were missing. "
+                        "Next action: revise the SQL projection or semantic contract columns "
+                        "before requesting an answer."
+                    ),
+                    insufficient_evidence_reason="missing_columns",
+                    next_action="revise_query_or_semantic_contract_columns",
+                ),
+            ],
+        )
+
+        snapshot = get_operator_workflow_snapshot(session)
+
+    run = snapshot.history[0].model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert {
+        "itemType": "run",
+        "recordId": "00000000-0000-4000-8000-000000000012",
+        "label": "Show approved vendors by quarterly spend",
+        "sourceId": "sap-approved-spend",
+        "sourceLabel": "SAP spend cube / approved_vendor_spend",
+        "lifecycleState": "insufficient_evidence",
+        "occurredAt": "2026-01-02T03:05:03Z",
+        "requestId": "preview-request-234",
+        "resultTruncated": False,
+        "rowCount": 1,
+        "runState": "insufficient_evidence",
+        "insufficientEvidence": {
+            "answerText": (
+                "Insufficient evidence: expected result columns were missing. "
+                "Next action: revise the SQL projection or semantic contract columns before "
+                "requesting an answer."
+            ),
+            "nextAction": "revise_query_or_semantic_contract_columns",
+            "reason": "missing_columns",
+        },
+    }.items() <= run.items()
 
 
 def test_operator_workflow_history_surfaces_safe_audit_evidence_and_citations() -> None:

--- a/backend/tests/test_result_validation_contract.py
+++ b/backend/tests/test_result_validation_contract.py
@@ -400,6 +400,7 @@ def test_result_validation_does_not_assume_expected_columns_for_empty_results() 
     assert validation.reason_codes == (
         "missing_expected_columns",
         "missing_required_columns",
+        "no_rows",
     )
     assert validation.evidence.observed_columns == ()
 

--- a/backend/tests/test_source_bound_execute_path.py
+++ b/backend/tests/test_source_bound_execute_path.py
@@ -360,11 +360,8 @@ def test_execute_candidate_sql_attaches_result_validation_to_execution_metadata(
     assert validation.evidence.row_count == 1
 
 
-def test_execute_candidate_sql_blocks_failed_result_validation_before_success() -> None:
-    from app.features.execution import (
-        ExecutionConnectorExecutionError,
-        execute_candidate_sql,
-    )
+def test_execute_candidate_sql_returns_insufficient_evidence_for_missing_columns() -> None:
+    from app.features.execution import execute_candidate_sql
 
     calls: list[str] = []
 
@@ -372,39 +369,38 @@ def test_execute_candidate_sql_blocks_failed_result_validation_before_success() 
         calls.append(canonical_sql)
         return [{"vendor_name": "Acme"}]
 
-    with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
-        execute_candidate_sql(
-            candidate=_candidate(),
-            selection=_selection(),
-            query_runner=query_runner,
-            audit_context=_audit_context(),
-            business_postgres_url=BUSINESS_POSTGRES_URL,
-            application_postgres_url=APPLICATION_POSTGRES_URL,
-            result_validation_contract=ResultValidationContract(
-                expected_columns=("vendor_name", "approved_spend"),
-                required_columns=("approved_spend",),
-            ),
-        )
+    result = execute_candidate_sql(
+        candidate=_candidate(),
+        selection=_selection(),
+        query_runner=query_runner,
+        audit_context=_audit_context(),
+        business_postgres_url=BUSINESS_POSTGRES_URL,
+        application_postgres_url=APPLICATION_POSTGRES_URL,
+        result_validation_contract=ResultValidationContract(
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("approved_spend",),
+        ),
+    )
 
     assert calls == ["SELECT vendor_name FROM finance.approved_vendor_spend LIMIT 1"]
-    assert exc_info.value.deny_code == DENY_RESULT_VALIDATION_FAILED
-    assert [event.event_type for event in exc_info.value.audit_events] == [
+    assert [event.event_type for event in result.audit_events] == [
         "execution_requested",
         "execution_started",
-        "execution_denied",
+        "execution_completed",
     ]
-    assert {
-        "primary_deny_code": DENY_RESULT_VALIDATION_FAILED,
-        "denial_cause": "result_validation_failed",
-        "denial_reason": "missing_expected_columns,missing_required_columns",
-    }.items() <= exc_info.value.audit_event.model_dump(exclude_none=True).items()
-
-
-def test_result_validation_denial_preserves_release_gate_metadata() -> None:
-    from app.features.execution import (
-        ExecutionConnectorExecutionError,
-        execute_candidate_sql,
+    assert result.metadata.result_validation is not None
+    assert result.metadata.result_validation.status == "fail"
+    assert result.metadata.result_validation.reason_codes == (
+        "missing_expected_columns",
+        "missing_required_columns",
     )
+    assert result.metadata.answer_summary is not None
+    assert result.metadata.answer_summary.answer_state == "insufficient_evidence"
+    assert result.metadata.answer_summary.insufficient_evidence_reason == "missing_columns"
+
+
+def test_result_validation_insufficient_evidence_preserves_release_gate_metadata() -> None:
+    from app.features.execution import execute_candidate_sql
 
     scenario = next(
         scenario
@@ -439,28 +435,27 @@ def test_result_validation_denial_preserves_release_gate_metadata() -> None:
         }
     )
 
-    with pytest.raises(ExecutionConnectorExecutionError) as exc_info:
-        execute_candidate_sql(
-            candidate=candidate,
-            selection=selection,
-            query_runner=lambda **_: [{"vendor_name": "Acme"}],
-            audit_context=audit_context,
-            business_postgres_url=BUSINESS_POSTGRES_URL,
-            application_postgres_url=APPLICATION_POSTGRES_URL,
-            result_validation_contract=ResultValidationContract(
-                semantic_contract_version="approved_vendor_spend.v1",
-                expected_columns=("vendor_name", "approved_spend"),
-                required_columns=("approved_spend",),
-            ),
-        )
+    result = execute_candidate_sql(
+        candidate=candidate,
+        selection=selection,
+        query_runner=lambda **_: [{"vendor_name": "Acme"}],
+        audit_context=audit_context,
+        business_postgres_url=BUSINESS_POSTGRES_URL,
+        application_postgres_url=APPLICATION_POSTGRES_URL,
+        result_validation_contract=ResultValidationContract(
+            semantic_contract_version="approved_vendor_spend.v1",
+            expected_columns=("vendor_name", "approved_spend"),
+            required_columns=("approved_spend",),
+        ),
+    )
 
-    release_gate_scenario = exc_info.value.audit_event.release_gate_scenario
+    release_gate_scenario = result.audit_event.release_gate_scenario
     assert release_gate_scenario is not None
     assert release_gate_scenario.scenario_id == scenario.scenario_id
     assert release_gate_scenario.guard_decision == "allow"
     assert (
         release_gate_scenario.execution_audit_event_id
-        == exc_info.value.audit_event.event_id
+        == result.audit_event.event_id
     )
 
 

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1464,6 +1464,115 @@ describe("HomePage", () => {
     expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("Result truncated");
   });
 
+  it("renders insufficient-evidence execute responses without speculative rows", async () => {
+    const csrfToken = document.createElement("meta");
+    csrfToken.name = "safequery-csrf-token";
+    csrfToken.content = "csrf-from-session-bootstrap";
+    document.head.appendChild(csrfToken);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Selected candidate",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-selected",
+                    requestId: "request-selected",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        if (url.endsWith("/candidates/candidate-selected/execute")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                audit: {
+                  events: [
+                    {
+                      candidate_state: "executed",
+                      event_id: "00000000-0000-4000-8000-000000000301",
+                      event_type: "execution_completed",
+                      execution_row_count: 1,
+                      occurred_at: "2026-04-21T14:45:17+09:00",
+                      query_candidate_id: "candidate-selected",
+                      request_id: "request-selected",
+                      result_truncated: false,
+                      source_id: "sap-approved-spend"
+                    }
+                  ]
+                },
+                candidate_id: "candidate-selected",
+                connector_id: "postgresql_readonly",
+                metadata: {
+                  answer_summary: {
+                    answer_state: "insufficient_evidence",
+                    answer_text:
+                      "Insufficient evidence: expected result columns were missing. Next action: revise the SQL projection or semantic contract columns before requesting an answer.",
+                    insufficient_evidence_reason: "missing_columns",
+                    next_action: "revise_query_or_semantic_contract_columns"
+                  },
+                  candidate_id: "candidate-selected",
+                  execution_run_id: "00000000-0000-4000-8000-000000000301",
+                  result_truncated: false,
+                  row_count: 1,
+                  source_family: "postgresql",
+                  source_flavor: "warehouse",
+                  source_id: "sap-approved-spend"
+                },
+                rows: [{ vendor_name: "Acme Supplies" }],
+                source_id: "sap-approved-spend"
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-selected",
+          question: "Selected candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /execute reviewed candidate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/insufficient evidence state reached/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/expected result columns were missing/i)).toBeInTheDocument();
+    expect(screen.getByText(/Reason: missing columns/i)).toBeInTheDocument();
+    expect(screen.getByText(/Next action: revise query or semantic contract columns/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table", { name: /execute response result rows/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Acme Supplies")).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("execution_completed");
+  });
+
   it("renders zero-row execute response audit context on the empty state", async () => {
     const csrfToken = document.createElement("meta");
     csrfToken.name = "safequery-csrf-token";

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -262,6 +262,24 @@ describe("HomePage", () => {
                     runState: "failed",
                     sourceId: "sap-approved-spend",
                     sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
+                  {
+                    insufficientEvidence: {
+                      answerText:
+                        "Insufficient evidence: expected result columns were missing. Next action: revise the SQL projection or semantic contract columns before requesting an answer.",
+                      nextAction: "revise_query_or_semantic_contract_columns",
+                      reason: "missing_columns"
+                    },
+                    itemType: "run",
+                    label: "Insufficient evidence run",
+                    lifecycleState: "insufficient_evidence",
+                    occurredAt: "2026-04-21T14:36:00Z",
+                    recordId: "run-insufficient-123",
+                    resultTruncated: false,
+                    rowCount: 1,
+                    runState: "insufficient_evidence",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
                   }
                 ],
                 sources: workflowPayload().sources
@@ -281,6 +299,9 @@ describe("HomePage", () => {
       name: /ambiguous candidate/i
     });
     const failedRunLink = within(history).getByRole("link", { name: /failed run/i });
+    const insufficientRunLink = within(history).getByRole("link", {
+      name: /insufficient evidence run/i
+    });
 
     expect(deniedCandidateLink).toHaveAttribute("href", expect.stringContaining("state=review_denied"));
     expect(deniedCandidateLink).toHaveAttribute(
@@ -297,6 +318,88 @@ describe("HomePage", () => {
     );
     expect(failedRunLink).toHaveAttribute("href", expect.stringContaining("state=failed"));
     expect(failedRunLink).toHaveAttribute("href", expect.stringContaining("history_record_id=run-123"));
+    expect(insufficientRunLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("state=insufficient_evidence")
+    );
+    expect(insufficientRunLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("history_record_id=run-insufficient-123")
+    );
+  });
+
+  it("reopens persisted insufficient evidence runs into the explicit state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    auditEvents: [
+                      {
+                        candidateId: "candidate-selected",
+                        eventId: "00000000-0000-4000-8000-000000000301",
+                        eventType: "execution_completed",
+                        executionRunId: "run-insufficient-123",
+                        occurredAt: "2026-04-21T14:36:00Z",
+                        requestId: "request-selected",
+                        resultTruncated: false,
+                        rowCount: 1,
+                        sourceId: "sap-approved-spend"
+                      }
+                    ],
+                    insufficientEvidence: {
+                      answerText:
+                        "Insufficient evidence: expected result columns were missing. Next action: revise the SQL projection or semantic contract columns before requesting an answer.",
+                      nextAction: "revise_query_or_semantic_contract_columns",
+                      reason: "missing_columns"
+                    },
+                    itemType: "run",
+                    label: "Insufficient evidence run",
+                    lifecycleState: "insufficient_evidence",
+                    occurredAt: "2026-04-21T14:36:00Z",
+                    recordId: "run-insufficient-123",
+                    resultTruncated: false,
+                    rowCount: 1,
+                    runState: "insufficient_evidence",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "run",
+          history_record_id: "run-insufficient-123",
+          question: "Insufficient evidence run",
+          source_id: "sap-approved-spend",
+          state: "insufficient_evidence"
+        }
+      })
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /insufficient evidence state/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/insufficient evidence state reached/i)).toBeInTheDocument();
+    expect(screen.getByText(/expected result columns were missing/i)).toBeInTheDocument();
+    expect(screen.getByText(/Reason: missing columns/i)).toBeInTheDocument();
+    expect(screen.getByText(/Next action: revise query or semantic contract columns/i)).toBeInTheDocument();
   });
 
   it("reports malformed workflow payloads separately from unavailable transport", async () => {
@@ -1565,6 +1668,9 @@ describe("HomePage", () => {
       expect(screen.getByText(/insufficient evidence state reached/i)).toBeInTheDocument();
     });
 
+    expect(
+      screen.getByRole("heading", { name: /insufficient evidence state/i })
+    ).toBeInTheDocument();
     expect(screen.getByText(/expected result columns were missing/i)).toBeInTheDocument();
     expect(screen.getByText(/Reason: missing columns/i)).toBeInTheDocument();
     expect(screen.getByText(/Next action: revise query or semantic contract columns/i)).toBeInTheDocument();

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -400,6 +400,10 @@ describe("HomePage", () => {
     expect(screen.getByText(/expected result columns were missing/i)).toBeInTheDocument();
     expect(screen.getByText(/Reason: missing columns/i)).toBeInTheDocument();
     expect(screen.getByText(/Next action: revise query or semantic contract columns/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /revise attempt/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /query input state/i })
+    ).not.toBeInTheDocument();
   });
 
   it("reports malformed workflow payloads separately from unavailable transport", async () => {
@@ -1674,6 +1678,10 @@ describe("HomePage", () => {
     expect(screen.getByText(/expected result columns were missing/i)).toBeInTheDocument();
     expect(screen.getByText(/Reason: missing columns/i)).toBeInTheDocument();
     expect(screen.getByText(/Next action: revise query or semantic contract columns/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /revise attempt/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /query input state/i })
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("table", { name: /execute response result rows/i })).not.toBeInTheDocument();
     expect(screen.queryByText("Acme Supplies")).not.toBeInTheDocument();
     expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("execution_completed");

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -24,6 +24,7 @@ type WorkflowState =
   | "review_denied"
   | "completed"
   | "empty"
+  | "insufficient_evidence"
   | "execution_denied"
   | "failed"
   | "canceled"
@@ -37,6 +38,7 @@ type CanonicalWorkflowState =
   | "review_denied"
   | "completed"
   | "empty"
+  | "insufficient_evidence"
   | "execution_denied"
   | "failed"
   | "canceled";
@@ -175,6 +177,7 @@ type AuthoritativeRunContext = {
   analystResponse: AnalystResponsePayload | null;
   auditEvents: OperatorWorkflowAuditEvent[];
   executedEvidence: OperatorWorkflowExecutedEvidence[];
+  insufficientEvidence?: InsufficientEvidenceState | null;
   lifecycleState: string;
   lifecycleTimestamp: string;
   primaryDenyCode?: string | null;
@@ -198,10 +201,23 @@ type ExecuteSubmissionResult = {
   candidateId: string;
   executedEvidence: OperatorWorkflowExecutedEvidence[];
   executionRunId?: string;
+  insufficientEvidence?: InsufficientEvidenceState | null;
   resultTruncated: boolean;
   rows: ResultRow[];
   rowCount: number;
   sourceId: string;
+};
+
+type InsufficientEvidenceReason =
+  | "no_rows"
+  | "missing_columns"
+  | "unsafe_truncation"
+  | "blocking_validation_warnings";
+
+type InsufficientEvidenceState = {
+  answerText: string;
+  nextAction: string;
+  reason: InsufficientEvidenceReason;
 };
 
 type ResultCell = string | number | boolean | null;
@@ -226,6 +242,10 @@ const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
   empty: {
     description: "Execution completed, but the reviewed run record returned no rows.",
     label: "Empty state"
+  },
+  insufficient_evidence: {
+    description: "Execution completed, but validation could not support an answer.",
+    label: "Insufficient evidence"
   },
   execution_denied: {
     description: "The reviewed candidate was blocked at execute time and no execution payload was produced.",
@@ -265,6 +285,7 @@ const workflowStateOrder: CanonicalWorkflowState[] = [
   "review_denied",
   "completed",
   "empty",
+  "insufficient_evidence",
   "execution_denied",
   "failed",
   "canceled"
@@ -643,6 +664,34 @@ function parseExecuteAuditEvents(value: unknown): OperatorWorkflowAuditEvent[] {
     .filter((event): event is OperatorWorkflowAuditEvent => event !== null);
 }
 
+function isInsufficientEvidenceReason(value: unknown): value is InsufficientEvidenceReason {
+  return (
+    value === "no_rows" ||
+    value === "missing_columns" ||
+    value === "unsafe_truncation" ||
+    value === "blocking_validation_warnings"
+  );
+}
+
+function parseInsufficientEvidenceState(value: unknown): InsufficientEvidenceState | null {
+  if (!isObject(value) || value.answer_state !== "insufficient_evidence") {
+    return null;
+  }
+
+  const answerText = readRequiredString(value.answer_text);
+  const nextAction = readRequiredString(value.next_action);
+  const reason = value.insufficient_evidence_reason;
+  if (!answerText || !nextAction || !isInsufficientEvidenceReason(reason)) {
+    return null;
+  }
+
+  return {
+    answerText,
+    nextAction,
+    reason
+  };
+}
+
 function isResultCell(value: unknown): value is ResultCell {
   return (
     value === null ||
@@ -862,6 +911,9 @@ function parseExecuteSubmissionResult(
   const rowCount = value.metadata.row_count;
   const resultTruncated = value.metadata.result_truncated;
   const rows = parseExecuteRows(value.rows);
+  const insufficientEvidence = parseInsufficientEvidenceState(
+    value.metadata.answer_summary
+  );
 
   if (
     candidateId !== expectedCandidateId ||
@@ -891,6 +943,7 @@ function parseExecuteSubmissionResult(
     candidateId,
     executedEvidence: buildExecutedEvidenceFromExecuteResponse(partialResult, value.metadata),
     executionRunId,
+    insufficientEvidence,
     resultTruncated,
     rows,
     rowCount,
@@ -1452,6 +1505,7 @@ function getWorkflowContext(
     runContext &&
     (state === "completed" ||
       state === "empty" ||
+      state === "insufficient_evidence" ||
       state === "execution_denied" ||
       state === "failed" ||
       state === "canceled")
@@ -1484,6 +1538,10 @@ function getGuardTone(state: CanonicalWorkflowState): string {
     return "success";
   }
 
+  if (state === "insufficient_evidence") {
+    return "warning";
+  }
+
   if (state === "canceled") {
     return "muted";
   }
@@ -1502,6 +1560,10 @@ function getGuardHeadline(state: CanonicalWorkflowState): string {
 
   if (state === "empty") {
     return "Execution completed with no approved rows";
+  }
+
+  if (state === "insufficient_evidence") {
+    return "Execution completed with insufficient evidence";
   }
 
   if (state === "execution_denied") {
@@ -1532,6 +1594,10 @@ function getGuardCopy(state: CanonicalWorkflowState): string {
     return "The result surface can represent a clean no-data outcome without restyling the rest of the page or hiding guard context.";
   }
 
+  if (state === "insufficient_evidence") {
+    return "Execution completed, but SafeQuery withheld the answer because validation could not support it. Follow the stated next action before trying again.";
+  }
+
   if (state === "execution_denied") {
     return "Execute-time checks revalidated ownership, approval freshness, and replay posture. The run stays denied instead of inferring success from an earlier preview.";
   }
@@ -1554,6 +1620,10 @@ function getResultTitle(state: CanonicalWorkflowState): string {
 
   if (state === "empty") {
     return "No rows returned";
+  }
+
+  if (state === "insufficient_evidence") {
+    return "Insufficient evidence";
   }
 
   if (state === "review_denied") {
@@ -1726,6 +1796,23 @@ function renderResultContent(
           </div>
         ) : null}
       </>
+    );
+  }
+
+  if (state === "insufficient_evidence") {
+    const reasonLabel = runContext?.insufficientEvidence?.reason.replaceAll("_", " ");
+    return (
+      <div className="state-callout state-callout-warning">
+        <p className="state-callout-title">Insufficient evidence state reached</p>
+        <p>
+          {runContext?.insufficientEvidence?.answerText ??
+            "SafeQuery completed execution, but validation could not support an answer."}
+        </p>
+        {reasonLabel ? <p>Reason: {reasonLabel}.</p> : null}
+        {runContext?.insufficientEvidence?.nextAction ? (
+          <p>Next action: {runContext.insufficientEvidence.nextAction.replaceAll("_", " ")}.</p>
+        ) : null}
+      </div>
     );
   }
 
@@ -2671,12 +2758,17 @@ export function QueryWorkflowShell({
         return;
       }
 
-      const nextState = result.rowCount === 0 ? "empty" : "completed";
+      const nextState = result.insufficientEvidence
+        ? "insufficient_evidence"
+        : result.rowCount === 0
+          ? "empty"
+          : "completed";
       setSubmittedState(nextState);
       setSubmittedRunContext({
         analystResponse: null,
         auditEvents: result.auditEvents,
         executedEvidence: result.executedEvidence,
+        insufficientEvidence: result.insufficientEvidence ?? null,
         lifecycleState: nextState,
         lifecycleTimestamp: new Date().toISOString(),
         reviewEvidence: candidatePreview.reviewEvidence,

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1359,6 +1359,7 @@ function revisionDraftFromSelectedContext(
     sourceId &&
     (state === "completed" ||
       state === "empty" ||
+      state === "insufficient_evidence" ||
       state === "failed" ||
       state === "execution_denied")
   ) {

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1134,6 +1134,13 @@ function historyItemToState(item: OperatorHistoryItem): CanonicalWorkflowState {
     return "empty";
   }
 
+  if (
+    runState === "insufficient_evidence" ||
+    lifecycleState === "insufficient_evidence"
+  ) {
+    return "insufficient_evidence";
+  }
+
   if (runState === "execution_denied" || lifecycleState === "execution_denied") {
     return "execution_denied";
   }
@@ -1263,6 +1270,7 @@ function findAuthoritativeRunContext(
     analystResponse: run.analystResponse,
     auditEvents: run.auditEvents,
     executedEvidence: run.executedEvidence,
+    insufficientEvidence: run.insufficientEvidence ?? null,
     lifecycleState: run.lifecycleState,
     lifecycleTimestamp: run.occurredAt,
     primaryDenyCode: run.primaryDenyCode,
@@ -2173,6 +2181,29 @@ function renderStatePanel(
         <p className="section-copy">
           Empty outcomes are modeled explicitly so the operator can distinguish no-data from
           denial, auth failure, or transport issues.
+        </p>
+        <div className="action-row">
+          {onStartRevision ? (
+            <button className="action-button" onClick={onStartRevision} type="button">
+              Revise attempt
+            </button>
+          ) : null}
+          <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
+            Back to SQL preview
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "insufficient_evidence") {
+    return (
+      <div className="state-hero">
+        <p className="eyebrow">Validation held</p>
+        <h2>Insufficient evidence state</h2>
+        <p className="section-copy">
+          Execution completed, but validation could not support an answer. The operator must
+          revise the query, source, or validation inputs before treating rows as evidence.
         </p>
         <div className="action-row">
           {onStartRevision ? (

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -103,6 +103,18 @@ export type OperatorWorkflowRevisionContext = {
   sourceId: string;
 };
 
+export type OperatorWorkflowInsufficientEvidenceReason =
+  | "no_rows"
+  | "missing_columns"
+  | "unsafe_truncation"
+  | "blocking_validation_warnings";
+
+export type OperatorWorkflowInsufficientEvidenceState = {
+  answerText: string;
+  nextAction: string;
+  reason: OperatorWorkflowInsufficientEvidenceReason;
+};
+
 export type OperatorHistoryItem = {
   analystResponse: AnalystResponsePayload | null;
   auditEvents: OperatorWorkflowAuditEvent[];
@@ -110,6 +122,7 @@ export type OperatorHistoryItem = {
   candidateSql?: string | null;
   executedEvidence: OperatorWorkflowExecutedEvidence[];
   guardStatus?: string | null;
+  insufficientEvidence?: OperatorWorkflowInsufficientEvidenceState | null;
   itemType: "request" | "candidate" | "run";
   label: string;
   lifecycleState: string;
@@ -422,6 +435,40 @@ function parseRevisionContext(value: unknown): OperatorWorkflowRevisionContext |
   };
 }
 
+function isInsufficientEvidenceReason(
+  value: unknown
+): value is OperatorWorkflowInsufficientEvidenceReason {
+  return (
+    value === "no_rows" ||
+    value === "missing_columns" ||
+    value === "unsafe_truncation" ||
+    value === "blocking_validation_warnings"
+  );
+}
+
+function parseInsufficientEvidenceState(
+  value: unknown
+): OperatorWorkflowInsufficientEvidenceState | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const answerText = readOptionalString(value.answerText);
+  const nextAction = readOptionalString(value.nextAction);
+  if (!answerText || !nextAction || !isInsufficientEvidenceReason(value.reason)) {
+    return null;
+  }
+
+  return {
+    answerText,
+    nextAction,
+    reason: value.reason
+  };
+}
+
 function parseGovernanceBindingStatus(value: unknown): GovernanceBindingStatus | null {
   if (!isObject(value)) {
     return null;
@@ -499,6 +546,11 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
   const retrievedCitations = parseArray(value.retrievedCitations, parseRetrievedCitation);
   const reviewEvidence = parseArray(value.reviewEvidence, parseReviewEvidence);
   const revisionContext = parseRevisionContext(value.revisionContext);
+  const hasInsufficientEvidence = Object.prototype.hasOwnProperty.call(
+    value,
+    "insufficientEvidence"
+  );
+  const insufficientEvidence = parseInsufficientEvidenceState(value.insufficientEvidence);
   const analystResponse =
     value.analystResponse === undefined || value.analystResponse === null
       ? null
@@ -516,7 +568,10 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     candidateAttempts === null ||
     executedEvidence === null ||
     retrievedCitations === null ||
-    reviewEvidence === null
+    reviewEvidence === null ||
+    (hasInsufficientEvidence &&
+      value.insufficientEvidence !== null &&
+      insufficientEvidence === null)
   ) {
     return null;
   }
@@ -528,6 +583,7 @@ function parseHistoryItem(value: unknown): OperatorHistoryItem | null {
     candidateSql: readOptionalString(value.candidateSql) ?? null,
     executedEvidence,
     guardStatus: readOptionalString(value.guardStatus) ?? null,
+    insufficientEvidence,
     itemType,
     label,
     lifecycleState,


### PR DESCRIPTION
Closes #478
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed checkpoint `699d80c Show insufficient evidence state for unsupported answers`.

Added backend insufficient-evidence answer summary fields (`answer_state`, `insufficient_evidence_reason`, `next_action`) and changed execute behavior so missing columns, no rows, unsafe truncation, and blocking warnings complete audibly without speculative answer text. UI now parses that payload and renders an `Insufficient evidence` state without showing returned rows as an answer.

Focused verification passed:
- `backend`: 81 adjacent tests passed for validation, summary, execute API, and source-bound execute.
- `frontend`: `app/page.test.tsx` passed, 41 tests.
- Repository hygiene and `git diff --check` passed.

Broader suites still show unrelated/pre-existing failures:
- backend full: package metadata missing, stale exact dump expectations, preview `submitted` vs `previewed`.
- frontend full: smoke tests do not mock `/auth/dev/session`, so preview submit never reaches `/requests/preview`.

Summary: implemented insufficient-evidence API/UI state and committed `699d80c`
State hint: stabilizing
Blocked reason: none
Tests: passed focused backend adjacent suite, focused frontend page suite, hygiene, diff check; full suites have unrelated failures noted above
Failure signature: none
Next action: open or update a draft PR for branch `codex/issue-478`