### PR TITLE
[codex] Explain disabled execute states

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -624,6 +624,16 @@ button:disabled {
   border-color: rgba(240, 193, 91, 0.24);
 }
 
+.state-callout-success {
+  background: rgba(79, 209, 139, 0.08);
+  border-color: rgba(79, 209, 139, 0.24);
+}
+
+.state-callout-warning {
+  background: rgba(240, 193, 91, 0.08);
+  border-color: rgba(240, 193, 91, 0.24);
+}
+
 .state-callout-danger {
   background: rgba(255, 107, 122, 0.08);
   border-color: rgba(255, 107, 122, 0.24);

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -2364,6 +2364,71 @@ describe("HomePage", () => {
     }
   });
 
+  it("preserves failed-execution guidance when execute transport fails before a run exists", async () => {
+    appendCsrfToken();
+
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.endsWith("/operator/workflow")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              history: [
+                {
+                  candidateSql: "select vendor_name from approved_vendor_spend;",
+                  guardStatus: "passed",
+                  itemType: "candidate",
+                  label: "Selected candidate",
+                  lifecycleState: "preview_ready",
+                  occurredAt: "2026-04-21T14:24:00Z",
+                  recordId: "candidate-selected",
+                  requestId: "request-selected",
+                  sourceId: "sap-approved-spend",
+                  sourceLabel: "SAP spend cube / approved_vendor_spend"
+                }
+              ],
+              sources: workflowPayload().sources
+            })
+        });
+      }
+
+      if (url.endsWith("/candidates/candidate-selected/execute")) {
+        return Promise.reject(new Error("transport unavailable"));
+      }
+
+      return new Promise(() => {});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-selected",
+          question: "Selected candidate",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /execute reviewed candidate/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /failed state/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(/execution failed/i);
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /previous run did not produce a trusted successful result payload/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).not.toHaveTextContent(
+      /no execution run selected/i
+    );
+  });
+
   it("renders successful execute response rows and audit context without sensitive extras", async () => {
     const csrfToken = document.createElement("meta");
     csrfToken.name = "safequery-csrf-token";

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -3054,13 +3054,83 @@ describe("HomePage", () => {
     );
 
     expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
-      /evidence-bound answer unavailable/i
+      /no execution run selected/i
     );
     expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
-      /result validation could not support an evidence-bound answer/i
+      /no server-owned run record is selected/i
     );
     expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
-      /follow the validation next action or revise the request/i
+      /open the authoritative run from history or execute the reviewed candidate first/i
+    );
+  });
+
+  it("keeps clarification guidance ahead of execute-ready copy when review supplied questions", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Ready candidate with questions",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-ready-with-questions",
+                    requestId: "request-ready-with-questions",
+                    reviewEvidence: [
+                      {
+                        auditEventId: "audit-ready-with-questions",
+                        assumptions: [],
+                        clarifyingQuestions: ["Should inactive vendors be included?"],
+                        reviewContractVersion: "review_llm_adapter_output.v1",
+                        reviewDecisionId: "review-ready-with-questions",
+                        reviewStatus: "ready",
+                        riskFlags: []
+                      }
+                    ],
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-ready-with-questions",
+          question: "Ready candidate with questions",
+          source_id: "sap-approved-spend",
+          state: "preview"
+        }
+      })
+    );
+
+    const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
+    expect(answerPlan).toHaveTextContent("Should inactive vendors be included?");
+    expect(answerPlan).toHaveTextContent(/answer the clarifying questions/i);
+    expect(answerPlan).not.toHaveTextContent(/execute the reviewed candidate/i);
+    expect(screen.getByRole("button", { name: /execute reviewed candidate/i })).toBeDisabled();
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /clarification required before execution/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /answer plan still contains business clarification questions/i
     );
   });
 

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -2350,6 +2350,14 @@ describe("HomePage", () => {
       expect(
         screen.getByRole("heading", { name: executeResponse.expectedHeading })
       ).toBeInTheDocument();
+      if (executeResponse.status === 403) {
+        expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+          /execution denied/i
+        );
+        expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+          /execute-time controls denied the run/i
+        );
+      }
       expect(screen.queryByText(/execution completed/i)).not.toBeInTheDocument();
       expect(screen.queryByRole("table", { name: /execute response result rows/i })).not.toBeInTheDocument();
       expect(screen.queryByText("driver-secret-should-not-render")).not.toBeInTheDocument();

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -2883,6 +2883,7 @@ describe("HomePage", () => {
         expectedTitle: /guard denied execution/i,
         guardStatus: "blocked",
         label: "Guard blocked candidate",
+        lifecycleState: "blocked",
         recordId: "candidate-guard-blocked",
         reviewEvidence: []
       },
@@ -2893,6 +2894,7 @@ describe("HomePage", () => {
         expectedTitle: /review blocked execution/i,
         guardStatus: "passed",
         label: "Review blocked candidate",
+        lifecycleState: "preview_ready",
         recordId: "candidate-review-blocked",
         reviewEvidence: [
           {
@@ -2926,7 +2928,7 @@ describe("HomePage", () => {
                       guardStatus: disabledCase.guardStatus,
                       itemType: "candidate",
                       label: disabledCase.label,
-                      lifecycleState: "preview_ready",
+                      lifecycleState: disabledCase.lifecycleState,
                       occurredAt: "2026-04-21T14:24:00Z",
                       recordId: disabledCase.recordId,
                       requestId: `request-${disabledCase.recordId}`,
@@ -3059,6 +3061,120 @@ describe("HomePage", () => {
     );
     expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
       /follow the validation next action or revise the request/i
+    );
+  });
+
+  it("reports guard-denied candidates as guard denials on the review-denied route", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "blocked",
+                    itemType: "candidate",
+                    label: "Guard denied candidate",
+                    lifecycleState: "blocked",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-guard-denied-route",
+                    requestId: "request-guard-denied-route",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-guard-denied-route",
+          question: "Guard denied candidate",
+          source_id: "sap-approved-spend",
+          state: "review_denied"
+        }
+      })
+    );
+
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /guard denied execution/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /deterministic guard denied this candidate/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).not.toHaveTextContent(
+      /review blocked execution/i
+    );
+  });
+
+  it("does not claim execution was recorded when completed route has only a preview candidate", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.endsWith("/operator/workflow")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                history: [
+                  {
+                    candidateSql: "select vendor_name from approved_vendor_spend;",
+                    guardStatus: "passed",
+                    itemType: "candidate",
+                    label: "Preview-only candidate",
+                    lifecycleState: "preview_ready",
+                    occurredAt: "2026-04-21T14:24:00Z",
+                    recordId: "candidate-preview-only",
+                    requestId: "request-preview-only",
+                    sourceId: "sap-approved-spend",
+                    sourceLabel: "SAP spend cube / approved_vendor_spend"
+                  }
+                ],
+                sources: workflowPayload().sources
+              })
+          });
+        }
+
+        return new Promise(() => {});
+      })
+    );
+
+    render(
+      await HomePage({
+        searchParams: {
+          history_item_type: "candidate",
+          history_record_id: "candidate-preview-only",
+          question: "Preview-only candidate",
+          source_id: "sap-approved-spend",
+          state: "completed"
+        }
+      })
+    );
+
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /no execution run selected/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /no server-owned run record is selected/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).not.toHaveTextContent(
+      /execution already recorded/i
     );
   });
 

--- a/frontend/app/page.test.tsx
+++ b/frontend/app/page.test.tsx
@@ -2863,7 +2863,110 @@ describe("HomePage", () => {
     );
 
     expect(screen.getByRole("button", { name: /execute reviewed candidate/i })).toBeDisabled();
-    expect(screen.getByText(/no executable candidate/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /no sql candidate available/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /wait for sql generation to finish or submit a revised preview/i
+    );
+    expect(screen.getByRole("button", { name: /execute reviewed candidate/i })).toHaveAccessibleDescription(
+      /no canonical sql candidate is available/i
+    );
+  });
+
+  it("explains guard-denied and review-blocked execute states without treating advisory review as authority", async () => {
+    const disabledCases = [
+      {
+        candidateSql: "select vendor_name from approved_vendor_spend;",
+        expectedNextAction: /resolve the guard finding and submit a revised preview/i,
+        expectedReason: /deterministic guard denied this candidate/i,
+        expectedTitle: /guard denied execution/i,
+        guardStatus: "blocked",
+        label: "Guard blocked candidate",
+        recordId: "candidate-guard-blocked",
+        reviewEvidence: []
+      },
+      {
+        candidateSql: "select vendor_name from approved_vendor_spend;",
+        expectedNextAction: /resolve the review finding and submit a revised preview/i,
+        expectedReason: /advisory review output cannot authorize execution/i,
+        expectedTitle: /review blocked execution/i,
+        guardStatus: "passed",
+        label: "Review blocked candidate",
+        recordId: "candidate-review-blocked",
+        reviewEvidence: [
+          {
+            auditEventId: "audit-review-blocked",
+            assumptions: [],
+            clarifyingQuestions: [],
+            reviewContractVersion: "review_llm_adapter_output.v1",
+            reviewDecisionId: "review-review-blocked",
+            reviewStatus: "blocked",
+            riskFlags: ["Business scope is unresolved."]
+          }
+        ]
+      }
+    ];
+
+    for (const disabledCase of disabledCases) {
+      cleanup();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((input: RequestInfo | URL) => {
+          const url = input.toString();
+
+          if (url.endsWith("/operator/workflow")) {
+            return Promise.resolve({
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  history: [
+                    {
+                      candidateSql: disabledCase.candidateSql,
+                      guardStatus: disabledCase.guardStatus,
+                      itemType: "candidate",
+                      label: disabledCase.label,
+                      lifecycleState: "preview_ready",
+                      occurredAt: "2026-04-21T14:24:00Z",
+                      recordId: disabledCase.recordId,
+                      requestId: `request-${disabledCase.recordId}`,
+                      reviewEvidence: disabledCase.reviewEvidence,
+                      sourceId: "sap-approved-spend",
+                      sourceLabel: "SAP spend cube / approved_vendor_spend"
+                    }
+                  ],
+                  sources: workflowPayload().sources
+                })
+            });
+          }
+
+          return new Promise(() => {});
+        })
+      );
+
+      render(
+        await HomePage({
+          searchParams: {
+            history_item_type: "candidate",
+            history_record_id: disabledCase.recordId,
+            question: disabledCase.label,
+            source_id: "sap-approved-spend",
+            state: "preview"
+          }
+        })
+      );
+
+      expect(screen.getByRole("button", { name: /execute reviewed candidate/i })).toBeDisabled();
+      expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+        disabledCase.expectedTitle
+      );
+      expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+        disabledCase.expectedReason
+      );
+      expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+        disabledCase.expectedNextAction
+      );
+    }
   });
 
   it("hides execute for clarification candidates opened through a generic preview URL", async () => {
@@ -2926,9 +3029,37 @@ describe("HomePage", () => {
     const answerPlan = screen.getByRole("region", { name: /business-readable answer plan/i });
     expect(answerPlan).toHaveTextContent("Should SafeQuery use committed or invoiced spend?");
     expect(answerPlan).toHaveTextContent(/answer the clarifying questions/i);
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /clarification required before execution/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /answer the clarifying questions, then submit a revised preview/i
+    );
     expect(
       screen.queryByRole("button", { name: /execute reviewed candidate/i })
     ).not.toBeInTheDocument();
+  });
+
+  it("explains validation-unavailable result states as blocked from another execute attempt", async () => {
+    render(
+      await HomePage({
+        searchParams: {
+          question: "Top approved vendors by quarterly spend",
+          source_id: "sap-approved-spend",
+          state: "insufficient_evidence"
+        }
+      })
+    );
+
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /evidence-bound answer unavailable/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /result validation could not support an evidence-bound answer/i
+    );
+    expect(screen.getByLabelText(/execute availability/i)).toHaveTextContent(
+      /follow the validation next action or revise the request/i
+    );
   });
 
   it("maps malformed and unavailable preview submission failures distinctly", async () => {

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1365,7 +1365,8 @@ function resolveExecuteAvailabilityGuidance(
   candidatePreview: AuthoritativeCandidatePreview | null,
   runContext: AuthoritativeRunContext | null,
   hasSourceMismatch: boolean,
-  executeInProgress: boolean
+  executeInProgress: boolean,
+  hasRecentExecuteDenial: boolean
 ): ExecuteAvailabilityGuidance {
   if (executeInProgress) {
     return {
@@ -1384,7 +1385,8 @@ function resolveExecuteAvailabilityGuidance(
       state === "execution_denied" ||
       state === "failed" ||
       state === "canceled") &&
-    runContext === null
+    runContext === null &&
+    !(state === "execution_denied" && hasRecentExecuteDenial)
   ) {
     return {
       nextAction: "Open the authoritative run from history or execute the reviewed candidate first.",
@@ -3269,7 +3271,8 @@ export function QueryWorkflowShell({
     candidatePreview,
     historyRunContext,
     historySourceMismatch,
-    executeSubmission.status === "executing"
+    executeSubmission.status === "executing",
+    executeSubmission.status === "denied"
   );
   const executeGuidanceId = "execute-availability-guidance";
   const executeControlVisible =

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -101,6 +101,13 @@ type OperatorRecoveryGuidance = {
   title: string;
 };
 
+type ExecuteAvailabilityGuidance = {
+  nextAction: string;
+  reason: string;
+  title: string;
+  tone: "danger" | "muted" | "success" | "warning";
+};
+
 type PreviewSubmissionStatus =
   | {
       status: "idle";
@@ -1326,8 +1333,201 @@ function canExecuteCandidate(
   const guardStatus = candidatePreview.guardStatus.toLowerCase();
   return (
     candidateState === "preview_ready" &&
-    (guardStatus === "allow" || guardStatus === "passed")
+    (guardStatus === "allow" || guardStatus === "passed") &&
+    candidatePreview.candidateSql !== null &&
+    candidatePreview.candidateSql.trim().length > 0 &&
+    !hasBlockingReviewEvidence(candidatePreview.reviewEvidence)
   );
+}
+
+function hasBlockingReviewEvidence(reviewEvidence: OperatorWorkflowReviewEvidence[]): boolean {
+  return reviewEvidence.some((evidence) => {
+    const reviewStatus = evidence.reviewStatus.toLowerCase();
+    return (
+      reviewStatus === "blocked" ||
+      reviewStatus === "denied" ||
+      reviewStatus === "needs_clarification" ||
+      reviewStatus === "clarification_required"
+    );
+  });
+}
+
+function resolveExecuteAvailabilityGuidance(
+  state: CanonicalWorkflowState,
+  candidatePreview: AuthoritativeCandidatePreview | null,
+  hasSourceMismatch: boolean,
+  executeInProgress: boolean
+): ExecuteAvailabilityGuidance {
+  if (executeInProgress) {
+    return {
+      nextAction:
+        "Wait for execute-time ownership, approval freshness, and replay checks to finish.",
+      reason: "SafeQuery has locked this candidate while execute-time controls run.",
+      title: "Execution in progress",
+      tone: "warning"
+    };
+  }
+
+  if (state === "completed" || state === "empty") {
+    return {
+      nextAction:
+        "Inspect the run record, result evidence, and audit events before starting a revised request.",
+      reason: "A reviewed execution result is already tied to this candidate and source.",
+      title: "Execution already recorded",
+      tone: "success"
+    };
+  }
+
+  if (state === "insufficient_evidence") {
+    return {
+      nextAction:
+        "Follow the validation next action or revise the request before trying another execution.",
+      reason:
+        "SafeQuery reached a run record, but result validation could not support an evidence-bound answer.",
+      title: "Evidence-bound answer unavailable",
+      tone: "warning"
+    };
+  }
+
+  if (state === "execution_denied") {
+    return {
+      nextAction: "Resolve the execute-time denial on the server-owned run path, then preview again.",
+      reason:
+        "Execute-time controls denied the run after rechecking ownership, approval freshness, or replay posture.",
+      title: "Execution denied",
+      tone: "danger"
+    };
+  }
+
+  if (state === "failed" || state === "canceled") {
+    return {
+      nextAction: "Review the run lifecycle and submit a revised preview before retrying execution.",
+      reason: "The previous run did not produce a trusted successful result payload.",
+      title: state === "failed" ? "Execution failed" : "Execution canceled",
+      tone: "danger"
+    };
+  }
+
+  if (state === "signin") {
+    return {
+      nextAction: "Sign in through the application authority before preview or execution.",
+      reason: "Execution cannot be offered before an authenticated operator context exists.",
+      title: "Operator authority required",
+      tone: "muted"
+    };
+  }
+
+  if (state === "query") {
+    return {
+      nextAction: "Select a source and submit the question for preview.",
+      reason: "SafeQuery needs an authoritative preview candidate before any execution decision.",
+      title: "No reviewed candidate",
+      tone: "warning"
+    };
+  }
+
+  if (state === "clarification_required") {
+    return {
+      nextAction: "Answer the clarifying questions, then submit a revised preview.",
+      reason: "SafeQuery cannot safely infer one business meaning for the request yet.",
+      title: "Clarification required before execution",
+      tone: "warning"
+    };
+  }
+
+  if (state === "review_denied") {
+    return {
+      nextAction: "Revise the request or source binding and submit a new preview.",
+      reason: "The candidate stopped during review and never became executable.",
+      title: "Review blocked execution",
+      tone: "danger"
+    };
+  }
+
+  if (candidatePreview === null) {
+    return {
+      nextAction: "Submit the question for preview or reopen a candidate history row.",
+      reason: "No server-owned candidate record is selected for this preview.",
+      title: "No reviewed candidate",
+      tone: "warning"
+    };
+  }
+
+  if (hasSourceMismatch) {
+    return {
+      nextAction:
+        "Return to the candidate's bound source or start a new preview for the selected source.",
+      reason: "The draft source differs from the reopened candidate's bound source.",
+      title: "Source mismatch blocks execution",
+      tone: "danger"
+    };
+  }
+
+  const candidateState = candidatePreview.candidateState.toLowerCase();
+  const guardStatus = candidatePreview.guardStatus.toLowerCase();
+
+  if (candidateState === "clarification_required" || candidateState === "needs_clarification") {
+    return {
+      nextAction: "Answer the clarifying questions, then submit a revised preview.",
+      reason: "The candidate needs clarification before SafeQuery can continue.",
+      title: "Clarification required before execution",
+      tone: "warning"
+    };
+  }
+
+  if (hasBlockingReviewEvidence(candidatePreview.reviewEvidence)) {
+    return {
+      nextAction: "Resolve the review finding and submit a revised preview.",
+      reason:
+        "Review evidence flagged unresolved business risk, and advisory review output cannot authorize execution.",
+      title: "Review blocked execution",
+      tone: "danger"
+    };
+  }
+
+  if (candidatePreview.candidateSql === null || candidatePreview.candidateSql.trim().length === 0) {
+    return {
+      nextAction: "Wait for SQL generation to finish or submit a revised preview.",
+      reason: "No canonical SQL candidate is available on the server-owned preview record.",
+      title: "No SQL candidate available",
+      tone: "warning"
+    };
+  }
+
+  if (candidateState !== "preview_ready") {
+    return {
+      nextAction: "Wait for the preview to reach review-ready state or submit a revised request.",
+      reason: `Candidate state is ${formatStatusLabel(
+        candidatePreview.candidateState
+      )}, so execution remains unavailable.`,
+      title: "Candidate not ready",
+      tone: candidateState === "blocked" || candidateState === "denied" ? "danger" : "warning"
+    };
+  }
+
+  if (guardStatus !== "allow" && guardStatus !== "passed") {
+    return {
+      nextAction: "Resolve the guard finding and submit a revised preview.",
+      reason:
+        guardStatus === "blocked" || guardStatus === "denied"
+          ? "The deterministic guard denied this candidate before execution."
+          : "The deterministic guard has not allowed this candidate yet.",
+      title:
+        guardStatus === "blocked" || guardStatus === "denied"
+          ? "Guard denied execution"
+          : "Guard review incomplete",
+      tone: guardStatus === "blocked" || guardStatus === "denied" ? "danger" : "warning"
+    };
+  }
+
+  return {
+    nextAction:
+      "Execute only if the business-readable answer plan, source identity, and guard posture match the request.",
+    reason:
+      "A server-owned candidate is review-ready and the deterministic guard allowed it. Advisory answer or semantic mapping output still cannot authorize execution by itself.",
+    title: "Execute reviewed candidate available",
+    tone: "success"
+  };
 }
 
 function candidateRequiresClarification(
@@ -1892,7 +2092,8 @@ function renderBusinessAnswerPlan(
   retrievedCitations: OperatorWorkflowRetrievedCitation[],
   reviewEvidence: OperatorWorkflowReviewEvidence[],
   candidateAttempts: OperatorWorkflowCandidateAttempt[],
-  executeEnabled: boolean
+  executeEnabled: boolean,
+  executeGuidance: ExecuteAvailabilityGuidance
 ) {
   const latestReview = reviewEvidence[0];
   const latestAttempt =
@@ -1934,13 +2135,9 @@ function renderBusinessAnswerPlan(
     ? `Candidate ${preview.candidateState}; guard ${preview.guardStatus}`
     : "No candidate selected";
   const nextAction =
-    preview === null
-      ? "Submit the question for preview, then review the answer plan returned by SafeQuery."
-      : clarificationRequired
-        ? "Answer the clarifying questions, then submit a revised preview before execution."
-      : executeEnabled
-        ? "Review the answer plan, then execute the reviewed candidate when the business intent and safety status match the request."
-        : "Review the answer plan and resolve the guard or candidate status before execution.";
+    executeEnabled
+      ? "Review the answer plan, then execute the reviewed candidate when the business intent and safety status match the request."
+      : executeGuidance.nextAction;
 
   return (
     <section
@@ -2012,6 +2209,33 @@ function renderBusinessAnswerPlan(
         </div>
       </div>
     </section>
+  );
+}
+
+function renderExecuteAvailabilityCallout(
+  guidance: ExecuteAvailabilityGuidance,
+  id: string
+) {
+  const toneClass =
+    guidance.tone === "danger"
+      ? " state-callout-danger"
+      : guidance.tone === "success"
+        ? " state-callout-success"
+        : guidance.tone === "warning"
+          ? " state-callout-warning"
+          : "";
+
+  return (
+    <div
+      aria-label="Execute availability"
+      className={`state-callout${toneClass}`}
+      id={id}
+      role={guidance.tone === "danger" ? "alert" : "status"}
+    >
+      <p className="state-callout-title">{guidance.title}</p>
+      <p>{guidance.reason}</p>
+      <p>{guidance.nextAction}</p>
+    </div>
   );
 }
 
@@ -2989,6 +3213,13 @@ export function QueryWorkflowShell({
     candidatePreview,
     historySourceMismatch
   );
+  const executeGuidance = resolveExecuteAvailabilityGuidance(
+    normalizedState,
+    candidatePreview,
+    historySourceMismatch,
+    executeSubmission.status === "executing"
+  );
+  const executeGuidanceId = "execute-availability-guidance";
   const executeControlVisible =
     candidatePreview !== null &&
     normalizedState !== "clarification_required" &&
@@ -3499,7 +3730,8 @@ export function QueryWorkflowShell({
                 selectedRetrievedCitations,
                 selectedReviewEvidence,
                 selectedAnswerPlanCandidateAttempts,
-                executeEnabled
+                executeEnabled,
+                executeGuidance
               )
             : null}
 
@@ -3697,6 +3929,9 @@ export function QueryWorkflowShell({
                   <p>{executeSubmission.message}</p>
                 </div>
               ) : null}
+              {executeEnabled
+                ? null
+                : renderExecuteAvailabilityCallout(executeGuidance, executeGuidanceId)}
               <div className="form-actions">
                 <button disabled={queryLocked} type="submit">
                   {previewSubmission.status === "submitting"
@@ -3705,6 +3940,7 @@ export function QueryWorkflowShell({
                 </button>
                 {executeControlVisible ? (
                   <button
+                    aria-describedby={!executeEnabled ? executeGuidanceId : undefined}
                     disabled={!executeEnabled || executeSubmission.status === "executing"}
                     onClick={executeCandidate}
                     type="button"
@@ -3847,9 +4083,8 @@ export function QueryWorkflowShell({
               </div>
               <div className="guard-item">
                 <span className="meta-label">Execution path</span>
-                <strong>
-                  {executeEnabled ? "Candidate execute available" : "No executable candidate"}
-                </strong>
+                <strong>{executeGuidance.title}</strong>
+                <p>{executeGuidance.reason}</p>
               </div>
             </div>
           </section>

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1336,7 +1336,15 @@ function canExecuteCandidate(
     (guardStatus === "allow" || guardStatus === "passed") &&
     candidatePreview.candidateSql !== null &&
     candidatePreview.candidateSql.trim().length > 0 &&
+    !hasClarifyingQuestions(candidatePreview) &&
     !hasBlockingReviewEvidence(candidatePreview.reviewEvidence)
+  );
+}
+
+function hasClarifyingQuestions(candidatePreview: AuthoritativeCandidatePreview): boolean {
+  return (
+    candidatePreview.clarifyingQuestions?.length > 0 ||
+    candidatePreview.reviewEvidence.some((evidence) => evidence.clarifyingQuestions.length > 0)
   );
 }
 
@@ -1369,7 +1377,25 @@ function resolveExecuteAvailabilityGuidance(
     };
   }
 
-  if ((state === "completed" || state === "empty") && runContext !== null) {
+  if (
+    (state === "completed" ||
+      state === "empty" ||
+      state === "insufficient_evidence" ||
+      state === "execution_denied" ||
+      state === "failed" ||
+      state === "canceled") &&
+    runContext === null
+  ) {
+    return {
+      nextAction: "Open the authoritative run from history or execute the reviewed candidate first.",
+      reason:
+        "This page is showing an execution-state route, but no server-owned run record is selected.",
+      title: "No execution run selected",
+      tone: "warning"
+    };
+  }
+
+  if (state === "completed" || state === "empty") {
     return {
       nextAction:
         "Inspect the run record, result evidence, and audit events before starting a revised request.",
@@ -1485,20 +1511,19 @@ function resolveExecuteAvailabilityGuidance(
     };
   }
 
-  if ((state === "completed" || state === "empty") && runContext === null) {
-    return {
-      nextAction: "Open the authoritative run from history or execute the reviewed candidate first.",
-      reason:
-        "This page is showing a completed-state route, but no server-owned run record is selected.",
-      title: "No execution run selected",
-      tone: "warning"
-    };
-  }
-
   if (candidateState === "clarification_required" || candidateState === "needs_clarification") {
     return {
       nextAction: "Answer the clarifying questions, then submit a revised preview.",
       reason: "The candidate needs clarification before SafeQuery can continue.",
+      title: "Clarification required before execution",
+      tone: "warning"
+    };
+  }
+
+  if (hasClarifyingQuestions(candidatePreview)) {
+    return {
+      nextAction: "Answer the clarifying questions, then submit a revised preview.",
+      reason: "The answer plan still contains business clarification questions.",
       title: "Clarification required before execution",
       tone: "warning"
     };
@@ -2159,7 +2184,9 @@ function renderBusinessAnswerPlan(
     ? `Candidate ${preview.candidateState}; guard ${preview.guardStatus}`
     : "No candidate selected";
   const nextAction =
-    executeEnabled
+    clarificationRequired
+      ? "Answer the clarifying questions, then submit a revised preview."
+      : executeEnabled
       ? "Review the answer plan, then execute the reviewed candidate when the business intent and safety status match the request."
       : executeGuidance.nextAction;
 

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1343,7 +1343,7 @@ function canExecuteCandidate(
 
 function hasClarifyingQuestions(candidatePreview: AuthoritativeCandidatePreview): boolean {
   return (
-    candidatePreview.clarifyingQuestions?.length > 0 ||
+    (candidatePreview.clarifyingQuestions?.length ?? 0) > 0 ||
     candidatePreview.reviewEvidence.some((evidence) => evidence.clarifyingQuestions.length > 0)
   );
 }

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1366,7 +1366,8 @@ function resolveExecuteAvailabilityGuidance(
   runContext: AuthoritativeRunContext | null,
   hasSourceMismatch: boolean,
   executeInProgress: boolean,
-  hasRecentExecuteDenial: boolean
+  hasRecentExecuteDenial: boolean,
+  hasRecentExecuteFailure: boolean
 ): ExecuteAvailabilityGuidance {
   if (executeInProgress) {
     return {
@@ -1386,7 +1387,8 @@ function resolveExecuteAvailabilityGuidance(
       state === "failed" ||
       state === "canceled") &&
     runContext === null &&
-    !(state === "execution_denied" && hasRecentExecuteDenial)
+    !(state === "execution_denied" && hasRecentExecuteDenial) &&
+    !(state === "failed" && hasRecentExecuteFailure)
   ) {
     return {
       nextAction: "Open the authoritative run from history or execute the reviewed candidate first.",
@@ -3272,7 +3274,8 @@ export function QueryWorkflowShell({
     historyRunContext,
     historySourceMismatch,
     executeSubmission.status === "executing",
-    executeSubmission.status === "denied"
+    executeSubmission.status === "denied",
+    executeSubmission.status === "failed"
   );
   const executeGuidanceId = "execute-availability-guidance";
   const executeControlVisible =

--- a/frontend/components/query-workflow-shell.tsx
+++ b/frontend/components/query-workflow-shell.tsx
@@ -1355,6 +1355,7 @@ function hasBlockingReviewEvidence(reviewEvidence: OperatorWorkflowReviewEvidenc
 function resolveExecuteAvailabilityGuidance(
   state: CanonicalWorkflowState,
   candidatePreview: AuthoritativeCandidatePreview | null,
+  runContext: AuthoritativeRunContext | null,
   hasSourceMismatch: boolean,
   executeInProgress: boolean
 ): ExecuteAvailabilityGuidance {
@@ -1368,7 +1369,7 @@ function resolveExecuteAvailabilityGuidance(
     };
   }
 
-  if (state === "completed" || state === "empty") {
+  if ((state === "completed" || state === "empty") && runContext !== null) {
     return {
       nextAction:
         "Inspect the run record, result evidence, and audit events before starting a revised request.",
@@ -1435,16 +1436,16 @@ function resolveExecuteAvailabilityGuidance(
     };
   }
 
-  if (state === "review_denied") {
-    return {
-      nextAction: "Revise the request or source binding and submit a new preview.",
-      reason: "The candidate stopped during review and never became executable.",
-      title: "Review blocked execution",
-      tone: "danger"
-    };
-  }
-
   if (candidatePreview === null) {
+    if (state === "review_denied") {
+      return {
+        nextAction: "Revise the request or source binding and submit a new preview.",
+        reason: "The request stopped during review and never became executable.",
+        title: "Review blocked execution",
+        tone: "danger"
+      };
+    }
+
     return {
       nextAction: "Submit the question for preview or reopen a candidate history row.",
       reason: "No server-owned candidate record is selected for this preview.",
@@ -1465,6 +1466,34 @@ function resolveExecuteAvailabilityGuidance(
 
   const candidateState = candidatePreview.candidateState.toLowerCase();
   const guardStatus = candidatePreview.guardStatus.toLowerCase();
+
+  if (guardStatus === "blocked" || guardStatus === "denied") {
+    return {
+      nextAction: "Resolve the guard finding and submit a revised preview.",
+      reason: "The deterministic guard denied this candidate before execution.",
+      title: "Guard denied execution",
+      tone: "danger"
+    };
+  }
+
+  if (state === "review_denied") {
+    return {
+      nextAction: "Revise the request or source binding and submit a new preview.",
+      reason: "The candidate stopped during review and never became executable.",
+      title: "Review blocked execution",
+      tone: "danger"
+    };
+  }
+
+  if ((state === "completed" || state === "empty") && runContext === null) {
+    return {
+      nextAction: "Open the authoritative run from history or execute the reviewed candidate first.",
+      reason:
+        "This page is showing a completed-state route, but no server-owned run record is selected.",
+      title: "No execution run selected",
+      tone: "warning"
+    };
+  }
 
   if (candidateState === "clarification_required" || candidateState === "needs_clarification") {
     return {
@@ -1509,14 +1538,9 @@ function resolveExecuteAvailabilityGuidance(
     return {
       nextAction: "Resolve the guard finding and submit a revised preview.",
       reason:
-        guardStatus === "blocked" || guardStatus === "denied"
-          ? "The deterministic guard denied this candidate before execution."
-          : "The deterministic guard has not allowed this candidate yet.",
-      title:
-        guardStatus === "blocked" || guardStatus === "denied"
-          ? "Guard denied execution"
-          : "Guard review incomplete",
-      tone: guardStatus === "blocked" || guardStatus === "denied" ? "danger" : "warning"
+        "The deterministic guard has not allowed this candidate yet.",
+      title: "Guard review incomplete",
+      tone: "warning"
     };
   }
 
@@ -3216,6 +3240,7 @@ export function QueryWorkflowShell({
   const executeGuidance = resolveExecuteAvailabilityGuidance(
     normalizedState,
     candidatePreview,
+    historyRunContext,
     historySourceMismatch,
     executeSubmission.status === "executing"
   );


### PR DESCRIPTION
## Summary

- Adds business-readable execute availability guidance with a reason and next action for disabled execution paths.
- Blocks execute when no canonical SQL candidate is present or review evidence is blocking, while keeping deterministic guard and server-owned candidate state authoritative.
- Surfaces the same guidance near the action area and in the guard context, with `aria-describedby` on disabled execute buttons.
- Adds restrained warning and success callout styling for the existing state-callout vocabulary.

Closes #494.

## Validation

- `npm test` in `frontend/` passed: 4 files, 77 tests.
- `python3 -m pytest tests/test_support_bundle.py` in `backend/` passed: 15 tests.

## Notes

- `.claude/` remains an unrelated untracked local directory and was not included.