### PR TITLE
[W-2] add clarification-required preview state (#492)

### DIFF
--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -419,7 +419,7 @@ describe("HomePage", () => {
     );
     expect(ambiguousCandidateLink).toHaveAttribute(
       "href",
-      expect.stringContaining("state=review_denied")
+      expect.stringContaining("state=clarification_required")
     );
     expect(ambiguousCandidateLink).toHaveAttribute(
       "href",
@@ -1852,6 +1852,9 @@ describe("HomePage", () => {
       expect(screen.queryByText(/preview request accepted/i)).not.toBeInTheDocument();
       expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
       if (stateCase.candidateState === "clarification_required") {
+        expect(
+          screen.getByRole("heading", { name: /clarification required state/i })
+        ).toBeInTheDocument();
         const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
         expect(answerPlan).toHaveTextContent("Should inactive vendors be included?");
         expect(answerPlan).toHaveTextContent(/answer the clarifying questions/i);
@@ -1861,6 +1864,9 @@ describe("HomePage", () => {
         expect(screen.getByLabelText(/review evidence/i)).toHaveTextContent(
           "needs_clarification"
         );
+        expect(
+          screen.queryByRole("button", { name: /execute reviewed candidate/i })
+        ).not.toBeInTheDocument();
       }
     }
   });
@@ -1932,6 +1938,9 @@ describe("HomePage", () => {
     expect(answerPlan).toHaveTextContent("Which fiscal quarter should SafeQuery use?");
     expect(answerPlan).toHaveTextContent("Should inactive vendors be included?");
     expect(answerPlan).toHaveTextContent(/answer the clarifying questions/i);
+    expect(
+      screen.queryByRole("button", { name: /execute reviewed candidate/i })
+    ).not.toBeInTheDocument();
   });
 
   it("executes only preview-ready candidates and maps stale-ui backend denials or cancellations to recovery states", async () => {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -2796,6 +2796,71 @@ describe("HomePage", () => {
     expect(screen.getByText(/no executable candidate/i)).toBeInTheDocument();
   });
 
+  it("hides execute for clarification candidates opened through a generic preview URL", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: null,
+                    guardStatus: "pending",
+                    itemType: "candidate",
+                    label: "Ambiguous candidate",
+                    lifecycleState: "clarification_required",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-preview-clarification",
+                    requestId: "request-preview-clarification",
+                    reviewEvidence: [
+                      {
+                        auditEventId: "audit-preview-clarification",
+                        assumptions: ["Spend could mean committed or invoiced spend."],
+                        clarifyingQuestions: ["Should SafeQuery use committed or invoiced spend?"],
+                        reviewContractVersion: "review_llm_adapter_output.v1",
+                        reviewDecisionId: "review-preview-clarification",
+                        reviewStatus: "needs_clarification",
+                        riskFlags: []
+                      }
+                    ],
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-preview-clarification",
+          question: "Ambiguous spend",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("Should SafeQuery use committed or invoiced spend?");
+    expect(answerPlan).toHaveTextContent(/answer the clarifying questions/i);
+    expect(
+      screen.queryByRole("button", { name: /execute reviewed candidate/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("maps malformed and unavailable preview submission failures distinctly", async () => {
     const failureCases = [
       {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -329,7 +329,7 @@ describe("HomePage", () => {
     expect(historyLink).not.toHaveAttribute("href", expect.stringContaining("state=query"));
   });
 
-  it("preserves request revision context from clarification-required history", async () => {
+  it("preserves request revision context from the clarification choose-meaning CTA", async () => {
     appendCsrfToken();
 
     const fetchMock = vi.fn((input: RequestInfo | URL) => {
@@ -405,7 +405,7 @@ describe("HomePage", () => {
       })
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+    fireEvent.click(screen.getByRole("button", { name: /choose meaning/i }));
     fireEvent.change(await screen.findByRole("combobox", { name: /source/i }), {
       target: { value: "sap-approved-spend" }
     });
@@ -429,6 +429,107 @@ describe("HomePage", () => {
         })
       );
     });
+  });
+
+  it("populates clarification details for request history rows from the linked candidate", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    itemType: "request",
+                    label: "Ambiguous quarter spend",
+                    lifecycleState: "clarification_required",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "request-clarification-details",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
+                  {
+                    candidateSql: "select 'wrong request' as preview;",
+                    guardStatus: "pending",
+                    itemType: "candidate",
+                    label: "Different ambiguous request",
+                    lifecycleState: "clarification_required",
+                    occurredAt: "2026-04-21T14:25:00Z",
+                    recordId: "candidate-unrelated-clarification",
+                    requestId: "request-unrelated-clarification",
+                    reviewEvidence: [
+                      {
+                        auditEventId: "audit-unrelated-clarification",
+                        assumptions: [],
+                        clarifyingQuestions: ["Wrong request question should not render."],
+                        reviewContractVersion: "review_llm_adapter_output.v1",
+                        reviewDecisionId: "review-unrelated-clarification",
+                        reviewStatus: "needs_clarification",
+                        riskFlags: []
+                      }
+                    ],
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  },
+                  {
+                    candidateSql: null,
+                    guardStatus: "pending",
+                    itemType: "candidate",
+                    label: "Ambiguous quarter spend candidate",
+                    lifecycleState: "clarification_required",
+                    occurredAt: "2026-04-21T14:26:00Z",
+                    recordId: "candidate-clarification-details",
+                    requestId: "request-clarification-details",
+                    reviewEvidence: [
+                      {
+                        auditEventId: "audit-clarification-details",
+                        assumptions: ["Quarter could mean fiscal or calendar quarter."],
+                        clarifyingQuestions: ["Which fiscal quarter should SafeQuery use?"],
+                        reviewContractVersion: "review_llm_adapter_output.v1",
+                        reviewDecisionId: "review-clarification-details",
+                        reviewStatus: "needs_clarification",
+                        riskFlags: ["Business intent is ambiguous."]
+                      }
+                    ],
+                    semanticContractVersion: "approved_vendor_spend.v1",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "request",
+          history_record_id: "request-clarification-details",
+          question: "Ambiguous quarter spend",
+          source_id: "sap-approved-spend",
+          state: "clarification_required"
+        }
+      })
+    );
+
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("Which fiscal quarter should SafeQuery use?");
+    expect(answerPlan).toHaveTextContent("Quarter could mean fiscal or calendar quarter.");
+    expect(answerPlan).toHaveTextContent("Candidate clarification_required; guard pending");
+    expect(answerPlan).not.toHaveTextContent("Wrong request question should not render.");
+    expect(answerPlan).not.toHaveTextContent("No candidate selected");
+    expect(
+      screen.queryByRole("button", { name: /execute reviewed candidate/i })
+    ).not.toBeInTheDocument();
   });
 
   it("reopens denied candidates and terminal runs into their lifecycle states", async () => {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -329,6 +329,108 @@ describe("HomePage", () => {
     expect(historyLink).not.toHaveAttribute("href", expect.stringContaining("state=query"));
   });
 
+  it("preserves request revision context from clarification-required history", async () => {
+    appendCsrfToken();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              history: [
+                {
+                  itemType: "request",
+                  label: "Ambiguous quarter spend",
+                  lifecycleState: "clarification_required",
+                  occurredAt: "2026-04-21T14:25:00Z",
+                  recordId: "request-clarification-only",
+                  sourceId: "sap-approved-spend",
+                  sourceLabel: "SAP spend cube / approved_vendor_spend"
+                }
+              ],
+              sources: workflowPayload().sources
+            })
+        });
+      }
+
+      if (url.endsWith("/requests/preview")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              audit: {
+                events: [],
+                source_id: "sap-approved-spend",
+                state: "recorded"
+              },
+              candidate: {
+                candidate_id: "candidate-clarified-preview",
+                candidate_sql: "select vendor_name from approved_vendor_spend;",
+                dataset_contract_version: 1,
+                guard_status: "passed",
+                review_evidence: [],
+                schema_snapshot_version: 1,
+                semantic_contract_version: "approved_vendor_spend.v1",
+                source_family: "postgresql",
+                source_flavor: "warehouse",
+                source_id: "sap-approved-spend",
+                state: "preview_ready"
+              },
+              request: {
+                question: "Show approved vendor spend for Q1 fiscal quarter",
+                request_id: "request-clarified-preview",
+                source_id: "sap-approved-spend",
+                state: "submitted"
+              }
+            })
+        });
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "request",
+          history_record_id: "request-clarification-only",
+          question: "Ambiguous quarter spend",
+          source_id: "sap-approved-spend",
+          state: "clarification_required"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /revise attempt/i }));
+    fireEvent.change(await screen.findByRole("combobox", { name: /source/i }), {
+      target: { value: "sap-approved-spend" }
+    });
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Show approved vendor spend for Q1 fiscal quarter" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/requests/preview",
+        expect.objectContaining({
+          body: JSON.stringify({
+            question: "Show approved vendor spend for Q1 fiscal quarter",
+            source_id: "sap-approved-spend",
+            revise_from: {
+              item_type: "request",
+              request_id: "request-clarification-only"
+            }
+          })
+        })
+      );
+    });
+  });
+
   it("reopens denied candidates and terminal runs into their lifecycle states", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -432,9 +432,9 @@ describe("HomePage", () => {
   });
 
   it("populates clarification details for request history rows from the linked candidate", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn((input: RequestInfo | URL) => {
+    appendCsrfToken();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
         const url = input.toString();
 
         if (url.endsWith("/operator/workflow")) {
@@ -505,9 +505,42 @@ describe("HomePage", () => {
           });
         }
 
+        if (url.endsWith("/requests/preview")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                audit: {
+                  events: [],
+                  source_id: "sap-approved-spend",
+                  state: "recorded"
+                },
+                candidate: {
+                  candidate_id: "candidate-clarified-from-request",
+                  candidate_sql: "select vendor_name from approved_vendor_spend;",
+                  dataset_contract_version: 1,
+                  guard_status: "passed",
+                  review_evidence: [],
+                  schema_snapshot_version: 1,
+                  semantic_contract_version: "approved_vendor_spend.v1",
+                  source_family: "postgresql",
+                  source_flavor: "warehouse",
+                  source_id: "sap-approved-spend",
+                  state: "preview_ready"
+                },
+                request: {
+                  question: "Use the fiscal quarter definition for approved vendor spend",
+                  request_id: "request-clarified-from-request",
+                  source_id: "sap-approved-spend",
+                  state: "submitted"
+                }
+              })
+          });
+        }
+
         return new Promise(() => {});
-      })
-    );
+      });
+    vi.stubGlobal("fetch", fetchMock);
 
     render(
       await HomePage({
@@ -530,6 +563,28 @@ describe("HomePage", () => {
     expect(
       screen.queryByRole("button", { name: /execute reviewed candidate/i })
     ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /choose meaning/i }));
+    fireEvent.change(screen.getByLabelText(/natural-language question/i), {
+      target: { value: "Use the fiscal quarter definition for approved vendor spend" }
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /submit for preview/i }).closest("form")!);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:8000/requests/preview",
+        expect.objectContaining({
+          body: JSON.stringify({
+            question: "Use the fiscal quarter definition for approved vendor spend",
+            source_id: "sap-approved-spend",
+            revise_from: {
+              item_type: "request",
+              request_id: "request-clarification-details"
+            }
+          })
+        })
+      );
+    });
   });
 
   it("reopens denied candidates and terminal runs into their lifecycle states", async () => {

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1712,6 +1712,19 @@ function revisionDraftFromSelectedContext(
   selectedHistoryItem?: OperatorHistoryItem,
   sourceId?: string
 ): RevisionDraftContext | null {
+  if (
+    (state === "review_denied" || state === "clarification_required") &&
+    selectedHistoryItem?.itemType === "request" &&
+    selectedHistoryItem.sourceId === sourceId &&
+    isRevisableRequestLifecycleState(selectedHistoryItem.lifecycleState)
+  ) {
+    return {
+      itemType: "request",
+      requestId: selectedHistoryItem.recordId,
+      sourceId: selectedHistoryItem.sourceId
+    };
+  }
+
   if ((state === "review_denied" || state === "clarification_required") && candidatePreview) {
     return {
       candidateId: candidatePreview.candidateId,
@@ -1739,19 +1752,6 @@ function revisionDraftFromSelectedContext(
       requestId: auditEvent?.requestId,
       runId: runContext.runIdentity,
       sourceId
-    };
-  }
-
-  if (
-    (state === "review_denied" || state === "clarification_required") &&
-    selectedHistoryItem?.itemType === "request" &&
-    selectedHistoryItem.sourceId === sourceId &&
-    isRevisableRequestLifecycleState(selectedHistoryItem.lifecycleState)
-  ) {
-    return {
-      itemType: "request",
-      requestId: selectedHistoryItem.recordId,
-      sourceId: selectedHistoryItem.sourceId
     };
   }
 

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1703,7 +1703,7 @@ function revisionDraftFromSelectedContext(
   }
 
   if (
-    state === "review_denied" &&
+    (state === "review_denied" || state === "clarification_required") &&
     selectedHistoryItem?.itemType === "request" &&
     selectedHistoryItem.sourceId === sourceId &&
     isRevisableRequestLifecycleState(selectedHistoryItem.lifecycleState)

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -21,6 +21,7 @@ type WorkflowState =
   | "signin"
   | "query"
   | "preview"
+  | "clarification_required"
   | "review_denied"
   | "completed"
   | "empty"
@@ -35,6 +36,7 @@ type CanonicalWorkflowState =
   | "signin"
   | "query"
   | "preview"
+  | "clarification_required"
   | "review_denied"
   | "completed"
   | "empty"
@@ -271,6 +273,11 @@ const workflowStates: Record<CanonicalWorkflowState, StateDefinition> = {
     description: "The operator request has been staged as a business-readable answer plan.",
     label: "Answer plan"
   },
+  clarification_required: {
+    description:
+      "SafeQuery needs the operator to clarify business intent before SQL generation or execution can continue.",
+    label: "Clarification required"
+  },
   query: {
     description: "Compose a governed question and move into review without leaving the product shell.",
     label: "Query input"
@@ -294,6 +301,7 @@ const workflowStateOrder: CanonicalWorkflowState[] = [
   "signin",
   "query",
   "preview",
+  "clarification_required",
   "review_denied",
   "completed",
   "empty",
@@ -412,6 +420,15 @@ function getOperatorRecoveryGuidance(
       anchor:
         "Use the authoritative SafeQuery request and candidate record; do not treat advisory context as approval.",
       title: "Recovery: review denied"
+    };
+  }
+
+  if (state === "clarification_required") {
+    return {
+      action: "Revise the request or choose one explicit business meaning before retrying preview.",
+      anchor:
+        "Use the clarifying questions attached to the SafeQuery review record; do not treat an ambiguous candidate as executable.",
+      title: "Recovery: clarification required"
     };
   }
 
@@ -1411,9 +1428,16 @@ function historyItemToState(item: OperatorHistoryItem): CanonicalWorkflowState {
 
   if (item.itemType === "request" || item.itemType === "candidate") {
     if (
+      lifecycleState === "clarification_required" ||
+      lifecycleState === "needs_clarification" ||
+      guardStatus === "needs_clarification"
+    ) {
+      return "clarification_required";
+    }
+
+    if (
       lifecycleState === "review_denied" ||
       lifecycleState === "blocked" ||
-      lifecycleState === "clarification_required" ||
       lifecycleState === "preview_denied" ||
       lifecycleState === "preview_generation_failed" ||
       lifecycleState === "preview_malformed" ||
@@ -1648,7 +1672,7 @@ function revisionDraftFromSelectedContext(
   selectedHistoryItem?: OperatorHistoryItem,
   sourceId?: string
 ): RevisionDraftContext | null {
-  if (state === "review_denied" && candidatePreview) {
+  if ((state === "review_denied" || state === "clarification_required") && candidatePreview) {
     return {
       candidateId: candidatePreview.candidateId,
       itemType: "candidate",
@@ -1699,6 +1723,7 @@ function isRevisableRequestLifecycleState(lifecycleState: string): boolean {
   return (
     normalizedLifecycleState === "blocked" ||
     normalizedLifecycleState === "clarification_required" ||
+    normalizedLifecycleState === "needs_clarification" ||
     normalizedLifecycleState === "preview_denied" ||
     normalizedLifecycleState === "preview_generation_failed" ||
     normalizedLifecycleState === "preview_malformed" ||
@@ -1950,7 +1975,12 @@ function getWorkflowContext(
     source?.displayLabel ??
     "No source selected yet";
 
-  if (candidatePreview && (state === "preview" || state === "review_denied")) {
+  if (
+    candidatePreview &&
+    (state === "preview" ||
+      state === "review_denied" ||
+      state === "clarification_required")
+  ) {
     return {
       candidateIdentity: candidatePreview.candidateId,
       candidateState: candidatePreview.candidateState,
@@ -1960,7 +1990,7 @@ function getWorkflowContext(
     };
   }
 
-  if (state === "preview" || state === "review_denied") {
+  if (state === "preview" || state === "review_denied" || state === "clarification_required") {
     return {
       sourceIdentity
     };
@@ -1995,8 +2025,16 @@ function getWorkflowContext(
 }
 
 function getGuardTone(state: CanonicalWorkflowState): string {
-  if (state === "review_denied" || state === "execution_denied" || state === "failed") {
+  if (
+    state === "review_denied" ||
+    state === "execution_denied" ||
+    state === "failed"
+  ) {
     return "danger";
+  }
+
+  if (state === "clarification_required") {
+    return "warning";
   }
 
   if (state === "completed" || state === "empty") {
@@ -2017,6 +2055,10 @@ function getGuardTone(state: CanonicalWorkflowState): string {
 function getGuardHeadline(state: CanonicalWorkflowState): string {
   if (state === "review_denied") {
     return "Review denied before execution";
+  }
+
+  if (state === "clarification_required") {
+    return "Clarification required before execution";
   }
 
   if (state === "completed") {
@@ -2049,6 +2091,10 @@ function getGuardHeadline(state: CanonicalWorkflowState): string {
 function getGuardCopy(state: CanonicalWorkflowState): string {
   if (state === "review_denied") {
     return "The request never crossed into execution. Guard denial stays anchored to the candidate review record instead of being restyled as a run failure.";
+  }
+
+  if (state === "clarification_required") {
+    return "SafeQuery cannot safely infer the business meaning yet. Execution stays unavailable until the operator revises the question or chooses one explicit meaning.";
   }
 
   if (state === "completed") {
@@ -2699,6 +2745,29 @@ function renderStatePanel(
     );
   }
 
+  if (state === "clarification_required") {
+    return (
+      <div className="state-hero">
+        <p className="eyebrow">Intent clarification</p>
+        <h2>Clarification required state</h2>
+        <p className="section-copy">
+          SafeQuery found business intent it cannot safely resolve. Answer the clarifying
+          questions or choose one explicit meaning before requesting a new preview.
+        </p>
+        <div className="action-row">
+          {onStartRevision ? (
+            <button className="action-button" onClick={onStartRevision} type="button">
+              Revise attempt
+            </button>
+          ) : null}
+          <a className="ghost-link" href={buildStateHref("query", question, sourceId)}>
+            Choose meaning
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   if (state === "execution_denied") {
     return (
       <div className="state-hero">
@@ -2863,14 +2932,19 @@ export function QueryWorkflowShell({
     historySourceMismatch
   );
   const historyHrefContext =
-    normalizedState === "preview" && historyRecordId && historyCandidatePreview
+    (normalizedState === "preview" ||
+      normalizedState === "clarification_required") &&
+    historyRecordId &&
+    historyCandidatePreview
       ? {
           historyItemType: "candidate" as const,
           historyRecordId
         }
       : undefined;
   const selectedEvidenceContext =
-    normalizedState === "preview" || normalizedState === "review_denied"
+    normalizedState === "preview" ||
+    normalizedState === "review_denied" ||
+    normalizedState === "clarification_required"
       ? candidatePreview
       : submittedRunContext ?? selectedHistoryRunContext ?? candidatePreview;
   const selectedAuditEvents = selectedEvidenceContext?.auditEvents ?? [];
@@ -3035,7 +3109,7 @@ export function QueryWorkflowShell({
       if (isClarificationRequiredPreviewState(result)) {
         setSubmittedQuestion(submittedQuestionText);
         setSubmittedSourceId(result.sourceId);
-        setSubmittedState("review_denied");
+        setSubmittedState("clarification_required");
         setRevisionDraft(result.revisionContext ?? revisionDraft);
         setSubmittedCandidatePreview(
           buildSubmittedCandidatePreview(result, selectedSource.displayLabel)
@@ -3353,7 +3427,9 @@ export function QueryWorkflowShell({
             )}
           </section>
 
-          {normalizedState === "preview" || normalizedState === "review_denied"
+          {normalizedState === "preview" ||
+          normalizedState === "review_denied" ||
+          normalizedState === "clarification_required"
             ? renderBusinessAnswerPlan(
                 candidatePreview,
                 submittedQuestion,
@@ -3565,7 +3641,7 @@ export function QueryWorkflowShell({
                     ? "Submitting preview"
                     : "Submit for preview"}
                 </button>
-                {candidatePreview ? (
+                {candidatePreview && normalizedState !== "clarification_required" ? (
                   <button
                     disabled={!executeEnabled || executeSubmission.status === "executing"}
                     onClick={executeCandidate}

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1542,17 +1542,7 @@ function findAuthoritativeCandidatePreview(
   sourceId?: string,
   historyRecordId?: string
 ): AuthoritativeCandidatePreview | null {
-  const candidate = history.find((item) => {
-    if (item.itemType !== "candidate") {
-      return false;
-    }
-
-    if (historyRecordId) {
-      return item.recordId === historyRecordId;
-    }
-
-    return !sourceId || item.sourceId === sourceId;
-  });
+  const candidate = findAuthoritativeCandidateHistoryItem(history, sourceId, historyRecordId);
   if (!candidate) {
     return null;
   }
@@ -1571,6 +1561,49 @@ function findAuthoritativeCandidatePreview(
     sourceId: candidate.sourceId,
     sourceLabel: candidate.sourceLabel
   };
+}
+
+function findAuthoritativeCandidateHistoryItem(
+  history: OperatorHistoryItem[],
+  sourceId?: string,
+  historyRecordId?: string
+): OperatorHistoryItem | null {
+  const candidates = history.filter((item) => item.itemType === "candidate");
+
+  if (!historyRecordId) {
+    return candidates.find((item) => !sourceId || item.sourceId === sourceId) ?? null;
+  }
+
+  const directCandidate = candidates.find((item) => item.recordId === historyRecordId);
+  if (directCandidate) {
+    return directCandidate;
+  }
+
+  if (!sourceId) {
+    return null;
+  }
+
+  const requestCandidates = candidates.filter(
+    (item) => item.sourceId === sourceId && item.requestId === historyRecordId
+  );
+  if (requestCandidates.length === 0) {
+    return null;
+  }
+
+  return requestCandidates.sort(compareHistoryCandidateRecency)[0] ?? null;
+}
+
+function compareHistoryCandidateRecency(
+  left: OperatorHistoryItem,
+  right: OperatorHistoryItem
+): number {
+  const leftTime = Date.parse(left.occurredAt);
+  const rightTime = Date.parse(right.occurredAt);
+  if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) {
+    return rightTime - leftTime;
+  }
+
+  return right.recordId.localeCompare(left.recordId);
 }
 
 function findAuthoritativeRunContext(
@@ -2760,9 +2793,15 @@ function renderStatePanel(
               Revise attempt
             </button>
           ) : null}
-          <a className="ghost-link" href={buildStateHref("query", question, sourceId)}>
-            Choose meaning
-          </a>
+          {onStartRevision ? (
+            <button className="ghost-button" onClick={onStartRevision} type="button">
+              Choose meaning
+            </button>
+          ) : (
+            <a className="ghost-link" href={buildStateHref("query", question, sourceId)}>
+              Choose meaning
+            </a>
+          )}
         </div>
       </div>
     );
@@ -2938,7 +2977,7 @@ export function QueryWorkflowShell({
     historyCandidatePreview
       ? {
           historyItemType: "candidate" as const,
-          historyRecordId
+          historyRecordId: historyCandidatePreview.candidateId
         }
       : undefined;
   const selectedEvidenceContext =

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1330,6 +1330,13 @@ function canExecuteCandidate(
   );
 }
 
+function candidateRequiresClarification(
+  candidatePreview: AuthoritativeCandidatePreview | null
+): boolean {
+  const candidateState = candidatePreview?.candidateState.toLowerCase();
+  return candidateState === "clarification_required" || candidateState === "needs_clarification";
+}
+
 function resolveSourceBinding(
   sourceOptions: SourceOption[],
   state: CanonicalWorkflowState,
@@ -2970,6 +2977,10 @@ export function QueryWorkflowShell({
     candidatePreview,
     historySourceMismatch
   );
+  const executeControlVisible =
+    candidatePreview !== null &&
+    normalizedState !== "clarification_required" &&
+    !candidateRequiresClarification(candidatePreview);
   const historyHrefContext =
     (normalizedState === "preview" ||
       normalizedState === "clarification_required") &&
@@ -3680,7 +3691,7 @@ export function QueryWorkflowShell({
                     ? "Submitting preview"
                     : "Submit for preview"}
                 </button>
-                {candidatePreview && normalizedState !== "clarification_required" ? (
+                {executeControlVisible ? (
                   <button
                     disabled={!executeEnabled || executeSubmission.status === "executing"}
                     onClick={executeCandidate}


### PR DESCRIPTION
Closes #492
This PR was opened by codex-supervisor.
Latest Codex summary:

Implemented and committed `449818a Add clarification-required preview state`.

The UI now has a distinct `clarification_required` workflow state, maps ambiguous/needs-clarification candidates into it, shows business-readable clarification guidance, and hides the execute button while ambiguity is unresolved. The focused reproducing test was added first and now passes.

Summary: Added clarification-required preview state and committed `449818a`
State hint: implementing
Blocked reason: none
Tests: `page.test.tsx`, `pilot-safety-smoke.test.tsx`, `health-status-card.test.tsx`, `analyst-response.test.ts`, `npx tsc --noEmit`, `git diff --check`
Failure signature: none
Next action: open or update a draft PR for `codex/issue-492`