### PR TITLE
[codex] Move raw SQL into technical details

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+SafeQuery is used by authenticated internal operators, reviewers, and governance owners who need to turn business questions into reviewed, auditable SQL-backed answers. They work in a controlled enterprise context where source identity, candidate state, guard posture, evidence, and execution eligibility must stay visible before any query can run.
+
+## Product Purpose
+
+SafeQuery provides a governed NL2SQL operator workflow. It accepts a natural language question, binds it to an approved business source, generates a candidate through an isolated adapter, validates the candidate through application-owned controls, and executes only reviewed read-only candidates. Success means the operator can approve or block work from business-readable evidence while technical SQL, audit, and export boundaries remain traceable.
+
+## Brand Personality
+
+Calm, precise, governed. The product should feel like controlled operational tooling, not a chat demo or a SQL generator showcase.
+
+## Anti-references
+
+Avoid chat-first database demos, vendor-owned SQL generation UIs, neon cybersecurity styling, decorative dashboard chrome, and flows that make raw SQL the primary business approval object. Do not imply that support bundles, handoff exports, LLM output, search results, or analyst summaries can authorize execution.
+
+## Design Principles
+
+- Keep the workflow source-bound: source identity and candidate lineage stay visible near every review or execution decision.
+- Make business review primary: answer plans, guard posture, citations, and lifecycle state lead before raw SQL.
+- Fail closed in the UI: missing candidate, source, guard, or entitlement context must read as blocked or draft-only.
+- Preserve technical traceability: authorized reviewers can inspect SQL and audit details without exposing them through support or export surfaces.
+- Separate advice from authority: supplemental analyst or retrieval context can explain, but only server-owned candidate and run records govern execution.
+
+## Accessibility & Inclusion
+
+Target WCAG AA contrast for operational text and controls. Keep keyboard-visible focus states, use semantic controls for progressive disclosure, support reduced-motion preferences, and avoid color-only status communication.

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -542,6 +542,55 @@ button:disabled {
   color: var(--text-primary);
 }
 
+.technical-sql-details {
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  background: rgba(7, 11, 20, 0.38);
+}
+
+.technical-sql-details summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 52px;
+  padding: 14px 16px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.technical-sql-details summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.technical-sql-details summary::marker {
+  color: var(--accent);
+}
+
+.technical-sql-details-hint {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.technical-sql-details[open] .technical-sql-details-hint {
+  color: var(--accent);
+}
+
+.technical-sql-details-body {
+  display: grid;
+  gap: 12px;
+  padding: 0 16px 16px;
+}
+
+.technical-sql-details-body p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
 .placeholder-title,
 .state-callout-title,
 .first-run-panel h3 {

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -1302,6 +1302,21 @@ describe("HomePage", () => {
     expect(
       screen.getByRole("heading", { name: /technical sql review/i })
     ).toBeInTheDocument();
+    const technicalDetails = screen.getByLabelText(/authorized technical sql details/i);
+    expect(technicalDetails).not.toHaveAttribute("open");
+    expect(
+      within(technicalDetails).getByText(/select vendor_name from approved_vendor_spend/i)
+    ).not.toBeVisible();
+    fireEvent.click(
+      within(technicalDetails).getByText(/inspect raw sql for authorized technical review/i)
+    );
+    expect(technicalDetails).toHaveAttribute("open");
+    expect(
+      within(technicalDetails).getByText(/select vendor_name from approved_vendor_spend/i)
+    ).toBeVisible();
+    expect(technicalDetails).toHaveTextContent(
+      /business approval should use the answer plan, guard posture, source identity, and evidence/i
+    );
     expect(screen.queryByRole("heading", { name: /sql preview state/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /authoritative sql preview/i })).not.toBeInTheDocument();
   });

--- a/frontend/app/pilot-safety-smoke.test.tsx
+++ b/frontend/app/pilot-safety-smoke.test.tsx
@@ -214,6 +214,22 @@ describe("pilot safety UI smoke", () => {
     expect(screen.getByLabelText(/authorized operator sql review/i)).toHaveTextContent(
       /Support bundles and handoff exports stay redacted/i
     );
+    const technicalDetails = screen.getByLabelText(/authorized technical sql details/i);
+    expect(technicalDetails).not.toHaveAttribute("open");
+    expect(
+      within(technicalDetails).getByText(
+        /select vendor_name from finance\.approved_vendor_spend limit 10/i
+      )
+    ).not.toBeVisible();
+    fireEvent.click(
+      within(technicalDetails).getByText(/inspect raw sql for authorized technical review/i)
+    );
+    expect(technicalDetails).toHaveAttribute("open");
+    expect(
+      within(technicalDetails).getByText(
+        /select vendor_name from finance\.approved_vendor_spend limit 10/i
+      )
+    ).toBeVisible();
     expect(screen.getByText("candidate-pilot-001")).toBeInTheDocument();
     expect(screen.getByLabelText(/audit lifecycle events/i)).toHaveTextContent("guard_evaluated");
     expect(screen.getByLabelText(/retrieved citation context/i)).toHaveTextContent(

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1847,9 +1847,21 @@ function renderCandidateSqlPreview(preview: AuthoritativeCandidatePreview | null
   }
 
   return (
-    <pre className="sql-preview">
-      <code>{preview.candidateSql}</code>
-    </pre>
+    <details className="technical-sql-details" aria-label="Authorized technical SQL details">
+      <summary>
+        <span>Inspect raw SQL for authorized technical review</span>
+        <span className="technical-sql-details-hint">Collapsed by default</span>
+      </summary>
+      <div className="technical-sql-details-body">
+        <p>
+          Raw SQL is available here for operator and reviewer inspection only. Business approval
+          should use the answer plan, guard posture, source identity, and evidence above.
+        </p>
+        <pre className="sql-preview">
+          <code>{preview.candidateSql}</code>
+        </pre>
+      </div>
+    </details>
   );
 }
 


### PR DESCRIPTION
## Summary

- Moves raw candidate SQL into a collapsed authorized technical details disclosure instead of showing it as the primary review object.
- Adds boundary copy that keeps business approval anchored on the answer plan, guard posture, source identity, and evidence.
- Adds product context for future UI work and regression coverage for collapsed and expanded SQL details.

Closes #493.

## Validation

- `npm test` in `frontend/` passed: 4 files, 75 tests.
- `python3 -m pytest tests/test_support_bundle.py` in `backend/` passed: 15 tests.

## Notes

- `.claude/` remains an unrelated untracked local directory and was not included.