### PR TITLE
[codex] Persist answer evidence bundle

### DIFF
--- a/backend/app/features/audit/event_model.py
+++ b/backend/app/features/audit/event_model.py
@@ -97,6 +97,39 @@ class ExecutedEvidenceAuditPayload(BaseModel):
     can_authorize_execution: Literal[False] = False
 
 
+class AnswerEvidenceBoundedMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    row_count: NonNegativeInt
+    row_limit: PositiveInt
+    result_truncated: bool
+    truncation_reason: Optional[NonEmptyTrimmedString] = None
+    rows_used: NonNegativeInt
+    reason_codes: tuple[NonEmptyTrimmedString, ...] = ()
+    redacted_columns: tuple[NonEmptyTrimmedString, ...] = ()
+    missing_expected_columns: tuple[NonEmptyTrimmedString, ...] = ()
+    missing_required_columns: tuple[NonEmptyTrimmedString, ...] = ()
+
+
+class AnswerEvidenceAuditPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["answer_evidence"] = "answer_evidence"
+    answer_id: UUID
+    request_id: NonEmptyTrimmedString
+    candidate_id: NonEmptyTrimmedString
+    execution_run_id: UUID
+    validation_status: Literal["pass", "warn", "fail"]
+    redaction_status: Literal["not_required", "applied", "fail"]
+    summary_strategy: NonEmptyTrimmedString
+    result_hash: NonEmptyTrimmedString
+    bounded_metadata: AnswerEvidenceBoundedMetadata
+    answer_state: Literal["answered", "insufficient_evidence"]
+    insufficient_evidence_reason: Optional[NonEmptyTrimmedString] = None
+    audit_event_id: UUID
+    audit_event_type: Literal["execution_completed"] = "execution_completed"
+
+
 class ReleaseGateScenarioAuditPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -140,6 +173,7 @@ class SourceAwareAuditEvent(BaseModel):
     retrieved_asset_ids: Optional[list[NonEmptyTrimmedString]] = None
     retrieved_citations: Optional[list[RetrievalCitationAuditPayload]] = None
     executed_evidence: Optional[list[ExecutedEvidenceAuditPayload]] = None
+    answer_evidence: Optional[AnswerEvidenceAuditPayload] = None
     release_gate_scenario: Optional[ReleaseGateScenarioAuditPayload] = None
     intent_mapping: Optional[dict[str, object]] = None
     analyst_mode_version: Optional[NonEmptyTrimmedString] = None

--- a/backend/app/features/execution/runtime.py
+++ b/backend/app/features/execution/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import importlib
+import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -14,6 +15,8 @@ from pydantic import BaseModel, ConfigDict, PrivateAttr, StringConstraints
 from typing_extensions import Annotated
 
 from app.features.audit.event_model import (
+    AnswerEvidenceAuditPayload,
+    AnswerEvidenceBoundedMetadata,
     ExecutedEvidenceAuditPayload,
     SourceAwareAuditEvent,
 )
@@ -346,6 +349,7 @@ def _build_execution_audit_event(
     answer_text: str | None = None,
     insufficient_evidence_reason: str | None = None,
     next_action: str | None = None,
+    answer_evidence: AnswerEvidenceAuditPayload | None = None,
     release_gate_guard_decision: Literal["allow", "reject"] | None = None,
 ) -> SourceAwareAuditEvent | None:
     if audit_context is None:
@@ -397,6 +401,7 @@ def _build_execution_audit_event(
         answer_text=answer_text,
         insufficient_evidence_reason=insufficient_evidence_reason,
         next_action=next_action,
+        answer_evidence=answer_evidence,
     )
     if canonical_sql is not None and event_type in {
         "execution_completed",
@@ -446,6 +451,7 @@ def _build_execution_audit_events(
     answer_text: str | None = None,
     insufficient_evidence_reason: str | None = None,
     next_action: str | None = None,
+    answer_evidence: AnswerEvidenceAuditPayload | None = None,
     release_gate_guard_decision: Literal["allow", "reject"] | None = None,
 ) -> list[SourceAwareAuditEvent]:
     if audit_context is None:
@@ -489,6 +495,9 @@ def _build_execution_audit_events(
                 else None
             ),
             next_action=next_action if event_type == "execution_completed" else None,
+            answer_evidence=(
+                answer_evidence if event_type == "execution_completed" else None
+            ),
             release_gate_guard_decision=(
                 release_gate_guard_decision
                 if event_type in {"execution_completed", "execution_denied"}
@@ -951,6 +960,60 @@ def _result_payload_size(rows: list[dict[str, Any]]) -> int:
     )
 
 
+def _result_hash(rows: list[dict[str, Any]]) -> str:
+    payload = json.dumps(
+        rows,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _build_answer_evidence(
+    *,
+    rows: list[dict[str, Any]],
+    metadata: ExecutionResultMetadata,
+    answer_summary: MVPAnswerSummary | None,
+    audit_context: ExecutionAuditContext | None,
+) -> AnswerEvidenceAuditPayload | None:
+    validation = metadata.result_validation
+    if (
+        audit_context is None
+        or validation is None
+        or answer_summary is None
+        or metadata.execution_run_id is None
+        or metadata.candidate_id is None
+    ):
+        return None
+
+    return AnswerEvidenceAuditPayload(
+        answer_id=audit_context.event_id,
+        request_id=audit_context.request_id,
+        candidate_id=metadata.candidate_id,
+        execution_run_id=metadata.execution_run_id,
+        validation_status=validation.status,
+        redaction_status=validation.evidence.redaction_status,
+        summary_strategy=answer_summary.contract_version,
+        result_hash=_result_hash(rows),
+        bounded_metadata=AnswerEvidenceBoundedMetadata(
+            row_count=metadata.row_count,
+            row_limit=metadata.row_limit,
+            result_truncated=metadata.result_truncated,
+            truncation_reason=metadata.truncation_reason,
+            rows_used=answer_summary.rows_used,
+            reason_codes=validation.reason_codes,
+            redacted_columns=validation.evidence.redacted_columns,
+            missing_expected_columns=validation.evidence.missing_expected_columns,
+            missing_required_columns=validation.evidence.missing_required_columns,
+        ),
+        answer_state=answer_summary.answer_state,
+        insufficient_evidence_reason=answer_summary.insufficient_evidence_reason,
+        audit_event_id=audit_context.event_id,
+    )
+
+
 def _postgres_identity_from_url(
     *,
     database_url: str,
@@ -1195,6 +1258,12 @@ def execute_candidate_sql(
         rows=result_rows,
         metadata=metadata,
     )
+    answer_evidence = _build_answer_evidence(
+        rows=result_rows,
+        metadata=metadata,
+        answer_summary=answer_summary,
+        audit_context=audit_context,
+    )
     result._audit_events = _build_execution_audit_events(
         event_types=["execution_requested", "execution_started", "execution_completed"],
         candidate_source=candidate.source,
@@ -1226,6 +1295,7 @@ def execute_candidate_sql(
             and answer_summary.answer_state == "insufficient_evidence"
             else None
         ),
+        answer_evidence=answer_evidence,
     )
     result._audit_event = result._audit_events[-1] if result._audit_events else None
     return result

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -151,6 +151,7 @@ _EXECUTION_DENIAL_AUDIT_FIELDS = frozenset(
         "answer_text",
         "insufficient_evidence_reason",
         "next_action",
+        "answer_evidence",
     }
 )
 

--- a/backend/tests/test_candidate_execute_api.py
+++ b/backend/tests/test_candidate_execute_api.py
@@ -402,6 +402,20 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             "1. Acme (unspecified period) - 1200.",
             answer_summary["answer_text"],
         )
+        persisted_events = (
+            self.session.query(PreviewAuditEvent)
+            .order_by(PreviewAuditEvent.lifecycle_order)
+            .all()
+        )
+        answer_evidence = persisted_events[-1].audit_payload["answer_evidence"]
+        self.assertEqual(answer_evidence["answer_state"], "answered")
+        self.assertEqual(answer_evidence["validation_status"], "pass")
+        self.assertEqual(answer_evidence["redaction_status"], "not_required")
+        self.assertEqual(answer_evidence["summary_strategy"], "mvp_answer_summary.v1")
+        self.assertEqual(answer_evidence["bounded_metadata"]["row_count"], 1)
+        self.assertEqual(answer_evidence["bounded_metadata"]["rows_used"], 1)
+        self.assertNotIn("rows", answer_evidence)
+        self.assertNotIn("Acme", str(answer_evidence))
 
     def test_execute_candidate_api_attaches_review_assumptions_to_answer_summary(
         self,
@@ -940,6 +954,39 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             "expected result columns were missing",
             persisted_events[-1].audit_payload["answer_text"],
         )
+        answer_evidence = persisted_events[-1].audit_payload["answer_evidence"]
+        self.assertEqual(
+            answer_evidence["answer_id"],
+            str(persisted_events[-1].event_id),
+        )
+        self.assertEqual(answer_evidence["request_id"], "request-123")
+        self.assertEqual(answer_evidence["candidate_id"], "candidate-123")
+        self.assertEqual(
+            answer_evidence["execution_run_id"],
+            payload["metadata"]["execution_run_id"],
+        )
+        self.assertEqual(answer_evidence["validation_status"], "fail")
+        self.assertEqual(answer_evidence["redaction_status"], "not_required")
+        self.assertEqual(
+            answer_evidence["summary_strategy"],
+            "mvp_answer_summary.v1",
+        )
+        self.assertEqual(answer_evidence["answer_state"], "insufficient_evidence")
+        self.assertEqual(
+            answer_evidence["insufficient_evidence_reason"],
+            "missing_columns",
+        )
+        self.assertEqual(
+            answer_evidence["audit_event_id"],
+            str(persisted_events[-1].event_id),
+        )
+        self.assertIn("result_hash", answer_evidence)
+        self.assertEqual(
+            answer_evidence["bounded_metadata"]["reason_codes"],
+            ["missing_expected_columns", "missing_required_columns"],
+        )
+        self.assertNotIn("rows", answer_evidence)
+        self.assertNotIn("Acme", str(answer_evidence))
 
         workflow_response = client.get(
             "/operator/workflow",
@@ -1006,7 +1053,14 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             return [{"vendor_name": f"Vendor {index}"} for index in range(225)]
 
         app_session = create_test_application_session(build_dev_authenticated_subject())
-        response = self._client(query_runner).post(
+        response = self._client(
+            query_runner,
+            result_validation_contract=ResultValidationContract(
+                semantic_contract_version="approved_vendor_spend.v1",
+                expected_columns=("vendor_name",),
+                required_columns=("vendor_name",),
+            ),
+        ).post(
             "/candidates/candidate-123/execute",
             headers=app_session.headers,
             cookies=app_session.cookies,
@@ -1063,6 +1117,23 @@ class CandidateExecuteApiTestCase(unittest.TestCase):
             self.assertEqual(event.audit_payload["execution_policy_version"], 3)
             self.assertNotIn("safequery_exec:secret", str(event.audit_payload))
             self.assertNotIn("business-postgres-source", str(event.audit_payload))
+
+        answer_evidence = persisted_events[-1].audit_payload["answer_evidence"]
+        self.assertEqual(answer_evidence["answer_state"], "insufficient_evidence")
+        self.assertEqual(answer_evidence["validation_status"], "warn")
+        self.assertEqual(answer_evidence["redaction_status"], "not_required")
+        self.assertEqual(
+            answer_evidence["insufficient_evidence_reason"],
+            "unsafe_truncation",
+        )
+        self.assertEqual(answer_evidence["bounded_metadata"]["row_count"], 200)
+        self.assertIs(answer_evidence["bounded_metadata"]["result_truncated"], True)
+        self.assertEqual(
+            answer_evidence["bounded_metadata"]["truncation_reason"],
+            "row_limit",
+        )
+        self.assertNotIn("rows", answer_evidence)
+        self.assertNotIn("Vendor 0", str(answer_evidence))
 
     def test_execute_candidate_missing_request_id_uses_controlled_fail_closed_error(
         self,


### PR DESCRIPTION
## Summary
- persist a structured answer evidence bundle on terminal execution audit events
- link answer evidence to request, candidate, execution run, validation, redaction, summary strategy, result hash, and audit event id
- tighten execute API tests for answered and insufficient-evidence answer evidence without exposing raw rows, secrets, or source endpoint details

## Root cause
Execution audit events persisted answer state and summary text, but there was no bounded evidence bundle that let reviewers reconstruct why a displayed answer was allowed or blocked.

## Validation
- cd backend && python3 -m pytest tests/test_candidate_execute_api.py
- cd backend && python3 -m pytest tests/test_audit_event_model.py tests/test_source_bound_execute_path.py tests/test_result_validation_contract.py tests/test_api_errors.py
- git diff --check

Part of #474. Addresses #480.