### PR TITLE
[Z-3] Add result-answer consistency citation review

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,15 @@ boundaries, and Level 3 unsupported-answer boundaries. Fixture levels with no
 observed artifacts are reported as `not_covered` with explicit coverage counts
 instead of being treated as passed.
 
+Future LLM-written summaries must pass result-to-answer consistency review
+before they become user-facing. Observed future-summary artifacts should mark
+their result metadata with `answer_surface: future_llm_summary` or
+`enforce_citations: true` so fixture-declared row-reference citation
+requirements are enforced. The review checks unsupported result values, missing
+row citations, and row-reference mismatches against returned rows and emits
+reviewer-readable diagnostics only; it is not execution authority and does not
+replace the deterministic MVP answer template path.
+
 Startup-guard verification:
 
 ```bash

--- a/backend/app/features/evaluation/governed_answer.py
+++ b/backend/app/features/evaluation/governed_answer.py
@@ -548,19 +548,12 @@ def _check_required_row_citations(
     ):
         return
     claimed_values = _claimed_result_value_matches(answer_text)
+    citation_claims: list[tuple[str, tuple[tuple[str, int, int], ...]]] = []
     paired_claim_spans: set[tuple[int, int]] = set()
     for left, right in _claimed_result_row_value_pairs(answer_text):
         paired_claim_spans.add((left[1], left[2]))
         paired_claim_spans.add((right[1], right[2]))
-        claim = f"{left[0]} with {right[0]}"
-        _check_required_row_citation_for_claim_values(
-            answer_text=answer_text,
-            claim_values=(left, right),
-            claim=claim,
-            result_rows=result_rows,
-            categories=categories,
-            unsupported_claims=unsupported_claims,
-        )
+        citation_claims.append((f"{left[0]} with {right[0]}", (left, right)))
 
     for claim_value, start, end in claimed_values:
         if (start, end) in paired_claim_spans:
@@ -577,10 +570,13 @@ def _check_required_row_citations(
             _supported_result_values(result_rows)
         ):
             continue
+        citation_claims.append((claim_value, ((claim_value, start, end),)))
+
+    for claim, claim_values in citation_claims:
         _check_required_row_citation_for_claim_values(
             answer_text=answer_text,
-            claim_values=((claim_value, start, end),),
-            claim=claim_value,
+            claim_values=claim_values,
+            claim=claim,
             result_rows=result_rows,
             categories=categories,
             unsupported_claims=unsupported_claims,

--- a/backend/app/features/evaluation/governed_answer.py
+++ b/backend/app/features/evaluation/governed_answer.py
@@ -15,6 +15,8 @@ from pydantic import (
 
 
 NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+ResultValueClaim = tuple[str, int, int]
+RowCitationClaim = tuple[str, tuple[ResultValueClaim, ...]]
 
 GovernedAnswerCaseType = Literal[
     "positive",
@@ -551,8 +553,29 @@ def _check_required_row_citations(
         or result_metadata.get("enforce_citations") is True
     ):
         return
+    for claim, claim_values in _required_row_citation_claims(
+        answer_text=answer_text,
+        result_rows=result_rows,
+        result_metadata=result_metadata,
+    ):
+        _check_required_row_citation_for_claim_values(
+            answer_text=answer_text,
+            claim_values=claim_values,
+            claim=claim,
+            result_rows=result_rows,
+            categories=categories,
+            unsupported_claims=unsupported_claims,
+        )
+
+
+def _required_row_citation_claims(
+    *,
+    answer_text: str,
+    result_rows: Sequence[Mapping[str, Any]],
+    result_metadata: Mapping[str, Any],
+) -> tuple[RowCitationClaim, ...]:
     claimed_values = _claimed_result_value_matches(answer_text)
-    citation_claims: list[tuple[str, tuple[tuple[str, int, int], ...]]] = []
+    citation_claims: list[RowCitationClaim] = []
     paired_claim_spans: set[tuple[int, int]] = set()
     for left, right in _claimed_result_row_value_pairs(answer_text):
         paired_claim_spans.add((left[1], left[2]))
@@ -576,21 +599,13 @@ def _check_required_row_citations(
             continue
         citation_claims.append((claim_value, ((claim_value, start, end),)))
 
-    for claim, claim_values in citation_claims:
-        _check_required_row_citation_for_claim_values(
-            answer_text=answer_text,
-            claim_values=claim_values,
-            claim=claim,
-            result_rows=result_rows,
-            categories=categories,
-            unsupported_claims=unsupported_claims,
-        )
+    return tuple(citation_claims)
 
 
 def _check_required_row_citation_for_claim_values(
     *,
     answer_text: str,
-    claim_values: Sequence[tuple[str, int, int]],
+    claim_values: Sequence[ResultValueClaim],
     claim: str,
     result_rows: Sequence[Mapping[str, Any]],
     categories: list[GovernedAnswerUnsupportedClaimCategory],
@@ -1014,8 +1029,8 @@ def _claimed_result_values(answer_text: str) -> tuple[str, ...]:
     )
 
 
-def _claimed_result_value_matches(answer_text: str) -> tuple[tuple[str, int, int], ...]:
-    claimed_values: list[tuple[str, int, int]] = []
+def _claimed_result_value_matches(answer_text: str) -> tuple[ResultValueClaim, ...]:
+    claimed_values: list[ResultValueClaim] = []
     for match in _RESULT_VALUE_PATTERN.finditer(answer_text):
         value = match.group(0)
         if _is_incidental_integer_claim(answer_text, match) or _is_row_reference_value(
@@ -1126,11 +1141,12 @@ def _unsupported_claimed_result_row_combinations(
 
 def _claimed_result_row_value_pairs(
     answer_text: str,
-) -> tuple[tuple[tuple[str, int, int], tuple[str, int, int]], ...]:
-    pairs: list[tuple[tuple[str, int, int], tuple[str, int, int]]] = []
+) -> tuple[tuple[ResultValueClaim, ResultValueClaim], ...]:
+    pairs: list[tuple[ResultValueClaim, ResultValueClaim]] = []
     claimed_values = _claimed_result_value_matches(answer_text)
     for left, right in zip(claimed_values, claimed_values[1:]):
-        if _claim_values_are_row_linked(answer_text[left[2] : right[1]]):
+        between_values = _claim_value_link_context(answer_text[left[2] : right[1]])
+        if _claim_values_are_row_linked(between_values):
             pairs.append((left, right))
     return tuple(pairs)
 

--- a/backend/app/features/evaluation/governed_answer.py
+++ b/backend/app/features/evaluation/governed_answer.py
@@ -412,7 +412,7 @@ def score_governed_answer_consistency(
     _check_required_row_citations(
         expected_result_shape=expected_result_shape,
         answer_text=answer_text,
-        result_rows=value_evidence_rows,
+        result_rows=result_rows,
         result_metadata=result_metadata,
         categories=categories,
         unsupported_claims=unsupported_claims,
@@ -547,30 +547,75 @@ def _check_required_row_citations(
         or result_metadata.get("enforce_citations") is True
     ):
         return
-    if not result_rows:
-        return
-
+    claimed_values = _claimed_result_value_matches(answer_text)
+    paired_claim_spans: set[tuple[int, int]] = set()
     for left, right in _claimed_result_row_value_pairs(answer_text):
-        row_citation = _row_reference_citation_for_claim(
-            answer_text=answer_text,
-            claim_end=right[2],
-        )
+        paired_claim_spans.add((left[1], left[2]))
+        paired_claim_spans.add((right[1], right[2]))
         claim = f"{left[0]} with {right[0]}"
-        if row_citation is None:
-            categories.append("missing_citation")
-            unsupported_claims.append(claim)
+        _check_required_row_citation_for_claim_values(
+            answer_text=answer_text,
+            claim_values=(left, right),
+            claim=claim,
+            result_rows=result_rows,
+            categories=categories,
+            unsupported_claims=unsupported_claims,
+        )
+
+    for claim_value, start, end in claimed_values:
+        if (start, end) in paired_claim_spans:
             continue
-        row_index = row_citation - 1
-        if row_index < 0 or row_index >= len(result_rows):
-            categories.append("row_reference_mismatch")
-            unsupported_claims.append(f"{claim} cited as row:{row_citation}")
+        if _metadata_row_count_claim_is_supported(
+            answer_text=answer_text,
+            claim_value=claim_value,
+            start=start,
+            end=end,
+            result_metadata=result_metadata,
+        ):
             continue
-        row_forms = _row_value_forms(result_rows[row_index])
-        if _value_forms(left[0]).isdisjoint(row_forms) or _value_forms(
-            right[0]
-        ).isdisjoint(row_forms):
-            categories.append("row_reference_mismatch")
-            unsupported_claims.append(f"{claim} cited as row:{row_citation}")
+        if result_rows and _value_forms(claim_value).isdisjoint(
+            _supported_result_values(result_rows)
+        ):
+            continue
+        _check_required_row_citation_for_claim_values(
+            answer_text=answer_text,
+            claim_values=((claim_value, start, end),),
+            claim=claim_value,
+            result_rows=result_rows,
+            categories=categories,
+            unsupported_claims=unsupported_claims,
+        )
+
+
+def _check_required_row_citation_for_claim_values(
+    *,
+    answer_text: str,
+    claim_values: Sequence[tuple[str, int, int]],
+    claim: str,
+    result_rows: Sequence[Mapping[str, Any]],
+    categories: list[GovernedAnswerUnsupportedClaimCategory],
+    unsupported_claims: list[str],
+) -> None:
+    claim_start = min(value[1] for value in claim_values)
+    claim_end = max(value[2] for value in claim_values)
+    row_citation = _row_reference_citation_for_claim(
+        answer_text=answer_text,
+        claim_start=claim_start,
+        claim_end=claim_end,
+    )
+    if row_citation is None:
+        categories.append("missing_citation")
+        unsupported_claims.append(claim)
+        return
+    row_index = row_citation - 1
+    if row_index < 0 or row_index >= len(result_rows):
+        categories.append("row_reference_mismatch")
+        unsupported_claims.append(f"{claim} cited as row:{row_citation}")
+        return
+    row_forms = _row_value_forms(result_rows[row_index])
+    if any(_value_forms(value[0]).isdisjoint(row_forms) for value in claim_values):
+        categories.append("row_reference_mismatch")
+        unsupported_claims.append(f"{claim} cited as row:{row_citation}")
 
 
 def _observed_result_columns(
@@ -1093,14 +1138,30 @@ def _claimed_result_row_value_pairs(
 def _row_reference_citation_for_claim(
     *,
     answer_text: str,
+    claim_start: int,
     claim_end: int,
 ) -> int | None:
+    sentence_start = _sentence_start_before(answer_text, claim_start)
     sentence_end = _sentence_end_after(answer_text, claim_end)
-    sentence_tail = answer_text[claim_end:sentence_end]
-    citation_match = _ROW_REFERENCE_CITATION_PATTERN.search(sentence_tail)
-    if citation_match is None:
+    citation_matches = tuple(
+        _ROW_REFERENCE_CITATION_PATTERN.finditer(
+            answer_text[sentence_start:sentence_end]
+        )
+    )
+    if not citation_matches:
         return None
-    return int(citation_match.group(1))
+
+    def citation_distance(match: re.Match[str]) -> int:
+        citation_start = sentence_start + match.start()
+        citation_end = sentence_start + match.end()
+        if citation_end < claim_start:
+            return claim_start - citation_end
+        if citation_start > claim_end:
+            return citation_start - claim_end
+        return 0
+
+    nearest_citation = min(citation_matches, key=citation_distance)
+    return int(nearest_citation.group(1))
 
 
 def _sentence_end_after(text: str, start: int) -> int:

--- a/backend/app/features/evaluation/governed_answer.py
+++ b/backend/app/features/evaluation/governed_answer.py
@@ -40,6 +40,8 @@ GovernedAnswerUnsupportedClaimCategory = Literal[
     "truncation_mismatch",
     "forbidden_answer_claim",
     "unsupported_result_value",
+    "missing_citation",
+    "row_reference_mismatch",
 ]
 
 _RESULT_VALUE_PATTERN = re.compile(
@@ -145,6 +147,7 @@ _CLAIM_VALUE_NON_ROW_COMPARISON_PATTERN = re.compile(
     r"\b(?:is|are|was|were)?\s*(?:after|before|follows?|precedes?)\s*$",
     re.IGNORECASE,
 )
+_ROW_REFERENCE_CITATION_PATTERN = re.compile(r"\[row:(\d+)\]", re.IGNORECASE)
 _FORBIDDEN_SUBJECT_SEPARATOR_PATTERN = re.compile(r"[\s\-\u2010-\u2015]+")
 _FORBIDDEN_SUBJECT_PLURAL_EXACT_TOKENS = {
     "as",
@@ -406,6 +409,14 @@ def score_governed_answer_consistency(
         categories=categories,
         unsupported_claims=unsupported_claims,
     )
+    _check_required_row_citations(
+        expected_result_shape=expected_result_shape,
+        answer_text=answer_text,
+        result_rows=value_evidence_rows,
+        result_metadata=result_metadata,
+        categories=categories,
+        unsupported_claims=unsupported_claims,
+    )
 
     unsupported_claim_categories = tuple(dict.fromkeys(categories))
     passed = not unsupported_claim_categories
@@ -513,6 +524,53 @@ def _check_deterministic_result_values(
     ):
         categories.append("unsupported_result_value")
         unsupported_claims.append(claim_value)
+
+
+def _check_required_row_citations(
+    *,
+    expected_result_shape: Mapping[str, Any],
+    answer_text: str,
+    result_rows: Sequence[Mapping[str, Any]],
+    result_metadata: Mapping[str, Any],
+    categories: list[GovernedAnswerUnsupportedClaimCategory],
+    unsupported_claims: list[str],
+) -> None:
+    citation_requirement = expected_result_shape.get("citation_requirement")
+    if not (
+        isinstance(citation_requirement, Mapping)
+        and citation_requirement.get("required") is True
+        and citation_requirement.get("style") == "row_reference"
+    ):
+        return
+    if not (
+        result_metadata.get("answer_surface") == "future_llm_summary"
+        or result_metadata.get("enforce_citations") is True
+    ):
+        return
+    if not result_rows:
+        return
+
+    for left, right in _claimed_result_row_value_pairs(answer_text):
+        row_citation = _row_reference_citation_for_claim(
+            answer_text=answer_text,
+            claim_end=right[2],
+        )
+        claim = f"{left[0]} with {right[0]}"
+        if row_citation is None:
+            categories.append("missing_citation")
+            unsupported_claims.append(claim)
+            continue
+        row_index = row_citation - 1
+        if row_index < 0 or row_index >= len(result_rows):
+            categories.append("row_reference_mismatch")
+            unsupported_claims.append(f"{claim} cited as row:{row_citation}")
+            continue
+        row_forms = _row_value_forms(result_rows[row_index])
+        if _value_forms(left[0]).isdisjoint(row_forms) or _value_forms(
+            right[0]
+        ).isdisjoint(row_forms):
+            categories.append("row_reference_mismatch")
+            unsupported_claims.append(f"{claim} cited as row:{row_citation}")
 
 
 def _observed_result_columns(
@@ -915,7 +973,10 @@ def _claimed_result_value_matches(answer_text: str) -> tuple[tuple[str, int, int
     claimed_values: list[tuple[str, int, int]] = []
     for match in _RESULT_VALUE_PATTERN.finditer(answer_text):
         value = match.group(0)
-        if _is_incidental_integer_claim(answer_text, match):
+        if _is_incidental_integer_claim(answer_text, match) or _is_row_reference_value(
+            answer_text,
+            match,
+        ):
             continue
         claimed_values.append((value, match.start(), match.end()))
     return tuple(claimed_values)
@@ -948,6 +1009,17 @@ def _is_numbered_list_marker(answer_text: str, match: re.Match[str]) -> bool:
     if value.startswith("(") and value.endswith(")"):
         return after.startswith((" ", "\t", "\n", "\r"))
     return after in {". ", ") "}
+
+
+def _is_row_reference_value(answer_text: str, match: re.Match[str]) -> bool:
+    if not match.group(0).isdigit():
+        return False
+    for citation_match in _ROW_REFERENCE_CITATION_PATTERN.finditer(answer_text):
+        citation_value_start = citation_match.start(1)
+        citation_value_end = citation_match.end(1)
+        if citation_value_start <= match.start() and match.end() <= citation_value_end:
+            return True
+    return False
 
 
 def _supported_result_values(result_rows: Sequence[Mapping[str, Any]]) -> set[str]:
@@ -1005,6 +1077,37 @@ def _unsupported_claimed_result_row_combinations(
         )
     )
     return tuple(unsupported)
+
+
+def _claimed_result_row_value_pairs(
+    answer_text: str,
+) -> tuple[tuple[tuple[str, int, int], tuple[str, int, int]], ...]:
+    pairs: list[tuple[tuple[str, int, int], tuple[str, int, int]]] = []
+    claimed_values = _claimed_result_value_matches(answer_text)
+    for left, right in zip(claimed_values, claimed_values[1:]):
+        if _claim_values_are_row_linked(answer_text[left[2] : right[1]]):
+            pairs.append((left, right))
+    return tuple(pairs)
+
+
+def _row_reference_citation_for_claim(
+    *,
+    answer_text: str,
+    claim_end: int,
+) -> int | None:
+    sentence_end = _sentence_end_after(answer_text, claim_end)
+    sentence_tail = answer_text[claim_end:sentence_end]
+    citation_match = _ROW_REFERENCE_CITATION_PATTERN.search(sentence_tail)
+    if citation_match is None:
+        return None
+    return int(citation_match.group(1))
+
+
+def _sentence_end_after(text: str, start: int) -> int:
+    sentence_end = re.search(r"[.!?]", text[start:])
+    if sentence_end is None:
+        return len(text)
+    return start + sentence_end.start()
 
 
 def _unsupported_no_evidence_result_value_claims(
@@ -1084,6 +1187,8 @@ def _row_value_forms(row: Mapping[str, Any]) -> set[str]:
 
 
 def _claim_values_are_row_linked(between_values: str) -> bool:
+    if re.search(r"[.!?]", between_values):
+        return False
     row_link_match = _CLAIM_VALUE_ROW_LINK_PATTERN.search(between_values)
     if row_link_match is None:
         return False

--- a/backend/app/features/evaluation/governed_answer.py
+++ b/backend/app/features/evaluation/governed_answer.py
@@ -148,6 +148,10 @@ _CLAIM_VALUE_NON_ROW_COMPARISON_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _ROW_REFERENCE_CITATION_PATTERN = re.compile(r"\[row:(\d+)\]", re.IGNORECASE)
+_CLAIM_VALUE_ABBREVIATION_PERIOD_PATTERN = re.compile(
+    r"\b(?:approx|est|e\.g|i\.e|etc|vs)\.",
+    re.IGNORECASE,
+)
 _FORBIDDEN_SUBJECT_SEPARATOR_PATTERN = re.compile(r"[\s\-\u2010-\u2015]+")
 _FORBIDDEN_SUBJECT_PLURAL_EXACT_TOKENS = {
     "as",
@@ -1244,18 +1248,31 @@ def _row_value_forms(row: Mapping[str, Any]) -> set[str]:
 
 
 def _claim_values_are_row_linked(between_values: str) -> bool:
-    if re.search(r"[.!?]", between_values):
+    link_context = _claim_value_link_context(between_values)
+    if _claim_value_link_context_has_sentence_break(link_context):
         return False
-    row_link_match = _CLAIM_VALUE_ROW_LINK_PATTERN.search(between_values)
+    row_link_match = _CLAIM_VALUE_ROW_LINK_PATTERN.search(link_context)
     if row_link_match is None:
         return False
-    if _has_unlinked_value_conjunction(between_values):
+    if _has_unlinked_value_conjunction(link_context):
         return False
-    if _CLAIM_VALUE_NON_ROW_COMPARISON_PATTERN.search(between_values):
+    if _CLAIM_VALUE_NON_ROW_COMPARISON_PATTERN.search(link_context):
         return False
-    if _CLAIM_VALUE_NEGATED_COPULA_PATTERN.search(between_values):
+    if _CLAIM_VALUE_NEGATED_COPULA_PATTERN.search(link_context):
         return False
     return True
+
+
+def _claim_value_link_context(between_values: str) -> str:
+    return _ROW_REFERENCE_CITATION_PATTERN.sub(" ", between_values)
+
+
+def _claim_value_link_context_has_sentence_break(link_context: str) -> bool:
+    abbreviation_safe_context = _CLAIM_VALUE_ABBREVIATION_PERIOD_PATTERN.sub(
+        lambda match: match.group(0).replace(".", ""),
+        link_context,
+    )
+    return bool(re.search(r"[.!?]", abbreviation_safe_context))
 
 
 def _has_unlinked_value_conjunction(between_values: str) -> bool:

--- a/backend/app/features/evaluation/release_gate.py
+++ b/backend/app/features/evaluation/release_gate.py
@@ -483,8 +483,11 @@ def _assurance_failures_for_observed_answers(
                     scenario_id=fixture.metadata.scenario_id,
                     scenario_category=fixture.case_type,
                     detail=(
-                        "Governed answer made unsupported claims: "
-                        f"{', '.join(score.unsupported_claims)}."
+                        "Governed answer made unsupported claims "
+                        f"({', '.join(score.unsupported_claim_categories)}): "
+                        f"{', '.join(score.unsupported_claims)}. "
+                        "This reviewer-readable consistency review is diagnostic "
+                        "only and grants no execution authority."
                     ),
                 )
             )

--- a/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
+++ b/backend/tests/fixtures/governed_answer_vendor_spend_fixtures.json
@@ -229,7 +229,16 @@
             "fiscal_quarter": "FY2025-Q2",
             "approved_spend": "98000.00"
           }
-        ]
+        ],
+        "citation_requirement": {
+          "required": true,
+          "style": "row_reference",
+          "accepted_formats": [
+            "[row:1]",
+            "[row:2]"
+          ],
+          "reviewer_note": "Future free-form summaries must cite each claimed row value to the returned row that supports it."
+        }
       },
       "forbidden_answer_claims": [
         "Do not report unapproved spend as approved spend.",

--- a/backend/tests/test_governed_answer_fixtures.py
+++ b/backend/tests/test_governed_answer_fixtures.py
@@ -559,6 +559,52 @@ def test_governed_answer_consistency_scoring_rejects_row_reference_mismatch() ->
     assert "FY2025-Q2 with 98000.00 cited as row:1" in score.unsupported_claims
 
 
+def test_governed_answer_consistency_scoring_rejects_citations_without_returned_rows() -> None:
+    fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
+    expected_rows = fixture.expected_result_shape["known_result_rows"]
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text=(
+            "FY2025-Q1 approved spend is 125000.00 [row:1]. "
+            "FY2025-Q2 approved spend is 98000.00 [row:2]."
+        ),
+        result_rows=[],
+        result_metadata={
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": len(expected_rows),
+            "truncated": False,
+            "answer_surface": "future_llm_summary",
+        },
+    )
+
+    assert score.passed is False
+    assert "row_reference_mismatch" in score.unsupported_claim_categories
+    assert "FY2025-Q1 with 125000.00 cited as row:1" in score.unsupported_claims
+    assert "FY2025-Q2 with 98000.00 cited as row:2" in score.unsupported_claims
+
+
+def test_governed_answer_consistency_scoring_rejects_single_value_row_mismatch() -> None:
+    fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
+    result_rows = fixture.expected_result_shape["known_result_rows"]
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text="Approved spend is 125000.00 [row:2].",
+        result_rows=result_rows,
+        result_metadata={
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": 2,
+            "truncated": False,
+            "answer_surface": "future_llm_summary",
+        },
+    )
+
+    assert score.passed is False
+    assert "row_reference_mismatch" in score.unsupported_claim_categories
+    assert "125000.00 cited as row:2" in score.unsupported_claims
+
+
 def test_governed_answer_consistency_scoring_accepts_supported_row_citations() -> None:
     fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
     result_rows = fixture.expected_result_shape["known_result_rows"]
@@ -568,6 +614,29 @@ def test_governed_answer_consistency_scoring_accepts_supported_row_citations() -
         answer_text=(
             "FY2025-Q1 approved spend is 125000.00 [row:1]. "
             "FY2025-Q2 approved spend is 98000.00 [row:2]."
+        ),
+        result_rows=result_rows,
+        result_metadata={
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": 2,
+            "truncated": False,
+            "answer_surface": "future_llm_summary",
+        },
+    )
+
+    assert score.passed is True
+    assert score.unsupported_claim_categories == ()
+
+
+def test_governed_answer_consistency_scoring_accepts_row_citation_before_amount() -> None:
+    fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
+    result_rows = fixture.expected_result_shape["known_result_rows"]
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text=(
+            "FY2025-Q1 [row:1] approved spend is 125000.00. "
+            "FY2025-Q2 [row:2] approved spend is 98000.00."
         ),
         result_rows=result_rows,
         result_metadata={

--- a/backend/tests/test_governed_answer_fixtures.py
+++ b/backend/tests/test_governed_answer_fixtures.py
@@ -280,6 +280,15 @@ def test_governed_answer_vendor_spend_fixtures_cover_mvp_semantic_contract() -> 
         {"fiscal_quarter": "FY2025-Q1", "approved_spend": "125000.00"},
         {"fiscal_quarter": "FY2025-Q2", "approved_spend": "98000.00"},
     ]
+    assert by_quarter["expected_result_shape"]["citation_requirement"] == {
+        "required": True,
+        "style": "row_reference",
+        "accepted_formats": ["[row:1]", "[row:2]"],
+        "reviewer_note": (
+            "Future free-form summaries must cite each claimed row value "
+            "to the returned row that supports it."
+        ),
+    }
 
     approval_distinction = fixtures_by_id[
         "gavsf-003-approved-vs-unapproved-distinction"
@@ -497,6 +506,80 @@ def test_governed_answer_consistency_scoring_names_unsupported_claim_category() 
     assert "unsupported_result_value" in score.unsupported_claim_categories
     assert "FY2025-Q3" in score.unsupported_claims
     assert "42000.00" in score.unsupported_claims
+
+
+def test_governed_answer_consistency_scoring_requires_row_citations() -> None:
+    fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
+    result_rows = fixture.expected_result_shape["known_result_rows"]
+    assert fixture.expected_result_shape["citation_requirement"]["required"] is True
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text=(
+            "FY2025-Q1 approved spend is 125000.00. "
+            "FY2025-Q2 approved spend is 98000.00."
+        ),
+        result_rows=result_rows,
+        result_metadata={
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": 2,
+            "truncated": False,
+            "answer_surface": "future_llm_summary",
+        },
+    )
+
+    assert score.passed is False
+    assert "missing_citation" in score.unsupported_claim_categories
+    assert "FY2025-Q1 with 125000.00" in score.unsupported_claims
+    assert "FY2025-Q2 with 98000.00" in score.unsupported_claims
+
+
+def test_governed_answer_consistency_scoring_rejects_row_reference_mismatch() -> None:
+    fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
+    result_rows = fixture.expected_result_shape["known_result_rows"]
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text=(
+            "FY2025-Q1 approved spend is 125000.00 [row:2]. "
+            "FY2025-Q2 approved spend is 98000.00 [row:1]."
+        ),
+        result_rows=result_rows,
+        result_metadata={
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": 2,
+            "truncated": False,
+            "answer_surface": "future_llm_summary",
+        },
+    )
+
+    assert score.passed is False
+    assert "row_reference_mismatch" in score.unsupported_claim_categories
+    assert "FY2025-Q1 with 125000.00 cited as row:2" in score.unsupported_claims
+    assert "FY2025-Q2 with 98000.00 cited as row:1" in score.unsupported_claims
+
+
+def test_governed_answer_consistency_scoring_accepts_supported_row_citations() -> None:
+    fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
+    result_rows = fixture.expected_result_shape["known_result_rows"]
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text=(
+            "FY2025-Q1 approved spend is 125000.00 [row:1]. "
+            "FY2025-Q2 approved spend is 98000.00 [row:2]."
+        ),
+        result_rows=result_rows,
+        result_metadata={
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": 2,
+            "truncated": False,
+            "answer_surface": "future_llm_summary",
+        },
+    )
+
+    assert score.passed is True
+    assert score.unsupported_claim_categories == ()
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_governed_answer_fixtures.py
+++ b/backend/tests/test_governed_answer_fixtures.py
@@ -651,6 +651,29 @@ def test_governed_answer_consistency_scoring_accepts_row_citation_before_amount(
     assert score.unsupported_claim_categories == ()
 
 
+def test_governed_answer_consistency_scoring_ignores_citation_colon_for_row_links() -> None:
+    fixture = validate_governed_answer_fixture_set(_load_fixture_set()).fixtures[1]
+    result_rows = fixture.expected_result_shape["known_result_rows"]
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text=(
+            "[row:1] FY2025-Q1 approved spend is 125000.00, and "
+            "[row:2] FY2025-Q2 approved spend is 98000.00."
+        ),
+        result_rows=result_rows,
+        result_metadata={
+            "columns": ["fiscal_quarter", "approved_spend"],
+            "row_count": 2,
+            "truncated": False,
+            "answer_surface": "future_llm_summary",
+        },
+    )
+
+    assert score.passed is True
+    assert score.unsupported_claim_categories == ()
+
+
 @pytest.mark.parametrize(
     "unsupported_claim",
     [
@@ -1720,6 +1743,29 @@ def test_governed_answer_consistency_scoring_rejects_verbose_swapped_row_facts()
             "and preserving the source ordering for audit traceability, was "
             "98000.00."
         ),
+        result_rows=result_rows,
+        result_metadata={
+            "columns": list(fixture.expected_result_shape.get("columns") or ()),
+            "row_count": len(result_rows),
+            "truncated": False,
+        },
+    )
+
+    assert score.passed is False
+    assert "unsupported_result_value" in score.unsupported_claim_categories
+    assert "FY2025-Q1 with 98000.00" in score.unsupported_claims
+
+
+def test_governed_answer_consistency_scoring_rejects_abbreviated_swapped_row_facts() -> None:
+    fixture_set = validate_governed_answer_fixture_set(_load_fixture_set())
+    fixture = {
+        fixture.metadata.scenario_id: fixture for fixture in fixture_set.fixtures
+    }["gavsf-002-vendor-spend-by-quarter"]
+    result_rows = fixture.expected_result_shape["known_result_rows"]
+
+    score = score_governed_answer_consistency(
+        fixture=fixture,
+        answer_text="FY2025-Q1 approx. approved spend is 98000.00.",
         result_rows=result_rows,
         result_metadata={
             "columns": list(fixture.expected_result_shape.get("columns") or ()),

--- a/backend/tests/test_release_gate.py
+++ b/backend/tests/test_release_gate.py
@@ -160,8 +160,8 @@ def test_release_gate_assurance_report_fails_on_unsupported_answer_claims() -> N
             {
                 "scenario_id": "gavsf-002-vendor-spend-by-quarter",
                 "answer_text": (
-                    "FY2025-Q1 approved spend is 125000.00. "
-                    "FY2025-Q2 approved spend is 98000.00. "
+                    "FY2025-Q1 approved spend is 125000.00 [row:1]. "
+                    "FY2025-Q2 approved spend is 98000.00 [row:2]. "
                     "FY2025-Q3 approved spend is 42000.00."
                 ),
                 "result_rows": [
@@ -196,7 +196,9 @@ def test_release_gate_assurance_report_fails_on_unsupported_answer_claims() -> N
     assert report.levels[3].status == "not_covered"
     assert report.failures[0].deny_code == "DENY_UNSUPPORTED_ANSWER_CLAIM"
     assert report.failures[0].scenario_id == "gavsf-002-vendor-spend-by-quarter"
+    assert "unsupported_result_value" in report.failures[0].detail
     assert "FY2025-Q3" in report.failures[0].detail
+    assert "grants no execution authority" in report.failures[0].detail
 
 
 def test_release_gate_assurance_report_fails_closed_on_zero_observed_coverage() -> None:

--- a/docs/design/evaluation-harness.md
+++ b/docs/design/evaluation-harness.md
@@ -131,6 +131,18 @@ in `schema_assumptions`, `source_binding`, semantic mapping values, SQL-shape
 constraints, and result-shape assertions so future source domains can add
 fixtures without rewriting the harness.
 
+Result-to-answer consistency review is required before any LLM-written summary
+can become user-facing. Fixtures may require row-reference citations such as
+`[row:1]` for result-backed claims. Observed artifacts activate that citation
+sub-gate by marking result metadata with `answer_surface: future_llm_summary` or
+`enforce_citations: true`; deterministic MVP template checks do not depend on
+the future-summary citation gate. The scorer fails missing citations,
+row-reference mismatches, unsupported result values, forbidden answer claims,
+column mismatches, row-count mismatches, and truncation mismatches. The report
+is reviewer-readable diagnostic evidence only. It does not grant execution
+authority, does not authorize SQL, and does not replace deterministic MVP answer
+templates.
+
 ## Baseline Success Dimensions
 
 The baseline evaluation dimensions are:


### PR DESCRIPTION
## Summary
- add explicit missing-citation and row-reference-mismatch categories to governed-answer consistency scoring
- add fixture-backed row-reference citation requirements for future LLM summary artifacts
- document that result-to-answer consistency review is required before LLM summaries become user-facing and remains reviewer-readable diagnostic evidence only

## Verification
- cd backend && python3 -m pytest tests/test_governed_answer_fixtures.py tests/test_release_gate.py tests/test_mvp_answer_summary.py -q
- python3 -m pytest tests/test_check_repository_hygiene.py tests/test_source_family_activation_criteria_docs.py tests/test_source_family_activation_selection_docs.py -q
- git diff --check

## Notes
- Citation enforcement is gated by fixture requirements plus result metadata marker `answer_surface: future_llm_summary` or `enforce_citations: true`; deterministic MVP answer templates remain independent of this future-summary review gate.

Closes #479