### PR TITLE
[Z-6] Add governance export answer traceability

### DIFF
--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -280,12 +280,72 @@ class GovernanceReviewAdapterEvidence(BaseModel):
     )
 
 
+class GovernanceReviewRequestEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    request_state: str = Field(serialization_alias="requestState")
+    request_text: str = Field(serialization_alias="requestText")
+    semantic_contract_version: Optional[str] = Field(
+        default=None,
+        serialization_alias="semanticContractVersion",
+    )
+
+
+class GovernanceReviewSemanticMappingEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    status: str
+    intent: Optional[str] = None
+    metric: Optional[str] = None
+    dimensions: list[str] = Field(default_factory=list)
+    filters: list[str] = Field(default_factory=list)
+    insufficient_evidence_reason: Optional[str] = Field(
+        default=None,
+        serialization_alias="insufficientEvidenceReason",
+    )
+
+
+class GovernanceReviewSqlCandidateEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    candidate_sql_redaction: Literal["raw_sql_excluded"] = Field(
+        default="raw_sql_excluded",
+        serialization_alias="candidateSqlRedaction",
+    )
+    release_gate_scenario_id: Optional[str] = Field(
+        default=None,
+        serialization_alias="releaseGateScenarioId",
+    )
+
+
+class GovernanceReviewGuardDecisionEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    decision: str
+    guard_version: Optional[str] = Field(
+        default=None,
+        serialization_alias="guardVersion",
+    )
+    guard_audit_event_id: str = Field(serialization_alias="guardAuditEventId")
+
+
 class GovernanceReviewCandidateEvidence(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     authority: Literal["safequery_control_plane"] = "safequery_control_plane"
     candidate_state: str = Field(serialization_alias="candidateState")
     guard_status: str = Field(serialization_alias="guardStatus")
+    sql_candidate: GovernanceReviewSqlCandidateEvidence = Field(
+        serialization_alias="sqlCandidate",
+    )
+    guard_decision: Optional[GovernanceReviewGuardDecisionEvidence] = Field(
+        default=None,
+        serialization_alias="guardDecision",
+    )
     adapter_evidence: GovernanceReviewAdapterEvidence = Field(
         serialization_alias="adapterEvidence",
     )
@@ -319,6 +379,48 @@ class GovernanceReviewExecuteResultEvidence(BaseModel):
         default=None,
         serialization_alias="resultTruncated",
     )
+    validation: Optional["GovernanceReviewValidationEvidence"] = None
+    redaction: Optional["GovernanceReviewRedactionEvidence"] = None
+    answer: Optional["GovernanceReviewAnswerEvidence"] = None
+
+
+class GovernanceReviewValidationEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    status: str
+    reason_codes: list[str] = Field(
+        default_factory=list,
+        serialization_alias="reasonCodes",
+    )
+    row_limit: Optional[int] = Field(default=None, serialization_alias="rowLimit")
+    rows_used: Optional[int] = Field(default=None, serialization_alias="rowsUsed")
+
+
+class GovernanceReviewRedactionEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    status: str
+    redacted_columns: list[str] = Field(
+        default_factory=list,
+        serialization_alias="redactedColumns",
+    )
+
+
+class GovernanceReviewAnswerEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authority: Literal["safequery_control_plane"] = "safequery_control_plane"
+    answer_state: str = Field(serialization_alias="answerState")
+    summary_strategy: str = Field(serialization_alias="summaryStrategy")
+    answer_evidence_id: str = Field(serialization_alias="answerEvidenceId")
+    execution_run_id: str = Field(serialization_alias="executionRunId")
+    result_hash: str = Field(serialization_alias="resultHash")
+    insufficient_evidence_reason: Optional[str] = Field(
+        default=None,
+        serialization_alias="insufficientEvidenceReason",
+    )
 
 
 class GovernanceReviewEvidence(BaseModel):
@@ -336,6 +438,11 @@ class GovernanceReviewEvidence(BaseModel):
     source_flavor: Optional[str] = Field(default=None, serialization_alias="sourceFlavor")
     dataset_contract_version: int = Field(serialization_alias="datasetContractVersion")
     schema_snapshot_version: int = Field(serialization_alias="schemaSnapshotVersion")
+    request: GovernanceReviewRequestEvidence
+    semantic_mapping: Optional[GovernanceReviewSemanticMappingEvidence] = Field(
+        default=None,
+        serialization_alias="semanticMapping",
+    )
     lifecycle: list[GovernanceReviewLifecycleEvent]
     actor: GovernanceReviewActorEvidence
     candidate: Optional[GovernanceReviewCandidateEvidence] = None
@@ -544,6 +651,149 @@ def _payload_bool(payload: Mapping[str, object], key: str) -> bool | None:
     return value if isinstance(value, bool) else None
 
 
+def _payload_mapping(
+    payload: Mapping[str, object],
+    key: str,
+) -> Mapping[str, object] | None:
+    value = payload.get(key)
+    return value if isinstance(value, Mapping) else None
+
+
+def _payload_string(payload: Mapping[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _payload_string_list(
+    payload: Mapping[str, object],
+    key: str,
+) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]
+
+
+def _latest_payload_mapping(
+    events: list[PreviewAuditEvent],
+    key: str,
+) -> Mapping[str, object] | None:
+    for event in sorted(events, key=_audit_event_sort_key, reverse=True):
+        payload = _payload_mapping(event.audit_payload, key)
+        if payload is not None:
+            return payload
+    return None
+
+
+def _semantic_mapping_evidence(
+    events: list[PreviewAuditEvent],
+) -> GovernanceReviewSemanticMappingEvidence | None:
+    intent_mapping = _latest_payload_mapping(events, "intent_mapping")
+    if intent_mapping is None:
+        return None
+    semantic_mapping = _payload_mapping(intent_mapping, "semantic_mapping") or {}
+    status = _payload_string(intent_mapping, "status")
+    if status is None:
+        return None
+    return GovernanceReviewSemanticMappingEvidence(
+        status=status,
+        intent=_payload_string(intent_mapping, "intent"),
+        metric=_payload_string(semantic_mapping, "metric"),
+        dimensions=_payload_string_list(semantic_mapping, "dimensions"),
+        filters=_payload_string_list(semantic_mapping, "filters"),
+        insufficient_evidence_reason=_payload_string(
+            intent_mapping,
+            "insufficient_evidence_reason",
+        ),
+    )
+
+
+def _release_gate_payload(
+    events: list[PreviewAuditEvent],
+) -> Mapping[str, object] | None:
+    return _latest_payload_mapping(events, "release_gate_scenario")
+
+
+def _guard_decision_evidence(
+    events: list[PreviewAuditEvent],
+) -> GovernanceReviewGuardDecisionEvidence | None:
+    guard_event = next(
+        (
+            event
+            for event in sorted(events, key=_audit_event_sort_key, reverse=True)
+            if event.event_type == "guard_evaluated"
+        ),
+        None,
+    )
+    if guard_event is None:
+        return None
+    decision = _payload_string(guard_event.audit_payload, "guard_decision")
+    if decision is None:
+        return None
+    return GovernanceReviewGuardDecisionEvidence(
+        decision=decision,
+        guard_version=_payload_string(guard_event.audit_payload, "guard_version"),
+        guard_audit_event_id=str(guard_event.event_id),
+    )
+
+
+def _validation_evidence(
+    answer_evidence: Mapping[str, object],
+) -> GovernanceReviewValidationEvidence | None:
+    status = _payload_string(answer_evidence, "validation_status")
+    bounded_metadata = _payload_mapping(answer_evidence, "bounded_metadata")
+    if status is None or bounded_metadata is None:
+        return None
+    return GovernanceReviewValidationEvidence(
+        status=status,
+        reason_codes=_payload_string_list(bounded_metadata, "reason_codes"),
+        row_limit=_payload_non_negative_int(bounded_metadata, "row_limit"),
+        rows_used=_payload_non_negative_int(bounded_metadata, "rows_used"),
+    )
+
+
+def _redaction_evidence(
+    answer_evidence: Mapping[str, object],
+) -> GovernanceReviewRedactionEvidence | None:
+    status = _payload_string(answer_evidence, "redaction_status")
+    if status is None:
+        return None
+    bounded_metadata = _payload_mapping(answer_evidence, "bounded_metadata") or {}
+    return GovernanceReviewRedactionEvidence(
+        status=status,
+        redacted_columns=_payload_string_list(bounded_metadata, "redacted_columns"),
+    )
+
+
+def _answer_evidence(
+    answer_evidence: Mapping[str, object],
+) -> GovernanceReviewAnswerEvidence | None:
+    answer_state = _payload_string(answer_evidence, "answer_state")
+    summary_strategy = _payload_string(answer_evidence, "summary_strategy")
+    answer_evidence_id = _payload_string(answer_evidence, "answer_id")
+    execution_run_id = _payload_string(answer_evidence, "execution_run_id")
+    result_hash = _payload_string(answer_evidence, "result_hash")
+    if (
+        answer_state is None
+        or summary_strategy is None
+        or answer_evidence_id is None
+        or execution_run_id is None
+        or result_hash is None
+    ):
+        return None
+    return GovernanceReviewAnswerEvidence(
+        answer_state=answer_state,
+        summary_strategy=summary_strategy,
+        answer_evidence_id=answer_evidence_id,
+        execution_run_id=execution_run_id,
+        result_hash=result_hash,
+        insufficient_evidence_reason=_payload_string(
+            answer_evidence,
+            "insufficient_evidence_reason",
+        ),
+    )
+
+
 def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
     requests = (
         session.execute(select(PreviewRequest).order_by(PreviewRequest.created_at))
@@ -624,6 +874,12 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
                 ),
                 None,
             )
+            release_gate = _release_gate_payload(lifecycle_events)
+            answer_payload = (
+                _payload_mapping(execution_event.audit_payload, "answer_evidence")
+                if execution_event is not None
+                else None
+            )
             evidence.append(
                 GovernanceReviewEvidence(
                     request_id=request.request_id,
@@ -633,6 +889,12 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
                     source_flavor=request.source_flavor,
                     dataset_contract_version=request.dataset_contract_version,
                     schema_snapshot_version=request.schema_snapshot_version,
+                    request=GovernanceReviewRequestEvidence(
+                        request_state=request.request_state,
+                        request_text=request.request_text,
+                        semantic_contract_version=request.semantic_contract_version,
+                    ),
+                    semantic_mapping=_semantic_mapping_evidence(lifecycle_events),
                     lifecycle=lifecycle,
                     actor=GovernanceReviewActorEvidence(
                         authenticated_subject_id=request.authenticated_subject_id,
@@ -644,6 +906,14 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
                         GovernanceReviewCandidateEvidence(
                             candidate_state=candidate.candidate_state,
                             guard_status=candidate.guard_status,
+                            sql_candidate=GovernanceReviewSqlCandidateEvidence(
+                                release_gate_scenario_id=(
+                                    _payload_string(release_gate, "scenario_id")
+                                    if release_gate is not None
+                                    else None
+                                ),
+                            ),
+                            guard_decision=_guard_decision_evidence(lifecycle_events),
                             adapter_evidence=GovernanceReviewAdapterEvidence(
                                 adapter_provider=candidate.adapter_provider,
                                 adapter_model=candidate.adapter_model,
@@ -691,6 +961,21 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
                             result_truncated=_payload_bool(
                                 execution_event.audit_payload,
                                 "result_truncated",
+                            ),
+                            validation=(
+                                _validation_evidence(answer_payload)
+                                if answer_payload is not None
+                                else None
+                            ),
+                            redaction=(
+                                _redaction_evidence(answer_payload)
+                                if answer_payload is not None
+                                else None
+                            ),
+                            answer=(
+                                _answer_evidence(answer_payload)
+                                if answer_payload is not None
+                                else None
                             ),
                         )
                         if execution_event is not None

--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -286,6 +286,10 @@ class GovernanceReviewRequestEvidence(BaseModel):
     authority: Literal["safequery_control_plane"] = "safequery_control_plane"
     request_state: str = Field(serialization_alias="requestState")
     request_text: str = Field(serialization_alias="requestText")
+    request_text_redaction: Optional[Literal["sensitive_terms_redacted"]] = Field(
+        default=None,
+        serialization_alias="requestTextRedaction",
+    )
     semantic_contract_version: Optional[str] = Field(
         default=None,
         serialization_alias="semanticContractVersion",
@@ -674,6 +678,38 @@ def _payload_string_list(
     return [item for item in value if isinstance(item, str) and item.strip()]
 
 
+def _is_forbidden_export_string(value: str) -> bool:
+    return any(
+        pattern.search(value) for _category, pattern in _FORBIDDEN_EXPORT_VALUE_PATTERNS
+    )
+
+
+def _request_text_evidence(request: PreviewRequest) -> GovernanceReviewRequestEvidence:
+    request_text = request.request_text
+    request_text_redaction: Literal["sensitive_terms_redacted"] | None = None
+    if _is_forbidden_export_string(request_text):
+        request_text = "[redacted_request_text]"
+        request_text_redaction = "sensitive_terms_redacted"
+    return GovernanceReviewRequestEvidence(
+        request_state=request.request_state,
+        request_text=request_text,
+        request_text_redaction=request_text_redaction,
+        semantic_contract_version=request.semantic_contract_version,
+    )
+
+
+def _redacted_column_names_for_export(columns: list[str]) -> list[str]:
+    redacted: list[str] = []
+    redacted_count = 0
+    for column in columns:
+        if _is_forbidden_export_string(column):
+            redacted_count += 1
+            redacted.append(f"redacted_column_{redacted_count}")
+        else:
+            redacted.append(column)
+    return redacted
+
+
 def _latest_payload_mapping(
     events: list[PreviewAuditEvent],
     key: str,
@@ -691,16 +727,20 @@ def _semantic_mapping_evidence(
     intent_mapping = _latest_payload_mapping(events, "intent_mapping")
     if intent_mapping is None:
         return None
-    semantic_mapping = _payload_mapping(intent_mapping, "semantic_mapping") or {}
+    semantic_mapping = _payload_mapping(intent_mapping, "semantic_mapping")
+    mapping_payload = semantic_mapping or intent_mapping
     status = _payload_string(intent_mapping, "status")
     if status is None:
         return None
     return GovernanceReviewSemanticMappingEvidence(
         status=status,
-        intent=_payload_string(intent_mapping, "intent"),
-        metric=_payload_string(semantic_mapping, "metric"),
-        dimensions=_payload_string_list(semantic_mapping, "dimensions"),
-        filters=_payload_string_list(semantic_mapping, "filters"),
+        intent=(
+            _payload_string(intent_mapping, "intent")
+            or _payload_string(intent_mapping, "mapping_id")
+        ),
+        metric=_payload_string(mapping_payload, "metric"),
+        dimensions=_payload_string_list(mapping_payload, "dimensions"),
+        filters=_payload_string_list(mapping_payload, "filters"),
         insufficient_evidence_reason=_payload_string(
             intent_mapping,
             "insufficient_evidence_reason",
@@ -761,7 +801,9 @@ def _redaction_evidence(
     bounded_metadata = _payload_mapping(answer_evidence, "bounded_metadata") or {}
     return GovernanceReviewRedactionEvidence(
         status=status,
-        redacted_columns=_payload_string_list(bounded_metadata, "redacted_columns"),
+        redacted_columns=_redacted_column_names_for_export(
+            _payload_string_list(bounded_metadata, "redacted_columns"),
+        ),
     )
 
 
@@ -889,11 +931,7 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
                     source_flavor=request.source_flavor,
                     dataset_contract_version=request.dataset_contract_version,
                     schema_snapshot_version=request.schema_snapshot_version,
-                    request=GovernanceReviewRequestEvidence(
-                        request_state=request.request_state,
-                        request_text=request.request_text,
-                        semantic_contract_version=request.semantic_contract_version,
-                    ),
+                    request=_request_text_evidence(request),
                     semantic_mapping=_semantic_mapping_evidence(lifecycle_events),
                     lifecycle=lifecycle,
                     actor=GovernanceReviewActorEvidence(

--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -20,6 +20,7 @@ from app.db.models.preview import (
 )
 from app.db.models.schema_snapshot import SchemaSnapshot
 from app.db.models.source_registry import RegisteredSource, SourceActivationPosture
+from app.features.guard.deny_taxonomy import DENY_RESULT_VALIDATION_FAILED
 from app.services.first_run_doctor import _alembic_heads
 from app.services.health import build_operator_health
 from app.services.operator_workflow import (
@@ -687,6 +688,12 @@ def _payload_string_list(
     return [item for item in value if isinstance(item, str) and item.strip()]
 
 
+def _split_csv_reason_codes(value: str | None) -> list[str]:
+    if value is None:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 def _is_forbidden_export_string(value: str) -> bool:
     return any(
         pattern.search(value) for _category, pattern in _FORBIDDEN_EXPORT_VALUE_PATTERNS
@@ -796,6 +803,25 @@ def _validation_evidence(
         reason_codes=_payload_string_list(bounded_metadata, "reason_codes"),
         row_limit=_payload_non_negative_int(bounded_metadata, "row_limit"),
         rows_used=_payload_non_negative_int(bounded_metadata, "rows_used"),
+    )
+
+
+def _execution_validation_evidence(
+    execution_event: PreviewAuditEvent,
+    answer_evidence: Mapping[str, object] | None,
+) -> GovernanceReviewValidationEvidence | None:
+    if answer_evidence is not None:
+        return _validation_evidence(answer_evidence)
+    if (
+        execution_event.event_type != "execution_denied"
+        or execution_event.primary_deny_code != DENY_RESULT_VALIDATION_FAILED
+    ):
+        return None
+    return GovernanceReviewValidationEvidence(
+        status="fail",
+        reason_codes=_split_csv_reason_codes(
+            _payload_string(execution_event.audit_payload, "denial_reason"),
+        ),
     )
 
 
@@ -1005,9 +1031,10 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
                                 "result_truncated",
                             ),
                             validation=(
-                                _validation_evidence(answer_payload)
-                                if answer_payload is not None
-                                else None
+                                _execution_validation_evidence(
+                                    execution_event,
+                                    answer_payload,
+                                )
                             ),
                             redaction=(
                                 _redaction_evidence(answer_payload)

--- a/backend/app/services/support_bundle.py
+++ b/backend/app/services/support_bundle.py
@@ -285,9 +285,12 @@ class GovernanceReviewRequestEvidence(BaseModel):
 
     authority: Literal["safequery_control_plane"] = "safequery_control_plane"
     request_state: str = Field(serialization_alias="requestState")
-    request_text: str = Field(serialization_alias="requestText")
-    request_text_redaction: Optional[Literal["sensitive_terms_redacted"]] = Field(
-        default=None,
+    request_text: Literal["[redacted_request_text]"] = Field(
+        default="[redacted_request_text]",
+        serialization_alias="requestText",
+    )
+    request_text_redaction: Literal["raw_request_text_excluded"] = Field(
+        default="raw_request_text_excluded",
         serialization_alias="requestTextRedaction",
     )
     semantic_contract_version: Optional[str] = Field(
@@ -308,6 +311,11 @@ class GovernanceReviewSemanticMappingEvidence(BaseModel):
     insufficient_evidence_reason: Optional[str] = Field(
         default=None,
         serialization_alias="insufficientEvidenceReason",
+    )
+    clarification: Optional[str] = None
+    unsupported_concepts: Optional[list[str]] = Field(
+        default=None,
+        serialization_alias="unsupportedConcepts",
     )
 
 
@@ -420,7 +428,6 @@ class GovernanceReviewAnswerEvidence(BaseModel):
     summary_strategy: str = Field(serialization_alias="summaryStrategy")
     answer_evidence_id: str = Field(serialization_alias="answerEvidenceId")
     execution_run_id: str = Field(serialization_alias="executionRunId")
-    result_hash: str = Field(serialization_alias="resultHash")
     insufficient_evidence_reason: Optional[str] = Field(
         default=None,
         serialization_alias="insufficientEvidenceReason",
@@ -614,7 +621,9 @@ def _redaction_policy() -> SupportBundleRedaction:
             "connection_strings",
             "raw_credentials",
             "tokens",
+            "raw_request_text",
             "raw_result_rows",
+            "deterministic_result_hashes",
             "candidate_sql",
             "raw_identity_payloads",
             "workstation_local_paths",
@@ -685,15 +694,8 @@ def _is_forbidden_export_string(value: str) -> bool:
 
 
 def _request_text_evidence(request: PreviewRequest) -> GovernanceReviewRequestEvidence:
-    request_text = request.request_text
-    request_text_redaction: Literal["sensitive_terms_redacted"] | None = None
-    if _is_forbidden_export_string(request_text):
-        request_text = "[redacted_request_text]"
-        request_text_redaction = "sensitive_terms_redacted"
     return GovernanceReviewRequestEvidence(
         request_state=request.request_state,
-        request_text=request_text,
-        request_text_redaction=request_text_redaction,
         semantic_contract_version=request.semantic_contract_version,
     )
 
@@ -732,6 +734,8 @@ def _semantic_mapping_evidence(
     status = _payload_string(intent_mapping, "status")
     if status is None:
         return None
+    clarification = _payload_string(intent_mapping, "clarification")
+    unsupported_concepts = _payload_string_list(intent_mapping, "unsupported_concepts")
     return GovernanceReviewSemanticMappingEvidence(
         status=status,
         intent=(
@@ -744,7 +748,10 @@ def _semantic_mapping_evidence(
         insufficient_evidence_reason=_payload_string(
             intent_mapping,
             "insufficient_evidence_reason",
-        ),
+        )
+        or clarification,
+        clarification=clarification,
+        unsupported_concepts=unsupported_concepts or None,
     )
 
 
@@ -814,13 +821,11 @@ def _answer_evidence(
     summary_strategy = _payload_string(answer_evidence, "summary_strategy")
     answer_evidence_id = _payload_string(answer_evidence, "answer_id")
     execution_run_id = _payload_string(answer_evidence, "execution_run_id")
-    result_hash = _payload_string(answer_evidence, "result_hash")
     if (
         answer_state is None
         or summary_strategy is None
         or answer_evidence_id is None
         or execution_run_id is None
-        or result_hash is None
     ):
         return None
     return GovernanceReviewAnswerEvidence(
@@ -828,7 +833,6 @@ def _answer_evidence(
         summary_strategy=summary_strategy,
         answer_evidence_id=answer_evidence_id,
         execution_run_id=execution_run_id,
-        result_hash=result_hash,
         insufficient_evidence_reason=_payload_string(
             answer_evidence,
             "insufficient_evidence_reason",
@@ -1027,7 +1031,7 @@ def _governance_review_bundle(session: Session) -> GovernanceReviewBundle:
         limitations=[
             "Bundle is read-only review evidence and does not authorize execution.",
             "Subordinate adapter, LLM, search, analyst, MLflow, UI, and external evidence is labeled as non-authoritative.",
-            "Raw SQL, result rows, credentials, connection references, tokens, and workstation-local paths are excluded.",
+            "Raw prompts, raw SQL, result rows, deterministic result hashes, credentials, connection references, tokens, and workstation-local paths are excluded.",
         ],
     )
 

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -149,6 +149,7 @@ def _add_governance_review_workflow_records(
         source_flavor=source.source_flavor,
         dataset_contract_id=source.dataset_contract_id,
         dataset_contract_version=1,
+        semantic_contract_version="approved_vendor_spend.v1",
         schema_snapshot_id=source.schema_snapshot_id,
         schema_snapshot_version=1,
         authenticated_subject_id="user:demo-local-operator",
@@ -173,6 +174,7 @@ def _add_governance_review_workflow_records(
         source_flavor=preview_request.source_flavor,
         dataset_contract_id=preview_request.dataset_contract_id,
         dataset_contract_version=preview_request.dataset_contract_version,
+        semantic_contract_version=preview_request.semantic_contract_version,
         schema_snapshot_id=preview_request.schema_snapshot_id,
         schema_snapshot_version=preview_request.schema_snapshot_version,
         authenticated_subject_id=preview_request.authenticated_subject_id,
@@ -219,10 +221,20 @@ def _add_governance_review_workflow_records(
         ("guard_evaluated", 4, preview_candidate.candidate_id, "preview_ready"),
         ("execution_completed", 7, preview_candidate.candidate_id, "executed"),
     ]
+    execution_run_id = uuid4()
+    answer_id = uuid4()
+    guard_audit_event_id = uuid4()
     for event_type, lifecycle_order, candidate_id, candidate_state in lifecycle_events:
+        event_id = (
+            execution_run_id
+            if event_type == "execution_completed"
+            else guard_audit_event_id
+            if event_type == "guard_evaluated"
+            else uuid4()
+        )
         session.add(
             PreviewAuditEvent(
-                event_id=uuid4(),
+                event_id=event_id,
                 lifecycle_order=lifecycle_order,
                 preview_request_id=preview_request.id,
                 preview_candidate_id=(
@@ -256,11 +268,78 @@ def _add_governance_review_workflow_records(
                 source_family=preview_request.source_family,
                 source_flavor=preview_request.source_flavor,
                 dataset_contract_version=preview_request.dataset_contract_version,
+                semantic_contract_version=preview_request.semantic_contract_version,
                 schema_snapshot_version=preview_request.schema_snapshot_version,
                 candidate_state=candidate_state,
                 audit_payload={
                     "execution_row_count": execution_row_count,
                     "result_truncated": False,
+                    "guard_decision": "allow" if event_type == "guard_evaluated" else None,
+                    "guard_version": (
+                        "postgresql-guard-v1"
+                        if event_type == "guard_evaluated"
+                        else None
+                    ),
+                    "intent_mapping": (
+                        {
+                            "status": "mapped",
+                            "intent": "approved_vendor_spend",
+                            "semantic_mapping": {
+                                "metric": "sum_approved_vendor_spend",
+                                "dimensions": ["vendor_name", "fiscal_quarter"],
+                                "filters": ["approved_spend_only"],
+                            },
+                        }
+                        if event_type
+                        in {
+                            "generation_completed",
+                            "guard_evaluated",
+                            "execution_completed",
+                        }
+                        else None
+                    ),
+                    "release_gate_scenario": (
+                        {
+                            "scenario_id": "gavsf-001-top-approved-vendors-by-quarterly-spend",
+                            "source_id": preview_request.source_id,
+                            "candidate_id": preview_candidate.candidate_id,
+                            "guard_decision": "allow",
+                            "guard_audit_event_id": str(guard_audit_event_id),
+                            "execution_run_id": str(execution_run_id),
+                            "execution_audit_event_id": str(execution_run_id),
+                        }
+                        if event_type == "execution_completed"
+                        else None
+                    ),
+                    "answer_evidence": (
+                        {
+                            "type": "answer_evidence",
+                            "answer_id": str(answer_id),
+                            "request_id": preview_request.request_id,
+                            "candidate_id": preview_candidate.candidate_id,
+                            "execution_run_id": str(execution_run_id),
+                            "validation_status": "pass",
+                            "redaction_status": "applied",
+                            "summary_strategy": "mvp_answer_summary.v1",
+                            "result_hash": "sha256:"
+                            + "a" * 64,
+                            "bounded_metadata": {
+                                "row_count": execution_row_count,
+                                "row_limit": 200,
+                                "result_truncated": False,
+                                "rows_used": 5,
+                                "reason_codes": [],
+                                "redacted_columns": ["vendor_email"],
+                                "missing_expected_columns": [],
+                                "missing_required_columns": [],
+                            },
+                            "answer_state": "answered",
+                            "audit_event_id": str(execution_run_id),
+                            "audit_event_type": "execution_completed",
+                        }
+                        if event_type == "execution_completed"
+                        else None
+                    ),
                     "raw_rows": [{"customer_secret": "sk-live-should-not-leak"}],
                     "debug_path": "/".join(
                         ["", "Users", "example", ".safequery", "private.log"]
@@ -518,6 +597,20 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
             "sourceFlavor": "warehouse",
             "datasetContractVersion": 1,
             "schemaSnapshotVersion": 1,
+            "request": {
+                "authority": "safequery_control_plane",
+                "requestState": "executed",
+                "requestText": "Show approved spend",
+                "semanticContractVersion": "approved_vendor_spend.v1",
+            },
+            "semanticMapping": {
+                "authority": "safequery_control_plane",
+                "status": "mapped",
+                "intent": "approved_vendor_spend",
+                "metric": "sum_approved_vendor_spend",
+                "dimensions": ["vendor_name", "fiscal_quarter"],
+                "filters": ["approved_spend_only"],
+            },
             "lifecycle": [
                 {
                     "eventType": "query_submitted",
@@ -558,6 +651,19 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
                 "authority": "safequery_control_plane",
                 "candidateState": "executed",
                 "guardStatus": "passed",
+                "sqlCandidate": {
+                    "authority": "safequery_control_plane",
+                    "candidateSqlRedaction": "raw_sql_excluded",
+                    "releaseGateScenarioId": "gavsf-001-top-approved-vendors-by-quarterly-spend",
+                },
+                "guardDecision": {
+                    "authority": "safequery_control_plane",
+                    "decision": "allow",
+                    "guardVersion": "postgresql-guard-v1",
+                    "guardAuditEventId": payload["governanceReview"]["evidence"][0][
+                        "candidate"
+                    ]["guardDecision"]["guardAuditEventId"],
+                },
                 "adapterEvidence": {
                     "authority": "subordinate_adapter",
                     "adapterProvider": "fixture-adapter",
@@ -584,6 +690,30 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
                 "occurredAt": "2026-01-02T03:11:05Z",
                 "rowCount": 12,
                 "resultTruncated": False,
+                "validation": {
+                    "authority": "safequery_control_plane",
+                    "status": "pass",
+                    "reasonCodes": [],
+                    "rowLimit": 200,
+                    "rowsUsed": 5,
+                },
+                "redaction": {
+                    "authority": "safequery_control_plane",
+                    "status": "applied",
+                    "redactedColumns": ["vendor_email"],
+                },
+                "answer": {
+                    "authority": "safequery_control_plane",
+                    "answerState": "answered",
+                    "summaryStrategy": "mvp_answer_summary.v1",
+                    "answerEvidenceId": payload["governanceReview"]["evidence"][0][
+                        "executeResult"
+                    ]["answer"]["answerEvidenceId"],
+                    "executionRunId": payload["governanceReview"]["evidence"][0][
+                        "executeResult"
+                    ]["answer"]["executionRunId"],
+                    "resultHash": "sha256:" + "a" * 64,
+                },
             },
         }
     ]
@@ -616,6 +746,158 @@ def test_governance_review_execute_result_rejects_boolean_row_count(
     execute_result = payload["governanceReview"]["evidence"][0]["executeResult"]
     assert "rowCount" not in execute_result
     assert execute_result["resultTruncated"] is False
+
+
+def test_governance_review_export_surfaces_insufficient_evidence_answer_state(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session, execution_row_count=0)
+        execution_event = (
+            session.query(PreviewAuditEvent)
+            .filter_by(
+                candidate_id="candidate-governance-bundle",
+                event_type="execution_completed",
+            )
+            .one()
+        )
+        answer_evidence = dict(execution_event.audit_payload["answer_evidence"])
+        bounded_metadata = dict(answer_evidence["bounded_metadata"])
+        bounded_metadata.update(
+            {
+                "row_count": 0,
+                "rows_used": 0,
+                "reason_codes": ["missing_expected_columns", "no_rows"],
+                "missing_expected_columns": ["vendor_name"],
+            }
+        )
+        answer_evidence.update(
+            {
+                "validation_status": "fail",
+                "redaction_status": "not_required",
+                "bounded_metadata": bounded_metadata,
+                "answer_state": "insufficient_evidence",
+                "insufficient_evidence_reason": "no_rows",
+            }
+        )
+        execution_event.audit_payload = {
+            **execution_event.audit_payload,
+            "execution_row_count": 0,
+            "answer_state": "insufficient_evidence",
+            "insufficient_evidence_reason": "no_rows",
+            "answer_evidence": answer_evidence,
+        }
+        session.commit()
+
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    evidence = bundle.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+    )["governanceReview"]["evidence"][0]
+    execute_result = evidence["executeResult"]
+    assert execute_result["rowCount"] == 0
+    assert execute_result["validation"] == {
+        "authority": "safequery_control_plane",
+        "status": "fail",
+        "reasonCodes": ["missing_expected_columns", "no_rows"],
+        "rowLimit": 200,
+        "rowsUsed": 0,
+    }
+    assert execute_result["redaction"] == {
+        "authority": "safequery_control_plane",
+        "status": "not_required",
+        "redactedColumns": ["vendor_email"],
+    }
+    assert execute_result["answer"]["answerState"] == "insufficient_evidence"
+    assert execute_result["answer"]["insufficientEvidenceReason"] == "no_rows"
+    _assert_secret_safe(json.dumps(evidence, sort_keys=True))
+
+
+def test_governance_review_export_distinguishes_blocked_answer_generation(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session)
+        request = session.query(PreviewRequest).one()
+        request.request_state = "blocked"
+        candidate = session.query(PreviewCandidate).one()
+        candidate.candidate_state = "blocked"
+        candidate.guard_status = "blocked"
+        session.query(PreviewCandidateApproval).delete()
+        session.query(PreviewAuditEvent).filter_by(
+            event_type="execution_completed"
+        ).delete()
+        guard_event = (
+            session.query(PreviewAuditEvent)
+            .filter_by(
+                candidate_id="candidate-governance-bundle",
+                event_type="guard_evaluated",
+            )
+            .one()
+        )
+        guard_event.candidate_state = "blocked"
+        guard_event.primary_deny_code = "DENY_WRITE_OPERATION"
+        guard_event.denial_cause = "guard_rejected"
+        guard_event.audit_payload = {
+            **guard_event.audit_payload,
+            "guard_decision": "reject",
+            "release_gate_scenario": {
+                "scenario_id": "gavsf-006-mutation-denied",
+                "source_id": request.source_id,
+                "candidate_id": candidate.candidate_id,
+                "guard_decision": "reject",
+                "guard_audit_event_id": str(guard_event.event_id),
+            },
+        }
+        session.commit()
+
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    evidence = bundle.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+    )["governanceReview"]["evidence"][0]
+    assert evidence["request"]["requestState"] == "blocked"
+    assert evidence["candidate"]["candidateState"] == "blocked"
+    assert evidence["candidate"]["guardStatus"] == "blocked"
+    assert evidence["candidate"]["guardDecision"]["decision"] == "reject"
+    assert evidence["candidate"]["sqlCandidate"] == {
+        "authority": "safequery_control_plane",
+        "candidateSqlRedaction": "raw_sql_excluded",
+        "releaseGateScenarioId": "gavsf-006-mutation-denied",
+    }
+    assert "review" not in evidence
+    assert "executeResult" not in evidence
+    _assert_secret_safe(json.dumps(evidence, sort_keys=True))
 
 
 def test_governance_review_export_rejects_unsafe_export_values_by_category(

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -24,6 +24,7 @@ from app.db.models.preview import (
 from app.db.models.source_registry import RegisteredSource
 from app.db.session import require_preview_submission_session
 from app.features.auth.context import AuthenticatedSubject, require_authenticated_subject
+from app.features.guard.deny_taxonomy import DENY_RESULT_VALIDATION_FAILED
 from app.services.demo_source_seed import seed_demo_source_governance
 from app.services.support_bundle import (
     build_bounded_result_summary_export,
@@ -829,6 +830,71 @@ def test_governance_review_export_surfaces_insufficient_evidence_answer_state(
     assert execute_result["answer"]["answerState"] == "insufficient_evidence"
     assert execute_result["answer"]["insufficientEvidenceReason"] == "no_rows"
     _assert_secret_safe(json.dumps(evidence, sort_keys=True))
+
+
+def test_governance_review_export_surfaces_validation_denied_execution(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session, execution_row_count=3)
+        execution_event = (
+            session.query(PreviewAuditEvent)
+            .filter_by(
+                candidate_id="candidate-governance-bundle",
+                event_type="execution_completed",
+            )
+            .one()
+        )
+        execution_event.event_type = "execution_denied"
+        execution_event.candidate_state = "denied"
+        execution_event.primary_deny_code = DENY_RESULT_VALIDATION_FAILED
+        execution_event.denial_cause = "result_validation_failed"
+        execution_event.audit_payload = {
+            **execution_event.audit_payload,
+            "event_type": "execution_denied",
+            "candidate_state": "denied",
+            "primary_deny_code": DENY_RESULT_VALIDATION_FAILED,
+            "denial_cause": "result_validation_failed",
+            "denial_reason": "missing_expected_columns,under_minimum_rows",
+            "execution_row_count": 3,
+            "result_truncated": False,
+            "answer_evidence": None,
+        }
+        session.commit()
+
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    execute_result = bundle.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+    )["governanceReview"]["evidence"][0]["executeResult"]
+    assert execute_result == {
+        "authority": "safequery_control_plane",
+        "eventType": "execution_denied",
+        "occurredAt": "2026-01-02T03:11:05Z",
+        "rowCount": 3,
+        "resultTruncated": False,
+        "validation": {
+            "authority": "safequery_control_plane",
+            "status": "fail",
+            "reasonCodes": ["missing_expected_columns", "under_minimum_rows"],
+        },
+    }
+    _assert_secret_safe(json.dumps(execute_result, sort_keys=True))
 
 
 def test_governance_review_export_always_redacts_request_text(monkeypatch) -> None:

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -283,12 +283,10 @@ def _add_governance_review_workflow_records(
                     "intent_mapping": (
                         {
                             "status": "mapped",
-                            "intent": "approved_vendor_spend",
-                            "semantic_mapping": {
-                                "metric": "sum_approved_vendor_spend",
-                                "dimensions": ["vendor_name", "fiscal_quarter"],
-                                "filters": ["approved_spend_only"],
-                            },
+                            "mapping_id": "approved_vendor_spend",
+                            "metric": "sum_approved_vendor_spend",
+                            "dimensions": ["vendor_name", "fiscal_quarter"],
+                            "filters": ["approved_spend_only"],
                         }
                         if event_type
                         in {
@@ -826,6 +824,107 @@ def test_governance_review_export_surfaces_insufficient_evidence_answer_state(
     assert execute_result["answer"]["answerState"] == "insufficient_evidence"
     assert execute_result["answer"]["insufficientEvidenceReason"] == "no_rows"
     _assert_secret_safe(json.dumps(evidence, sort_keys=True))
+
+
+def test_governance_review_export_redacts_unsafe_request_text(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session)
+        request = session.query(PreviewRequest).one()
+        request.request_text = "Show password reset request counts by quarter"
+        session.commit()
+
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    request_evidence = bundle.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+    )["governanceReview"]["evidence"][0]["request"]
+    assert request_evidence == {
+        "authority": "safequery_control_plane",
+        "requestState": "executed",
+        "requestText": "[redacted_request_text]",
+        "requestTextRedaction": "sensitive_terms_redacted",
+        "semanticContractVersion": "approved_vendor_spend.v1",
+    }
+    serialized = json.dumps(request_evidence, sort_keys=True)
+    _assert_secret_safe(serialized)
+    assert "password reset" not in serialized
+
+
+def test_governance_review_export_redacts_sensitive_redacted_column_names(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session)
+        execution_event = (
+            session.query(PreviewAuditEvent)
+            .filter_by(
+                candidate_id="candidate-governance-bundle",
+                event_type="execution_completed",
+            )
+            .one()
+        )
+        answer_evidence = dict(execution_event.audit_payload["answer_evidence"])
+        bounded_metadata = dict(answer_evidence["bounded_metadata"])
+        bounded_metadata["redacted_columns"] = [
+            "vendor_email",
+            "api_key",
+            "database_password",
+        ]
+        answer_evidence["bounded_metadata"] = bounded_metadata
+        execution_event.audit_payload = {
+            **execution_event.audit_payload,
+            "answer_evidence": answer_evidence,
+        }
+        session.commit()
+
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    redaction = bundle.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+    )["governanceReview"]["evidence"][0]["executeResult"]["redaction"]
+    assert redaction == {
+        "authority": "safequery_control_plane",
+        "status": "applied",
+        "redactedColumns": [
+            "vendor_email",
+            "redacted_column_1",
+            "redacted_column_2",
+        ],
+    }
+    serialized = json.dumps(redaction, sort_keys=True)
+    _assert_secret_safe(serialized)
+    assert "api_key" not in serialized
+    assert "database_password" not in serialized
 
 
 def test_governance_review_export_distinguishes_blocked_answer_generation(

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -404,7 +404,7 @@ def test_support_bundle_service_includes_bounded_diagnostics_without_secrets(
     assert governance_review["limitations"] == [
         "Bundle is read-only review evidence and does not authorize execution.",
         "Subordinate adapter, LLM, search, analyst, MLflow, UI, and external evidence is labeled as non-authoritative.",
-        "Raw SQL, result rows, credentials, connection references, tokens, and workstation-local paths are excluded.",
+        "Raw prompts, raw SQL, result rows, deterministic result hashes, credentials, connection references, tokens, and workstation-local paths are excluded.",
     ]
     assert governance_review["evidence"][0]["sourceId"] == "demo-business-postgres"
     assert governance_review["evidence"][0]["authority"] == "safequery_control_plane"
@@ -546,7 +546,9 @@ def test_support_bundle_service_includes_bounded_diagnostics_without_secrets(
                 "connection_strings",
                 "raw_credentials",
                 "tokens",
+                "raw_request_text",
                 "raw_result_rows",
+                "deterministic_result_hashes",
                 "candidate_sql",
                 "raw_identity_payloads",
                 "workstation_local_paths",
@@ -582,7 +584,7 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
     assert payload["governanceReview"]["limitations"] == [
         "Bundle is read-only review evidence and does not authorize execution.",
         "Subordinate adapter, LLM, search, analyst, MLflow, UI, and external evidence is labeled as non-authoritative.",
-        "Raw SQL, result rows, credentials, connection references, tokens, and workstation-local paths are excluded.",
+        "Raw prompts, raw SQL, result rows, deterministic result hashes, credentials, connection references, tokens, and workstation-local paths are excluded.",
     ]
     assert payload["governanceReview"]["evidence"] == [
         {
@@ -598,7 +600,8 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
             "request": {
                 "authority": "safequery_control_plane",
                 "requestState": "executed",
-                "requestText": "Show approved spend",
+                "requestText": "[redacted_request_text]",
+                "requestTextRedaction": "raw_request_text_excluded",
                 "semanticContractVersion": "approved_vendor_spend.v1",
             },
             "semanticMapping": {
@@ -710,7 +713,6 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
                     "executionRunId": payload["governanceReview"]["evidence"][0][
                         "executeResult"
                     ]["answer"]["executionRunId"],
-                    "resultHash": "sha256:" + "a" * 64,
                 },
             },
         }
@@ -718,6 +720,9 @@ def test_support_bundle_includes_source_aware_governance_review_evidence(
     serialized = json.dumps(payload, sort_keys=True)
     _assert_secret_safe(serialized)
     assert "raw_private_rows" not in serialized
+    assert "Show approved spend" not in serialized
+    assert "resultHash" not in serialized
+    assert "sha256:" + "a" * 64 not in serialized
 
 
 def test_governance_review_execute_result_rejects_boolean_row_count(
@@ -826,7 +831,7 @@ def test_governance_review_export_surfaces_insufficient_evidence_answer_state(
     _assert_secret_safe(json.dumps(evidence, sort_keys=True))
 
 
-def test_governance_review_export_redacts_unsafe_request_text(monkeypatch) -> None:
+def test_governance_review_export_always_redacts_request_text(monkeypatch) -> None:
     monkeypatch.setenv(
         "SAFEQUERY_APP_POSTGRES_URL",
         "postgresql://safequery:app-secret@db:5432/safequery",
@@ -837,7 +842,9 @@ def test_governance_review_export_redacts_unsafe_request_text(monkeypatch) -> No
     with _session_scope() as session:
         _add_governance_review_workflow_records(session)
         request = session.query(PreviewRequest).one()
-        request.request_text = "Show password reset request counts by quarter"
+        request.request_text = (
+            "Email operator@example.test the SSN and api key rotation counts"
+        )
         session.commit()
 
         bundle = build_support_bundle(
@@ -857,12 +864,14 @@ def test_governance_review_export_redacts_unsafe_request_text(monkeypatch) -> No
         "authority": "safequery_control_plane",
         "requestState": "executed",
         "requestText": "[redacted_request_text]",
-        "requestTextRedaction": "sensitive_terms_redacted",
+        "requestTextRedaction": "raw_request_text_excluded",
         "semanticContractVersion": "approved_vendor_spend.v1",
     }
     serialized = json.dumps(request_evidence, sort_keys=True)
     _assert_secret_safe(serialized)
-    assert "password reset" not in serialized
+    assert "operator@example.test" not in serialized
+    assert "SSN" not in serialized
+    assert "api key" not in serialized
 
 
 def test_governance_review_export_redacts_sensitive_redacted_column_names(
@@ -925,6 +934,81 @@ def test_governance_review_export_redacts_sensitive_redacted_column_names(
     _assert_secret_safe(serialized)
     assert "api_key" not in serialized
     assert "database_password" not in serialized
+
+
+def test_governance_review_export_preserves_intent_blocking_reasons(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "SAFEQUERY_APP_POSTGRES_URL",
+        "postgresql://safequery:app-secret@db:5432/safequery",
+    )
+    monkeypatch.setenv("SAFEQUERY_SQL_GENERATION_PROVIDER", "disabled")
+    get_settings.cache_clear()
+
+    with _session_scope() as session:
+        _add_governance_review_workflow_records(session)
+        request = session.query(PreviewRequest).one()
+        request.request_state = "clarification_required"
+        candidate = session.query(PreviewCandidate).one()
+        candidate.candidate_state = "clarification_required"
+        candidate.guard_status = "blocked"
+        session.query(PreviewCandidateApproval).delete()
+        session.query(PreviewAuditEvent).filter_by(
+            event_type="execution_completed"
+        ).delete()
+        for event in session.query(PreviewAuditEvent).all():
+            event.candidate_state = (
+                "clarification_required"
+                if event.candidate_id == candidate.candidate_id
+                else event.candidate_state
+            )
+            event.audit_payload = {
+                **event.audit_payload,
+                "intent_mapping": {
+                    "status": "unsupported",
+                    "clarification": (
+                        "The requested concept is outside the governed vendor spend "
+                        "contract."
+                    ),
+                    "unsupported_concepts": [
+                        "employee headcount",
+                        "payroll expense",
+                    ],
+                },
+            }
+        session.commit()
+
+        bundle = build_support_bundle(
+            session,
+            settings=get_settings(),
+            database={"status": "ok", "detail": "ready"},
+            sql_generation={"status": "disabled", "detail": "provider_disabled"},
+            generated_at=datetime(2026, 1, 2, 3, 10, 5, tzinfo=timezone.utc),
+        )
+
+    semantic_mapping = bundle.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+    )["governanceReview"]["evidence"][0]["semanticMapping"]
+    assert semantic_mapping == {
+        "authority": "safequery_control_plane",
+        "status": "unsupported",
+        "dimensions": [],
+        "filters": [],
+        "insufficientEvidenceReason": (
+            "The requested concept is outside the governed vendor spend contract."
+        ),
+        "clarification": (
+            "The requested concept is outside the governed vendor spend contract."
+        ),
+        "unsupportedConcepts": [
+            "employee headcount",
+            "payroll expense",
+        ],
+    }
+    _assert_secret_safe(json.dumps(semantic_mapping, sort_keys=True))
 
 
 def test_governance_review_export_distinguishes_blocked_answer_generation(
@@ -1117,7 +1201,9 @@ def test_support_bundle_endpoint_returns_secret_safe_json(monkeypatch) -> None:
         "connection_strings",
         "raw_credentials",
         "tokens",
+        "raw_request_text",
         "raw_result_rows",
+        "deterministic_result_hashes",
         "candidate_sql",
         "raw_identity_payloads",
         "workstation_local_paths",
@@ -1194,7 +1280,9 @@ def test_bounded_result_summary_export_includes_execution_context_without_raw_ro
                 "connection_strings",
                 "raw_credentials",
                 "tokens",
+                "raw_request_text",
                 "raw_result_rows",
+                "deterministic_result_hashes",
                 "candidate_sql",
                 "raw_identity_payloads",
                 "workstation_local_paths",


### PR DESCRIPTION
## Summary
- extend governance review evidence with request, semantic mapping, redacted SQL candidate, guard decision, validation, redaction, and answer evidence metadata
- add fixture coverage for supported, insufficient-evidence, and guard-blocked answer states
- keep raw SQL and raw result rows excluded from exported review evidence

## Verification
- cd backend && python3 -m pytest tests/test_support_bundle.py -q
- cd backend && python3 -m pytest tests/test_result_validation_contract.py tests/test_mvp_answer_summary.py tests/test_governed_answer_fixtures.py -q

Closes #481