### PR TITLE
Replace SQL-first preview with answer plan

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -294,6 +294,7 @@ button:focus-visible {
 .signin-actions,
 .action-row,
 .guard-list,
+.answer-plan-grid,
 .evidence-list,
 .attempt-list,
 .history-list,
@@ -450,6 +451,10 @@ button:disabled {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.answer-plan-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .guard-item {
   display: grid;
   gap: 6px;
@@ -457,6 +462,32 @@ button:disabled {
   border: 1px solid var(--border-soft);
   border-radius: 14px;
   background: rgba(7, 11, 20, 0.38);
+}
+
+.answer-plan-item {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: rgba(7, 11, 20, 0.34);
+}
+
+.answer-plan-item-wide {
+  grid-column: 1 / -1;
+}
+
+.answer-plan-item p,
+.answer-plan-list {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.answer-plan-list {
+  display: grid;
+  gap: 6px;
+  padding-left: 18px;
 }
 
 .attempt-list {
@@ -610,6 +641,7 @@ button:disabled {
   }
 
   .frame-meta,
+  .answer-plan-grid,
   .guard-list {
     grid-template-columns: 1fr;
   }

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1119,6 +1119,7 @@ describe("HomePage", () => {
   it("uses authoritative run evidence after executing a submitted preview candidate", async () => {
     appendCsrfToken();
 
+    let previewRequestCount = 0;
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
       const url = input.toString();
 
@@ -1130,6 +1131,74 @@ describe("HomePage", () => {
       }
 
       if (url.endsWith("/requests/preview")) {
+        previewRequestCount += 1;
+        if (previewRequestCount === 2) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                audit: {
+                  events: [
+                    {
+                      candidate_state: "preview_ready",
+                      event_id: "revised-preview-audit-event",
+                      event_type: "candidate_previewed",
+                      occurred_at: "2026-04-21T14:50:00Z",
+                      query_candidate_id: "candidate-revised-preview",
+                      request_id: "request-revised-preview",
+                      source_id: "sap-approved-spend"
+                    }
+                  ],
+                  source_id: "sap-approved-spend",
+                  state: "recorded"
+                },
+                candidate: {
+                  candidate_id: "candidate-revised-preview",
+                  candidate_sql: "select vendor_name from approved_vendor_spend where fiscal_year = 2026;",
+                  dataset_contract_version: 9,
+                  guard_status: "passed",
+                  retrieved_citations: [
+                    {
+                      asset_id: "revised-metric-definition",
+                      asset_kind: "metric_definition",
+                      authority: "advisory_context",
+                      can_authorize_execution: false,
+                      citation_label: "Revised preview citation",
+                      dataset_contract_version: 9,
+                      schema_snapshot_version: 10,
+                      source_family: "postgresql",
+                      source_flavor: "warehouse",
+                      source_id: "sap-approved-spend"
+                    }
+                  ],
+                  review_evidence: [
+                    {
+                      audit_event_id: "review-revised-preview",
+                      assumptions: ["Revised preview assumption."],
+                      clarifying_questions: [],
+                      review_contract_version: "review_llm_adapter_output.v1",
+                      review_decision_id: "review-revised-preview",
+                      review_status: "ready",
+                      risk_flags: ["Revised preview risk."]
+                    }
+                  ],
+                  schema_snapshot_version: 10,
+                  semantic_contract_version: "approved_vendor_spend.v3",
+                  source_family: "postgresql",
+                  source_flavor: "warehouse",
+                  source_id: "sap-approved-spend",
+                  state: "preview_ready"
+                },
+                request: {
+                  question: "Revise the completed answer for 2026",
+                  request_id: "request-revised-preview",
+                  source_id: "sap-approved-spend",
+                  state: "submitted"
+                }
+              })
+          });
+        }
+
         return Promise.resolve({
           ok: true,
           json: () =>
@@ -1266,6 +1335,33 @@ describe("HomePage", () => {
     expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("1 row");
     expect(screen.getByLabelText(/audit lifecycle events/i)).not.toHaveTextContent(
       "candidate_previewed"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+    fireEvent.change(screen.getByRole("combobox", { name: /source/i }), {
+      target: { value: "sap-approved-spend" }
+    });
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Revise the completed answer for 2026" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await waitFor(() => {
+      expect(previewRequestCount).toBe(2);
+    });
+
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("Revised preview citation");
+    expect(answerPlan).toHaveTextContent("Revised preview assumption.");
+    expect(answerPlan).toHaveTextContent("Revised preview risk.");
+    expect(answerPlan).toHaveTextContent(/dataset contract v9/i);
+    expect(answerPlan).toHaveTextContent(/schema snapshot v10/i);
+    expect(answerPlan).not.toHaveTextContent("Submitted preview citation");
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent(
+      "revised-preview-audit-event"
+    );
+    expect(screen.getByLabelText(/audit lifecycle events/i)).not.toHaveTextContent(
+      "execution-audit-event"
     );
   });
 
@@ -2492,6 +2588,38 @@ describe("HomePage", () => {
               request: {
                 question: "Show approved vendors by quarterly spend",
                 request_id: "request-citation-malformed",
+                source_id: "sap-approved-spend",
+                state: "submitted"
+              }
+            })
+        }
+      },
+      {
+        expectedCopy: /malformed_preview_response/i,
+        response: {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                source_id: "sap-approved-spend",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-audit-malformed",
+                candidate_sql: "select vendor_name from approved_vendor_spend;",
+                dataset_contract_version: 1,
+                guard_status: "allow",
+                retrieved_citations: [],
+                review_evidence: [],
+                schema_snapshot_version: 1,
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                state: "preview_ready"
+              },
+              request: {
+                question: "Show approved vendors by quarterly spend",
+                request_id: "request-audit-malformed",
                 source_id: "sap-approved-spend",
                 state: "submitted"
               }

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -875,6 +875,8 @@ describe("HomePage", () => {
                         authority: "advisory_context",
                         canAuthorizeExecution: false,
                         citationLabel: "Approved spend metric definition",
+                        datasetContractVersion: 3,
+                        schemaSnapshotVersion: 5,
                         sourceFamily: "postgresql",
                         sourceFlavor: "warehouse",
                         sourceId: "sap-approved-spend"
@@ -924,6 +926,8 @@ describe("HomePage", () => {
     expect(answerPlan).toHaveTextContent("Top approved vendors by quarterly spend");
     expect(answerPlan).toHaveTextContent("SAP spend cube / approved_vendor_spend");
     expect(answerPlan).toHaveTextContent("Approved spend metric definition");
+    expect(answerPlan).toHaveTextContent(/dataset contract v3/i);
+    expect(answerPlan).toHaveTextContent(/schema snapshot v5/i);
     expect(answerPlan).toHaveTextContent("Vendor means normalized vendor_id.");
     expect(answerPlan).toHaveTextContent(/review ready/i);
     expect(answerPlan).toHaveTextContent(/review the answer plan, then execute the reviewed candidate/i);
@@ -933,6 +937,183 @@ describe("HomePage", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /authoritative sql preview/i })).not.toBeInTheDocument();
+  });
+
+  it("uses submitted preview evidence instead of stale selected run context after revision submit", async () => {
+    appendCsrfToken();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              history: [
+                {
+                  auditEvents: [
+                    {
+                      candidateId: "candidate-old-run",
+                      eventId: "run-stale-context",
+                      eventType: "execution_completed",
+                      occurredAt: "2026-04-21T14:24:00Z",
+                      requestId: "request-old-run",
+                      sourceId: "sap-approved-spend"
+                    }
+                  ],
+                  executedEvidence: [],
+                  itemType: "run",
+                  label: "Prior completed run",
+                  lifecycleState: "completed",
+                  occurredAt: "2026-04-21T14:25:00Z",
+                  recordId: "run-stale-context",
+                  retrievedCitations: [
+                    {
+                      assetId: "old-metric-definition",
+                      assetKind: "metric_definition",
+                      authority: "advisory_context",
+                      canAuthorizeExecution: false,
+                      citationLabel: "Old run citation should not be primary",
+                      datasetContractVersion: 1,
+                      schemaSnapshotVersion: 1,
+                      sourceFamily: "postgresql",
+                      sourceFlavor: "warehouse",
+                      sourceId: "sap-approved-spend"
+                    }
+                  ],
+                  reviewEvidence: [
+                    {
+                      auditEventId: "run-stale-context",
+                      assumptions: ["Old run assumption should not be primary."],
+                      clarifyingQuestions: ["Old run question should not be primary?"],
+                      reviewContractVersion: "review_llm_adapter_output.v1",
+                      reviewDecisionId: "review-old-run",
+                      reviewStatus: "needs_clarification",
+                      riskFlags: ["Old run risk should not be primary."]
+                    }
+                  ],
+                  rowCount: 2,
+                  runState: "completed",
+                  sourceId: "sap-approved-spend",
+                  sourceLabel: "SAP spend cube / approved_vendor_spend"
+                }
+              ],
+              sources: workflowPayload().sources
+            })
+        });
+      }
+
+      if (url.endsWith("/requests/preview")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [],
+                source_id: "sap-approved-spend",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-new-preview",
+                candidate_sql: "select vendor_name from approved_vendor_spend;",
+                dataset_contract_version: 7,
+                guard_status: "passed",
+                retrieved_citations: [
+                  {
+                    asset_id: "new-metric-definition",
+                    asset_kind: "metric_definition",
+                    authority: "advisory_context",
+                    can_authorize_execution: false,
+                    citation_label: "New submitted preview citation",
+                    dataset_contract_version: 7,
+                    schema_snapshot_version: 8,
+                    source_family: "postgresql",
+                    source_flavor: "warehouse",
+                    source_id: "sap-approved-spend"
+                  }
+                ],
+                review_evidence: [
+                  {
+                    audit_event_id: "review-new-preview",
+                    assumptions: ["New submitted assumption."],
+                    clarifying_questions: [],
+                    review_contract_version: "review_llm_adapter_output.v1",
+                    review_decision_id: "review-new-preview",
+                    review_status: "ready",
+                    risk_flags: ["New submitted risk."]
+                  }
+                ],
+                schema_snapshot_version: 8,
+                semantic_contract_version: "approved_vendor_spend.v2",
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                state: "preview_ready"
+              },
+              request: {
+                question: "Revise the completed run answer",
+                request_id: "request-new-preview",
+                source_id: "sap-approved-spend",
+                state: "submitted"
+              }
+            })
+        });
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "run",
+          history_record_id: "run-stale-context",
+          question: "Prior completed run",
+          source_id: "sap-approved-spend",
+          state: "completed"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+    fireEvent.change(screen.getByRole("combobox", { name: /source/i }), {
+      target: { value: "sap-approved-spend" }
+    });
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Revise the completed run answer" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/requests/preview",
+        expect.objectContaining({
+          body: JSON.stringify({
+            question: "Revise the completed run answer",
+            source_id: "sap-approved-spend",
+            revise_from: {
+              item_type: "run",
+              request_id: "request-old-run",
+              candidate_id: "candidate-old-run",
+              run_id: "run-stale-context"
+            }
+          })
+        })
+      );
+    });
+
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("New submitted preview citation");
+    expect(answerPlan).toHaveTextContent("New submitted assumption.");
+    expect(answerPlan).toHaveTextContent("New submitted risk.");
+    expect(answerPlan).toHaveTextContent(/dataset contract v7/i);
+    expect(answerPlan).toHaveTextContent(/schema snapshot v8/i);
+    expect(answerPlan).not.toHaveTextContent("Old run citation should not be primary");
+    expect(answerPlan).not.toHaveTextContent("Old run assumption should not be primary.");
+    expect(answerPlan).not.toHaveTextContent("Old run question should not be primary?");
+    expect(answerPlan).not.toHaveTextContent("Old run risk should not be primary.");
   });
 
   it("renders candidate attempt guard comparisons as read-only history evidence", async () => {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1116,6 +1116,159 @@ describe("HomePage", () => {
     expect(answerPlan).not.toHaveTextContent("Old run risk should not be primary.");
   });
 
+  it("uses authoritative run evidence after executing a submitted preview candidate", async () => {
+    appendCsrfToken();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(workflowPayload())
+        });
+      }
+
+      if (url.endsWith("/requests/preview")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [
+                  {
+                    candidate_state: "preview_ready",
+                    event_id: "preview-audit-event",
+                    event_type: "candidate_previewed",
+                    occurred_at: "2026-04-21T14:24:00Z",
+                    query_candidate_id: "candidate-submitted-preview",
+                    request_id: "request-submitted-preview",
+                    source_id: "sap-approved-spend"
+                  }
+                ],
+                source_id: "sap-approved-spend",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-submitted-preview",
+                candidate_sql: "select vendor_name from approved_vendor_spend;",
+                dataset_contract_version: 7,
+                guard_status: "passed",
+                retrieved_citations: [
+                  {
+                    asset_id: "submitted-metric-definition",
+                    asset_kind: "metric_definition",
+                    authority: "advisory_context",
+                    can_authorize_execution: false,
+                    citation_label: "Submitted preview citation",
+                    dataset_contract_version: 7,
+                    schema_snapshot_version: 8,
+                    source_family: "postgresql",
+                    source_flavor: "warehouse",
+                    source_id: "sap-approved-spend"
+                  }
+                ],
+                review_evidence: [
+                  {
+                    audit_event_id: "review-submitted-preview",
+                    assumptions: ["Submitted preview assumption."],
+                    clarifying_questions: [],
+                    review_contract_version: "review_llm_adapter_output.v1",
+                    review_decision_id: "review-submitted-preview",
+                    review_status: "ready",
+                    risk_flags: []
+                  }
+                ],
+                schema_snapshot_version: 8,
+                semantic_contract_version: "approved_vendor_spend.v2",
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                state: "preview_ready"
+              },
+              request: {
+                question: "Show approved vendors by quarterly spend",
+                request_id: "request-submitted-preview",
+                source_id: "sap-approved-spend",
+                state: "submitted"
+              }
+            })
+        });
+      }
+
+      if (url.endsWith("/candidates/candidate-submitted-preview/execute")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [
+                  {
+                    candidate_state: "executed",
+                    event_id: "execution-audit-event",
+                    event_type: "execution_completed",
+                    execution_row_count: 1,
+                    execution_run_id: "run-submitted-preview",
+                    occurred_at: "2026-04-21T14:42:17+09:00",
+                    query_candidate_id: "candidate-submitted-preview",
+                    request_id: "request-submitted-preview",
+                    result_truncated: false,
+                    source_id: "sap-approved-spend"
+                  }
+                ]
+              },
+              candidate_id: "candidate-submitted-preview",
+              metadata: {
+                candidate_id: "candidate-submitted-preview",
+                execution_run_id: "run-submitted-preview",
+                result_truncated: false,
+                row_count: 1,
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend"
+              },
+              rows: [{ total_spend: 1200, vendor_name: "Acme Supplies" }],
+              source_id: "sap-approved-spend"
+            })
+        });
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(await HomePage({}));
+
+    fireEvent.change(screen.getByRole("combobox", { name: /source/i }), {
+      target: { value: "sap-approved-spend" }
+    });
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Show approved vendors by quarterly spend" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await screen.findByText(/preview request accepted/i);
+    fireEvent.click(screen.getByRole("button", { name: /execute reviewed candidate/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/execution completed/i).length).toBeGreaterThan(0);
+    });
+
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent(
+      "execution_completed"
+    );
+    expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent(
+      "execution-audit-event"
+    );
+    expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent(
+      "backend_execution_result"
+    );
+    expect(screen.getByLabelText(/executed evidence/i)).toHaveTextContent("1 row");
+    expect(screen.getByLabelText(/audit lifecycle events/i)).not.toHaveTextContent(
+      "candidate_previewed"
+    );
+  });
+
   it("renders candidate attempt guard comparisons as read-only history evidence", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1505,6 +1658,75 @@ describe("HomePage", () => {
         );
       }
     }
+  });
+
+  it("surfaces backend-only clarification prompts in the answer plan", async () => {
+    appendCsrfToken();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(workflowPayload())
+        });
+      }
+
+      if (url.endsWith("/requests/preview")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [],
+                source_id: "sap-approved-spend",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-intent-clarification",
+                candidate_sql: null,
+                dataset_contract_version: 1,
+                denial_reason: "Which fiscal quarter should SafeQuery use?",
+                guard_status: "pending",
+                intent_mapping: {
+                  clarification: "Should inactive vendors be included?"
+                },
+                review_evidence: [],
+                schema_snapshot_version: 1,
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                state: "clarification_required"
+              },
+              request: {
+                question: "Show approved vendors by quarterly spend",
+                request_id: "request-intent-clarification",
+                source_id: "sap-approved-spend",
+                state: "clarification_required"
+              }
+            })
+        });
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(await HomePage({}));
+
+    fireEvent.change(screen.getByRole("combobox", { name: /source/i }), {
+      target: { value: "sap-approved-spend" }
+    });
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Show approved vendors by quarterly spend" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    expect((await screen.findAllByText(/clarification required/i)).length).toBeGreaterThan(0);
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("Which fiscal quarter should SafeQuery use?");
+    expect(answerPlan).toHaveTextContent("Should inactive vendors be included?");
+    expect(answerPlan).toHaveTextContent(/answer the clarifying questions/i);
   });
 
   it("executes only preview-ready candidates and maps stale-ui backend denials or cancellations to recovery states", async () => {
@@ -2214,6 +2436,64 @@ describe("HomePage", () => {
                 request_id: "request-review-malformed",
                 source_id: "sap-approved-spend",
                 state: "blocked"
+              }
+            })
+        }
+      },
+      {
+        expectedCopy: /malformed_preview_response/i,
+        response: {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [],
+                source_id: "sap-approved-spend",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-citation-malformed",
+                candidate_sql: "select vendor_name from approved_vendor_spend;",
+                dataset_contract_version: 1,
+                guard_status: "allow",
+                retrieved_citations: [
+                  {
+                    asset_id: "spend-metric-definition",
+                    asset_kind: "metric_definition",
+                    authority: "advisory_context",
+                    can_authorize_execution: false,
+                    citation_label: "Approved spend metric definition",
+                    dataset_contract_version: 1,
+                    schema_snapshot_version: 1,
+                    source_family: "postgresql",
+                    source_flavor: "warehouse",
+                    source_id: "sap-approved-spend"
+                  },
+                  {
+                    asset_id: "mismatched-source-definition",
+                    asset_kind: "metric_definition",
+                    authority: "advisory_context",
+                    can_authorize_execution: false,
+                    citation_label: "Mismatched source metric definition",
+                    dataset_contract_version: 1,
+                    schema_snapshot_version: 1,
+                    source_family: "postgresql",
+                    source_flavor: "warehouse",
+                    source_id: "legacy-finance-archive"
+                  }
+                ],
+                review_evidence: [],
+                schema_snapshot_version: 1,
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                state: "preview_ready"
+              },
+              request: {
+                question: "Show approved vendors by quarterly spend",
+                request_id: "request-citation-malformed",
+                source_id: "sap-approved-spend",
+                state: "submitted"
               }
             })
         }

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1119,7 +1119,30 @@ describe("HomePage", () => {
           json: () =>
             Promise.resolve({
               audit: {
-                events: [],
+                events: [
+                  {
+                    event_id: "00000000-0000-4000-8000-000000000490",
+                    event_type: "retrieval_completed",
+                    occurred_at: "2026-04-21T14:24:00Z",
+                    request_id: "request-accepted-123",
+                    source_id: "sap-approved-spend",
+                    retrieved_citations: [
+                      {
+                        asset_id: "spend-metric-definition",
+                        asset_kind: "metric_definition",
+                        authority: "advisory_context",
+                        can_authorize_execution: false,
+                        citation_label: "Approved spend metric definition",
+                        dataset_contract_version: 1,
+                        schema_snapshot_version: 1,
+                        source_family: "postgresql",
+                        source_flavor: "warehouse",
+                        source_id: "sap-approved-spend"
+                      }
+                    ],
+                    semantic_contract_version: "approved_vendor_spend.v1"
+                  }
+                ],
                 source_id: "sap-approved-spend",
                 state: "recorded"
               },
@@ -1129,6 +1152,7 @@ describe("HomePage", () => {
                 dataset_contract_version: 1,
                 guard_status: "pending",
                 schema_snapshot_version: 1,
+                semantic_contract_version: "approved_vendor_spend.v1",
                 source_family: "postgresql",
                 source_flavor: "warehouse",
                 source_id: "sap-approved-spend",
@@ -1181,6 +1205,11 @@ describe("HomePage", () => {
     });
     expect(screen.getByText(/preview request accepted/i)).toBeInTheDocument();
     expect(screen.getByText("candidate-accepted-123")).toBeInTheDocument();
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("approved_vendor_spend.v1");
+    expect(answerPlan).toHaveTextContent(/dataset contract v1/i);
+    expect(answerPlan).toHaveTextContent(/schema snapshot v1/i);
+    expect(answerPlan).toHaveTextContent("Approved spend metric definition");
     expect(screen.getByText(/canonical sql has not been generated for this candidate/i)).toBeInTheDocument();
     expect(screen.queryByText(/placeholder sql generated from the question review surface/i)).not.toBeInTheDocument();
   });
@@ -1280,10 +1309,13 @@ describe("HomePage", () => {
       });
       fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
 
-      expect(await screen.findByText(stateCase.expectedCopy)).toBeInTheDocument();
+      expect((await screen.findAllByText(stateCase.expectedCopy)).length).toBeGreaterThan(0);
       expect(screen.queryByText(/preview request accepted/i)).not.toBeInTheDocument();
       expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
       if (stateCase.candidateState === "clarification_required") {
+        const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+        expect(answerPlan).toHaveTextContent("Should inactive vendors be included?");
+        expect(answerPlan).toHaveTextContent(/answer the clarifying questions/i);
         expect(screen.getByLabelText(/review evidence/i)).toHaveTextContent(
           "Should inactive vendors be included?"
         );

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -80,13 +80,13 @@ describe("HomePage", () => {
     expect(screen.getByRole("link", { name: /sign in/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /submit for preview/i })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: /source/i })).toBeInTheDocument();
-    expect(screen.getByText("Generated SQL")).toBeInTheDocument();
+    expect(screen.getByText("Technical SQL review")).toBeInTheDocument();
     expect(screen.getByText("Guard status")).toBeInTheDocument();
     expect(screen.getByText("Results")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /review denied/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /empty state/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /compose the operator request/i })).toBeInTheDocument();
-    expect(screen.getByText(/operator shell for governed question review, sql preview, and execution posture/i)).toBeInTheDocument();
+    expect(screen.getByText(/operator shell for governed question review, answer planning, and execution posture/i)).toBeInTheDocument();
     expect(screen.queryByText(/compose the analyst question/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/awaiting analyst review/i)).not.toBeInTheDocument();
   });
@@ -749,9 +749,10 @@ describe("HomePage", () => {
       })
     );
 
-    expect(screen.getByRole("heading", { name: /sql preview state/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /answer plan preview/i })).toBeInTheDocument();
     expect(screen.getByDisplayValue("Show approved vendors by quarterly spend")).toBeInTheDocument();
-    expect(screen.getByText(/authoritative sql preview/i)).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /business-readable answer plan/i })).toBeInTheDocument();
+    expect(screen.getByText(/technical sql review/i)).toBeInTheDocument();
     expect(screen.getByText(/no authoritative candidate selected/i)).toBeInTheDocument();
     expect(screen.queryByText(/placeholder sql generated from the question review surface/i)).not.toBeInTheDocument();
   });
@@ -832,6 +833,106 @@ describe("HomePage", () => {
       "href",
       expect.stringContaining("history_record_id=candidate-selected")
     );
+  });
+
+  it("presents reopened candidate previews as a business-readable answer plan before SQL", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    auditEvents: [
+                      {
+                        candidateId: "candidate-selected",
+                        candidateState: "preview_ready",
+                        eventId: "audit-candidate-selected",
+                        eventType: "guard_evaluated",
+                        guardDecision: "allow",
+                        occurredAt: "2026-04-21T14:24:00Z",
+                        requestId: "request-selected",
+                        sourceId: "sap-approved-spend"
+                      }
+                    ],
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Top approved vendors by quarterly spend",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-selected",
+                    requestId: "request-selected",
+                    retrievedCitations: [
+                      {
+                        assetId: "spend-metric-definition",
+                        assetKind: "metric_definition",
+                        authority: "advisory_context",
+                        canAuthorizeExecution: false,
+                        citationLabel: "Approved spend metric definition",
+                        sourceFamily: "postgresql",
+                        sourceFlavor: "warehouse",
+                        sourceId: "sap-approved-spend"
+                      }
+                    ],
+                    reviewEvidence: [
+                      {
+                        auditEventId: "audit-candidate-selected",
+                        assumptions: [
+                          "Vendor means normalized vendor_id.",
+                          "Quarter means fiscal quarter."
+                        ],
+                        clarifyingQuestions: [],
+                        reviewContractVersion: "review_llm_adapter_output.v1",
+                        reviewDecisionId: "review-candidate-selected",
+                        reviewStatus: "ready",
+                        riskFlags: ["Uses advisory semantic mapping evidence."]
+                      }
+                    ],
+                    semanticContractVersion: "approved_vendor_spend.v1",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-selected",
+          question: "Top approved vendors by quarterly spend",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("Top approved vendors by quarterly spend");
+    expect(answerPlan).toHaveTextContent("SAP spend cube / approved_vendor_spend");
+    expect(answerPlan).toHaveTextContent("Approved spend metric definition");
+    expect(answerPlan).toHaveTextContent("Vendor means normalized vendor_id.");
+    expect(answerPlan).toHaveTextContent(/review ready/i);
+    expect(answerPlan).toHaveTextContent(/review the answer plan, then execute the reviewed candidate/i);
+
+    expect(
+      screen.getByRole("heading", { name: /technical sql review/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /authoritative sql preview/i })).not.toBeInTheDocument();
   });
 
   it("renders candidate attempt guard comparisons as read-only history evidence", async () => {

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -203,7 +203,8 @@ describe("pilot safety UI smoke", () => {
       })
     );
 
-    expect(screen.getByRole("heading", { name: /sql preview state/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /answer plan preview/i })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: /business-readable answer plan/i })).toBeInTheDocument();
     expect(
       screen.getByText("select vendor_name from finance.approved_vendor_spend limit 10;")
     ).toBeInTheDocument();
@@ -465,6 +466,11 @@ describe("pilot safety UI smoke", () => {
   });
 
   it("submits a revised preview attempt from execution-denied run context", async () => {
+    const csrfToken = document.createElement("meta");
+    csrfToken.name = "safequery-csrf-token";
+    csrfToken.content = "csrf-from-session-bootstrap";
+    document.head.appendChild(csrfToken);
+
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
 
@@ -561,6 +567,11 @@ describe("pilot safety UI smoke", () => {
   ])(
     "submits a revised preview attempt from %s request-backed failure history",
     async (lifecycleState, failureLabel) => {
+      const csrfToken = document.createElement("meta");
+      csrfToken.name = "safequery-csrf-token";
+      csrfToken.content = "csrf-from-session-bootstrap";
+      document.head.appendChild(csrfToken);
+
       const requestId = `request-pilot-${failureLabel}-001`;
       const question = `Pilot ${failureLabel} preview`;
       const revisedQuestion = `Pilot ${failureLabel} preview with revised source context`;

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -148,15 +148,22 @@ type ExecuteSubmissionStatus =
     };
 
 type PreviewSubmissionResult = {
+  auditEvents: OperatorWorkflowAuditEvent[];
   candidateId: string;
   candidateSql: string | null;
   candidateState: string;
+  datasetContractVersion: number | null;
   guardStatus: string;
   requestId: string;
   requestState: string;
   reviewEvidence: OperatorWorkflowReviewEvidence[];
+  retrievedCitations: OperatorWorkflowRetrievedCitation[];
   revisionContext: RevisionDraftContext | null;
+  schemaSnapshotVersion: number | null;
+  semanticContractVersion: string | null;
   sourceId: string;
+  sourceFamily: string | null;
+  sourceFlavor: string | null;
 };
 
 type AuthoritativeCandidatePreview = {
@@ -164,11 +171,13 @@ type AuthoritativeCandidatePreview = {
   candidateId: string;
   candidateSql: string | null;
   candidateState: string;
+  datasetContractVersion?: number | null;
   executedEvidence: OperatorWorkflowExecutedEvidence[];
   guardStatus: string;
   requestId?: string;
   reviewEvidence: OperatorWorkflowReviewEvidence[];
   retrievedCitations: OperatorWorkflowRetrievedCitation[];
+  schemaSnapshotVersion?: number | null;
   semanticContractVersion?: string | null;
   sourceId: string;
   sourceLabel?: string;
@@ -566,6 +575,10 @@ function readOptionalNonNegativeInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
 }
 
+function readRequiredPositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
 function readStringArray(value: unknown): string[] | null {
   if (value === undefined) {
     return [];
@@ -625,6 +638,165 @@ function parsePreviewReviewEvidence(value: unknown): OperatorWorkflowReviewEvide
     reviewStatus,
     riskFlags
   };
+}
+
+function parsePreviewAuditEvent(
+  value: unknown,
+  expectedSourceId: string
+): OperatorWorkflowAuditEvent | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const eventId = readOptionalString(value.event_id) ?? readOptionalString(value.eventId);
+  const eventType = readOptionalString(value.event_type) ?? readOptionalString(value.eventType);
+  const occurredAt = readOptionalString(value.occurred_at) ?? readOptionalString(value.occurredAt);
+  const requestId = readOptionalString(value.request_id) ?? readOptionalString(value.requestId);
+  const sourceId = readOptionalString(value.source_id) ?? readOptionalString(value.sourceId);
+
+  if (!eventId || !eventType || !occurredAt || !requestId || sourceId !== expectedSourceId) {
+    return null;
+  }
+
+  return {
+    candidateId:
+      readOptionalString(value.query_candidate_id) ??
+      readOptionalString(value.queryCandidateId) ??
+      readOptionalString(value.candidate_id) ??
+      readOptionalString(value.candidateId),
+    candidateState:
+      readOptionalString(value.candidate_state) ?? readOptionalString(value.candidateState),
+    denialReason: readOptionalString(value.denial_reason) ?? readOptionalString(value.denialReason),
+    eventId,
+    eventType,
+    executionRunId:
+      readOptionalString(value.execution_run_id) ?? readOptionalString(value.executionRunId),
+    guardDecision: readOptionalString(value.guard_decision) ?? readOptionalString(value.guardDecision),
+    occurredAt,
+    primaryDenyCode:
+      readOptionalString(value.primary_deny_code) ?? readOptionalString(value.primaryDenyCode),
+    requestId,
+    resultTruncated:
+      typeof value.result_truncated === "boolean"
+        ? value.result_truncated
+        : typeof value.resultTruncated === "boolean"
+          ? value.resultTruncated
+          : null,
+    rowCount:
+      readOptionalNonNegativeInteger(value.execution_row_count) ??
+      readOptionalNonNegativeInteger(value.rowCount),
+    semanticContractVersion:
+      readOptionalString(value.semantic_contract_version) ??
+      readOptionalString(value.semanticContractVersion),
+    sourceId
+  };
+}
+
+function parsePreviewRetrievedCitation(
+  value: unknown,
+  expectedSourceId: string
+): OperatorWorkflowRetrievedCitation | null {
+  if (!isObject(value)) {
+    return null;
+  }
+
+  const assetId = readOptionalString(value.asset_id) ?? readOptionalString(value.assetId);
+  const assetKind = readOptionalString(value.asset_kind) ?? readOptionalString(value.assetKind);
+  const citationLabel =
+    readOptionalString(value.citation_label) ?? readOptionalString(value.citationLabel);
+  const sourceId = readOptionalString(value.source_id) ?? readOptionalString(value.sourceId);
+  const sourceFamily =
+    readOptionalString(value.source_family) ?? readOptionalString(value.sourceFamily);
+  const sourceFlavor =
+    readOptionalString(value.source_flavor) ?? readOptionalString(value.sourceFlavor);
+  const canAuthorizeExecution =
+    typeof value.can_authorize_execution === "boolean"
+      ? value.can_authorize_execution
+      : value.canAuthorizeExecution;
+
+  if (
+    value.authority !== "advisory_context" ||
+    canAuthorizeExecution !== false ||
+    !assetId ||
+    !assetKind ||
+    !citationLabel ||
+    sourceId !== expectedSourceId ||
+    !sourceFamily
+  ) {
+    return null;
+  }
+
+  return {
+    assetId,
+    assetKind,
+    authority: "advisory_context",
+    canAuthorizeExecution: false,
+    citationLabel,
+    sourceId,
+    sourceFamily,
+    sourceFlavor: sourceFlavor ?? null
+  };
+}
+
+function parsePreviewRetrievedCitationsFromValue(
+  value: unknown,
+  expectedSourceId: string
+): OperatorWorkflowRetrievedCitation[] | null {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const parsed = value
+    .map((item) => parsePreviewRetrievedCitation(item, expectedSourceId))
+    .filter((item): item is OperatorWorkflowRetrievedCitation => item !== null);
+  return parsed;
+}
+
+function parsePreviewRetrievedCitationsFromEvents(
+  events: unknown,
+  expectedSourceId: string
+): OperatorWorkflowRetrievedCitation[] | null {
+  if (events === undefined) {
+    return [];
+  }
+  if (!Array.isArray(events)) {
+    return null;
+  }
+
+  const citations: OperatorWorkflowRetrievedCitation[] = [];
+  for (const event of events) {
+    if (!isObject(event)) {
+      return null;
+    }
+    const eventCitations = parsePreviewRetrievedCitationsFromValue(
+      event.retrieved_citations === undefined
+        ? event.retrievedCitations
+        : event.retrieved_citations,
+      expectedSourceId
+    );
+    if (eventCitations === null) {
+      return null;
+    }
+    citations.push(...eventCitations);
+  }
+  return citations;
+}
+
+function dedupeRetrievedCitations(
+  citations: OperatorWorkflowRetrievedCitation[]
+): OperatorWorkflowRetrievedCitation[] {
+  const seen = new Set<string>();
+  return citations.filter((citation) => {
+    const key = `${citation.sourceId}:${citation.assetKind}:${citation.assetId}:${citation.citationLabel}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }
 
 function parseExecuteAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
@@ -819,9 +991,26 @@ function parsePreviewSubmissionResult(
     value.candidate.candidate_sql.trim().length > 0
       ? value.candidate.candidate_sql
       : null;
+  const datasetContractVersion =
+    readRequiredPositiveInteger(value.candidate.dataset_contract_version) ??
+    readRequiredPositiveInteger(value.candidate.datasetContractVersion);
   const guardStatus = readRequiredString(value.candidate.guard_status);
   const requestState = readRequiredString(value.request.state);
+  const schemaSnapshotVersion =
+    readRequiredPositiveInteger(value.candidate.schema_snapshot_version) ??
+    readRequiredPositiveInteger(value.candidate.schemaSnapshotVersion);
+  const semanticContractVersion =
+    readOptionalString(value.candidate.semantic_contract_version) ??
+    readOptionalString(value.candidate.semanticContractVersion) ??
+    readOptionalString(value.request.semantic_contract_version) ??
+    readOptionalString(value.request.semanticContractVersion);
   const candidateState = readRequiredString(value.candidate.state);
+  const sourceFamily =
+    readOptionalString(value.candidate.source_family) ??
+    readOptionalString(value.candidate.sourceFamily);
+  const sourceFlavor =
+    readOptionalString(value.candidate.source_flavor) ??
+    readOptionalString(value.candidate.sourceFlavor);
   const hasSnakeReviewEvidence = Object.prototype.hasOwnProperty.call(
     value.candidate,
     "review_evidence"
@@ -843,6 +1032,32 @@ function parsePreviewSubmissionResult(
     return null;
   }
   const reviewEvidence = parsedReviewEvidence as OperatorWorkflowReviewEvidence[];
+  const auditEventsValue =
+    isObject(value.audit) && Array.isArray(value.audit.events) ? value.audit.events : [];
+  const parsedAuditEvents = auditEventsValue.map((event) =>
+    parsePreviewAuditEvent(event, expectedSourceId)
+  );
+  if (parsedAuditEvents.some((item) => item === null)) {
+    return null;
+  }
+  const auditEvents = parsedAuditEvents as OperatorWorkflowAuditEvent[];
+  const directRetrievedCitations = parsePreviewRetrievedCitationsFromValue(
+    value.candidate.retrieved_citations === undefined
+      ? value.candidate.retrievedCitations
+      : value.candidate.retrieved_citations,
+    expectedSourceId
+  );
+  const auditRetrievedCitations = parsePreviewRetrievedCitationsFromEvents(
+    auditEventsValue,
+    expectedSourceId
+  );
+  if (directRetrievedCitations === null || auditRetrievedCitations === null) {
+    return null;
+  }
+  const retrievedCitations = dedupeRetrievedCitations([
+    ...directRetrievedCitations,
+    ...auditRetrievedCitations
+  ]);
 
   if (
     !requestId ||
@@ -857,17 +1072,46 @@ function parsePreviewSubmissionResult(
   }
 
   return {
+    auditEvents,
     candidateId,
     candidateSql,
     candidateState,
+    datasetContractVersion,
     guardStatus,
     requestId,
     requestState,
     reviewEvidence,
+    retrievedCitations,
     revisionContext:
       parsePreviewRevisionContext(value.request.revision_context, expectedSourceId) ??
       parsePreviewRevisionContext(value.candidate.revision_context, expectedSourceId),
-    sourceId: expectedSourceId
+    schemaSnapshotVersion,
+    semanticContractVersion,
+    sourceId: expectedSourceId,
+    sourceFamily,
+    sourceFlavor: sourceFlavor ?? null
+  };
+}
+
+function buildSubmittedCandidatePreview(
+  result: PreviewSubmissionResult,
+  sourceLabel: string
+): AuthoritativeCandidatePreview {
+  return {
+    auditEvents: result.auditEvents,
+    candidateId: result.candidateId,
+    candidateSql: result.candidateSql,
+    candidateState: result.candidateState,
+    datasetContractVersion: result.datasetContractVersion,
+    executedEvidence: [],
+    guardStatus: result.guardStatus,
+    requestId: result.requestId,
+    reviewEvidence: result.reviewEvidence,
+    retrievedCitations: result.retrievedCitations,
+    schemaSnapshotVersion: result.schemaSnapshotVersion,
+    semanticContractVersion: result.semanticContractVersion,
+    sourceId: result.sourceId,
+    sourceLabel
   };
 }
 
@@ -1519,16 +1763,21 @@ function renderBusinessAnswerPlan(
     candidateAttempts[0];
   const semanticContractVersion =
     preview?.semanticContractVersion ?? latestAttempt?.semanticContractVersion ?? null;
+  const datasetContractVersion =
+    preview?.datasetContractVersion ?? latestAttempt?.datasetContractVersion ?? null;
+  const schemaSnapshotVersion =
+    preview?.schemaSnapshotVersion ?? latestAttempt?.schemaSnapshotVersion ?? null;
   const sourceEvidence = retrievedCitations.map((citation) => citation.citationLabel);
   const semanticEvidence = [
     semanticContractVersion ? `Semantic contract ${semanticContractVersion}` : null,
-    latestAttempt ? `Dataset contract v${latestAttempt.datasetContractVersion}` : null,
-    latestAttempt ? `Schema snapshot v${latestAttempt.schemaSnapshotVersion}` : null,
+    datasetContractVersion !== null ? `Dataset contract v${datasetContractVersion}` : null,
+    schemaSnapshotVersion !== null ? `Schema snapshot v${schemaSnapshotVersion}` : null,
     ...retrievedCitations.map(
       (citation) => `${formatStatusLabel(citation.assetKind)}: ${citation.citationLabel}`
     )
   ].filter((item): item is string => item !== null);
   const assumptions = latestReview?.assumptions ?? [];
+  const clarifyingQuestions = latestReview?.clarifyingQuestions ?? [];
   const reviewStatus = latestReview
     ? `Review ${latestReview.reviewStatus.replace(/_/g, " ")}`
     : "Review evidence not provided";
@@ -1538,6 +1787,8 @@ function renderBusinessAnswerPlan(
   const nextAction =
     preview === null
       ? "Submit the question for preview, then review the answer plan returned by SafeQuery."
+      : clarifyingQuestions.length > 0
+        ? "Answer the clarifying questions, then submit a revised preview before execution."
       : executeEnabled
         ? "Review the answer plan, then execute the reviewed candidate when the business intent and safety status match the request."
         : "Review the answer plan and resolve the guard or candidate status before execution.";
@@ -1585,6 +1836,18 @@ function renderBusinessAnswerPlan(
           <span className="meta-label">Assumptions</span>
           <strong>{assumptions.length > 0 ? "Review evidence supplied" : "No assumptions supplied"}</strong>
           {renderListOrPlaceholder(assumptions, "No review assumptions were supplied.")}
+        </div>
+        <div className="answer-plan-item">
+          <span className="meta-label">Clarifying questions</span>
+          <strong>
+            {clarifyingQuestions.length > 0
+              ? "Business clarification required"
+              : "No clarification requested"}
+          </strong>
+          {renderListOrPlaceholder(
+            clarifyingQuestions,
+            "No clarifying questions were supplied."
+          )}
         </div>
         <div className="answer-plan-item">
           <span className="meta-label">Safety and review status</span>
@@ -2698,19 +2961,9 @@ export function QueryWorkflowShell({
         setSubmittedSourceId(result.sourceId);
         setSubmittedState("review_denied");
         setRevisionDraft(result.revisionContext ?? revisionDraft);
-        setSubmittedCandidatePreview({
-          auditEvents: [],
-          candidateId: result.candidateId,
-          candidateSql: result.candidateSql,
-          candidateState: result.candidateState,
-          executedEvidence: [],
-          guardStatus: result.guardStatus,
-          requestId: result.requestId,
-          reviewEvidence: result.reviewEvidence,
-          retrievedCitations: [],
-          sourceId: result.sourceId,
-          sourceLabel: selectedSource.displayLabel
-        });
+        setSubmittedCandidatePreview(
+          buildSubmittedCandidatePreview(result, selectedSource.displayLabel)
+        );
         setPreviewSubmission({
           candidateState: result.candidateState,
           requestState: result.requestState,
@@ -2725,19 +2978,9 @@ export function QueryWorkflowShell({
         setSubmittedSourceId(result.sourceId);
         setSubmittedState("review_denied");
         setRevisionDraft(result.revisionContext ?? revisionDraft);
-        setSubmittedCandidatePreview({
-          auditEvents: [],
-          candidateId: result.candidateId,
-          candidateSql: result.candidateSql,
-          candidateState: result.candidateState,
-          executedEvidence: [],
-          guardStatus: result.guardStatus,
-          requestId: result.requestId,
-          reviewEvidence: result.reviewEvidence,
-          retrievedCitations: [],
-          sourceId: result.sourceId,
-          sourceLabel: selectedSource.displayLabel
-        });
+        setSubmittedCandidatePreview(
+          buildSubmittedCandidatePreview(result, selectedSource.displayLabel)
+        );
         setPreviewSubmission({
           candidateState: result.candidateState,
           requestState: result.requestState,
@@ -2751,19 +2994,9 @@ export function QueryWorkflowShell({
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
         setRevisionDraft(result.revisionContext ?? revisionDraft);
-        setSubmittedCandidatePreview({
-          auditEvents: [],
-          candidateId: result.candidateId,
-          candidateSql: result.candidateSql,
-          candidateState: result.candidateState,
-          executedEvidence: [],
-          guardStatus: result.guardStatus,
-          requestId: result.requestId,
-          reviewEvidence: result.reviewEvidence,
-          retrievedCitations: [],
-          sourceId: result.sourceId,
-          sourceLabel: selectedSource.displayLabel
-        });
+        setSubmittedCandidatePreview(
+          buildSubmittedCandidatePreview(result, selectedSource.displayLabel)
+        );
         setPreviewSubmission({
           candidateState: result.candidateState,
           requestState: result.requestState,
@@ -2786,19 +3019,9 @@ export function QueryWorkflowShell({
       setSubmittedSourceId(result.sourceId);
       setSubmittedState("preview");
       setRevisionDraft(result.revisionContext ?? revisionDraft);
-      setSubmittedCandidatePreview({
-        auditEvents: [],
-        candidateId: result.candidateId,
-        candidateSql: result.candidateSql,
-        candidateState: result.candidateState,
-        executedEvidence: [],
-        guardStatus: result.guardStatus,
-        requestId: result.requestId,
-        reviewEvidence: result.reviewEvidence,
-        retrievedCitations: [],
-        sourceId: result.sourceId,
-        sourceLabel: selectedSource.displayLabel
-      });
+      setSubmittedCandidatePreview(
+        buildSubmittedCandidatePreview(result, selectedSource.displayLabel)
+      );
       setPreviewSubmission({
         candidateState: result.candidateState,
         requestState: result.requestState,

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -732,10 +732,31 @@ function parsePreviewRetrievedCitation(
     authority: "advisory_context",
     canAuthorizeExecution: false,
     citationLabel,
+    datasetContractVersion:
+      readRequiredPositiveInteger(value.dataset_contract_version) ??
+      readRequiredPositiveInteger(value.datasetContractVersion),
+    schemaSnapshotVersion:
+      readRequiredPositiveInteger(value.schema_snapshot_version) ??
+      readRequiredPositiveInteger(value.schemaSnapshotVersion),
     sourceId,
     sourceFamily,
     sourceFlavor: sourceFlavor ?? null
   };
+}
+
+function singleCitationContractVersion(
+  citations: OperatorWorkflowRetrievedCitation[],
+  key: "datasetContractVersion" | "schemaSnapshotVersion"
+): number | null {
+  const versions = new Set<number>();
+  for (const citation of citations) {
+    const version = citation[key];
+    if (typeof version === "number" && Number.isInteger(version) && version > 0) {
+      versions.add(version);
+    }
+  }
+
+  return versions.size === 1 ? [...versions][0] : null;
 }
 
 function parsePreviewRetrievedCitationsFromValue(
@@ -1764,9 +1785,13 @@ function renderBusinessAnswerPlan(
   const semanticContractVersion =
     preview?.semanticContractVersion ?? latestAttempt?.semanticContractVersion ?? null;
   const datasetContractVersion =
-    preview?.datasetContractVersion ?? latestAttempt?.datasetContractVersion ?? null;
+    preview?.datasetContractVersion ??
+    latestAttempt?.datasetContractVersion ??
+    singleCitationContractVersion(retrievedCitations, "datasetContractVersion");
   const schemaSnapshotVersion =
-    preview?.schemaSnapshotVersion ?? latestAttempt?.schemaSnapshotVersion ?? null;
+    preview?.schemaSnapshotVersion ??
+    latestAttempt?.schemaSnapshotVersion ??
+    singleCitationContractVersion(retrievedCitations, "schemaSnapshotVersion");
   const sourceEvidence = retrievedCitations.map((citation) => citation.citationLabel);
   const semanticEvidence = [
     semanticContractVersion ? `Semantic contract ${semanticContractVersion}` : null,
@@ -2797,14 +2822,12 @@ export function QueryWorkflowShell({
           historyRecordId
         }
       : undefined;
-  const selectedAuditEvents =
-    historyRunContext?.auditEvents ?? candidatePreview?.auditEvents ?? [];
-  const selectedExecutedEvidence =
-    historyRunContext?.executedEvidence ?? candidatePreview?.executedEvidence ?? [];
-  const selectedRetrievedCitations =
-    historyRunContext?.retrievedCitations ?? candidatePreview?.retrievedCitations ?? [];
-  const selectedReviewEvidence =
-    historyRunContext?.reviewEvidence ?? candidatePreview?.reviewEvidence ?? [];
+  const selectedEvidenceContext =
+    submittedCandidatePreview ?? historyRunContext ?? candidatePreview;
+  const selectedAuditEvents = selectedEvidenceContext?.auditEvents ?? [];
+  const selectedExecutedEvidence = selectedEvidenceContext?.executedEvidence ?? [];
+  const selectedRetrievedCitations = selectedEvidenceContext?.retrievedCitations ?? [];
+  const selectedReviewEvidence = selectedEvidenceContext?.reviewEvidence ?? [];
   const firstRunGuidance = getFirstRunGuidance(operatorWorkflow);
   const operatorRecoveryGuidance = getOperatorRecoveryGuidance(
     normalizedState,
@@ -2819,6 +2842,9 @@ export function QueryWorkflowShell({
       ? operatorWorkflow.history.find((item) => item.recordId === candidatePreview.candidateId)
       : undefined);
   const selectedCandidateAttempts = selectedCandidateAttemptHistory?.candidateAttempts ?? [];
+  const selectedAnswerPlanCandidateAttempts = submittedCandidatePreview
+    ? []
+    : selectedCandidateAttempts;
   const selectedRevisionDraft = revisionDraftFromSelectedContext(
     normalizedState,
     candidatePreview,
@@ -3283,7 +3309,7 @@ export function QueryWorkflowShell({
                 workflowContext.sourceIdentity,
                 selectedRetrievedCitations,
                 selectedReviewEvidence,
-                selectedCandidateAttempts,
+                selectedAnswerPlanCandidateAttempts,
                 executeEnabled
               )
             : null}

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -169,6 +169,7 @@ type AuthoritativeCandidatePreview = {
   requestId?: string;
   reviewEvidence: OperatorWorkflowReviewEvidence[];
   retrievedCitations: OperatorWorkflowRetrievedCitation[];
+  semanticContractVersion?: string | null;
   sourceId: string;
   sourceLabel?: string;
 };
@@ -256,8 +257,8 @@ const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
     label: "Failed"
   },
   preview: {
-    description: "The operator request has been staged for governed candidate review.",
-    label: "SQL preview"
+    description: "The operator request has been staged as a business-readable answer plan.",
+    label: "Answer plan"
   },
   query: {
     description: "Compose a governed question and move into review without leaving the product shell.",
@@ -1241,6 +1242,7 @@ function findAuthoritativeCandidatePreview(
     requestId: candidate.requestId ?? undefined,
     reviewEvidence: candidate.reviewEvidence,
     retrievedCitations: candidate.retrievedCitations,
+    semanticContractVersion: candidate.semanticContractVersion,
     sourceId: candidate.sourceId,
     sourceLabel: candidate.sourceLabel
   };
@@ -1459,8 +1461,8 @@ function renderCandidateSqlPreview(preview: AuthoritativeCandidatePreview | null
       <div className="placeholder-block">
         <p className="placeholder-title">No authoritative candidate selected</p>
         <p>
-          Submit the question for preview or reopen a candidate history row before SQL preview can
-          be shown.
+          Submit the question for preview or reopen a candidate history row before technical SQL
+          details can be shown.
         </p>
       </div>
     );
@@ -1479,6 +1481,125 @@ function renderCandidateSqlPreview(preview: AuthoritativeCandidatePreview | null
     <pre className="sql-preview">
       <code>{preview.candidateSql}</code>
     </pre>
+  );
+}
+
+function formatStatusLabel(value: string): string {
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function renderListOrPlaceholder(items: string[], placeholder: string) {
+  if (items.length === 0) {
+    return <p className="section-copy">{placeholder}</p>;
+  }
+
+  return (
+    <ul className="answer-plan-list">
+      {items.map((item, index) => (
+        <li key={`${item}:${index}`}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+function renderBusinessAnswerPlan(
+  preview: AuthoritativeCandidatePreview | null,
+  question: string,
+  sourceIdentity: string,
+  retrievedCitations: OperatorWorkflowRetrievedCitation[],
+  reviewEvidence: OperatorWorkflowReviewEvidence[],
+  candidateAttempts: OperatorWorkflowCandidateAttempt[],
+  executeEnabled: boolean
+) {
+  const latestReview = reviewEvidence[0];
+  const latestAttempt =
+    candidateAttempts.find((attempt) => attempt.candidateId === preview?.candidateId) ??
+    candidateAttempts[0];
+  const semanticContractVersion =
+    preview?.semanticContractVersion ?? latestAttempt?.semanticContractVersion ?? null;
+  const sourceEvidence = retrievedCitations.map((citation) => citation.citationLabel);
+  const semanticEvidence = [
+    semanticContractVersion ? `Semantic contract ${semanticContractVersion}` : null,
+    latestAttempt ? `Dataset contract v${latestAttempt.datasetContractVersion}` : null,
+    latestAttempt ? `Schema snapshot v${latestAttempt.schemaSnapshotVersion}` : null,
+    ...retrievedCitations.map(
+      (citation) => `${formatStatusLabel(citation.assetKind)}: ${citation.citationLabel}`
+    )
+  ].filter((item): item is string => item !== null);
+  const assumptions = latestReview?.assumptions ?? [];
+  const reviewStatus = latestReview
+    ? `Review ${latestReview.reviewStatus.replace(/_/g, " ")}`
+    : "Review evidence not provided";
+  const safetyStatus = preview
+    ? `Candidate ${preview.candidateState}; guard ${preview.guardStatus}`
+    : "No candidate selected";
+  const nextAction =
+    preview === null
+      ? "Submit the question for preview, then review the answer plan returned by SafeQuery."
+      : executeEnabled
+        ? "Review the answer plan, then execute the reviewed candidate when the business intent and safety status match the request."
+        : "Review the answer plan and resolve the guard or candidate status before execution.";
+
+  return (
+    <section
+      aria-label="Business-readable answer plan"
+      className="surface surface-primary answer-plan-panel"
+    >
+      <div className="section-header">
+        <div>
+          <p className="eyebrow">Answer plan</p>
+          <h2 className="panel-title">Business-readable answer plan</h2>
+        </div>
+        <span className={`surface-badge surface-badge-${executeEnabled ? "success" : "warning"}`}>
+          {executeEnabled ? "Ready" : "Review"}
+        </span>
+      </div>
+      <div className="answer-plan-grid">
+        <div className="answer-plan-item answer-plan-item-wide">
+          <span className="meta-label">What SafeQuery understood</span>
+          <strong>{question}</strong>
+          <p>
+            SafeQuery will answer this as a governed business request, not as a raw SQL approval
+            task.
+          </p>
+        </div>
+        <div className="answer-plan-item">
+          <span className="meta-label">Source and data used</span>
+          <strong>{sourceIdentity}</strong>
+          {renderListOrPlaceholder(
+            sourceEvidence,
+            "No retrieved source evidence was supplied with this candidate."
+          )}
+        </div>
+        <div className="answer-plan-item">
+          <span className="meta-label">Semantic mapping evidence</span>
+          <strong>{semanticContractVersion ?? "No semantic contract version supplied"}</strong>
+          {renderListOrPlaceholder(
+            semanticEvidence,
+            "Metric, dimension, and filter details were not supplied in the workflow payload."
+          )}
+        </div>
+        <div className="answer-plan-item">
+          <span className="meta-label">Assumptions</span>
+          <strong>{assumptions.length > 0 ? "Review evidence supplied" : "No assumptions supplied"}</strong>
+          {renderListOrPlaceholder(assumptions, "No review assumptions were supplied.")}
+        </div>
+        <div className="answer-plan-item">
+          <span className="meta-label">Safety and review status</span>
+          <strong>{formatStatusLabel(reviewStatus)}</strong>
+          <p>{safetyStatus}</p>
+          {latestReview?.riskFlags.length
+            ? renderListOrPlaceholder(latestReview.riskFlags, "")
+            : null}
+        </div>
+        <div className="answer-plan-item answer-plan-item-wide">
+          <span className="meta-label">Next action</span>
+          <strong>{nextAction}</strong>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -1619,7 +1740,7 @@ function getGuardCopy(state: CanonicalWorkflowState): string {
     return "Cancellation is distinct from denial and failure. The shell preserves run lineage and lifecycle context so the operator can see that execution started but did not finish.";
   }
 
-  return "The shell stops at review boundaries unless an authoritative candidate record supplies guard posture and SQL preview data.";
+  return "The shell stops at review boundaries unless an authoritative candidate record supplies guard posture and candidate context.";
 }
 
 function getResultTitle(state: CanonicalWorkflowState): string {
@@ -1866,8 +1987,8 @@ function renderResultContent(
     <div className="placeholder-block">
       <p className="placeholder-title">Result preview pending</p>
       <p>
-        Submit the question to move into SQL review. Results remain unavailable until execution
-        returns authoritative rows.
+        Submit the question to move into answer plan review. Results remain unavailable until
+        execution returns authoritative rows.
       </p>
     </div>
   );
@@ -2129,10 +2250,10 @@ function renderStatePanel(
     return (
       <div className="state-hero">
         <p className="eyebrow">Review mode</p>
-        <h2>SQL preview state</h2>
+        <h2>Answer plan preview</h2>
         <p className="section-copy">
-          Query submission lands here first so generated SQL and guard posture can be reviewed
-          before any future execution path is introduced.
+          Query submission lands here first so business intent, source evidence, assumptions,
+          review status, and next action can be reviewed before execution.
         </p>
         {canOpenCompleted ? (
           <div className="action-row">
@@ -2190,7 +2311,7 @@ function renderStatePanel(
             </button>
           ) : null}
           <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
-            Back to SQL preview
+            Back to answer plan
           </a>
         </div>
       </div>
@@ -2213,7 +2334,7 @@ function renderStatePanel(
             </button>
           ) : null}
           <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
-            Back to SQL preview
+            Back to answer plan
           </a>
         </div>
       </div>
@@ -2236,7 +2357,7 @@ function renderStatePanel(
             </button>
           ) : null}
           <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
-            Back to SQL preview
+            Back to answer plan
           </a>
         </div>
       </div>
@@ -2259,7 +2380,7 @@ function renderStatePanel(
             </button>
           ) : null}
           <a className="action-link" href={buildStateHref("preview", question, sourceId)}>
-            Back to SQL preview
+            Back to answer plan
           </a>
         </div>
       </div>
@@ -2303,7 +2424,7 @@ function renderStatePanel(
             Start a new draft
           </a>
           <a className="ghost-link" href={buildStateHref("preview", question, sourceId)}>
-            Back to SQL preview
+            Back to answer plan
           </a>
         </div>
       </div>
@@ -2315,8 +2436,9 @@ function renderStatePanel(
       <p className="eyebrow">Compose</p>
       <h2>Query input state</h2>
       <p className="section-copy">
-        The custom shell is now SafeQuery-owned. Question input, SQL preview, guard status, and
-        results are separated into stable surfaces before real execution wiring is added.
+        The custom shell is now SafeQuery-owned. Question input, answer planning, guard status,
+        technical review, and results are separated into stable surfaces before real execution
+        wiring is added.
       </p>
     </div>
   );
@@ -2837,7 +2959,7 @@ export function QueryWorkflowShell({
             <h1>Query workflow</h1>
           </div>
           <p className="frame-copy">
-            Operator shell for governed question review, SQL preview, and execution posture.
+            Operator shell for governed question review, answer planning, and execution posture.
             Analyst-style extensions stay optional and outside the core shell.
           </p>
         </div>
@@ -2930,6 +3052,18 @@ export function QueryWorkflowShell({
               selectedRevisionDraft ? startRevision : undefined
             )}
           </section>
+
+          {normalizedState === "preview" || normalizedState === "review_denied"
+            ? renderBusinessAnswerPlan(
+                candidatePreview,
+                submittedQuestion,
+                workflowContext.sourceIdentity,
+                selectedRetrievedCitations,
+                selectedReviewEvidence,
+                selectedCandidateAttempts,
+                executeEnabled
+              )
+            : null}
 
           <section className="surface surface-primary">
             <div className="section-header">
@@ -3066,7 +3200,7 @@ export function QueryWorkflowShell({
                   <p className="state-callout-title">Preview denied</p>
                   <p>
                     Request state {previewSubmission.requestState}; candidate state{" "}
-                    {previewSubmission.candidateState}. No successful SQL preview is displayed.
+                    {previewSubmission.candidateState}. No successful answer plan is displayed.
                   </p>
                 </div>
               ) : null}
@@ -3171,7 +3305,7 @@ export function QueryWorkflowShell({
             <div className="section-header">
               <div>
                 <p className="eyebrow">Generated SQL</p>
-                <h2 className="panel-title">Authoritative SQL preview</h2>
+                <h2 className="panel-title">Technical SQL review</h2>
               </div>
               <span className="surface-badge surface-badge-code">Preview</span>
             </div>

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -152,6 +152,7 @@ type PreviewSubmissionResult = {
   candidateId: string;
   candidateSql: string | null;
   candidateState: string;
+  clarifyingQuestions: string[];
   datasetContractVersion: number | null;
   guardStatus: string;
   requestId: string;
@@ -171,6 +172,7 @@ type AuthoritativeCandidatePreview = {
   candidateId: string;
   candidateSql: string | null;
   candidateState: string;
+  clarifyingQuestions?: string[];
   datasetContractVersion?: number | null;
   executedEvidence: OperatorWorkflowExecutedEvidence[];
   guardStatus: string;
@@ -770,10 +772,15 @@ function parsePreviewRetrievedCitationsFromValue(
     return null;
   }
 
-  const parsed = value
-    .map((item) => parsePreviewRetrievedCitation(item, expectedSourceId))
-    .filter((item): item is OperatorWorkflowRetrievedCitation => item !== null);
-  return parsed;
+  const citations: OperatorWorkflowRetrievedCitation[] = [];
+  for (const item of value) {
+    const citation = parsePreviewRetrievedCitation(item, expectedSourceId);
+    if (citation === null) {
+      return null;
+    }
+    citations.push(citation);
+  }
+  return citations;
 }
 
 function parsePreviewRetrievedCitationsFromEvents(
@@ -818,6 +825,29 @@ function dedupeRetrievedCitations(
     seen.add(key);
     return true;
   });
+}
+
+function dedupeStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function parseBackendClarifyingQuestions(candidate: Record<string, unknown>): string[] {
+  const intentMapping = isObject(candidate.intent_mapping)
+    ? candidate.intent_mapping
+    : isObject(candidate.intentMapping)
+      ? candidate.intentMapping
+      : null;
+
+  return dedupeStrings(
+    [
+      readOptionalString(candidate.denial_reason) ?? readOptionalString(candidate.denialReason),
+      intentMapping
+        ? readOptionalString(intentMapping.clarification) ??
+          readOptionalString(intentMapping.clarifying_question) ??
+          readOptionalString(intentMapping.clarifyingQuestion)
+        : null
+    ].filter((item): item is string => item !== null)
+  );
 }
 
 function parseExecuteAuditEvent(value: unknown): OperatorWorkflowAuditEvent | null {
@@ -1079,6 +1109,7 @@ function parsePreviewSubmissionResult(
     ...directRetrievedCitations,
     ...auditRetrievedCitations
   ]);
+  const clarifyingQuestions = parseBackendClarifyingQuestions(value.candidate);
 
   if (
     !requestId ||
@@ -1097,6 +1128,7 @@ function parsePreviewSubmissionResult(
     candidateId,
     candidateSql,
     candidateState,
+    clarifyingQuestions,
     datasetContractVersion,
     guardStatus,
     requestId,
@@ -1123,6 +1155,7 @@ function buildSubmittedCandidatePreview(
     candidateId: result.candidateId,
     candidateSql: result.candidateSql,
     candidateState: result.candidateState,
+    clarifyingQuestions: result.clarifyingQuestions,
     datasetContractVersion: result.datasetContractVersion,
     executedEvidence: [],
     guardStatus: result.guardStatus,
@@ -1802,7 +1835,15 @@ function renderBusinessAnswerPlan(
     )
   ].filter((item): item is string => item !== null);
   const assumptions = latestReview?.assumptions ?? [];
-  const clarifyingQuestions = latestReview?.clarifyingQuestions ?? [];
+  const reviewClarifyingQuestions = latestReview?.clarifyingQuestions ?? [];
+  const clarifyingQuestions =
+    reviewClarifyingQuestions.length > 0
+      ? reviewClarifyingQuestions
+      : (preview?.clarifyingQuestions ?? []);
+  const clarificationRequired =
+    clarifyingQuestions.length > 0 ||
+    preview?.candidateState.toLowerCase() === "clarification_required" ||
+    preview?.candidateState.toLowerCase() === "needs_clarification";
   const reviewStatus = latestReview
     ? `Review ${latestReview.reviewStatus.replace(/_/g, " ")}`
     : "Review evidence not provided";
@@ -1812,7 +1853,7 @@ function renderBusinessAnswerPlan(
   const nextAction =
     preview === null
       ? "Submit the question for preview, then review the answer plan returned by SafeQuery."
-      : clarifyingQuestions.length > 0
+      : clarificationRequired
         ? "Answer the clarifying questions, then submit a revised preview before execution."
       : executeEnabled
         ? "Review the answer plan, then execute the reviewed candidate when the business intent and safety status match the request."
@@ -2823,7 +2864,7 @@ export function QueryWorkflowShell({
         }
       : undefined;
   const selectedEvidenceContext =
-    submittedCandidatePreview ?? historyRunContext ?? candidatePreview;
+    submittedRunContext ?? submittedCandidatePreview ?? selectedHistoryRunContext ?? candidatePreview;
   const selectedAuditEvents = selectedEvidenceContext?.auditEvents ?? [];
   const selectedExecutedEvidence = selectedEvidenceContext?.executedEvidence ?? [];
   const selectedRetrievedCitations = selectedEvidenceContext?.retrievedCitations ?? [];

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1083,8 +1083,10 @@ function parsePreviewSubmissionResult(
     return null;
   }
   const reviewEvidence = parsedReviewEvidence as OperatorWorkflowReviewEvidence[];
-  const auditEventsValue =
-    isObject(value.audit) && Array.isArray(value.audit.events) ? value.audit.events : [];
+  if (!isObject(value.audit) || !Array.isArray(value.audit.events)) {
+    return null;
+  }
+  const auditEventsValue = value.audit.events;
   const parsedAuditEvents = auditEventsValue.map((event) =>
     parsePreviewAuditEvent(event, expectedSourceId)
   );
@@ -2864,7 +2866,9 @@ export function QueryWorkflowShell({
         }
       : undefined;
   const selectedEvidenceContext =
-    submittedRunContext ?? submittedCandidatePreview ?? selectedHistoryRunContext ?? candidatePreview;
+    normalizedState === "preview" || normalizedState === "review_denied"
+      ? candidatePreview
+      : submittedRunContext ?? selectedHistoryRunContext ?? candidatePreview;
   const selectedAuditEvents = selectedEvidenceContext?.auditEvents ?? [];
   const selectedExecutedEvidence = selectedEvidenceContext?.executedEvidence ?? [];
   const selectedRetrievedCitations = selectedEvidenceContext?.retrievedCitations ?? [];
@@ -3022,6 +3026,7 @@ export function QueryWorkflowShell({
         });
         return;
       }
+      setSubmittedRunContext(null);
 
       if (isClarificationRequiredPreviewState(result)) {
         setSubmittedQuestion(submittedQuestionText);

--- a/frontend/lib/operator-workflow.ts
+++ b/frontend/lib/operator-workflow.ts
@@ -81,6 +81,8 @@ export type OperatorWorkflowRetrievedCitation = {
   authority: "advisory_context";
   canAuthorizeExecution: false;
   citationLabel: string;
+  datasetContractVersion?: number | null;
+  schemaSnapshotVersion?: number | null;
   sourceId: string;
   sourceFamily: string;
   sourceFlavor: string | null;
@@ -189,6 +191,10 @@ function readOptionalString(value: unknown): string | undefined {
 
 function readOptionalNonNegativeInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function readOptionalPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
 function parseArray<T>(value: unknown, parser: (item: unknown) => T | null): T[] | null {
@@ -359,6 +365,8 @@ function parseRetrievedCitation(value: unknown): OperatorWorkflowRetrievedCitati
     authority: "advisory_context",
     canAuthorizeExecution: false,
     citationLabel,
+    datasetContractVersion: readOptionalPositiveInteger(value.datasetContractVersion) ?? null,
+    schemaSnapshotVersion: readOptionalPositiveInteger(value.schemaSnapshotVersion) ?? null,
     sourceId,
     sourceFamily,
     sourceFlavor: readOptionalString(value.sourceFlavor) ?? null


### PR DESCRIPTION
## Summary
- replace the preview primary surface with a business-readable answer plan
- keep raw SQL available in a demoted technical SQL review panel
- add focused component coverage for intent, source, evidence, assumptions, safety status, and next action

## Verification
- cd frontend && npm test
- cd frontend && npx tsc --noEmit

Closes #490